### PR TITLE
[Feat] 공통 예외 처리 및 UserRepository 작성

### DIFF
--- a/src/main/java/com/wanted/codebombalms/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/user/repository/UserRepository.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.domain.user.repository;
+
+import com.wanted.codebombalms.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 로그인 — 이메일로 회원 조회
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
+    // 회원가입 — 이메일 중복 체크
+    boolean existsByEmail(String email);
+
+    // 회원가입 — 닉네임 중복 체크
+    boolean existsByNickname(String nickname);
+
+    // 내 정보 조회 — userId로 회원 조회
+    Optional<User> findByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/CustomException.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/CustomException.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/ErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/ErrorCode.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ===== AUTH =====
+    AUTH_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 일치하지 않습니다."),
+    AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    AUTH_REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
+    AUTH_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 Refresh Token입니다."),
+    AUTH_TEMP_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 임시 토큰입니다."),
+    AUTH_LOCK_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 계정 잠금 토큰입니다."),
+    AUTH_LOCK_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 계정 잠금 토큰입니다."),
+    AUTH_CODE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다."),
+    AUTH_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 인증 코드입니다."),
+    AUTH_PASSWORD_RESET_CODE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 재설정 코드입니다."),
+    AUTH_PASSWORD_RESET_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 재설정 코드입니다."),
+    AUTH_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    AUTH_EMAIL_SEND_TOO_MANY(HttpStatus.TOO_MANY_REQUESTS, "이메일 발송 횟수를 초과했습니다."),
+    AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // ===== USER =====
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    USER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
+    USER_NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
+    USER_PASSWORD_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 형식이 올바르지 않습니다. (8자 이상, 영문+숫자+특수문자 조합)"),
+    USER_PHONE_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "전화번호 형식이 올바르지 않습니다."),
+    USER_PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
+    USER_ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "잠긴 계정입니다."),
+    USER_SOCIAL_ACCOUNT_NO_PASSWORD(HttpStatus.BAD_REQUEST, "소셜 가입 계정은 비밀번호 재설정을 사용할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/GlobalExceptionHandler.java
@@ -60,4 +60,22 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
+
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(
+            CustomException exception,
+            HttpServletRequest request
+    ) {
+        ErrorCode errorCode = exception.getErrorCode();
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                errorCode.getHttpStatus(),
+                errorCode.name(),
+                exception.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE


---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #98 
---

## 🛠️ 기능 관련 작업 내용

User/Auth 도메인 구현 전 필요한 공통 인프라(예외 처리, Repository)를 작성했습니다.
- `ErrorCode` enum 정의 — AUTH/USER 도메인 에러코드 23종을 HttpStatus + 기본 메시지와 함께 관리
- `CustomException` 작성 — `RuntimeException` 상속, `ErrorCode`를 그대로 보유하는 단일 예외 클래스로 통일
- `GlobalExceptionHandler` 확장 — 기존 핸들러(`CourseNotFoundException`, `MethodArgumentNotValidException`, `Exception`)는 그대로 유지하고, `CustomException` 핸들러만 신규 추가
- `UserRepository` 생성 — 회원가입/로그인/내 정보 조회에 필요한 기본 쿼리 메서드 정의
  - `findByEmailAndDeletedAtIsNull` (로그인)
  - `existsByEmail`, `existsByNickname` (가입 시 중복 체크, 탈퇴 회원 포함)
  - `findByUserIdAndDeletedAtIsNull` (내 정보 조회)
추가 결정 사항:
- 응답 포맷은 팀 컨벤션에 맞춰 기존 `ResponseDTO` / `ErrorResponse`를 그대로 활용 (별도 `ApiResponse` 신설 X)
- 이메일/닉네임 중복 체크는 **탈퇴 회원 포함** 정책 — 동일 이메일/닉네임 재사용 방지 (사칭 방지 + 1년 후 완전 삭제 정책과 일관)
- 
---

## ♻️ 패키지 변경 사항

 `global/error/ErrorCode` : AUTH/USER 도메인 에러코드 enum 신규 작성
- `global/error/CustomException` : 도메인 예외 통합 클래스 신규 작성
- `global/error/GlobalExceptionHandler` : `CustomException` 핸들러 추가 (기존 핸들러는 변경 없음)
- `domain/user/repository/UserRepository` : User 도메인 JpaRepository 신규 작성

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
