### PR TITLE
[Feat] spring security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ logs/
 CLAUDE.md
 CLAUREAD.md
 CLAUREAD-API.md
+CLAUEND.md
 .claude
 API.md

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ logs/
 ### Local Dev Notes ###
 CLAUDE.md
 CLAUREAD.md
+CLAUREAD-API.md
 .claude
 API.md
-
-ExportBlock-fa3efc6a-17e1-48f1-903a-ee07c60c2445-Part-1

--- a/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
@@ -1,21 +1,70 @@
 package com.wanted.codebombalms.global.config;
 
+import com.wanted.codebombalms.global.jwt.JwtAuthenticationFilter;
+import com.wanted.codebombalms.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        // 인증 불필요
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/users/find-email").permitAll()
+                        // 관리자 전용
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        // 그 외 모두 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #96 
---

## 🛠️ 기능 관련 작업 내용

Spring Security 설정을 완성하여 JWT 기반 인증 체계를 구축
- `SecurityFilterChain`에 `JwtAuthenticationFilter` 등록 (UsernamePasswordAuthenticationFilter 앞)
- `PasswordEncoder` 빈 등록 (BCrypt 방식)
- CSRF disable, CORS 설정 (프론트 `localhost:3000` 허용)
- 세션 정책 STATELESS (JWT 방식)
- formLogin / httpBasic 비활성화
- 경로별 권한 분리
  - `/api/v1/auth/**` → 누구나 접근 가능 (회원가입/로그인)
  - `/api/v1/users/find-email` → 누구나 접근 가능 (이메일 찾기)
  - `/api/v1/admin/**` → ADMIN 권한 필요
  - 그 외 → 인증 필요
- `application-local.yml` 의 `jwt:` 설정이 `spring:` 하위에 잘못 들여쓰기 되어있던 문제 수정 (최상단으로 이동)

---

## ♻️ 패키지 변경 사항

- `global/config/SecurityConfig` : Spring Security 설정 완성 (JwtAuthenticationFilter 등록, PasswordEncoder 빈, CORS, 경로별 권한)
- `src/main/resources/application-local.yml` : `jwt` 설정 들여쓰기 수정 (최상단으로 이동)

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
