### PR TITLE
[Feat] logging error handling 전역 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,5 @@ CLAUREAD.md
 CLAUREAD-API.md
 CLAUEND.md
 .claude
+CONTEXT.md
 API.md

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '3.5.14'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -23,20 +23,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-thymeleaf-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -48,6 +45,11 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+
+    //로깅
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wanted/codebombalms/domain/course/exception/CourseErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/course/exception/CourseErrorCode.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.domain.course.exception;
+
+import com.wanted.codebombalms.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseErrorCode implements ErrorCode {
+
+    COURSE_NOT_FOUND(404, "CR-001", "존재하지 않는 강좌입니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/course/service/CourseService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/course/service/CourseService.java
@@ -5,8 +5,11 @@ import com.wanted.codebombalms.domain.course.dto.request.CourseUpdateRequest;
 import com.wanted.codebombalms.domain.course.dto.response.CourseDetailResponse;
 import com.wanted.codebombalms.domain.course.dto.response.CourseResponse;
 import com.wanted.codebombalms.domain.course.entity.Course;
-import com.wanted.codebombalms.domain.course.exception.CourseNotFoundException;
+import com.wanted.codebombalms.domain.course.exception.CourseErrorCode;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import com.wanted.codebombalms.domain.course.repository.CourseRepository;
+import com.wanted.codebombalms.global.logging.aop.LogBusiness;
+import com.wanted.codebombalms.global.logging.aop.LogPerformance;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +30,8 @@ public class CourseService {
     /**
      * 강좌 등록
      */
+    @LogBusiness
+    @LogPerformance
     @Transactional
     public CourseDetailResponse createCourse(CourseCreateRequest request) {
 
@@ -49,6 +54,8 @@ public class CourseService {
     /**
      * 강좌 목록 조회
      */
+    @LogBusiness
+    @LogPerformance
     public List<CourseResponse> findAllCourses() {
 
         log.info("[CourseService] 강좌 목록 조회 시작");
@@ -71,7 +78,7 @@ public class CourseService {
         log.info("[CourseService] 강좌 상세 조회 시작 - courseId: {}", courseId);
 
         Course course = courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)
-                .orElseThrow(() -> new CourseNotFoundException(courseId));
+                .orElseThrow(() -> new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
 
         log.info("[CourseService] 강좌 상세 조회 완료 - courseId: {}", courseId);
 
@@ -87,7 +94,7 @@ public class CourseService {
         log.info("[CourseService] 강좌 수정 시작 - courseId: {}", courseId);
 
         Course course = courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)
-                .orElseThrow(() -> new CourseNotFoundException(courseId));
+                .orElseThrow(() -> new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
 
         if (request.getTitle() != null) {
             course.setTitle(request.getTitle());
@@ -119,7 +126,7 @@ public class CourseService {
         log.info("[CourseService] 강좌 삭제 시작 - courseId: {}", courseId);
 
         Course course = courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)
-                .orElseThrow(() -> new CourseNotFoundException(courseId));
+                .orElseThrow(() -> new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
 
         course.delete();
 

--- a/src/main/java/com/wanted/codebombalms/domain/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/exception/ProblemErrorCode.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.domain.problems.exception;
+
+import com.wanted.codebombalms.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProblemErrorCode implements ErrorCode {
+
+    PROBLEM_NOT_FOUND(404, "P-001", "존재하지 않는 문제입니다."),
+    PROBLEM_SET_NOT_FOUND(404, "P-002", "존재하지 않는 문제세트입니다."),
+    CATEGORY_NOT_FOUND(404, "P-003", "존재하지 않는 카테고리입니다."),
+    ATTEMPT_LIMIT_EXCEEDED(400, "P-004", "시도 횟수를 초과했습니다."),
+    ALREADY_COMPLETED(409, "P-005", "이미 완료된 문제집입니다."),
+    PROBLEM_NOT_UNLOCKED(400, "P-006", "아직 열리지 않은 문제입니다."),
+    PROBLEM_SET_NOT_COMPLETED(400, "P-007", "문제 세트를 완료하지 않았습니다."),
+    NO_CURRENT_PROBLEM(404, "P-008", "현재 풀 문제가 없습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
@@ -3,6 +3,8 @@ package com.wanted.codebombalms.domain.problems.problem.service;
 import com.wanted.codebombalms.domain.problems.problem.dto.response.ProblemResponse;
 import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
 import com.wanted.codebombalms.domain.problems.problem.repository.ProblemRepository;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -32,12 +34,12 @@ public class ProblemService {
                         "ACTIVE"
                 )
                 .map(ProblemResponse::new)
-                .orElseThrow(() -> new RuntimeException("현재 풀 문제가 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.NO_CURRENT_PROBLEM));
     }
 
     public Problem findProblemEntity(Long problemId) {
         return problemRepository.findById(problemId)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 문제입니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND));
     }
 
     public Optional<Long> findProblemIdByProblemSetAndOrder(Long problemSetId, Integer problemOrder) {

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
@@ -3,6 +3,8 @@ package com.wanted.codebombalms.domain.problems.problem.service;
 import com.wanted.codebombalms.domain.problems.problem.dto.response.ProblemResponse;
 import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
 import com.wanted.codebombalms.domain.problems.problem.repository.ProblemRepository;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemCreateRequest;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
 import org.springframework.stereotype.Service;
@@ -34,12 +36,12 @@ public class ProblemService {
                         "ACTIVE"
                 )
                 .map(ProblemResponse::new)
-                .orElseThrow(() -> new RuntimeException("현재 풀 문제가 없습니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.NO_CURRENT_PROBLEM));
     }
 
     public Problem findProblemEntity(Long problemId) {
         return problemRepository.findById(problemId)
-                    .orElseThrow(() -> new RuntimeException("존재하지 않는 문제입니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND));
     }
 
     public Optional<Long> findProblemIdByProblemSetAndOrder(Long problemSetId, Integer problemOrder) {

--- a/src/main/java/com/wanted/codebombalms/domain/problems/progress/service/ProgressService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/progress/service/ProgressService.java
@@ -8,7 +8,10 @@ import com.wanted.codebombalms.domain.problems.progress.entitiy.Progress;
 import com.wanted.codebombalms.domain.problems.progress.enums.ProblemProgressStatus;
 import com.wanted.codebombalms.domain.problems.progress.repository.ProgressRepository;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
-import com.wanted.codebombalms.domain.problems.set.exception.SetNotFoundException;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.global.error.exception.ConflictException;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
 import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
 import com.wanted.codebombalms.domain.submission.dto.response.LatestSubmissionResult;
 import com.wanted.codebombalms.domain.submission.service.SubmissionQueryService;
@@ -63,11 +66,11 @@ public class ProgressService {
         Progress progress = findOrCreateProgress(userId, problemSet);
 
         if (Boolean.TRUE.equals(progress.getCompleted())) {
-            throw new RuntimeException("이미 완료된 문제 세트입니다.");
+            throw new ConflictException(ProblemErrorCode.ALREADY_COMPLETED);
         }
 
         if (!progress.getCurrentProblemNumber().equals(problemOrder)) {
-            throw new RuntimeException("아직 열리지 않은 문제입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_NOT_UNLOCKED);
         }
     }
 
@@ -98,7 +101,7 @@ public class ProgressService {
     @Transactional(readOnly = true)
     public ProblemProgressResponse findProblemSetProgress(Long problemSetId, Long userId) {
         ProblemSet problemSet = problemSetRepository.findById(problemSetId)
-                .orElseThrow(() -> new SetNotFoundException("존재하지 않는 문제 세트입니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
 
         Integer currentProblemNumber = findCurrentProblemNumber(userId, problemSetId);
         List<Problem> problems = problemService.findActiveProblemEntitiesByProblemSet(problemSetId);

--- a/src/main/java/com/wanted/codebombalms/domain/problems/result/service/ResultService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/result/service/ResultService.java
@@ -7,7 +7,10 @@ import com.wanted.codebombalms.domain.problems.progress.repository.ProgressRepos
 import com.wanted.codebombalms.domain.problems.result.dto.response.ProblemSetResultResponse;
 import com.wanted.codebombalms.domain.problems.result.dto.response.ProblemSubmissionResultResponse;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
 import com.wanted.codebombalms.domain.submission.dto.response.LatestSubmissionResult;
 import com.wanted.codebombalms.domain.submission.service.SubmissionQueryService;
 import org.springframework.stereotype.Service;
@@ -38,14 +41,14 @@ public class ResultService {
     @Transactional(readOnly = true)
     public ProblemSetResultResponse findResult(Long problemSetId, Long userId) {
         ProblemSet problemSet = problemSetRepository.findById(problemSetId)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 문제 세트입니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
 
         Progress progress = progressRepository
                 .findByUserIdAndProblemSet_ProblemSetId(userId, problemSetId)
-                .orElseThrow(() -> new RuntimeException("문제 세트를 완료하지 않았습니다."));
+                .orElseThrow(() -> new ValidationException(ProblemErrorCode.PROBLEM_SET_NOT_COMPLETED));
 
         if (!Boolean.TRUE.equals(progress.getCompleted())) {
-            throw new RuntimeException("문제 세트를 완료하지 않았습니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_SET_NOT_COMPLETED);
         }
 
         List<ProblemSubmissionResultResponse> submissions = problemService

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetService.java
@@ -13,7 +13,8 @@ import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetCreate
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetEnterResponse;
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetListResponse;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
-import com.wanted.codebombalms.domain.problems.set.exception.SetNotFoundException;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,7 +47,7 @@ public class ProblemSetService {
 
     public List<ProblemSetListResponse> findActiveSetsByCategory(Long categoryId) {
         if (!problemCategoryService.existsActiveCategory(categoryId)) {
-            throw new SetNotFoundException("존재하지 않는 문제 분야입니다.");
+            throw new NotFoundException(ProblemErrorCode.CATEGORY_NOT_FOUND);
         }
 
         List<ProblemSet> problemSets = problemSetRepository
@@ -59,7 +60,7 @@ public class ProblemSetService {
 
     public ProblemSetEnterResponse enterProblemSet(Long problemSetId, Long userId) {
         ProblemSet problemSet = problemSetRepository.findById(problemSetId)
-                .orElseThrow(() -> new SetNotFoundException("존재하지 않는 문제 세트입니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
 
         Integer currentProblemNumber =
                 progressService.findOrCreateCurrentProblemNumber(userId, problemSet);

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetService.java
@@ -7,7 +7,8 @@ import com.wanted.codebombalms.domain.problems.progress.service.ProgressService;
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetEnterResponse;
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetListResponse;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
-import com.wanted.codebombalms.domain.problems.set.exception.SetNotFoundException;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
 import org.springframework.stereotype.Service;
 
@@ -36,7 +37,7 @@ public class ProblemSetService {
 
     public List<ProblemSetListResponse> findActiveSetsByCategory(Long categoryId) {
         if (!problemCategoryService.existsActiveCategory(categoryId)) {
-            throw new SetNotFoundException("존재하지 않는 문제 분야입니다.");
+            throw new NotFoundException(ProblemErrorCode.CATEGORY_NOT_FOUND);
         }
 
         List<ProblemSet> problemSets = problemSetRepository
@@ -49,7 +50,7 @@ public class ProblemSetService {
 
     public ProblemSetEnterResponse enterProblemSet(Long problemSetId, Long userId) {
         ProblemSet problemSet = problemSetRepository.findById(problemSetId)
-                .orElseThrow(() -> new SetNotFoundException("존재하지 않는 문제 세트입니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
 
         Integer currentProblemNumber =
                 progressService.findOrCreateCurrentProblemNumber(userId, problemSet);

--- a/src/main/java/com/wanted/codebombalms/domain/submission/exception/SubmissionErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/submission/exception/SubmissionErrorCode.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.domain.submission.exception;
+
+import com.wanted.codebombalms.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubmissionErrorCode implements ErrorCode {
+
+    INVALID_ANSWER(400, "S-001", "답변 내용이 비어있습니다."),
+    PROBLEM_NOT_RETRIABLE(400, "S-002", "재시도할 수 없는 문제입니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/submission/service/SubmissionAttemptService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/submission/service/SubmissionAttemptService.java
@@ -1,6 +1,9 @@
 package com.wanted.codebombalms.domain.submission.service;
 
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
+import com.wanted.codebombalms.domain.submission.exception.SubmissionErrorCode;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -8,11 +11,11 @@ public class SubmissionAttemptService {
 
     public void validateAttemptLimit(Problem problem, int previousAttemptCount) {
         if (problem.getAttemptLimit() != null && previousAttemptCount >= problem.getAttemptLimit()) {
-            throw new RuntimeException("제출 가능 횟수를 초과했습니다.");
+            throw new ValidationException(ProblemErrorCode.ATTEMPT_LIMIT_EXCEEDED);
         }
 
         if (!Boolean.TRUE.equals(problem.getRetriable()) && previousAttemptCount > 0) {
-            throw new RuntimeException("재시도할 수 없는 문제입니다.");
+            throw new ValidationException(SubmissionErrorCode.PROBLEM_NOT_RETRIABLE);
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/domain/submission/service/SubmissionService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/submission/service/SubmissionService.java
@@ -8,6 +8,10 @@ import com.wanted.codebombalms.domain.submission.dto.response.SubmissionResponse
 import com.wanted.codebombalms.domain.submission.entitiy.Submission;
 import com.wanted.codebombalms.domain.submission.event.ProblemSetCompletedEvent;
 import com.wanted.codebombalms.domain.submission.repository.SubmissionRepository;
+import com.wanted.codebombalms.domain.submission.exception.SubmissionErrorCode;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
+import com.wanted.codebombalms.global.logging.aop.LogBusiness;
+import com.wanted.codebombalms.global.logging.aop.LogPerformance;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,10 +42,12 @@ public class SubmissionService {
         this.eventPublisher = eventPublisher;
     }
 
+    @LogBusiness
+    @LogPerformance
     @Transactional
     public SubmissionResponse submitAnswer(Long problemId, SubmissionRequest request) {
         if (request.getSubmittedAnswer() == null || request.getSubmittedAnswer().isEmpty()) {
-            throw new IllegalArgumentException("답안을 입력해주세요.");
+            throw new ValidationException(SubmissionErrorCode.INVALID_ANSWER);
         }
 
         Problem problem = problemService.findProblemEntity(problemId);

--- a/src/main/java/com/wanted/codebombalms/domain/user/exception/AuthErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/user/exception/AuthErrorCode.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.domain.user.exception;
+
+import com.wanted.codebombalms.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    AUTH_LOGIN_FAIL(400, "A-001", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    AUTH_TOKEN_INVALID(401, "A-002", "유효하지 않은 토큰입니다."),
+    AUTH_TOKEN_EXPIRED(401, "A-003", "만료된 토큰입니다."),
+    AUTH_REFRESH_TOKEN_INVALID(401, "A-004", "유효하지 않은 Refresh Token입니다."),
+    AUTH_REFRESH_TOKEN_EXPIRED(401, "A-005", "만료된 Refresh Token입니다."),
+    AUTH_TEMP_TOKEN_INVALID(401, "A-006", "유효하지 않은 임시 토큰입니다."),
+    AUTH_LOCK_TOKEN_INVALID(400, "A-007", "유효하지 않은 계정 잠금 토큰입니다."),
+    AUTH_LOCK_TOKEN_EXPIRED(400, "A-008", "만료된 계정 잠금 토큰입니다."),
+    AUTH_CODE_INVALID(400, "A-009", "유효하지 않은 인증 코드입니다."),
+    AUTH_CODE_EXPIRED(400, "A-010", "만료된 인증 코드입니다."),
+    AUTH_PASSWORD_RESET_CODE_INVALID(400, "A-011", "유효하지 않은 재설정 코드입니다."),
+    AUTH_PASSWORD_RESET_CODE_EXPIRED(400, "A-012", "만료된 재설정 코드입니다."),
+    AUTH_PASSWORD_MISMATCH(400, "A-013", "비밀번호가 일치하지 않습니다."),
+    AUTH_EMAIL_SEND_TOO_MANY(429, "A-014", "이메일 발송 횟수를 초과했습니다."),
+    AUTH_FORBIDDEN(403, "A-015", "접근 권한이 없습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.domain.user.exception;
+
+import com.wanted.codebombalms.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(404, "U-001", "존재하지 않는 회원입니다."),
+    USER_EMAIL_DUPLICATED(400, "U-002", "이미 사용 중인 이메일입니다."),
+    USER_NICKNAME_DUPLICATED(400, "U-003", "이미 사용 중인 닉네임입니다."),
+    USER_PASSWORD_FORMAT_INVALID(400, "U-004", "비밀번호 형식이 올바르지 않습니다. (8자 이상, 영문+숫자+특수문자 조합)"),
+    USER_PHONE_FORMAT_INVALID(400, "U-005", "전화번호 형식이 올바르지 않습니다."),
+    USER_PASSWORD_CONFIRM_MISMATCH(400, "U-006", "비밀번호 확인이 일치하지 않습니다."),
+    USER_ACCOUNT_LOCKED(403, "U-007", "잠긴 계정입니다."),
+    USER_SOCIAL_ACCOUNT_NO_PASSWORD(400, "U-008", "소셜 가입 계정은 비밀번호 재설정을 사용할 수 없습니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.wanted.codebombalms.global.config;
 
 import com.wanted.codebombalms.global.jwt.JwtAuthenticationFilter;
 import com.wanted.codebombalms.global.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.security.exception.CustomAccessDeniedHandler;
+import com.wanted.codebombalms.global.security.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +25,8 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -39,6 +43,8 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        // Swagger
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // 인증 불필요
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/users/find-email").permitAll()
@@ -48,11 +54,14 @@ public class SecurityConfig {
                         // 관리자 전용
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         // 그 외 모두 인증 필요
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class
+                ).exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 );
 
         return http.build();

--- a/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.wanted.codebombalms.global.config;
 
 import com.wanted.codebombalms.global.jwt.JwtAuthenticationFilter;
 import com.wanted.codebombalms.global.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.security.exception.CustomAccessDeniedHandler;
+import com.wanted.codebombalms.global.security.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +25,8 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -39,17 +43,22 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        // Swagger
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // 인증 불필요
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/users/find-email").permitAll()
                         // 관리자 전용
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         // 그 외 모두 인증 필요
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class
+                ).exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 );
 
         return http.build();

--- a/src/main/java/com/wanted/codebombalms/global/error/BusinessException.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/BusinessException.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.global.error;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/ErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/ErrorCode.java
@@ -1,40 +1,7 @@
 package com.wanted.codebombalms.global.error;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-
-@Getter
-@RequiredArgsConstructor
-public enum ErrorCode {
-
-    // ===== AUTH =====
-    AUTH_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 일치하지 않습니다."),
-    AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
-    AUTH_REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
-    AUTH_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 Refresh Token입니다."),
-    AUTH_TEMP_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 임시 토큰입니다."),
-    AUTH_LOCK_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 계정 잠금 토큰입니다."),
-    AUTH_LOCK_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 계정 잠금 토큰입니다."),
-    AUTH_CODE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다."),
-    AUTH_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 인증 코드입니다."),
-    AUTH_PASSWORD_RESET_CODE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 재설정 코드입니다."),
-    AUTH_PASSWORD_RESET_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "만료된 재설정 코드입니다."),
-    AUTH_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    AUTH_EMAIL_SEND_TOO_MANY(HttpStatus.TOO_MANY_REQUESTS, "이메일 발송 횟수를 초과했습니다."),
-    AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-
-    // ===== USER =====
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-    USER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
-    USER_NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
-    USER_PASSWORD_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 형식이 올바르지 않습니다. (8자 이상, 영문+숫자+특수문자 조합)"),
-    USER_PHONE_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "전화번호 형식이 올바르지 않습니다."),
-    USER_PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호 확인이 일치하지 않습니다."),
-    USER_ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "잠긴 계정입니다."),
-    USER_SOCIAL_ACCOUNT_NO_PASSWORD(HttpStatus.BAD_REQUEST, "소셜 가입 계정은 비밀번호 재설정을 사용할 수 없습니다.");
-
-    private final HttpStatus httpStatus;
-    private final String message;
+public interface ErrorCode {
+    int getStatus();
+    String getCode();
+    String getMessage();
 }

--- a/src/main/java/com/wanted/codebombalms/global/error/ErrorResponse.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/ErrorResponse.java
@@ -1,24 +1,30 @@
 package com.wanted.codebombalms.global.error;
 
-import lombok.*;
-import org.springframework.http.HttpStatus;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@NoArgsConstructor
 @Getter
-@Setter
-@ToString
 public class ErrorResponse {
 
-    private int status;
-    private String errorCode;
-    private String message;
-    private String path;
-    private LocalDateTime timestamp;
+    private final int status;
+    private final String errorCode;
+    private final String message;
+    private final String path;
+    private final LocalDateTime timestamp;
 
-    public ErrorResponse(HttpStatus status, String errorCode, String message, String path) {
-        this.status = status.value();
+    // BusinessException용
+    public ErrorResponse(ErrorCode errorCode, String path) {
+        this.status = errorCode.getStatus();
+        this.errorCode = errorCode.getCode();
+        this.message = errorCode.getMessage();
+        this.path = path;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    // Validation / 500용
+    public ErrorResponse(int status, String errorCode, String message, String path) {
+        this.status = status;
         this.errorCode = errorCode;
         this.message = message;
         this.path = path;

--- a/src/main/java/com/wanted/codebombalms/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/GlobalExceptionHandler.java
@@ -1,98 +1,77 @@
 package com.wanted.codebombalms.global.error;
 
-import com.wanted.codebombalms.domain.course.exception.CourseNotFoundException;  // course 예외처리에 필요
-import com.wanted.codebombalms.domain.lecture.exception.LectureNotFoundException;  // lecture 예외처리에 필요
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Arrays;
 
+@Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(CourseNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleCourseNotFoundException(
-            CourseNotFoundException exception,
+    private final Environment env;
+
+    // ===== 비즈니스 예외 (우리가 만든 예외 전부) =====
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(
+            BusinessException e,
             HttpServletRequest request
     ) {
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.NOT_FOUND,
-                exception.getErrorCode(),
-                exception.getMessage(),
-                request.getRequestURI()
-        );
+        ErrorCode errorCode = e.getErrorCode();
 
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+        if (isDev()) {
+            log.warn("[GlobalExceptionHandler] {} - path: {}", e.getMessage(), request.getRequestURI(), e);
+        } else {
+            log.warn("[GlobalExceptionHandler] {} - path: {}", e.getMessage(), request.getRequestURI());
+        }
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode, request.getRequestURI()));
     }
 
-    @ExceptionHandler(LectureNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleLectureNotFoundException(
-            LectureNotFoundException exception,
-            HttpServletRequest request
-    ) {
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.NOT_FOUND,
-                exception.getErrorCode(),
-                exception.getMessage(),
-                request.getRequestURI()
-        );
-
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
-    }
-
+    // ===== @Valid 검증 실패 =====
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(
-            MethodArgumentNotValidException exception,
+            MethodArgumentNotValidException e,
             HttpServletRequest request
     ) {
-        String message = exception.getBindingResult()
+        String message = e.getBindingResult()
                 .getFieldErrors()
                 .get(0)
                 .getDefaultMessage();
 
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.BAD_REQUEST,
-                "VALIDATION_FAILED",
-                message,
-                request.getRequestURI()
-        );
+        log.warn("[GlobalExceptionHandler] validation failed - path: {}, message: {}",
+                request.getRequestURI(), message);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        return ResponseEntity
+                .status(400)
+                .body(new ErrorResponse(400, "VALIDATION_FAILED", message, request.getRequestURI()));
     }
 
+    // ===== 예상치 못한 예외 (항상 스택트레이스) =====
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(
-            Exception exception,
+            Exception e,
             HttpServletRequest request
     ) {
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                "INTERNAL_SERVER_ERROR",
-                "서버 내부 오류가 발생했습니다.",
-                request.getRequestURI()
-        );
+        log.error("[GlobalExceptionHandler] 예상치 못한 예외 - path: {}", request.getRequestURI(), e);
 
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+        String message = isDev() ? e.getMessage() : "서버 오류가 발생했습니다.";
+
+        return ResponseEntity
+                .status(500)
+                .body(new ErrorResponse(500, "INTERNAL_ERROR", message, request.getRequestURI()));
     }
 
-
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(
-            CustomException exception,
-            HttpServletRequest request
-    ) {
-        ErrorCode errorCode = exception.getErrorCode();
-
-        ErrorResponse errorResponse = new ErrorResponse(
-                errorCode.getHttpStatus(),
-                errorCode.name(),
-                exception.getMessage(),
-                request.getRequestURI()
-        );
-
-        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    private boolean isDev() {
+        return Arrays.asList(env.getActiveProfiles()).contains("local");
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/GlobalExceptionHandler.java
@@ -1,81 +1,77 @@
 package com.wanted.codebombalms.global.error;
 
-import com.wanted.codebombalms.domain.course.exception.CourseNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Arrays;
+
+@Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(CourseNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleCourseNotFoundException(
-            CourseNotFoundException exception,
+    private final Environment env;
+
+    // ===== 비즈니스 예외 (우리가 만든 예외 전부) =====
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(
+            BusinessException e,
             HttpServletRequest request
     ) {
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.NOT_FOUND,
-                exception.getErrorCode(),
-                exception.getMessage(),
-                request.getRequestURI()
-        );
+        ErrorCode errorCode = e.getErrorCode();
 
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+        if (isDev()) {
+            log.warn("[GlobalExceptionHandler] {} - path: {}", e.getMessage(), request.getRequestURI(), e);
+        } else {
+            log.warn("[GlobalExceptionHandler] {} - path: {}", e.getMessage(), request.getRequestURI());
+        }
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode, request.getRequestURI()));
     }
 
+    // ===== @Valid 검증 실패 =====
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(
-            MethodArgumentNotValidException exception,
+            MethodArgumentNotValidException e,
             HttpServletRequest request
     ) {
-        String message = exception.getBindingResult()
+        String message = e.getBindingResult()
                 .getFieldErrors()
                 .get(0)
                 .getDefaultMessage();
 
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.BAD_REQUEST,
-                "VALIDATION_FAILED",
-                message,
-                request.getRequestURI()
-        );
+        log.warn("[GlobalExceptionHandler] validation failed - path: {}, message: {}",
+                request.getRequestURI(), message);
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+        return ResponseEntity
+                .status(400)
+                .body(new ErrorResponse(400, "VALIDATION_FAILED", message, request.getRequestURI()));
     }
 
+    // ===== 예상치 못한 예외 (항상 스택트레이스) =====
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(
-            Exception exception,
+            Exception e,
             HttpServletRequest request
     ) {
-        ErrorResponse errorResponse = new ErrorResponse(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                "INTERNAL_SERVER_ERROR",
-                "서버 내부 오류가 발생했습니다.",
-                request.getRequestURI()
-        );
+        log.error("[GlobalExceptionHandler] 예상치 못한 예외 - path: {}", request.getRequestURI(), e);
 
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+        String message = isDev() ? e.getMessage() : "서버 오류가 발생했습니다.";
+
+        return ResponseEntity
+                .status(500)
+                .body(new ErrorResponse(500, "INTERNAL_ERROR", message, request.getRequestURI()));
     }
 
-
-    @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ErrorResponse> handleCustomException(
-            CustomException exception,
-            HttpServletRequest request
-    ) {
-        ErrorCode errorCode = exception.getErrorCode();
-
-        ErrorResponse errorResponse = new ErrorResponse(
-                errorCode.getHttpStatus(),
-                errorCode.name(),
-                exception.getMessage(),
-                request.getRequestURI()
-        );
-
-        return ResponseEntity.status(errorCode.getHttpStatus()).body(errorResponse);
+    private boolean isDev() {
+        return Arrays.asList(env.getActiveProfiles()).contains("local");
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/error/exception/ConflictException.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/exception/ConflictException.java
@@ -1,0 +1,11 @@
+// Conflict 409 (이미 존재) 중복 이메일, 이미 완료된 항목
+package com.wanted.codebombalms.global.error.exception;
+
+import com.wanted.codebombalms.global.error.BusinessException;
+import com.wanted.codebombalms.global.error.ErrorCode;
+
+public class ConflictException extends BusinessException {
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/exception/ForbiddenException.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/exception/ForbiddenException.java
@@ -1,0 +1,11 @@
+// 403 Forbidden 인가 안 됨(권한 없음) 로그인은 됐는데 접근 불가
+package com.wanted.codebombalms.global.error.exception;
+
+import com.wanted.codebombalms.global.error.BusinessException;
+import com.wanted.codebombalms.global.error.ErrorCode;
+
+public class ForbiddenException extends BusinessException {
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/exception/NotFoundException.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+// 404 NotFound 리소스 없음 없는 Id조회
+package com.wanted.codebombalms.global.error.exception;
+
+import com.wanted.codebombalms.global.error.BusinessException;
+import com.wanted.codebombalms.global.error.ErrorCode;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/exception/UnauthorizedException.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/exception/UnauthorizedException.java
@@ -1,0 +1,11 @@
+// 401 Unauthorized 인증 안 됨 (로그인 안 함) 토큰 없음, 토큰 만료
+package com.wanted.codebombalms.global.error.exception;
+
+import com.wanted.codebombalms.global.error.BusinessException;
+import com.wanted.codebombalms.global.error.ErrorCode;
+
+public class UnauthorizedException extends BusinessException {
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/error/exception/ValidationException.java
+++ b/src/main/java/com/wanted/codebombalms/global/error/exception/ValidationException.java
@@ -1,0 +1,11 @@
+// 400 Bad Request 클라이언트 요청이 잘못됨 입력값 오류, 빈 필드
+package com.wanted.codebombalms.global.error.exception;
+
+import com.wanted.codebombalms.global.error.BusinessException;
+import com.wanted.codebombalms.global.error.ErrorCode;
+
+public class ValidationException extends BusinessException {
+    public ValidationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/logging/LoggingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/logging/LoggingConfig.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.global.logging;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+public class LoggingConfig {
+
+    @Bean
+    public FilterRegistrationBean<MdcLoggingFilter> mdcLoggingFilter() {
+        FilterRegistrationBean<MdcLoggingFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new MdcLoggingFilter());
+        registrationBean.addUrlPatterns("/*");
+        registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/logging/MdcLoggingFilter.java
@@ -1,0 +1,41 @@
+package com.wanted.codebombalms.global.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public class MdcLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        try {
+            MDC.put("traceId", UUID.randomUUID().toString().substring(0, 8));
+            MDC.put("requestURI", request.getRequestURI());
+            MDC.put("method", request.getMethod());
+            MDC.put("clientIp", resolveClientIp(request));
+
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip != null && !ip.isEmpty()) {
+            return ip.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/logging/aop/LogBusiness.java
+++ b/src/main/java/com/wanted/codebombalms/global/logging/aop/LogBusiness.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.global.logging.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogBusiness {
+}

--- a/src/main/java/com/wanted/codebombalms/global/logging/aop/LogPerformance.java
+++ b/src/main/java/com/wanted/codebombalms/global/logging/aop/LogPerformance.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.global.logging.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogPerformance {
+}

--- a/src/main/java/com/wanted/codebombalms/global/logging/aop/LoggingAspect.java
+++ b/src/main/java/com/wanted/codebombalms/global/logging/aop/LoggingAspect.java
@@ -1,0 +1,57 @@
+package com.wanted.codebombalms.global.logging.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class LoggingAspect {
+
+    private static final Logger businessLog =
+            LoggerFactory.getLogger("com.wanted.codebombalms.business");
+
+    private static final Logger performanceLog =
+            LoggerFactory.getLogger("com.wanted.codebombalms.performance");
+
+    @Around("@annotation(LogBusiness)")
+    public Object logBusinessEvent(ProceedingJoinPoint jp) throws Throwable {
+        String className = jp.getTarget().getClass().getSimpleName();
+        String methodName = jp.getSignature().getName();
+
+        businessLog.info("[{}] {} 시작 - args: {}", className, methodName, jp.getArgs());
+
+        try {
+            Object result = jp.proceed();
+            businessLog.info("[{}] {} 완료", className, methodName);
+            return result;
+        } catch (Exception e) {
+            businessLog.warn("[{}] {} 실패 - {}", className, methodName, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Around("@annotation(LogPerformance)")
+    public Object logPerformance(ProceedingJoinPoint jp) throws Throwable {
+        long start = System.currentTimeMillis();
+        String className = jp.getTarget().getClass().getSimpleName();
+        String methodName = jp.getSignature().getName();
+
+        try {
+            return jp.proceed();
+        } finally {
+            long duration = System.currentTimeMillis() - start;
+
+            if (duration >= 1000) {
+                performanceLog.warn("[SLOW] {}.{} - {}ms", className, methodName, duration);
+            } else {
+                performanceLog.info("{}.{} - {}ms", className, methodName, duration);
+            }
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/security/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.global.security.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.codebombalms.global.error.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    // CustomAccessDeniedHandler.java
+    public CustomAccessDeniedHandler(ObjectMapper objectMapper) {  // 클래스명과 일치해야 함
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException e
+    ) throws IOException {
+        response.setStatus(403);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                objectMapper.writeValueAsString(
+                        new ErrorResponse(403, "A-015", "접근 권한이 없습니다.", request.getRequestURI())
+                )
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/wanted/codebombalms/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.global.security.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.codebombalms.global.error.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException e
+    ) throws IOException {
+        response.setStatus(401);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                objectMapper.writeValueAsString(
+                        new ErrorResponse(401, "A-002", "유효하지 않은 토큰입니다.", request.getRequestURI())
+                )
+        );
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- ===== 콘솔 (개발 환경용 텍스트) ===== -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) [%X{traceId:-}] %cyan(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- ===== 전체 로그 파일 (JSON) ===== -->
+    <appender name="APP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/lms-app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/lms-app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"code-bomba-lms"}</customFields>
+        </encoder>
+    </appender>
+
+    <!-- ===== ERROR 전용 파일 (JSON) ===== -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/lms-error.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/lms-error.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"code-bomba-lms"}</customFields>
+        </encoder>
+    </appender>
+
+    <!-- ===== 비즈니스 이벤트 파일 (JSON, 90일) ===== -->
+    <appender name="BUSINESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/lms-business.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/lms-business.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"code-bomba-lms","log-type":"business"}</customFields>
+        </encoder>
+    </appender>
+
+    <!-- ===== 성능 측정 파일 (JSON) ===== -->
+    <appender name="PERFORMANCE_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/lms-performance.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>logs/lms-performance.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"code-bomba-lms","log-type":"performance"}</customFields>
+        </encoder>
+    </appender>
+
+    <!-- ===== 로거 설정 ===== -->
+
+    <!-- 비즈니스 로거 → business 파일로 -->
+    <logger name="com.wanted.codebombalms.business" level="INFO" additivity="false">
+        <appender-ref ref="BUSINESS_FILE"/>
+    </logger>
+
+    <!-- 성능 로거 → performance 파일로 -->
+    <logger name="com.wanted.codebombalms.performance" level="INFO" additivity="false">
+        <appender-ref ref="PERFORMANCE_FILE"/>
+    </logger>
+
+    <!-- 프로파일별 분기 -->
+    <springProfile name="local,dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="APP_FILE"/>
+            <appender-ref ref="ERROR_FILE"/>
+        </root>
+        <!-- SQL 로그 -->
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="WARN">
+            <appender-ref ref="APP_FILE"/>
+            <appender-ref ref="ERROR_FILE"/>
+        </root>
+        <logger name="com.wanted.codebombalms" level="INFO"/>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [v] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #
#43 #44 #45 #46 #47 #48 #49 #50 

---오늘 작업한 내용 기반으로 PR 내용 작성했습니다.

---

## 🛠️ 기능 관련 작업 내용

- JSON 구조화 로그 시스템을 구축했습니다. (logback-spring.xml, logstash-logback-encoder)
- MDC 필터를 추가해 모든 요청에 traceId를 자동 주입하여 요청 단위 로그 추적이 가능하도록 했습니다.
- AOP 기반 LoggingAspect를 구현해 `@LogBusiness`, `@LogPerformance` 어노테이션으로 비즈니스 이벤트 및 실행시간을 자동 측정합니다.
- 계층적 에러핸들링 구조를 구축했습니다. (`BusinessException` → HTTP 상태코드별 하위 클래스, 도메인별 `ErrorCode` enum)
- 도메인별 ErrorCode에 고유 식별번호를 적용했습니다. (A-001~A-015, U-001~U-008, CR-001, P-001~P-008, S-001~S-002)
- Spring Security 401/403 응답을 `ErrorResponse` JSON 포맷으로 커스텀했습니다.
- 기존 `RuntimeException`, `IllegalArgumentException` 직접 throw를 전부 타입화된 예외로 교체했습니다.
- Spring Boot 버전을 3.5.14로 업데이트하고 관련 의존성을 호환 버전으로 정리했습니다.

---

## ♻️ 패키지 변경 사항

- `build.gradle` : Spring Boot 3.5.14 업데이트, AOP/logstash 의존성 추가
- `src/main/resources/logback-spring.xml` : JSON 포맷 로그 설정 신규 추가 (app/error/business/performance 4종)
- `global/error/ErrorCode.java` : 기존 enum → 인터페이스로 교체
- `global/error/BusinessException.java` : 기반 추상 예외 클래스 신규 추가
- `global/error/exception/NotFoundException.java` : 404 예외 클래스 신규 추가
- `global/error/exception/ConflictException.java` : 409 예외 클래스 신규 추가
- `global/error/exception/ValidationException.java` : 400 예외 클래스 신규 추가
- `global/error/exception/UnauthorizedException.java` : 401 예외 클래스 신규 추가
- `global/error/exception/ForbiddenException.java` : 403 예외 클래스 신규 추가
- `global/error/ErrorResponse.java` : ErrorCode 인터페이스 기반으로 생성자 수정
- `global/error/GlobalExceptionHandler.java` : BusinessException 통합 처리, 환경별 스택트레이스 분기 추가
- `global/security/exception/CustomAuthenticationEntryPoint.java` : 401 JSON 응답 처리 신규 추가
- `global/security/exception/CustomAccessDeniedHandler.java` : 403 JSON 응답 처리 신규 추가
- `global/config/SecurityConfig.java` : EntryPoint/AccessDeniedHandler 연결
- `global/logging/MdcLoggingFilter.java` : traceId/URI/method/clientIp MDC 주입 필터 신규 추가
- `global/logging/LoggingConfig.java` : MDC 필터 최우선 순위 등록
- `global/logging/aop/LoggingAspect.java` : 비즈니스/성능 로깅 AOP 신규 추가
- `global/logging/aop/LogBusiness.java` : 비즈니스 이벤트 로깅 어노테이션 신규 추가
- `global/logging/aop/LogPerformance.java` : 실행시간 측정 어노테이션 신규 추가
- `domain/course/exception/CourseErrorCode.java` : ErrorCode 인터페이스 구현, 식별번호 적용
- `domain/problems/exception/ProblemErrorCode.java` : ErrorCode 인터페이스 구현, 식별번호 적용
- `domain/submission/exception/SubmissionErrorCode.java` : ErrorCode 인터페이스 구현, 식별번호 적용
- `domain/user/exception/AuthErrorCode.java` : 기존 중앙 enum → 도메인별 enum으로 분리
- `domain/user/exception/UserErrorCode.java` : 기존 중앙 enum → 도메인별 enum으로 분리
- `domain/course/service/CourseService.java` : 새 예외 구조 적용, `@LogBusiness`/`@LogPerformance` 추가
- `domain/submission/service/SubmissionService.java` : 새 예외 구조 적용, `@LogBusiness`/`@LogPerformance` 추가
- `domain/submission/service/SubmissionAttemptService.java` : RuntimeException → ValidationException 교체
- `domain/problems/set/service/ProblemSetService.java` : RuntimeException → NotFoundException 교체
- `domain/problems/progress/service/ProgressService.java` : RuntimeException → 타입화된 예외 교체
- `domain/problems/problem/service/ProblemService.java` : RuntimeException → NotFoundException 교체
- `domain/problems/result/service/ResultService.java` : RuntimeException → 타입화된 예외 교체

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.