### PR TITLE
[FEAT] 문제 세트 수정 및 비활성화 기능 구현

### DIFF
--- a/src/main/java/com/wanted/codebombalms/domain/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/exception/ProblemErrorCode.java
@@ -8,14 +8,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProblemErrorCode implements ErrorCode {
 
-    PROBLEM_NOT_FOUND(404, "P-001", "존재하지 않는 문제입니다."),
-    PROBLEM_SET_NOT_FOUND(404, "P-002", "존재하지 않는 문제세트입니다."),
-    CATEGORY_NOT_FOUND(404, "P-003", "존재하지 않는 카테고리입니다."),
-    ATTEMPT_LIMIT_EXCEEDED(400, "P-004", "시도 횟수를 초과했습니다."),
-    ALREADY_COMPLETED(409, "P-005", "이미 완료된 문제집입니다."),
-    PROBLEM_NOT_UNLOCKED(400, "P-006", "아직 열리지 않은 문제입니다."),
-    PROBLEM_SET_NOT_COMPLETED(400, "P-007", "문제 세트를 완료하지 않았습니다."),
-    NO_CURRENT_PROBLEM(404, "P-008", "현재 풀 문제가 없습니다.");
+    PROBLEM_NOT_FOUND(404, "PROBLEM_NOT_FOUND", "문제를 찾을 수 없습니다."),
+    PROBLEM_SET_NOT_FOUND(404, "PROBLEM_SET_NOT_FOUND", "문제 세트를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(404, "PROBLEM_CATEGORY_NOT_FOUND", "문제 분야를 찾을 수 없습니다."),
+    INVALID_CATEGORY(400, "PROBLEM_INVALID_CATEGORY", "잘못된 문제 분야입니다."),
+    ACCESS_DENIED(403, "PROBLEM_ACCESS_DENIED", "문제 접근 권한이 없습니다."),
+    ATTEMPT_LIMIT_EXCEEDED(429, "PROBLEM_ATTEMPT_LIMIT_EXCEEDED", "제출 가능 횟수를 초과했습니다."),
+    ALREADY_COMPLETED(409, "PROBLEM_ALREADY_COMPLETED", "이미 완료된 문제 세트입니다."),
+    PROBLEM_NOT_UNLOCKED(409, "PROBLEM_NOT_UNLOCKED", "이전 문제를 먼저 풀어야 합니다."),
+    PROBLEM_SET_NOT_COMPLETED(400, "PROBLEM_SET_NOT_COMPLETED", "문제 세트를 끝까지 풀지 않았습니다."),
+    NO_CURRENT_PROBLEM(404, "PROBLEM_NOT_FOUND", "현재 풀 문제가 없습니다."),
+    INVALID_INPUT(400, "PROBLEM_INVALID_INPUT", "필수값이 누락되었습니다."),
+    PROBLEM_SET_TITLE_REQUIRED(400, "PROBLEM_INVALID_INPUT", "문제 세트 제목은 필수입니다."),
+    PROBLEM_CATEGORY_REQUIRED(400, "PROBLEM_INVALID_INPUT", "카테고리는 필수입니다."),
+    PROBLEM_REQUIRED(400, "PROBLEM_INVALID_INPUT", "소문제는 1개 이상 필요합니다."),
+    PROBLEM_TITLE_REQUIRED(400, "PROBLEM_INVALID_INPUT", "소문제 제목은 필수입니다."),
+    PROBLEM_CONTENT_REQUIRED(400, "PROBLEM_INVALID_INPUT", "소문제 내용은 필수입니다."),
+    PROBLEM_ANSWER_REQUIRED(400, "PROBLEM_INVALID_INPUT", "소문제 정답은 필수입니다."),
+    PROBLEM_HAS_SUBMISSION(409, "PROBLEM_HAS_SUBMISSION", "제출 기록이 존재합니다."),
+    SERVER_ERROR(500, "PROBLEM_SERVER_ERROR", "문제 도메인 처리 중 서버 오류가 발생했습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/wanted/codebombalms/domain/problems/hint/entity/ProblemHint.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/hint/entity/ProblemHint.java
@@ -42,6 +42,10 @@ public class ProblemHint {
         this.createdAt = LocalDateTime.now();
     }
 
+    public void update(String hintContent) {
+        this.hintContent = hintContent;
+    }
+
     public Long getHintId() {
         return hintId;
     }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/hint/problem-hint.http
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/hint/problem-hint.http
@@ -1,5 +1,5 @@
 @baseUrl = http://localhost:8080
-@problemId = 1
+@problemId = 2001
 
 ### 문제 힌트 조회
 GET {{baseUrl}}/api/v1/problems/{{problemId}}/hints

--- a/src/main/java/com/wanted/codebombalms/domain/problems/hint/repository/ProblemHintRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/hint/repository/ProblemHintRepository.java
@@ -4,8 +4,11 @@ import com.wanted.codebombalms.domain.problems.hint.entity.ProblemHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProblemHintRepository extends JpaRepository<ProblemHint, Long> {
 
     List<ProblemHint> findByProblem_ProblemIdOrderByHintOrderAsc(Long problemId);
+
+    Optional<ProblemHint> findByHintIdAndProblem_ProblemId(Long hintId, Long problemId);
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/hint/service/ProblemHintService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/hint/service/ProblemHintService.java
@@ -40,4 +40,23 @@ public class ProblemHintService {
         return problemHintRepository.save(problemHint);
     }
 
+    public ProblemHint updateHint(Long hintId, String hintContent) {
+        ProblemHint problemHint = problemHintRepository.findById(hintId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 힌트입니다."));
+
+        problemHint.update(hintContent);
+
+        return problemHint;
+    }
+
+    public ProblemHint updateHint(Problem problem, Long hintId, String hintContent) {
+        ProblemHint problemHint = problemHintRepository
+                .findByHintIdAndProblem_ProblemId(hintId, problem.getProblemId())
+                .orElseThrow(() -> new RuntimeException("해당 소문제에 속한 힌트가 아닙니다."));
+
+        problemHint.update(hintContent);
+
+        return problemHint;
+    }
+
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemManageController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemManageController.java
@@ -1,21 +1,24 @@
 package com.wanted.codebombalms.domain.problems.problem.controller;
 
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemSetCreateRequest;
+import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemSetUpdateRequest;
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetCreateResponse;
+import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetUpdateResponse;
 import com.wanted.codebombalms.domain.problems.set.service.ProblemSetRegistrationService;
+import com.wanted.codebombalms.domain.problems.set.service.ProblemSetUpdateService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class ProblemManageController {
 
     private final ProblemSetRegistrationService problemSetRegistrationService;
-
-    public ProblemManageController(ProblemSetRegistrationService problemSetRegistrationService) {
+    private final ProblemSetUpdateService  problemSetUpdateService;
+    public ProblemManageController(ProblemSetRegistrationService problemSetRegistrationService,
+                                   ProblemSetUpdateService problemSetUpdateService) {
         this.problemSetRegistrationService = problemSetRegistrationService;
+        this.problemSetUpdateService = problemSetUpdateService;
     }
 
     @PostMapping("/api/v1/problems")
@@ -27,4 +30,16 @@ public class ProblemManageController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @PutMapping("/api/v1/problems/{problemSetId}")
+    public ResponseEntity<ProblemSetUpdateResponse> updateProblemSet(
+            @PathVariable Long problemSetId,
+            @RequestBody ProblemSetUpdateRequest request
+    ) {
+        ProblemSetUpdateResponse response =
+                problemSetUpdateService.updateProblemSet(problemSetId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemManageController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemManageController.java
@@ -3,7 +3,9 @@ package com.wanted.codebombalms.domain.problems.problem.controller;
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemSetCreateRequest;
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemSetUpdateRequest;
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetCreateResponse;
+import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetDeleteResponse;
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetUpdateResponse;
+import com.wanted.codebombalms.domain.problems.set.service.ProblemSetDeleteService;
 import com.wanted.codebombalms.domain.problems.set.service.ProblemSetRegistrationService;
 import com.wanted.codebombalms.domain.problems.set.service.ProblemSetUpdateService;
 import org.springframework.http.HttpStatus;
@@ -15,10 +17,14 @@ public class ProblemManageController {
 
     private final ProblemSetRegistrationService problemSetRegistrationService;
     private final ProblemSetUpdateService  problemSetUpdateService;
+    private final ProblemSetDeleteService problemSetDeleteService;
+
     public ProblemManageController(ProblemSetRegistrationService problemSetRegistrationService,
-                                   ProblemSetUpdateService problemSetUpdateService) {
+                                   ProblemSetUpdateService problemSetUpdateService,
+                                   ProblemSetDeleteService problemSetDeleteService) {
         this.problemSetRegistrationService = problemSetRegistrationService;
         this.problemSetUpdateService = problemSetUpdateService;
+        this.problemSetDeleteService = problemSetDeleteService;
     }
 
     @PostMapping("/api/v1/problems")
@@ -42,4 +48,14 @@ public class ProblemManageController {
         return ResponseEntity.ok(response);
     }
 
+    @DeleteMapping("/api/v1/problems/{problemSetId}")
+    public ResponseEntity<ProblemSetDeleteResponse> deleteProblemSet(
+            @PathVariable Long problemSetId,
+            @RequestParam(defaultValue = "false") boolean force
+    ) {
+        ProblemSetDeleteResponse response =
+                problemSetDeleteService.deactivateProblemSet(problemSetId, force);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/entitiy/Problem.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/entitiy/Problem.java
@@ -65,6 +65,23 @@ public class Problem {
         this.problemOrder = problemOrder;
     }
 
+    public void update(
+            String title,
+            String content,
+            String answer,
+            String explanation,
+            int score
+    ) {
+        this.title = title;
+        this.content = content;
+        this.answer = answer;
+        this.explanation = explanation;
+        this.score = score;
+    }
+
+    public void deactivate() {
+        this.status = "INACTIVE";
+    }
 
     public Long getProblemId() {
         return problemId;

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/repository/ProblemRepository.java
@@ -27,4 +27,9 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
             String status
     );
 
+    Optional<Problem> findByProblemIdAndProblemSet_ProblemSetId(
+            Long problemId,
+            Long problemSetId
+    );
+
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.domain.problems.problem.dto.response.ProblemRespo
 import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
 import com.wanted.codebombalms.domain.problems.problem.repository.ProblemRepository;
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemCreateRequest;
+import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemUpdateRequest;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
 import org.springframework.stereotype.Service;
 
@@ -40,6 +41,11 @@ public class ProblemService {
     public Problem findProblemEntity(Long problemId) {
         return problemRepository.findById(problemId)
                     .orElseThrow(() -> new RuntimeException("존재하지 않는 문제입니다."));
+    }
+
+    public Problem findProblemEntity(Long problemSetId, Long problemId) {
+        return problemRepository.findByProblemIdAndProblemSet_ProblemSetId(problemId, problemSetId)
+                .orElseThrow(() -> new RuntimeException("해당 문제 세트에 속한 소문제가 아닙니다."));
     }
 
     public Optional<Long> findProblemIdByProblemSetAndOrder(Long problemSetId, Integer problemOrder) {
@@ -83,6 +89,43 @@ public class ProblemService {
         );
 
         return problemRepository.save(problem);
+    }
+
+    public Problem createProblem(
+            ProblemSet problemSet,
+            ProblemUpdateRequest request,
+            Integer problemOrder
+    ) {
+        int score = request.point() == null ? 0 : request.point();
+
+        Problem problem = new Problem(
+                problemSet,
+                request.title(),
+                request.content(),
+                request.answer(),
+                request.explanation(),
+                score,
+                problemOrder
+        );
+
+        return problemRepository.save(problem);
+    }
+
+
+    public Problem updateProblem(Long problemSetId, ProblemUpdateRequest request) {
+        Problem problem = findProblemEntity(problemSetId, request.problemId());
+
+        int score = request.point() == null ? 0 : request.point();
+
+        problem.update(
+                request.title(),
+                request.content(),
+                request.answer(),
+                request.explanation(),
+                score
+        );
+
+        return problem;
     }
 
 

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/request/ProblemSetUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/request/ProblemSetUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.domain.problems.set.dto.request;
+
+import java.util.List;
+
+public record ProblemSetUpdateRequest(
+        String title,
+        String categoryName,
+        String description,
+        String dataFileName,
+        List<ProblemUpdateRequest> problems
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/request/ProblemUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/request/ProblemUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.domain.problems.set.dto.request;
+
+public record ProblemUpdateRequest(
+        Long problemId,
+        String title,
+        String content,
+        Integer point,
+        String startCode,
+        String answer,
+        Long hintId,
+        String hint,
+        String explanation
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/response/ProblemSetDeleteResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/response/ProblemSetDeleteResponse.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.domain.problems.set.dto.response;
+
+public record ProblemSetDeleteResponse(
+        Long problemSetId,
+        String status,
+        int deactivatedProblemCount
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/response/ProblemSetUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/dto/response/ProblemSetUpdateResponse.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.problems.set.dto.response;
+
+public record ProblemSetUpdateResponse(
+        Long problemSetId,
+        String title,
+        String categoryName,
+        Integer updatedProblemCount
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/entity/ProblemSet.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/entity/ProblemSet.java
@@ -56,6 +56,24 @@ public class ProblemSet {
         this.createdAt = LocalDateTime.now();
     }
 
+    public void update(
+            ProblemCategory category,
+            String title,
+            String description
+    ) {
+        this.category = category;
+        this.title = title;
+        this.description = description;
+    }
+
+    public void updateTotalProblemCount(Integer totalProblemCount) {
+        this.totalProblemCount = totalProblemCount;
+    }
+
+    public void deactivate() {
+        this.status = "INACTIVE";
+    }
+
     public Long getProblemSetId() {
         return problemSetId;
     }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/problem-set.http
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/problem-set.http
@@ -1,97 +1,134 @@
 @baseUrl = http://localhost:8080
-@categoryId = 1
-@problemSetId = 1
-@userId = 3
 
-### 문제 세트 목록 조회
+# =====================================================
+# M1 문제 도메인 테스트용 변수
+# =====================================================
+# 더미 데이터 기준:
+# - category_id = 2001, 2002, 2003
+# - problem_set_id = 2001, 2002, 2003
+# - problem_id = 2001 ~ 2009
+# - hint_id = 2001 ~ 2009
+#
+# 수정 테스트 기본 대상:
+# - 문제 세트: 2001
+# - 소문제: 2001
+# - 힌트: 2001
+#
+# 현재 SecurityConfig가 permitAll이면 accessToken은 없어도 됩니다.
+# 다시 인증이 켜지면 실제 로그인 토큰으로 바꾸고 Cookie 헤더를 사용하세요.
+
+@categoryId = 2001
+@problemSetId = 2001
+@userId = 3
+@accessToken = PUT_REAL_ACCESS_TOKEN_HERE
+
+@updateProblemSetId = 2001
+@updateProblemId = 2001
+@updateHintId = 2001
+
+
+### 1. 문제 세트 목록 조회 - 분야별 문제 세트 조회
+# 기대 결과:
+# - categoryId=2001인 "비즈니스 기초" 분야의 문제 세트가 조회됩니다.
+# - 더미 데이터 기준 "비즈니스 모델 이해 입문" 문제 세트가 포함되어야 합니다.
 GET {{baseUrl}}/api/v1/problem-sets?categoryId={{categoryId}}
 Accept: application/json
 
-### 문제 세트 상세 진입 및 현재 문제 조회
+
+### 2. 문제 세트 상세 진입 - 현재 풀 문제 조회
+# 기대 결과:
+# - userId=3 사용자가 problemSetId=2001 문제 세트에 진입합니다.
+# - 진행 상태가 없으면 1번 소문제부터 조회됩니다.
+# - 이미 완료된 문제 세트라면 결과 화면 또는 완료 응답 흐름으로 이동할 수 있습니다.
 GET {{baseUrl}}/api/v1/problem-sets/{{problemSetId}}?userId={{userId}}
 Accept: application/json
 
-### 문제 세트 등록 성공 - 기존 카테고리 사용
+
+### 3. 문제 세트 등록 성공 - 기존 카테고리 사용
 # 기대 결과:
-# - 이미 ACTIVE 상태의 "데이터 분석" 카테고리가 있으면 기존 카테고리를 사용합니다.
+# - categoryName이 이미 있으면 기존 ACTIVE 카테고리를 사용합니다.
 # - problem_set 1건, problem 2건, problem_hint 2건이 저장됩니다.
-# - 응답 상태는 201 Created 입니다.
+# - 응답 상태는 201 Created입니다.
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
+Cookie: accessToken={{accessToken}}
 
 {
   "title": "고객 분석 기초 문제 세트",
-  "categoryName": "데이터 분석",
-  "description": "고객 세그먼트와 핵심 지표를 이해하는 문제 세트입니다.",
+  "categoryName": "테스트 데이터 분석",
+  "description": "고객 세그먼트와 재방문 지표를 이해하는 문제 세트입니다.",
   "dataFileName": "customer_analysis.csv",
   "problems": [
     {
-      "title": "고객 세그먼트 식별",
-      "content": "서비스를 설계할 때 고객 세그먼트를 나누는 이유를 설명하시오.",
+      "title": "고객 세그먼트 목적",
+      "content": "고객 세그먼트를 나누는 이유를 한 문장으로 작성하세요.",
       "point": 10,
       "startCode": "df = pd.read_csv(\"data/customer_analysis.csv\")",
-      "answer": "고객별 특성에 맞는 서비스를 제공하기 위해서",
+      "answer": "고객 특성에 맞는 서비스를 제공하기 위해서",
       "hint": "모든 고객이 같은 요구를 가진 것은 아닙니다.",
-      "explanation": "고객 세그먼트는 고객을 특성별로 나누어 더 적절한 서비스와 전략을 제공하기 위해 사용합니다."
+      "explanation": "고객 세그먼트는 고객을 특성별로 나누어 더 적절한 서비스 전략을 세우기 위해 사용합니다."
     },
     {
-      "title": "핵심 지표 선택",
-      "content": "서비스 성장 여부를 판단하기 위해 확인할 수 있는 대표 지표를 하나 작성하시오.",
+      "title": "재방문 지표",
+      "content": "사용자가 서비스를 다시 이용하는지 확인하는 대표 지표를 작성하세요.",
       "point": 10,
       "startCode": "df = pd.read_csv(\"data/customer_analysis.csv\")",
       "answer": "재방문율",
-      "hint": "고객이 다시 돌아오는지를 생각해보세요.",
-      "explanation": "재방문율은 사용자가 서비스를 반복해서 이용하는지 확인할 수 있는 대표적인 지표입니다."
+      "hint": "사용자가 다시 돌아오는지를 보는 지표입니다.",
+      "explanation": "재방문율은 사용자가 서비스를 다시 이용하는지 확인할 수 있는 중요한 지표입니다."
     }
   ]
 }
 
-### 문제 세트 등록 성공 - 신규 카테고리 자동 생성
+
+### 4. 문제 세트 등록 성공 - 새로운 카테고리 자동 생성
 # 기대 결과:
-# - "Python 실습" 카테고리가 없으면 problem_category에 새로 저장됩니다.
+# - "Python 실습 테스트" 카테고리가 없으면 새로 생성됩니다.
 # - 이미 있으면 기존 ACTIVE 카테고리를 재사용합니다.
-# - 카테고리 중복 입력은 실패가 아니라 재사용이 현재 정책입니다.
+# - M2 코드 실행형 확장을 고려해 startCode 값도 함께 보냅니다.
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
+Cookie: accessToken={{accessToken}}
 
 {
-  "title": "M2 코드 실행형 준비 세트",
-  "categoryName": "Python 실습",
+  "title": "M2 코드 실행형 준비 문제 세트",
+  "categoryName": "Python 실습 테스트",
   "description": "M2 코드 실행형 문제를 고려한 테스트 문제 세트입니다.",
   "dataFileName": "employee_performance.csv",
   "problems": [
     {
-      "title": "데이터프레임 행 개수 확인",
-      "content": "직원 성과 데이터의 전체 행 개수를 확인하는 코드를 작성하기 전, 행 개수를 확인할 때 사용하는 pandas 속성을 작성하시오.",
+      "title": "DataFrame 행과 열 개수 확인",
+      "content": "pandas DataFrame의 행과 열 개수를 확인할 때 사용하는 속성을 작성하세요.",
       "point": 15,
       "startCode": "df = pd.read_csv(\"data/employee_performance.csv\")",
       "answer": "shape",
-      "hint": "행과 열 개수를 함께 알려주는 속성입니다.",
-      "explanation": "pandas DataFrame의 shape 속성은 행과 열 개수를 튜플 형태로 반환합니다."
+      "hint": "행과 열 개수를 튜플 형태로 알려주는 속성입니다.",
+      "explanation": "shape는 DataFrame의 행 수와 열 수를 튜플 형태로 반환합니다."
     }
   ]
 }
 
-### 문제 세트 등록 성공 - 힌트 없이 등록
+
+### 5. 문제 세트 등록 성공 - 힌트 없이 등록
 # 기대 결과:
 # - problem_set과 problem은 저장됩니다.
-# - hint가 비어 있으므로 problem_hint는 저장되지 않습니다.
-# - 현재 정책상 힌트는 필수가 아닙니다.
+# - hint가 빈 문자열이므로 problem_hint는 저장되지 않습니다.
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
+Cookie: accessToken={{accessToken}}
 
 {
   "title": "힌트 없는 단답형 문제 세트",
   "categoryName": "SQL",
-  "description": "힌트 없이도 풀 수 있는 단답형 문제 세트입니다.",
+  "description": "힌트가 없어도 등록 가능한지 확인하는 문제 세트입니다.",
   "dataFileName": null,
   "problems": [
     {
-      "title": "SELECT 키워드 의미",
-      "content": "SQL에서 데이터를 조회할 때 사용하는 대표 키워드를 작성하시오.",
+      "title": "SELECT 키워드",
+      "content": "SQL에서 데이터를 조회할 때 사용하는 대표 키워드를 작성하세요.",
       "point": 5,
       "startCode": null,
       "answer": "SELECT",
@@ -101,169 +138,245 @@ Content-Type: application/json
   ]
 }
 
-### 문제 세트 등록 성공 - M1에서 startCode/dataFileName은 받아만 둠
+
+### 6. 문제 세트 등록 실패 - 소문제 없음
 # 기대 결과:
-# - M1 DB에는 dataFileName, startCode 저장 칼럼이 없으므로 저장되지 않습니다.
-# - 요청 DTO로만 받고, M2 데이터셋/코드 실행형 확장 때 저장 대상으로 전환할 수 있습니다.
+# - problems가 빈 배열이므로 실패해야 합니다.
+# - 현재 예외 포맷 정책에 따라 400 또는 공통 에러 응답이 내려올 수 있습니다.
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
-
-{
-  "title": "시작 코드 포함 문제 세트",
-  "categoryName": "Python 실습",
-  "description": "M2 확장을 위해 시작 코드 입력을 포함한 문제 세트입니다.",
-  "dataFileName": "sales.csv",
-  "problems": [
-    {
-      "title": "매출 컬럼 확인",
-      "content": "매출 데이터에서 금액 컬럼을 확인할 때 사용할 수 있는 DataFrame 속성을 작성하시오.",
-      "point": 10,
-      "startCode": "df = pd.read_csv(\"data/sales.csv\")",
-      "answer": "columns",
-      "hint": "DataFrame이 가진 컬럼 이름 목록을 확인하는 속성입니다.",
-      "explanation": "columns 속성은 DataFrame의 컬럼 이름 목록을 반환합니다."
-    }
-  ]
-}
-
-### 문제 세트 등록 실패 - 카테고리 없음
-# 기대 결과:
-# - categoryName이 빈 문자열이므로 실패합니다.
-# - 현재 전역 예외 포맷이 완성되지 않았다면 Spring 기본 오류 응답이 나올 수 있습니다.
-POST {{baseUrl}}/api/v1/problems
-Accept: application/json
-Content-Type: application/json
-
-{
-  "title": "카테고리 없는 문제 세트",
-  "categoryName": "",
-  "description": "카테고리 검증 실패 확인용 요청입니다.",
-  "dataFileName": null,
-  "problems": [
-    {
-      "title": "문제 제목",
-      "content": "문제 내용",
-      "point": 10,
-      "startCode": null,
-      "answer": "정답",
-      "hint": "힌트",
-      "explanation": "해설"
-    }
-  ]
-}
-
-### 문제 세트 등록 실패 - 문제 세트 제목 없음
-# 기대 결과:
-# - title이 빈 문자열이므로 실패합니다.
-POST {{baseUrl}}/api/v1/problems
-Accept: application/json
-Content-Type: application/json
-
-{
-  "title": "",
-  "categoryName": "데이터 분석",
-  "description": "문제 세트 제목 검증 실패 확인용 요청입니다.",
-  "dataFileName": null,
-  "problems": [
-    {
-      "title": "문제 제목",
-      "content": "문제 내용",
-      "point": 10,
-      "startCode": null,
-      "answer": "정답",
-      "hint": "힌트",
-      "explanation": "해설"
-    }
-  ]
-}
-
-### 문제 세트 등록 실패 - 소문제 없음
-# 기대 결과:
-# - problems가 빈 배열이므로 실패합니다.
-POST {{baseUrl}}/api/v1/problems
-Accept: application/json
-Content-Type: application/json
+Cookie: accessToken={{accessToken}}
 
 {
   "title": "소문제 없는 문제 세트",
-  "categoryName": "테스트",
-  "description": "소문제가 없어서 실패해야 하는 요청입니다.",
+  "categoryName": "테스트 데이터 분석",
+  "description": "소문제가 없으므로 실패해야 하는 요청입니다.",
   "dataFileName": null,
   "problems": []
 }
 
-### 문제 세트 등록 실패 - 소문제 제목 없음
+
+### 7. 문제 세트 수정 성공 - 기존 소문제와 기존 힌트 수정
+# 실행 전 DB 확인:
+# SELECT * FROM problem_set WHERE problem_set_id = 2001;
+# SELECT * FROM problem WHERE problem_id = 2001;
+# SELECT * FROM problem_hint WHERE hint_id = 2001;
+#
 # 기대 결과:
-# - 첫 번째 소문제의 title이 빈 문자열이므로 실패합니다.
-POST {{baseUrl}}/api/v1/problems
+# - problem_set의 제목/설명/카테고리가 수정됩니다.
+# - problem_id=2001 소문제의 제목/내용/정답/해설/점수가 수정됩니다.
+# - hint_id=2001 힌트 내용이 수정됩니다.
+PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
 Accept: application/json
 Content-Type: application/json
+Cookie: accessToken={{accessToken}}
 
 {
-  "title": "소문제 제목 검증 세트",
-  "categoryName": "데이터 분석",
-  "description": "소문제 제목 검증 실패 확인용 요청입니다.",
+  "title": "비즈니스 모델 이해 입문 - 수정",
+  "categoryName": "테스트 데이터 분석",
+  "description": "고객 세그먼트와 수익 모델을 다시 점검하는 수정된 문제 세트입니다.",
+  "dataFileName": "business_basic.csv",
+  "problems": [
+    {
+      "problemId": {{updateProblemId}},
+      "title": "고객 세그먼트 식별 - 수정",
+      "content": "서비스 설계에서 고객 세그먼트를 나누는 이유를 정확히 작성하세요.",
+      "point": 20,
+      "startCode": null,
+      "answer": "고객 특성에 맞는 서비스를 제공하기 위해서",
+      "hintId": {{updateHintId}},
+      "hint": "모든 고객이 같은 문제와 요구를 가진 것은 아닙니다.",
+      "explanation": "고객 세그먼트는 고객을 특성별로 나누어 더 적절한 서비스와 전략을 제공하기 위해 사용합니다."
+    }
+  ]
+}
+
+
+### 8. 문제 세트 수정 성공 - 기존 소문제 수정 + 새 소문제와 새 힌트 추가
+# 기대 결과:
+# - 첫 번째 항목은 기존 problem_id=2001, hint_id=2001을 수정합니다.
+# - 두 번째 항목은 problemId가 null이므로 새 소문제가 추가됩니다.
+# - 두 번째 항목은 hintId가 null이므로 새 힌트가 추가됩니다.
+# - problem_set.total_problem_count가 요청한 problems 개수에 맞게 갱신됩니다.
+PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
+Accept: application/json
+Content-Type: application/json
+Cookie: accessToken={{accessToken}}
+
+{
+  "title": "비즈니스 모델 이해 입문 - 확장",
+  "categoryName": "테스트 데이터 분석",
+  "description": "기존 소문제 수정과 새 소문제 추가를 함께 확인하는 요청입니다.",
+  "dataFileName": "business_basic.csv",
+  "problems": [
+    {
+      "problemId": 2001,
+      "title": "고객 세그먼트 식별 - 최종 수정",
+      "content": "서비스 설계에서 고객 세그먼트를 나누는 핵심 이유를 작성하세요.",
+      "point": 20,
+      "startCode": null,
+      "answer": "고객 특성에 맞는 서비스를 제공하기 위해서",
+      "hintId": 2001,
+      "hint": "고객마다 필요한 서비스와 메시지가 다를 수 있습니다.",
+      "explanation": "고객 세그먼트를 나누면 사용자 특성에 맞는 서비스 전략을 세울 수 있습니다."
+    },
+    {
+      "problemId": 2002,
+      "title": "수익 모델 구분",
+      "content": "정기적으로 반복 결제가 발생하는 수익 모델을 무엇이라고 부르는지 작성하세요.",
+      "point": 10,
+      "startCode": null,
+      "answer": "구독형 수익 모델",
+      "hintId": 2002,
+      "hint": "넷플릭스나 SaaS 요금제를 떠올려보세요.",
+      "explanation": "구독형 수익 모델은 사용자가 일정 주기마다 비용을 지불하고 서비스를 이용하는 방식입니다."
+    },
+    {
+      "problemId": 2003,
+      "title": "핵심 지표 선택",
+      "content": "초기 서비스에서 재방문을 확인하는 주요 지표를 작성하세요.",
+      "point": 10,
+      "startCode": null,
+      "answer": "재방문율",
+      "hintId": 2003,
+      "hint": "사용자가 다시 방문하는지를 확인하는 지표입니다.",
+      "explanation": "재방문율은 사용자가 서비스를 다시 이용하는지 확인할 수 있는 중요한 지표입니다."
+    },
+    {
+      "problemId": null,
+      "title": "전환율 이해",
+      "content": "사용자가 목표 행동을 완료한 비율을 무엇이라고 부르는지 작성하세요.",
+      "point": 10,
+      "startCode": null,
+      "answer": "전환율",
+      "hintId": null,
+      "hint": "방문자가 구매나 가입 같은 목표 행동을 했는지 보는 지표입니다.",
+      "explanation": "전환율은 전체 사용자 중 목표 행동을 완료한 사용자의 비율입니다."
+    }
+  ]
+}
+ㅌ`
+
+
+### 9. 문제 세트 수정 성공 - 힌트 없이 수정
+# 기대 결과:
+# - 소문제는 수정됩니다.
+# - hint가 빈 문자열이므로 힌트 수정/생성은 건너뜁니다.
+# - 기존 힌트가 빈 값으로 덮어쓰기 되지 않아야 합니다.
+PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
+Accept: application/json
+Content-Type: application/json
+Cookie: accessToken={{accessToken}}
+
+{
+  "title": "힌트 수정 없이 문제 세트 수정",
+  "categoryName": "테스트 데이터 분석",
+  "description": "힌트가 비어 있을 때 힌트 처리를 건너뛰는지 확인합니다.",
   "dataFileName": null,
   "problems": [
     {
-      "title": "",
-      "content": "문제 내용",
+      "problemId": {{updateProblemId}},
+      "title": "힌트 없이 수정되는 소문제",
+      "content": "힌트 없이도 소문제 정보만 수정되는지 확인합니다.",
       "point": 10,
       "startCode": null,
       "answer": "정답",
-      "hint": "힌트",
-      "explanation": "해설"
+      "hintId": null,
+      "hint": "",
+      "explanation": "hint가 비어 있으면 힌트 생성과 수정은 수행하지 않습니다."
     }
   ]
 }
 
-### 문제 세트 등록 실패 - 소문제 내용 없음
+
+### 10. 문제 세트 수정 실패 - 존재하지 않는 문제 세트
 # 기대 결과:
-# - 첫 번째 소문제의 content가 빈 문자열이므로 실패합니다.
-POST {{baseUrl}}/api/v1/problems
+# - problemSetId=999999가 없으므로 실패해야 합니다.
+PUT {{baseUrl}}/api/v1/problems/999999
 Accept: application/json
 Content-Type: application/json
+Cookie: accessToken={{accessToken}}
 
 {
-  "title": "소문제 내용 검증 세트",
-  "categoryName": "데이터 분석",
-  "description": "소문제 내용 검증 실패 확인용 요청입니다.",
+  "title": "존재하지 않는 문제 세트 수정",
+  "categoryName": "테스트 데이터 분석",
+  "description": "실패해야 하는 요청입니다.",
   "dataFileName": null,
   "problems": [
     {
-      "title": "문제 제목",
-      "content": "",
+      "problemId": null,
+      "title": "소문제",
+      "content": "내용",
       "point": 10,
       "startCode": null,
       "answer": "정답",
+      "hintId": null,
       "hint": "힌트",
       "explanation": "해설"
     }
   ]
 }
 
-### 문제 세트 등록 실패 - 소문제 정답 없음
+
+### 11. 문제 세트 수정 실패 - 카테고리 없음
 # 기대 결과:
-# - 첫 번째 소문제의 answer가 빈 문자열이므로 실패합니다.
-POST {{baseUrl}}/api/v1/problems
+# - categoryName이 비어 있으므로 실패해야 합니다.
+PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
 Accept: application/json
 Content-Type: application/json
+Cookie: accessToken={{accessToken}}
 
 {
-  "title": "소문제 정답 검증 세트",
-  "categoryName": "데이터 분석",
-  "description": "소문제 정답 검증 실패 확인용 요청입니다.",
+  "title": "카테고리 없는 수정 요청",
+  "categoryName": "",
+  "description": "실패해야 하는 요청입니다.",
   "dataFileName": null,
   "problems": [
     {
-      "title": "문제 제목",
-      "content": "문제 내용",
+      "problemId": {{updateProblemId}},
+      "title": "소문제",
+      "content": "내용",
       "point": 10,
       "startCode": null,
-      "answer": "",
+      "answer": "정답",
+      "hintId": null,
       "hint": "힌트",
       "explanation": "해설"
     }
   ]
 }
+
+
+### 12. 문제 세트 수정 실패 - 소문제 없음
+# 기대 결과:
+# - problems가 빈 배열이므로 실패해야 합니다.
+PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
+Accept: application/json
+Content-Type: application/json
+Cookie: accessToken={{accessToken}}
+
+{
+  "title": "소문제 없는 수정 요청",
+  "categoryName": "테스트 데이터 분석",
+  "description": "실패해야 하는 요청입니다.",
+  "dataFileName": null,
+  "problems": []
+}
+
+
+### 13. 수정 후 DB 확인용 쿼리
+# 아래 쿼리는 MySQL Workbench에서 실행하세요.
+#
+# SELECT * FROM problem_set WHERE problem_set_id = 2001;
+#
+# SELECT *
+# FROM problem
+# WHERE problem_set_id = 2001
+# ORDER BY problem_order;
+#
+# SELECT h.*
+# FROM problem_hint h
+# JOIN problem p ON h.problem_id = p.problem_id
+# WHERE p.problem_set_id = 2001
+# ORDER BY h.hint_id;

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/problem-set.http
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/problem-set.http
@@ -256,7 +256,7 @@ Cookie: accessToken={{accessToken}}
     }
   ]
 }
-ㅌ`
+
 
 
 ### 9. 문제 세트 수정 성공 - 힌트 없이 수정
@@ -380,3 +380,93 @@ Cookie: accessToken={{accessToken}}
 # JOIN problem p ON h.problem_id = p.problem_id
 # WHERE p.problem_set_id = 2001
 # ORDER BY h.hint_id;
+
+
+### 14. 문제 세트 삭제 성공 - 제출 기록이 없는 문제 세트 비활성화
+# 목적:
+# - 제출 기록이 없는 문제 세트를 삭제 요청했을 때 바로 비활성화되는지 확인합니다.
+#
+# 실행 전 확인:
+# - problem_set_id=2003에 제출 기록이 없어야 합니다.
+# - 제출 기록이 있으면 409 PROBLEM_HAS_SUBMISSION이 나올 수 있습니다.
+#
+# 기대 결과:
+# - HTTP 200
+# - problem_set.status = INACTIVE
+# - 해당 problem_set에 속한 problem.status = INACTIVE
+#
+# DB 확인:
+# SELECT problem_set_id, title, status
+# FROM problem_set
+# WHERE problem_set_id = 2003;
+#
+# SELECT problem_id, problem_set_id, title, status
+# FROM problem
+# WHERE problem_set_id = 2003
+# ORDER BY problem_order;
+DELETE {{baseUrl}}/api/v1/problems/2003
+Accept: application/json
+Cookie: accessToken={{accessToken}}
+
+
+### 15. 문제 세트 삭제 실패 - 제출 기록이 있어 확인이 필요한 경우
+# 목적:
+# - 제출 기록이 있는 문제 세트는 바로 비활성화하지 않고 409로 막는지 확인합니다.
+# - 프론트는 이 응답을 보고 "제출 기록이 있습니다. 그래도 비활성화하시겠습니까?" 경고창을 띄우면 됩니다.
+#
+# 실행 전 확인:
+# - problem_set_id=2001에 submission 기록이 있어야 합니다.
+#
+# 기대 결과:
+# - HTTP 409
+# - errorCode = PROBLEM_HAS_SUBMISSION
+# - message = 제출 기록이 존재합니다.
+DELETE {{baseUrl}}/api/v1/problems/2001
+Accept: application/json
+Cookie: accessToken={{accessToken}}
+
+
+### 16. 문제 세트 삭제 성공 - 제출 기록이 있지만 확인 후 강제 비활성화
+# 목적:
+# - 프론트 경고창에서 확인 버튼을 누른 뒤 force=true로 다시 요청하는 상황을 확인합니다.
+#
+# 기대 결과:
+# - HTTP 200
+# - problem_set.status = INACTIVE
+# - 해당 problem_set에 속한 problem.status = INACTIVE
+#
+# DB 확인:
+# SELECT problem_set_id, title, status
+# FROM problem_set
+# WHERE problem_set_id = 2001;
+#
+# SELECT problem_id, problem_set_id, title, status
+# FROM problem
+# WHERE problem_set_id = 2001
+# ORDER BY problem_order;
+DELETE {{baseUrl}}/api/v1/problems/2001?force=true
+Accept: application/json
+Cookie: accessToken={{accessToken}}
+
+
+### 17. 문제 세트 삭제 실패 - 존재하지 않는 문제 세트
+# 목적:
+# - 존재하지 않는 문제 세트를 삭제하려고 할 때 404가 내려오는지 확인합니다.
+#
+# 기대 결과:
+# - HTTP 404
+# - errorCode = PROBLEM_SET_NOT_FOUND
+DELETE {{baseUrl}}/api/v1/problems/999999
+Accept: application/json
+Cookie: accessToken={{accessToken}}
+
+
+### 18. 삭제 후 목록 조회 - 비활성화된 문제 세트가 목록에서 빠지는지 확인
+# 목적:
+# - 삭제된 문제 세트가 문제 세트 목록 조회에서 보이지 않는지 확인합니다.
+#
+# 기대 결과:
+# - status = ACTIVE인 문제 세트만 조회됩니다.
+# - 2001 또는 2003을 삭제했다면 해당 문제 세트는 목록에 나오지 않아야 합니다.
+GET {{baseUrl}}/api/v1/problem-sets?categoryId={{categoryId}}
+Accept: application/json

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetDeleteService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetDeleteService.java
@@ -1,0 +1,59 @@
+package com.wanted.codebombalms.domain.problems.set.service;
+
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
+import com.wanted.codebombalms.domain.problems.problem.repository.ProblemRepository;
+import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetDeleteResponse;
+import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
+import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
+import com.wanted.codebombalms.domain.submission.repository.SubmissionRepository;
+import com.wanted.codebombalms.global.error.exception.ConflictException;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class ProblemSetDeleteService {
+
+    private final ProblemSetRepository problemSetRepository;
+    private final ProblemRepository problemRepository;
+    private final SubmissionRepository submissionRepository;
+
+    public ProblemSetDeleteService(
+            ProblemSetRepository problemSetRepository,
+            ProblemRepository problemRepository,
+            SubmissionRepository submissionRepository
+    ) {
+        this.problemSetRepository = problemSetRepository;
+        this.problemRepository = problemRepository;
+        this.submissionRepository = submissionRepository;
+    }
+
+    @Transactional
+    public ProblemSetDeleteResponse deactivateProblemSet(Long problemSetId, boolean force) {
+        ProblemSet problemSet = problemSetRepository.findById(problemSetId)
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
+
+        boolean hasSubmission = submissionRepository.existsByProblem_ProblemSet_ProblemSetId(problemSetId);
+
+        if (hasSubmission && !force) {
+            throw new ConflictException(ProblemErrorCode.PROBLEM_HAS_SUBMISSION);
+        }
+
+        List<Problem> problems = problemRepository.findByProblemSet_ProblemSetIdAndStatusOrderByProblemOrderAsc(
+                problemSetId,
+                "ACTIVE"
+        );
+
+        problemSet.deactivate();
+        problems.forEach(Problem::deactivate);
+
+        return new ProblemSetDeleteResponse(
+                problemSet.getProblemSetId(),
+                "INACTIVE",
+                problems.size()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetRegistrationService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetRegistrationService.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.domain.problems.set.service;
 
 import com.wanted.codebombalms.domain.problems.category.entity.ProblemCategory;
 import com.wanted.codebombalms.domain.problems.category.service.ProblemCategoryService;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.domain.problems.hint.service.ProblemHintService;
 import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
 import com.wanted.codebombalms.domain.problems.problem.service.ProblemService;
@@ -10,6 +11,7 @@ import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemSetCreateR
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetCreateResponse;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
 import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,15 +77,15 @@ public class ProblemSetRegistrationService {
 
     private void validateCreateRequest(ProblemSetCreateRequest request) {
         if (request.title() == null || request.title().isBlank()) {
-            throw new IllegalArgumentException("문제 세트 제목은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_SET_TITLE_REQUIRED);
         }
 
         if (request.categoryName() == null || request.categoryName().isBlank()) {
-            throw new IllegalArgumentException("카테고리는 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_CATEGORY_REQUIRED);
         }
 
         if (request.problems() == null || request.problems().isEmpty()) {
-            throw new IllegalArgumentException("소문제는 1개 이상 등록해야 합니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_REQUIRED);
         }
 
         for (ProblemCreateRequest problem : request.problems()) {
@@ -93,15 +95,15 @@ public class ProblemSetRegistrationService {
 
     private void validateProblemRequest(ProblemCreateRequest problem) {
         if (problem.title() == null || problem.title().isBlank()) {
-            throw new IllegalArgumentException("소문제 제목은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TITLE_REQUIRED);
         }
 
         if (problem.content() == null || problem.content().isBlank()) {
-            throw new IllegalArgumentException("소문제 내용은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_CONTENT_REQUIRED);
         }
 
         if (problem.answer() == null || problem.answer().isBlank()) {
-            throw new IllegalArgumentException("소문제 정답은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_ANSWER_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetUpdateService.java
@@ -1,0 +1,129 @@
+package com.wanted.codebombalms.domain.problems.set.service;
+
+import com.wanted.codebombalms.domain.problems.category.entity.ProblemCategory;
+import com.wanted.codebombalms.domain.problems.category.service.ProblemCategoryService;
+import com.wanted.codebombalms.domain.problems.hint.service.ProblemHintService;
+import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
+import com.wanted.codebombalms.domain.problems.problem.service.ProblemService;
+import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemUpdateRequest;
+import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemSetUpdateRequest;
+import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetUpdateResponse;
+import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
+import com.wanted.codebombalms.domain.problems.set.exception.SetNotFoundException;
+import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProblemSetUpdateService {
+
+    private final ProblemSetRepository problemSetRepository;
+    private final ProblemCategoryService problemCategoryService;
+    private final ProblemService problemService;
+    private final ProblemHintService problemHintService;
+
+    public ProblemSetUpdateService(
+            ProblemSetRepository problemSetRepository,
+            ProblemCategoryService problemCategoryService,
+            ProblemService problemService,
+            ProblemHintService problemHintService
+    ) {
+        this.problemSetRepository = problemSetRepository;
+        this.problemCategoryService = problemCategoryService;
+        this.problemService = problemService;
+        this.problemHintService = problemHintService;
+    }
+
+    @Transactional
+    public ProblemSetUpdateResponse updateProblemSet(Long problemSetId, ProblemSetUpdateRequest request) {
+        validateUpdateRequest(request);
+
+        ProblemSet problemSet = problemSetRepository.findById(problemSetId)
+                .orElseThrow(() -> new SetNotFoundException("존재하지 않는 문제 세트입니다."));
+
+        ProblemCategory category = problemCategoryService.findOrCreateActiveCategory(
+                request.categoryName()
+        );
+
+        problemSet.update(
+                category,
+                request.title(),
+                request.description()
+        );
+
+        int updatedProblemCount = 0;
+
+        for (int i = 0; i < request.problems().size(); i++) {
+            ProblemUpdateRequest problemRequest = request.problems().get(i);
+            Problem problem = updateOrCreateProblem(problemSet, problemRequest, i + 1);
+            updateOrCreateHint(problem, problemRequest);
+            updatedProblemCount++;
+        }
+
+        problemSet.updateTotalProblemCount(request.problems().size());
+
+        return new ProblemSetUpdateResponse(
+                problemSet.getProblemSetId(),
+                problemSet.getTitle(),
+                problemSet.getCategory().getCategoryName(),
+                updatedProblemCount
+        );
+    }
+
+    private Problem updateOrCreateProblem(
+            ProblemSet problemSet,
+            ProblemUpdateRequest problemRequest,
+            Integer problemOrder
+    ) {
+        if (problemRequest.problemId() == null) {
+            return problemService.createProblem(problemSet, problemRequest, problemOrder);
+        }
+
+        return problemService.updateProblem(problemSet.getProblemSetId(), problemRequest);
+    }
+
+    private void updateOrCreateHint(Problem problem, ProblemUpdateRequest problemRequest) {
+        if (problemRequest.hint() == null || problemRequest.hint().isBlank()) {
+            return;
+        }
+
+        if (problemRequest.hintId() == null) {
+            problemHintService.createHint(problem, problemRequest.hint());
+            return;
+        }
+
+        problemHintService.updateHint(problem, problemRequest.hintId(), problemRequest.hint());
+    }
+
+    private void validateUpdateRequest(ProblemSetUpdateRequest request) {
+        if (request.title() == null || request.title().isBlank()) {
+            throw new IllegalArgumentException("문제 세트 제목은 필수입니다.");
+        }
+
+        if (request.categoryName() == null || request.categoryName().isBlank()) {
+            throw new IllegalArgumentException("카테고리는 필수입니다.");
+        }
+
+        if (request.problems() == null || request.problems().isEmpty()) {
+            throw new IllegalArgumentException("소문제는 1개 이상 필요합니다.");
+        }
+
+        for (ProblemUpdateRequest problem : request.problems()) {
+            validateProblemRequest(problem);
+        }
+    }
+
+    private void validateProblemRequest(ProblemUpdateRequest problem) {
+        if (problem.title() == null || problem.title().isBlank()) {
+            throw new IllegalArgumentException("소문제 제목은 필수입니다.");
+        }
+
+        if (problem.content() == null || problem.content().isBlank()) {
+            throw new IllegalArgumentException("소문제 내용은 필수입니다.");
+        }
+
+        if (problem.answer() == null || problem.answer().isBlank()) {
+            throw new IllegalArgumentException("소문제 정답은 필수입니다.");
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetUpdateService.java
@@ -2,15 +2,17 @@ package com.wanted.codebombalms.domain.problems.set.service;
 
 import com.wanted.codebombalms.domain.problems.category.entity.ProblemCategory;
 import com.wanted.codebombalms.domain.problems.category.service.ProblemCategoryService;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.domain.problems.hint.service.ProblemHintService;
 import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
 import com.wanted.codebombalms.domain.problems.problem.service.ProblemService;
-import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemUpdateRequest;
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemSetUpdateRequest;
+import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemUpdateRequest;
 import com.wanted.codebombalms.domain.problems.set.dto.response.ProblemSetUpdateResponse;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
-import com.wanted.codebombalms.domain.problems.set.exception.SetNotFoundException;
 import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,7 +41,7 @@ public class ProblemSetUpdateService {
         validateUpdateRequest(request);
 
         ProblemSet problemSet = problemSetRepository.findById(problemSetId)
-                .orElseThrow(() -> new SetNotFoundException("존재하지 않는 문제 세트입니다."));
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
 
         ProblemCategory category = problemCategoryService.findOrCreateActiveCategory(
                 request.categoryName()
@@ -97,15 +99,15 @@ public class ProblemSetUpdateService {
 
     private void validateUpdateRequest(ProblemSetUpdateRequest request) {
         if (request.title() == null || request.title().isBlank()) {
-            throw new IllegalArgumentException("문제 세트 제목은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_SET_TITLE_REQUIRED);
         }
 
         if (request.categoryName() == null || request.categoryName().isBlank()) {
-            throw new IllegalArgumentException("카테고리는 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_CATEGORY_REQUIRED);
         }
 
         if (request.problems() == null || request.problems().isEmpty()) {
-            throw new IllegalArgumentException("소문제는 1개 이상 필요합니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_REQUIRED);
         }
 
         for (ProblemUpdateRequest problem : request.problems()) {
@@ -115,15 +117,15 @@ public class ProblemSetUpdateService {
 
     private void validateProblemRequest(ProblemUpdateRequest problem) {
         if (problem.title() == null || problem.title().isBlank()) {
-            throw new IllegalArgumentException("소문제 제목은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TITLE_REQUIRED);
         }
 
         if (problem.content() == null || problem.content().isBlank()) {
-            throw new IllegalArgumentException("소문제 내용은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_CONTENT_REQUIRED);
         }
 
         if (problem.answer() == null || problem.answer().isBlank()) {
-            throw new IllegalArgumentException("소문제 정답은 필수입니다.");
+            throw new ValidationException(ProblemErrorCode.PROBLEM_ANSWER_REQUIRED);
         }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/domain/submission/exception/SubmissionErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/submission/exception/SubmissionErrorCode.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SubmissionErrorCode implements ErrorCode {
 
-    INVALID_ANSWER(400, "S-001", "답변 내용이 비어있습니다."),
-    PROBLEM_NOT_RETRIABLE(400, "S-002", "재시도할 수 없는 문제입니다.");
+    INVALID_ANSWER(400, "PROBLEM_INVALID_ANSWER", "답안 값이 비어 있습니다."),
+    PROBLEM_NOT_RETRIABLE(400, "PROBLEM_NOT_RETRIABLE", "재시도할 수 없는 문제입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/wanted/codebombalms/domain/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/submission/repository/SubmissionRepository.java
@@ -13,4 +13,6 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
             Long userId,
             Long problemId
     );
+
+    boolean existsByProblem_ProblemSet_ProblemSetId(Long problemSetId);
 }

--- a/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                         // 관리자 전용
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         // 그 외 모두 인증 필요
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider),


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #94 
- Closes #95

---

## 🛠️ 기능 관련 작업 내용

- 문제 세트 수정 기능을 구현했습니다.
- 문제 세트 수정 시 카테고리, 문제 세트 정보, 소문제, 힌트를 함께 수정할 수 있도록 처리했습니다.
- 기존 소문제는 수정하고, `problemId`가 없는 소문제는 새로 추가되도록 구현했습니다.
- 기존 힌트는 수정하고, `hintId`가 없는 힌트는 새로 추가되도록 구현했습니다.
- 문제 세트 삭제는 실제 삭제가 아니라 `status = INACTIVE` 비활성화 방식으로 구현했습니다.
- 문제 세트 비활성화 시 연결된 소문제도 함께 `INACTIVE` 처리되도록 구현했습니다.
- 제출 기록이 있는 문제 세트는 기본 삭제 요청 시 `PROBLEM_HAS_SUBMISSION` 예외를 반환하도록 처리했습니다.
- 프론트에서 확인 후 `force=true`로 다시 요청하면 제출 기록이 있어도 비활성화되도록 처리했습니다.
- 문제 관련 예외 코드를 API 명세서의 `PROBLEM_` prefix 기준으로 정리했습니다.
- problem-set.http에 수정/삭제 테스트 케이스를 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `domain/problems/problem/controller/ProblemManageController` : 문제 세트 수정 및 비활성화 API 요청 처리 추가
- `domain/problems/set/service/ProblemSetUpdateService` : 문제 세트, 소문제, 힌트 수정 로직 구현
- `domain/problems/set/service/ProblemSetDeleteService` : 문제 세트 및 소문제 비활성화 로직 구현
- `domain/problems/set/dto/response/ProblemSetUpdateResponse` : 문제 세트 수정 응답 DTO 사용
- `domain/problems/set/dto/response/ProblemSetDeleteResponse` : 문제 세트 비활성화 응답 DTO 추가
- `domain/problems/exception/ProblemErrorCode` : 문제 도메인 에러 코드 정리 및 추가
- `domain/submission/repository/SubmissionRepository` : 문제 세트 제출 기록 존재 여부 조회 메서드 추가
- `domain/problems/set/problem-set.http` : 문제 세트 수정/삭제 API 테스트 케이스 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.
