### PR TITLE
[Feat] #34 #35 #36 문제상세 조회까지 기능구현

### DIFF
--- a/src/main/java/com/wanted/codebombalms/domain/problem/category/controller/ProblemCategoryController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/category/controller/ProblemCategoryController.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.domain.problem.category.controller;
+
+import com.wanted.codebombalms.domain.problem.category.dto.response.CategoryResponse;
+import com.wanted.codebombalms.domain.problem.category.service.ProblemCategoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/problem-categories")
+public class ProblemCategoryController {
+
+    private final ProblemCategoryService problemCategoryService;
+
+    public ProblemCategoryController(ProblemCategoryService problemCategoryService) {
+        this.problemCategoryService = problemCategoryService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponse>> findCategories() {
+        return ResponseEntity.ok(problemCategoryService.findActiveCategories());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/category/dto/request/CategoryRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/category/dto/request/CategoryRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.domain.problem.category.dto.request;
+
+public class CategoryRequest {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/category/dto/response/CategoryResponse.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.domain.problem.category.dto.response;
+
+import com.wanted.codebombalms.domain.problem.category.entity.ProblemCategory;
+
+public class CategoryResponse {
+
+    private Long categoryId;
+    private String categoryName;
+    private String description;
+
+    public CategoryResponse(ProblemCategory category) {
+        this.categoryId = category.getCategoryId();
+        this.categoryName = category.getCategoryName();
+        this.description = category.getDescription();
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/category/entity/ProblemCategory.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/category/entity/ProblemCategory.java
@@ -1,0 +1,36 @@
+package com.wanted.codebombalms.domain.problem.category.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class ProblemCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    @Column(nullable = false)
+    private String categoryName;
+
+    private String description;
+
+    @Column(nullable = false)
+    private String status;
+
+    protected ProblemCategory() {
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.domain.problem.category.exception;
+
+public class CategoryNotFoundException {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/category/repository/ProblemCategoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/category/repository/ProblemCategoryRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.domain.problem.category.repository;
+
+import com.wanted.codebombalms.domain.problem.category.entity.ProblemCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProblemCategoryRepository extends JpaRepository<ProblemCategory, Long> {
+    List<ProblemCategory> findByStatus(String status);
+
+    List<ProblemCategory> findByStatusOrderByCategoryIdAsc(String status);
+
+    boolean existsByCategoryIdAndStatus(Long categoryId, String status);
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/category/service/ProblemCategoryService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/category/service/ProblemCategoryService.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.domain.problem.category.service;
+
+import com.wanted.codebombalms.domain.problem.category.dto.response.CategoryResponse;
+import com.wanted.codebombalms.domain.problem.category.repository.ProblemCategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProblemCategoryService {
+
+    private final ProblemCategoryRepository problemCategoryRepository;
+
+    public ProblemCategoryService(ProblemCategoryRepository problemCategoryRepository) {
+        this.problemCategoryRepository = problemCategoryRepository;
+    }
+
+    public List<CategoryResponse> findActiveCategories() {
+        return problemCategoryRepository.findByStatusOrderByCategoryIdAsc("ACTIVE")
+                .stream()
+                .map(CategoryResponse::new)
+                .toList();
+    }
+
+    public boolean existsActiveCategory(Long categoryId) {
+        return problemCategoryRepository.existsByCategoryIdAndStatus(categoryId, "ACTIVE");
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/problem/controller/ProblemController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/problem/controller/ProblemController.java
@@ -1,0 +1,53 @@
+package com.wanted.codebombalms.domain.problem.problem.controller;
+
+import com.wanted.codebombalms.domain.problem.category.dto.response.CategoryResponse;
+import com.wanted.codebombalms.domain.problem.category.service.ProblemCategoryService;
+import com.wanted.codebombalms.domain.problem.set.dto.response.SetResponse;
+import com.wanted.codebombalms.domain.problem.set.service.ProblemSetService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+public class ProblemController {
+
+    private final ProblemCategoryService problemCategoryService;
+    private final ProblemSetService problemSetService;
+
+    public ProblemController(
+            ProblemCategoryService problemCategoryService,
+            ProblemSetService problemSetService
+    ) {
+        this.problemCategoryService = problemCategoryService;
+        this.problemSetService = problemSetService;
+    }
+
+    @GetMapping("/problem")
+    public String problemList(
+            @RequestParam(required = false) Long categoryId,
+            Model model
+    ) {
+        List<CategoryResponse> categories = problemCategoryService.findActiveCategories();
+
+        Long selectedCategoryId = categoryId;
+
+        if (selectedCategoryId == null && !categories.isEmpty()) {
+            selectedCategoryId = categories.get(0).getCategoryId();
+        }
+
+        List<SetResponse> problemSets = List.of();
+
+        if (selectedCategoryId != null) {
+            problemSets = problemSetService.findActiveSetsByCategory(selectedCategoryId);
+        }
+
+        model.addAttribute("categories", categories);
+        model.addAttribute("selectedCategoryId", selectedCategoryId);
+        model.addAttribute("problemSets", problemSets);
+
+        return "problem/list";
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/problem/dto/request/ProblemRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/problem/dto/request/ProblemRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.domain.problem.problem.dto.request;
+
+public class ProblemRequest {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/problem/dto/response/ProblemResponse.java
@@ -1,0 +1,33 @@
+package com.wanted.codebombalms.domain.problem.problem.dto.response;
+
+import com.wanted.codebombalms.domain.problem.problem.entitiy.Problem;
+
+public class ProblemResponse {
+
+    private Long problemId;
+    private String title;
+    private String content;
+    private String problemType;
+
+    public ProblemResponse(Problem problem) {
+        this.problemId = problem.getProblemId();
+        this.title = problem.getTitle();
+        this.content = problem.getContent();
+        this.problemType = problem.getProblemType();
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+    public String getContent() {
+        return content;
+    }
+
+    public String getProblemType() {
+        return problemType;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/problem/entitiy/Problem.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/problem/entitiy/Problem.java
@@ -1,0 +1,69 @@
+package com.wanted.codebombalms.domain.problem.problem.entitiy;
+
+import com.wanted.codebombalms.domain.problem.set.entity.ProblemSet;
+import jakarta.persistence.*;
+
+@Entity
+public class Problem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long problemId;
+
+    @ManyToOne
+    @JoinColumn(name = "problem_set_id")
+    private ProblemSet problemSet;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private String problemType;
+
+    private String difficulty;
+
+    @Column(columnDefinition = "TEXT")
+    private String answer;
+
+    @Column(columnDefinition = "TEXT")
+    private String explanation;
+
+    @Column(nullable = false)
+    private int score;
+
+    private Integer attemptLimit;
+
+    private Boolean isRetriable;
+
+    @Column(nullable = false)
+    private String status;
+
+    private Integer problemOrder;
+
+    protected Problem() {
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public ProblemSet getProblemSet() {
+        return problemSet;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Integer getProblemOrder() {
+        return problemOrder;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getProblemType() {
+        return problemType;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/problem/exception/ProblemNotFound.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/problem/exception/ProblemNotFound.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.domain.problem.problem.exception;
+
+public class ProblemNotFound {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/problem/repository/ProblemRepository.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.domain.problem.problem.repository;
+
+import com.wanted.codebombalms.domain.problem.problem.entitiy.Problem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+    List<Problem> findByProblemSet_Category_CategoryIdAndStatusOrderByProblemOrderAsc(
+            Long categoryId,
+            String status
+    );
+    Optional<Problem> findByProblemSet_ProblemSetIdAndProblemOrderAndStatus(
+            Long problemSetId,
+            Integer problemOrder,
+            String status
+    );
+
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/problem/service/ProblemService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/problem/service/ProblemService.java
@@ -1,0 +1,36 @@
+package com.wanted.codebombalms.domain.problem.problem.service;
+
+import com.wanted.codebombalms.domain.problem.problem.dto.response.ProblemResponse;
+import com.wanted.codebombalms.domain.problem.problem.repository.ProblemRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+@Service
+public class ProblemService {
+    private final ProblemRepository problemRepository;
+
+
+    public ProblemService(ProblemRepository problemRepository) {
+        this.problemRepository = problemRepository;
+    }
+
+    public List<ProblemResponse> findProblemsByCategory(Long categoryId) {
+        return problemRepository
+                .findByProblemSet_Category_CategoryIdAndStatusOrderByProblemOrderAsc(categoryId, "ACTIVE")
+                .stream()
+                .map(ProblemResponse::new)
+                .toList();
+    }
+    public ProblemResponse findCurrentProblem(Long problemSetId,
+                                              Integer currentProblemNumber) {
+        return problemRepository
+                .findByProblemSet_ProblemSetIdAndProblemOrderAndStatus(
+                        problemSetId,
+                        currentProblemNumber,
+                        "ACTIVE"
+                )
+                .map(ProblemResponse::new)
+                .orElseThrow(() -> new RuntimeException("현재 풀 문제가 없습니다."));
+
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/progress/controller/ProgressController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/progress/controller/ProgressController.java
@@ -1,0 +1,33 @@
+package com.wanted.codebombalms.domain.problem.progress.controller;
+
+import com.wanted.codebombalms.domain.problem.set.dto.response.SetEnterResponse;
+import com.wanted.codebombalms.domain.problem.set.service.ProblemSetService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class ProgressController {
+
+    private final ProblemSetService problemSetService;
+
+    public ProgressController(ProblemSetService problemSetService) {
+        this.problemSetService = problemSetService;
+    }
+
+    @GetMapping("/problem/sets/{problemSetId}")
+    public String solvePage(
+            @PathVariable Long problemSetId,
+            @RequestParam(defaultValue = "1") Long userId,
+            Model model
+    ) {
+        SetEnterResponse response =
+                problemSetService.enterProblemSet(problemSetId, userId);
+
+        model.addAttribute("problemSet", response);
+
+        return "problem/solve";
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/progress/entitiy/Progress.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/progress/entitiy/Progress.java
@@ -1,0 +1,68 @@
+package com.wanted.codebombalms.domain.problem.progress.entitiy;
+
+import com.wanted.codebombalms.domain.problem.set.entity.ProblemSet;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "problem_progress")
+public class Progress {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long progressId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @ManyToOne
+    @JoinColumn(name = "problem_set_id")
+    private ProblemSet problemSet;
+
+    @Column(nullable = false)
+    private Integer currentProblemNumber;
+
+    private Long lastProblemId;
+
+    @Column(nullable = false)
+    private Boolean isCompleted;
+
+    private LocalDateTime completedAt;
+
+    private LocalDateTime updatedAt;
+
+    protected Progress() {
+    }
+
+    public Long getProgressId() {
+        return progressId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public ProblemSet getProblemSet() {
+        return problemSet;
+    }
+
+    public Integer getCurrentProblemNumber() {
+        return currentProblemNumber;
+    }
+
+    public Long getLastProblemId() {
+        return lastProblemId;
+    }
+
+    public Boolean getCompleted() {
+        return isCompleted;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/progress/repository/ProgressRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/progress/repository/ProgressRepository.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.domain.problem.progress.repository;
+
+import com.wanted.codebombalms.domain.problem.progress.entitiy.Progress;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProgressRepository extends JpaRepository<Progress, Long> {
+
+    Optional<Progress> findByUserIdAndProblemSet_ProblemSetId(
+            Long userId,
+            Long problemSetId
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/progress/service/ProgressService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/progress/service/ProgressService.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.domain.problem.progress.service;
+
+import com.wanted.codebombalms.domain.problem.progress.entitiy.Progress;
+import com.wanted.codebombalms.domain.problem.progress.repository.ProgressRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProgressService {
+    private final ProgressRepository problemProgressRepository;
+
+    public ProgressService(ProgressRepository problemProgressRepository) {
+        this.problemProgressRepository = problemProgressRepository;
+    }
+
+    public Integer findCurrentProblemNumber(Long userId, Long problemSetId) {
+        return problemProgressRepository
+                .findByUserIdAndProblemSet_ProblemSetId(userId, problemSetId)
+                .map(Progress::getCurrentProblemNumber)
+                .orElse(1);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/controller/ProblemSetController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/controller/ProblemSetController.java
@@ -1,0 +1,33 @@
+package com.wanted.codebombalms.domain.problem.set.controller;
+
+import com.wanted.codebombalms.domain.problem.set.dto.response.SetEnterResponse;
+import com.wanted.codebombalms.domain.problem.set.dto.response.SetResponse;
+import com.wanted.codebombalms.domain.problem.set.service.ProblemSetService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class ProblemSetController {
+
+    private final ProblemSetService problemSetService;
+
+    public ProblemSetController(ProblemSetService problemSetService) {
+        this.problemSetService = problemSetService;
+    }
+
+    @GetMapping("/api/v1/problem-sets")
+    public ResponseEntity<List<SetResponse>> findProblemSets(
+            @RequestParam Long categoryId
+    ) {
+        return ResponseEntity.ok(problemSetService.findActiveSetsByCategory(categoryId));
+    }
+    @PostMapping("/api/v1/problem-sets/{id}")
+    public ResponseEntity<SetEnterResponse> enterProblemSet(
+            @PathVariable Long id,
+            @RequestParam Long userId
+    ) {
+        return ResponseEntity.ok(problemSetService.enterProblemSet(id, userId));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/dto/request/SetRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/dto/request/SetRequest.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.domain.problem.set.dto.request;
+
+public class SetRequest {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/dto/response/SetEnterResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/dto/response/SetEnterResponse.java
@@ -1,0 +1,58 @@
+package com.wanted.codebombalms.domain.problem.set.dto.response;
+
+public class SetEnterResponse {
+
+    private Long problemSetId;
+    private String problemSetTitle;
+    private Integer currentProblemNumber;
+    private Long problemId;
+    private String problemTitle;
+    private String problemContent;
+    private String problemType;
+
+    public SetEnterResponse(
+            Long problemSetId,
+            String problemSetTitle,
+            Integer currentProblemNumber,
+            Long problemId,
+            String problemTitle,
+            String problemContent,
+            String problemType
+    ) {
+        this.problemSetId = problemSetId;
+        this.problemSetTitle = problemSetTitle;
+        this.currentProblemNumber = currentProblemNumber;
+        this.problemId = problemId;
+        this.problemTitle = problemTitle;
+        this.problemContent = problemContent;
+        this.problemType = problemType;
+    }
+
+    public Long getProblemSetId() {
+        return problemSetId;
+    }
+
+    public String getProblemSetTitle() {
+        return problemSetTitle;
+    }
+
+    public Integer getCurrentProblemNumber() {
+        return currentProblemNumber;
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public String getProblemTitle() {
+        return problemTitle;
+    }
+
+    public String getProblemContent() {
+        return problemContent;
+    }
+
+    public String getProblemType() {
+        return problemType;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/dto/response/SetResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/dto/response/SetResponse.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.domain.problem.set.dto.response;
+
+import com.wanted.codebombalms.domain.problem.set.entity.ProblemSet;
+
+public class SetResponse {
+
+    private Long problemSetId;
+    private String title;
+
+    public SetResponse(ProblemSet problemSet) {
+        this.problemSetId = problemSet.getProblemSetId();
+        this.title = problemSet.getTitle();
+    }
+
+    public Long getProblemSetId() {
+        return problemSetId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/entity/ProblemSet.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/entity/ProblemSet.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.domain.problem.set.entity;
+
+import com.wanted.codebombalms.domain.problem.category.entity.ProblemCategory;
+import jakarta.persistence.*;
+
+@Entity
+public class ProblemSet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long problemSetId;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private ProblemCategory category;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    private String difficulty;
+
+    @Column(nullable = false)
+    private String status;
+
+    protected ProblemSet() {
+    }
+
+    public Long getProblemSetId() {
+        return problemSetId;
+    }
+
+    public ProblemCategory getCategory() {
+        return category;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/exception/SetNotFoundException.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/exception/SetNotFoundException.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.domain.problem.set.exception;
+
+public class SetNotFoundException extends RuntimeException {
+
+    public SetNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/repository/ProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/repository/ProblemSetRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.domain.problem.set.repository;
+
+import com.wanted.codebombalms.domain.problem.set.entity.ProblemSet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProblemSetRepository extends JpaRepository<ProblemSet, Long> {
+
+    List<ProblemSet> findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(
+            Long categoryId,
+            String status
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problem/set/service/ProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problem/set/service/ProblemSetService.java
@@ -1,0 +1,68 @@
+package com.wanted.codebombalms.domain.problem.set.service;
+
+import com.wanted.codebombalms.domain.problem.category.service.ProblemCategoryService;
+import com.wanted.codebombalms.domain.problem.problem.dto.response.ProblemResponse;
+import com.wanted.codebombalms.domain.problem.problem.service.ProblemService;
+import com.wanted.codebombalms.domain.problem.progress.service.ProgressService;
+import com.wanted.codebombalms.domain.problem.set.dto.response.SetEnterResponse;
+import com.wanted.codebombalms.domain.problem.set.dto.response.SetResponse;
+import com.wanted.codebombalms.domain.problem.set.entity.ProblemSet;
+import com.wanted.codebombalms.domain.problem.set.exception.SetNotFoundException;
+import com.wanted.codebombalms.domain.problem.set.repository.ProblemSetRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProblemSetService {
+
+    private final ProblemSetRepository problemSetRepository;
+    private final ProblemCategoryService problemCategoryService;
+    private final ProblemService problemService;
+    private final ProgressService progressService;
+
+    public ProblemSetService(
+            ProblemSetRepository problemSetRepository,
+            ProblemCategoryService problemCategoryService,
+            ProblemService problemService,
+            ProgressService progressService
+    ) {
+        this.problemSetRepository = problemSetRepository;
+        this.problemCategoryService = problemCategoryService;
+        this.problemService = problemService;
+        this.progressService = progressService;
+    }
+
+    public List<SetResponse> findActiveSetsByCategory(Long categoryId) {
+        if (!problemCategoryService.existsActiveCategory(categoryId)) {
+            throw new SetNotFoundException("존재하지 않는 문제 분야입니다.");
+        }
+
+        return problemSetRepository
+                .findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(categoryId, "ACTIVE")
+                .stream()
+                .map(SetResponse::new)
+                .toList();
+    }
+
+    public SetEnterResponse enterProblemSet(Long problemSetId, Long userId) {
+        ProblemSet problemSet = problemSetRepository.findById(problemSetId)
+                .orElseThrow(() -> new SetNotFoundException("존재하지 않는 문제 세트입니다."));
+
+        Integer currentProblemNumber =
+                progressService.findCurrentProblemNumber(userId, problemSetId);
+
+        ProblemResponse currentProblem =
+                problemService.findCurrentProblem(problemSetId, currentProblemNumber);
+
+        return new SetEnterResponse(
+                problemSet.getProblemSetId(),
+                problemSet.getTitle(),
+                currentProblemNumber,
+                currentProblem.getProblemId(),
+                currentProblem.getTitle(),
+                currentProblem.getContent(),
+                currentProblem.getProblemType()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,5 @@
-spring.application.name=Code-Bomba-LMS
+spring:
+  application:
+    name: Code-Bomba-LMS
+  profiles:
+    active: local

--- a/src/main/resources/templates/problem/list.html
+++ b/src/main/resources/templates/problem/list.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>codebomba - 문제 목록</title>
+    <style>
+        :root {
+            --primary: #1f2588;
+            --text: #1f2937;
+            --muted: #6b7280;
+            --line: #e5e7eb;
+            --soft: #f3f4f6;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-width: 1024px;
+            color: var(--text);
+            font-family: Arial, "Noto Sans KR", sans-serif;
+            background: #ffffff;
+        }
+
+        .topbar {
+            height: 70px;
+            display: grid;
+            grid-template-columns: 360px 1fr 430px;
+            align-items: center;
+            border-bottom: 1px solid var(--line);
+            padding: 0 56px 0 68px;
+        }
+
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            color: var(--primary);
+            font-weight: 800;
+            font-size: 28px;
+        }
+
+        .brand-mark {
+            width: 28px;
+            height: 28px;
+            border: 4px solid var(--primary);
+            border-radius: 50%;
+            position: relative;
+        }
+
+        .brand-mark::after {
+            content: "";
+            width: 8px;
+            height: 8px;
+            border: 2px solid var(--primary);
+            border-left: 0;
+            border-bottom: 0;
+            border-radius: 50%;
+            position: absolute;
+            top: -8px;
+            right: -5px;
+        }
+
+        .search {
+            width: min(864px, 100%);
+            justify-self: center;
+            position: relative;
+        }
+
+        .search input {
+            width: 100%;
+            height: 52px;
+            padding: 0 56px 0 26px;
+            border: 1px solid #d9dde5;
+            border-radius: 9px;
+            color: var(--text);
+            font-size: 19px;
+            outline: none;
+        }
+
+        .search span {
+            position: absolute;
+            right: 23px;
+            top: 50%;
+            width: 20px;
+            height: 20px;
+            border: 3px solid #64748b;
+            border-radius: 50%;
+            transform: translateY(-50%);
+        }
+
+        .search span::after {
+            content: "";
+            position: absolute;
+            width: 10px;
+            height: 3px;
+            right: -9px;
+            bottom: -5px;
+            background: #64748b;
+            transform: rotate(45deg);
+            border-radius: 999px;
+        }
+
+        .nav {
+            justify-self: end;
+            display: flex;
+            align-items: center;
+            gap: 34px;
+            font-size: 18px;
+            font-weight: 700;
+        }
+
+        .profile {
+            height: 52px;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 0 18px;
+            border: 2px solid var(--primary);
+            border-radius: 999px;
+            color: var(--primary);
+        }
+
+        .profile .brand-mark {
+            width: 24px;
+            height: 24px;
+            border-width: 3px;
+        }
+
+        .layout {
+            display: grid;
+            grid-template-columns: 404px 1fr;
+            min-height: calc(100vh - 70px);
+        }
+
+        .sidebar {
+            border-right: 1px solid var(--line);
+            padding: 62px 27px;
+        }
+
+        .sidebar h1 {
+            margin: 0 0 34px;
+            font-size: 34px;
+            line-height: 1;
+        }
+
+        .category {
+            width: 100%;
+            height: 62px;
+            display: flex;
+            align-items: center;
+            padding: 0 20px;
+            border-radius: 7px;
+            color: var(--text);
+            font-weight: 800;
+            font-size: 22px;
+            margin-bottom: 14px;
+            text-decoration: none;
+        }
+
+        .category.active {
+            background: var(--primary);
+            color: #ffffff;
+        }
+
+        .content {
+            padding: 27px 50px 26px;
+        }
+
+        .board {
+            min-height: calc(100vh - 124px);
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            padding: 35px 32px;
+        }
+
+        .board-head {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 34px;
+        }
+
+        .board h2 {
+            margin: 0;
+            font-size: 36px;
+        }
+
+        .sort {
+            height: 52px;
+            min-width: 180px;
+            padding: 0 22px;
+            border: 1px solid #d9dde5;
+            border-radius: 8px;
+            background: #ffffff;
+            color: var(--text);
+            font-weight: 800;
+            font-size: 16px;
+        }
+
+        .table-wrap {
+            overflow: hidden;
+            border: 1px solid #d9dde5;
+            border-radius: 8px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+            font-size: 20px;
+        }
+
+        thead th {
+            height: 64px;
+            background: var(--soft);
+            text-align: left;
+            font-weight: 900;
+        }
+
+        th,
+        td {
+            padding: 0 22px;
+            border-bottom: 1px solid var(--line);
+            white-space: nowrap;
+        }
+
+        tbody td {
+            height: 63px;
+        }
+
+        tbody tr:last-child td {
+            border-bottom: 0;
+        }
+
+        .col-no {
+            width: 102px;
+        }
+
+        .col-submit {
+            width: 330px;
+        }
+
+        .col-rate {
+            width: 205px;
+        }
+
+        .problem-link {
+            color: var(--text);
+            text-decoration: none;
+        }
+
+        .problem-link:hover {
+            color: var(--primary);
+            text-decoration: underline;
+        }
+
+        .empty-message {
+            text-align: center;
+            color: var(--muted);
+        }
+    </style>
+</head>
+<body>
+<header class="topbar">
+    <div class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span>codebomba</span>
+    </div>
+    <label class="search" aria-label="강의 검색">
+        <input type="search" placeholder="강의 검색...">
+        <span aria-hidden="true"></span>
+    </label>
+    <nav class="nav" aria-label="주요 메뉴">
+        <span>내 강의실</span>
+        <span>문제 풀이</span>
+        <span class="profile"><span class="brand-mark" aria-hidden="true"></span>닉네임</span>
+    </nav>
+</header>
+
+<main class="layout">
+    <aside class="sidebar">
+        <h1>카테고리</h1>
+        <a class="category"
+           th:each="category : ${categories}"
+           th:href="@{/problem(categoryId=${category.categoryId})}"
+           th:text="${category.categoryName}"
+           th:classappend="${category.categoryId == selectedCategoryId} ? ' active' : ''">
+            데이터 분석
+        </a>
+    </aside>
+
+    <section class="content">
+        <div class="board">
+            <div class="board-head">
+                <h2>문제 목록</h2>
+                <select class="sort" aria-label="문제 정렬">
+                    <option>전체 정렬</option>
+                    <option>최신순</option>
+                </select>
+            </div>
+
+            <div class="table-wrap">
+                <table>
+                    <thead>
+                    <tr>
+                        <th class="col-no">No.</th>
+                        <th>문제명</th>
+                        <th class="col-submit">제출</th>
+                        <th class="col-rate">정답률</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="problemSet, stat : ${problemSets}">
+                        <td th:text="${#numbers.formatInteger(stat.count, 2)}">01</td>
+                        <td>
+                            <a class="problem-link"
+                               th:href="@{/problem/sets/{problemSetId}(problemSetId=${problemSet.problemSetId})}"
+                               th:text="${problemSet.title}">
+                                문제 세트명이 들어가는 자리입니다.
+                            </a>
+                        </td>
+                        <td>-</td>
+                        <td>-</td>
+                    </tr>
+                    <tr th:if="${#lists.isEmpty(problemSets)}">
+                        <td class="empty-message" colspan="4">등록된 문제 세트가 없습니다.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/problem/solve.html
+++ b/src/main/resources/templates/problem/solve.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>codebomba - 문제 풀이</title>
+    <style>
+        :root {
+            --primary: #1f2588;
+            --text: #1f2937;
+            --muted: #6b7280;
+            --line: #e5e7eb;
+            --soft: #f3f4f6;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-width: 1180px;
+            color: var(--text);
+            font-family: Arial, "Noto Sans KR", sans-serif;
+            background: #ffffff;
+        }
+
+        button {
+            font: inherit;
+            cursor: pointer;
+        }
+
+        .topbar {
+            height: 56px;
+            display: grid;
+            grid-template-columns: 300px 1fr 420px;
+            align-items: center;
+            border-bottom: 1px solid var(--line);
+            padding: 0 48px 0 56px;
+        }
+
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            color: var(--primary);
+            font-size: 22px;
+            font-weight: 800;
+        }
+
+        .brand-mark {
+            width: 22px;
+            height: 22px;
+            border: 3px solid var(--primary);
+            border-radius: 50%;
+            position: relative;
+        }
+
+        .brand-mark::after {
+            content: "";
+            width: 7px;
+            height: 7px;
+            border: 2px solid var(--primary);
+            border-left: 0;
+            border-bottom: 0;
+            border-radius: 50%;
+            position: absolute;
+            top: -7px;
+            right: -5px;
+        }
+
+        .search {
+            width: min(672px, 100%);
+            justify-self: center;
+            position: relative;
+        }
+
+        .search input {
+            width: 100%;
+            height: 40px;
+            padding: 0 48px 0 20px;
+            border: 1px solid #d9dde5;
+            border-radius: 8px;
+            font-size: 16px;
+            outline: none;
+        }
+
+        .nav {
+            justify-self: end;
+            display: flex;
+            align-items: center;
+            gap: 32px;
+            font-size: 16px;
+        }
+
+        .profile {
+            height: 40px;
+            display: inline-flex;
+            align-items: center;
+            gap: 7px;
+            padding: 0 14px;
+            border: 1.5px solid var(--primary);
+            border-radius: 999px;
+            color: var(--primary);
+        }
+
+        .toolbar {
+            height: 68px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0 47px;
+            background: #f4f5f7;
+            border-bottom: 1px solid var(--line);
+        }
+
+        .secondary-button,
+        .primary-button {
+            min-width: 123px;
+            height: 47px;
+            border: 0;
+            border-radius: 8px;
+            font-weight: 800;
+        }
+
+        .secondary-button {
+            background: #ffffff;
+            color: var(--text);
+        }
+
+        .primary-button {
+            background: var(--primary);
+            color: #ffffff;
+        }
+
+        .layout {
+            display: grid;
+            grid-template-columns: 304px 1fr;
+            min-height: calc(100vh - 124px);
+        }
+
+        .sidebar {
+            border-right: 1px solid var(--line);
+            padding: 50px 23px;
+        }
+
+        .sidebar h1 {
+            margin: 0 0 28px;
+            font-size: 25px;
+        }
+
+        .problem-state {
+            width: 100%;
+            height: 46px;
+            display: flex;
+            align-items: center;
+            padding: 0 16px;
+            border: 1px solid #111827;
+            border-radius: 6px;
+            margin-bottom: 9px;
+            background: #ffffff;
+            color: var(--text);
+            font-weight: 700;
+        }
+
+        .problem-state.selected {
+            border-color: var(--primary);
+            background: var(--primary);
+            color: #ffffff;
+        }
+
+        .problem-state.locked {
+            background: #d6d7d9;
+        }
+
+        .problem-state.correct {
+            background: #b9c7f0;
+        }
+
+        .workspace {
+            padding: 23px 28px 26px;
+            display: grid;
+            grid-template-columns: minmax(420px, 1fr) minmax(560px, 1.27fr);
+            gap: 32px;
+        }
+
+        .card {
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            background: #ffffff;
+        }
+
+        .problem-card {
+            min-height: calc(100vh - 173px);
+            padding: 25px;
+        }
+
+        .problem-card h2,
+        .solution-card h2 {
+            margin: 0;
+            font-size: 26px;
+            line-height: 1.25;
+        }
+
+        .problem-meta {
+            margin: 16px 0 24px;
+            color: var(--muted);
+            font-weight: 700;
+        }
+
+        .problem-content {
+            margin: 0;
+            white-space: pre-wrap;
+            line-height: 1.7;
+            font-size: 18px;
+        }
+
+        .answer-area {
+            min-height: calc(100vh - 173px);
+            display: grid;
+            grid-template-rows: 488px 1fr;
+            gap: 27px;
+        }
+
+        .solution-card {
+            padding: 26px 22px;
+        }
+
+        .hint-bar {
+            height: 68px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-top: 334px;
+            border: 1px solid #d9dde5;
+            border-radius: 8px;
+            background: var(--soft);
+            font-size: 20px;
+            font-weight: 800;
+        }
+
+        .result-card {
+            position: relative;
+            overflow: hidden;
+        }
+
+        .tabs {
+            height: 48px;
+            display: grid;
+            grid-template-columns: 124px 176px 124px 1fr;
+            background: var(--soft);
+            border-bottom: 1px solid #d9dde5;
+        }
+
+        .tab {
+            border: 1px solid #d9dde5;
+            border-left: 0;
+            border-bottom: 0;
+            background: #ffffff;
+            color: var(--text);
+            font-weight: 800;
+        }
+
+        .result-body {
+            min-height: 274px;
+            padding: 22px;
+        }
+
+        .submit-bottom {
+            position: absolute;
+            right: 22px;
+            bottom: 23px;
+        }
+
+        .modal-backdrop {
+            position: fixed;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            background: rgb(0 0 0 / 48%);
+            z-index: 10;
+        }
+
+        .modal-backdrop.open {
+            display: flex;
+        }
+
+        .modal {
+            width: 480px;
+            height: 348px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 48px;
+            border-radius: 16px;
+            background: #ffffff;
+            box-shadow: 0 24px 60px rgb(15 23 42 / 28%);
+        }
+
+        .info-icon {
+            width: 58px;
+            height: 58px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border: 5px solid var(--primary);
+            border-radius: 50%;
+            color: var(--primary);
+            font-size: 36px;
+            font-weight: 800;
+            line-height: 1;
+        }
+
+        .modal strong {
+            font-size: 25px;
+        }
+
+        .modal-actions {
+            display: flex;
+            gap: 12px;
+        }
+
+        .modal-actions button {
+            width: 128px;
+            height: 48px;
+            border: 0;
+            border-radius: 9px;
+            font-weight: 800;
+        }
+
+        .confirm {
+            background: var(--primary);
+            color: #ffffff;
+        }
+
+        .cancel {
+            background: #f0f1f4;
+            color: var(--text);
+        }
+    </style>
+</head>
+<body>
+<header class="topbar">
+    <div class="brand">
+        <span class="brand-mark" aria-hidden="true"></span>
+        <span>codebomba</span>
+    </div>
+    <label class="search" aria-label="강의 검색">
+        <input type="search" placeholder="강의 검색...">
+    </label>
+    <nav class="nav" aria-label="주요 메뉴">
+        <span>내 강의실</span>
+        <span>문제 풀이</span>
+        <span class="profile"><span class="brand-mark" aria-hidden="true"></span>닉네임</span>
+    </nav>
+</header>
+
+<div class="toolbar">
+    <button class="secondary-button" type="button" onclick="history.back()">뒤로가기</button>
+    <button class="primary-button" type="button">실행하기</button>
+</div>
+
+<main class="layout">
+    <aside class="sidebar">
+        <h1>전체 문제 n/m</h1>
+        <div class="problem-state selected"
+             th:text="'문제 ' + ${problemSet.currentProblemNumber}">문제 1</div>
+        <div class="problem-state">열린 문제</div>
+        <div class="problem-state locked">안 열린 문제</div>
+        <div class="problem-state correct">맞춘 문제</div>
+    </aside>
+
+    <section class="workspace">
+        <article class="card problem-card">
+            <h2 th:text="${problemSet.problemTitle}">문제 제목</h2>
+            <div class="problem-meta">
+                <span th:text="'문제 유형: ' + ${problemSet.problemType}">문제 유형</span>
+                <span th:text="' | 문제 ID: ' + ${problemSet.problemId}"> | 문제 ID</span>
+            </div>
+            <p class="problem-content"
+               th:text="${problemSet.problemContent}">문제 내용이 들어갑니다.</p>
+        </article>
+
+        <section class="answer-area">
+            <article class="card solution-card">
+                <h2>문제풀이영역</h2>
+                <div class="hint-bar">힌트를 확인할 수 있습니다.</div>
+            </article>
+
+            <article class="card result-card">
+                <div class="tabs" role="tablist" aria-label="문제 풀이 보조 탭">
+                    <button class="tab" type="button">실행결과</button>
+                    <button class="tab" type="button">힌트</button>
+                    <button class="tab" type="button">강의보기</button>
+                    <span></span>
+                </div>
+                <div class="result-body"></div>
+                <button class="primary-button submit-bottom" type="button" id="openSubmitModal">제출하기</button>
+            </article>
+        </section>
+    </section>
+</main>
+
+<div class="modal-backdrop" id="submitModal" aria-hidden="true">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="submitTitle">
+        <div class="info-icon" aria-hidden="true">i</div>
+        <strong id="submitTitle">제출하시겠습니까?</strong>
+        <div class="modal-actions">
+            <button class="confirm" type="button" id="confirmSubmit">확인</button>
+            <button class="cancel" type="button" id="closeSubmitModal">취소</button>
+        </div>
+    </div>
+</div>
+
+<script>
+    const modal = document.getElementById("submitModal");
+    const openButton = document.getElementById("openSubmitModal");
+    const closeButton = document.getElementById("closeSubmitModal");
+    const confirmButton = document.getElementById("confirmSubmit");
+
+    function openModal() {
+        modal.classList.add("open");
+        modal.setAttribute("aria-hidden", "false");
+    }
+
+    function closeModal() {
+        modal.classList.remove("open");
+        modal.setAttribute("aria-hidden", "true");
+    }
+
+    openButton.addEventListener("click", openModal);
+    closeButton.addEventListener("click", closeModal);
+    confirmButton.addEventListener("click", closeModal);
+    modal.addEventListener("click", (event) => {
+        if (event.target === modal) {
+            closeModal();
+        }
+    });
+    window.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+            closeModal();
+        }
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 🛠️ 기능 관련 작업 내용

- 사용자가 문제 세트에 진입했을 때 현재 풀어야 할 문제를 조회하는 기능을 구현했습니다.
- 문제 세트 ID를 기준으로 문제 세트 정보를 조회합니다.
- 사용자 ID와 문제 세트 ID를 기준으로 이어풀기 진행 상태를 확인합니다.
- 진행 상태가 없으면 첫 번째 문제부터 조회하도록 처리했습니다.
- 현재 문제 번호를 기준으로 문제 ID, 문제 제목, 문제 내용, 문제 유형을 반환하도록 구현했습니다.
- 문제 상세 응답에 정답 정보가 포함되지 않도록 처리했습니다.
- 문제 목록 화면에서 문제 세트를 클릭하면 문제 풀이 화면으로 이동하도록 연결했습니다.
- 추가로 답안 제출 기능이 아직 미구현 상태라 다음 문제로 넘어가지 않습니다. 추후 구현하겠습니다
---

## ♻️ 패키지 변경 사항

- `domain/problem/set/controller/ProblemSetController` : 문제 세트 진입 API 요청 처리 추가
- `domain/problem/set/service/ProblemSetService` : 문제 세트 상세 조회 및 현재 문제 조회 흐름 구현
- `domain/problem/set/dto/response/SetEnterResponse` : 문제 풀이 화면에 필요한 응답 DTO 추가
- `domain/problem/problem/service/ProblemService` : 문제 세트 ID와 현재 문제 번호 기준 문제 조회 로직 추가
- `domain/problem/problem/repository/ProblemRepository` : 문제 세트 ID, 문제 순서, 상태 기준 조회 메서드 추가
- `domain/problem/progress/service/ProgressService` : 사용자별 이어풀기 현재 문제 번호 조회 로직 추가
- `domain/problem/progress/repository/ProgressRepository` : 사용자 ID와 문제 세트 ID 기준 진행 상태 조회 메서드 추가
- `domain/problem/progress/controller/ProgressController` : 문제 세트 클릭 시 문제 풀이 화면으로 이동하는 화면 연결 처리
- `templates/problem/list.html` : 문제 세트 목록 클릭 시 문제 풀이 화면으로 이동하도록 수정

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
