### PR TITLE
[Feat] 관리자 알림 조회 및 상태 변경 API

### DIFF
--- a/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/entity/AutomationRule.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/entity/AutomationRule.java
@@ -1,0 +1,76 @@
+package com.wanted.codebombalms.domain.admin.automationrule.entity;
+
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationRuleCode;
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationSeverity;
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationTargetType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "automation_rule")
+@Getter
+@NoArgsConstructor
+public class AutomationRule {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "operation_rule_id")
+    private Long operationRuleId;
+
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "rule_code", nullable = false)
+    private OperationRuleCode ruleCode;
+
+    @Column(name = "rule_name", nullable = false, length = 100)
+    private String ruleName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private OperationTargetType targetType;
+
+    @Column(name = "threshold_value", nullable = false, precision = 10, scale = 2)
+    private BigDecimal thresholdValue;
+
+    @Column(name = "min_sample_count")
+    private Integer minSampleCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", nullable = false)
+    private OperationSeverity severity;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled = true;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void delete() {
+        this.enabled = false;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/enums/OperationRuleCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/enums/OperationRuleCode.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.domain.admin.automationrule.enums;
+
+public enum OperationRuleCode {
+    COURSE_LOW_ENROLLMENT,
+    USER_INACTIVE_NO_COURSE,
+    PROBLEM_HIGH_WRONG_RATE
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/enums/OperationSeverity.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/enums/OperationSeverity.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.domain.admin.automationrule.enums;
+
+public enum OperationSeverity {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/enums/OperationTargetType.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/automationrule/enums/OperationTargetType.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.domain.admin.automationrule.enums;
+
+public enum OperationTargetType {
+    COURSE,
+    USER,
+    PROBLEM
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/automationalert.http
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/automationalert.http
@@ -1,0 +1,235 @@
+@baseUrl = http://localhost:8080
+@adminAccessToken = 여기에_관리자_ACCESS_TOKEN_입력
+@operationAlertId = 1
+@resolvedBy = 1
+
+### =========================================================
+### 운영 알림 목록 조회 - 전체
+### 응답 data 페이징 필드:
+### content, page, size, totalElements, totalPages,
+### first, last, hasNext, hasPrevious
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 문제 알림
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=PROBLEM&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 학생 알림
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=USER&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 강좌 알림
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=COURSE&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - OPEN 상태
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?status=OPEN&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - RESOLVED 상태
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?status=RESOLVED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - IGNORED 상태
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?status=IGNORED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 문제 + OPEN
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=PROBLEM&status=OPEN&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 문제 + RESOLVED
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=PROBLEM&status=RESOLVED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 문제 + IGNORED
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=PROBLEM&status=IGNORED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 학생 + OPEN
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=USER&status=OPEN&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 학생 + RESOLVED
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=USER&status=RESOLVED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 학생 + IGNORED
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=USER&status=IGNORED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 강좌 + OPEN
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=COURSE&status=OPEN&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 강좌 + RESOLVED
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=COURSE&status=RESOLVED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 강좌 + IGNORED
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=COURSE&status=IGNORED&page=0&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 페이지 변경
+### page=1은 두 번째 페이지
+### size=10은 한 페이지당 10개 조회
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?targetType=PROBLEM&page=1&size=10
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 작은 사이즈 테스트
+### totalPages, hasNext, hasPrevious 확인용
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?page=0&size=3
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 두 번째 페이지 테스트
+### first=false, hasPrevious=true 확인용
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?page=1&size=3
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 잘못된 page 요청
+### 기대 결과: INVALID_PAGE_REQUEST
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?page=-1&size=20
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - 잘못된 size 요청
+### 기대 결과: INVALID_PAGE_REQUEST
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?page=0&size=0
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 목록 조회 - size 최대값 초과
+### 기대 결과: INVALID_PAGE_REQUEST
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?page=0&size=101
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 상세 조회
+### 상세 조회 구현한 경우 사용
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts/{{operationAlertId}}
+Cookie: accessToken={{adminAccessToken}}
+
+
+### =========================================================
+### 운영 알림 상태 변경 - 처리 완료 RESOLVED
+### OPEN 상태 알림에만 사용
+### =========================================================
+PATCH {{baseUrl}}/api/v1/admin/operation-alerts/{{operationAlertId}}/status
+Content-Type: application/json
+Cookie: accessToken={{adminAccessToken}}
+
+{
+  "status": "RESOLVED",
+  "adminMemo": "문제 해설을 수정했고 테스트 완료",
+  "resolvedBy": {{resolvedBy}}
+}
+
+
+### =========================================================
+### 운영 알림 상태 변경 - 무시 IGNORED
+### OPEN 상태 알림에만 사용
+### =========================================================
+PATCH {{baseUrl}}/api/v1/admin/operation-alerts/{{operationAlertId}}/status
+Content-Type: application/json
+Cookie: accessToken={{adminAccessToken}}
+
+{
+  "status": "IGNORED",
+  "adminMemo": "현재 수치 확인 결과 조치 불필요",
+  "resolvedBy": {{resolvedBy}}
+}
+
+
+### =========================================================
+### 운영 알림 상태 변경 - 잘못된 상태 OPEN 요청
+### 기대 결과: INVALID_STATUS_UPDATE_REQUEST
+### 처리 API에서는 RESOLVED 또는 IGNORED만 허용
+### =========================================================
+PATCH {{baseUrl}}/api/v1/admin/operation-alerts/{{operationAlertId}}/status
+Content-Type: application/json
+Cookie: accessToken={{adminAccessToken}}
+
+{
+  "status": "OPEN",
+  "adminMemo": "잘못된 상태 변경 테스트",
+  "resolvedBy": {{resolvedBy}}
+}
+
+
+### =========================================================
+### 운영 알림 상태 변경 - resolvedBy 누락
+### 기대 결과: INVALID_STATUS_UPDATE_REQUEST
+### =========================================================
+PATCH {{baseUrl}}/api/v1/admin/operation-alerts/{{operationAlertId}}/status
+Content-Type: application/json
+Cookie: accessToken={{adminAccessToken}}
+
+{
+  "status": "RESOLVED",
+  "adminMemo": "resolvedBy 누락 테스트"
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/controller/OperationAlertController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/controller/OperationAlertController.java
@@ -1,0 +1,57 @@
+package com.wanted.codebombalms.domain.admin.operationalert.controller;
+
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationTargetType;
+import com.wanted.codebombalms.domain.admin.operationalert.dto.request.OperationAlertStatusUpdateRequest;
+import com.wanted.codebombalms.domain.admin.operationalert.enums.OperationAlertStatus;
+import com.wanted.codebombalms.domain.admin.operationalert.service.OperationAlertService;
+import com.wanted.codebombalms.global.common.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/admin/operation-alerts")
+@RequiredArgsConstructor
+public class OperationAlertController {
+
+    private final OperationAlertService operationAlertService;
+    private static final Logger log = LoggerFactory.getLogger(OperationAlertController.class);
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO> findOperationAlerts(
+            @RequestParam(required = false) OperationTargetType targetType,
+            @RequestParam(required = false) OperationAlertStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        log.info("[OperationAlertController] 운영 알림 목록 조회 요청 - targetType: {}, status: {}, page: {}, size: {}",
+                targetType, status, page, size);
+
+        return ResponseEntity.ok(new ResponseDTO(
+                HttpStatus.OK,
+                "운영 알림 목록 조회 성공",
+                operationAlertService.findOperationAlerts(targetType, status, page, size)
+        ));
+    }
+
+    @PatchMapping("/{operationAlertId}/status")
+    public ResponseEntity<ResponseDTO> updateOperationAlertStatus(
+            @PathVariable Long operationAlertId,
+            @RequestBody OperationAlertStatusUpdateRequest request
+    ) {
+        log.info("[OperationAlertController] 운영 알림 상태 변경 요청 - operationAlertId: {}, status: {}, resolvedBy: {}",
+                operationAlertId,
+                request == null ? null : request.getStatus(),
+                request == null ? null : request.getResolvedBy()
+        );
+
+        return ResponseEntity.ok(new ResponseDTO(
+                HttpStatus.OK,
+                "운영 알림 처리에 성공했습니다.",
+                operationAlertService.updateOperationAlertStatus(operationAlertId, request)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/request/OperationAlertStatusUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/request/OperationAlertStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.domain.admin.operationalert.dto.request;
+
+import com.wanted.codebombalms.domain.admin.operationalert.enums.OperationAlertStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OperationAlertStatusUpdateRequest {
+
+    private OperationAlertStatus status;
+
+    private String adminMemo;
+
+    private Long resolvedBy;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/response/OperationAlertListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/response/OperationAlertListResponse.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.domain.admin.operationalert.dto.response;
+
+import com.wanted.codebombalms.domain.admin.operationalert.entity.OperationAlert;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OperationAlertListResponse {
+
+    private List<OperationAlertResponse> content;
+
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+
+    private boolean first;
+    private boolean last;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    public static OperationAlertListResponse from(Page<OperationAlert> alertPage) {
+        List<OperationAlertResponse> content = alertPage.getContent()
+                .stream()
+                .map(OperationAlertResponse::from)
+                .toList();
+
+        return new OperationAlertListResponse(
+                content,
+                alertPage.getNumber(),
+                alertPage.getSize(),
+                alertPage.getTotalElements(),
+                alertPage.getTotalPages(),
+                alertPage.isFirst(),
+                alertPage.isLast(),
+                alertPage.hasNext(),
+                alertPage.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/response/OperationAlertResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/response/OperationAlertResponse.java
@@ -1,0 +1,50 @@
+package com.wanted.codebombalms.domain.admin.operationalert.dto.response;
+
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationSeverity;
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationTargetType;
+import com.wanted.codebombalms.domain.admin.operationalert.entity.OperationAlert;
+import com.wanted.codebombalms.domain.admin.operationalert.enums.OperationAlertStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OperationAlertResponse {
+
+    private Long operationAlertId;
+    private Long operationRuleId;
+    private OperationTargetType targetType;
+    private Long targetId;
+    private BigDecimal detectedValue;
+    private BigDecimal thresholdValueSnapshot;
+    private OperationSeverity severity;
+    private OperationAlertStatus status;
+    private Long assigneeId;
+    private String reason;
+    private String recommendedAction;
+    private LocalDateTime firstDetectedAt;
+    private LocalDateTime lastDetectedAt;
+
+    public static OperationAlertResponse from(OperationAlert alert) {
+        return new OperationAlertResponse(
+                alert.getOperationAlertId(),
+                alert.getAutomationRule().getOperationRuleId(),
+                alert.getTargetType(),
+                alert.getTargetId(),
+                alert.getDetectedValue(),
+                alert.getThresholdValueSnapshot(),
+                alert.getAutomationRule().getSeverity(),
+                alert.getStatus(),
+                alert.getAssigneeId(),
+                alert.getReason(),
+                alert.getRecommendedAction(),
+                alert.getFirstDetectedAt(),
+                alert.getLastDetectedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/response/OperationAlertStatusUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/dto/response/OperationAlertStatusUpdateResponse.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.domain.admin.operationalert.dto.response;
+
+import com.wanted.codebombalms.domain.admin.operationalert.entity.OperationAlert;
+import com.wanted.codebombalms.domain.admin.operationalert.enums.OperationAlertStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OperationAlertStatusUpdateResponse {
+
+    private Long operationAlertId;
+    private OperationAlertStatus status;
+    private String adminMemo;
+    private Long resolvedBy;
+    private LocalDateTime resolvedAt;
+
+    public static OperationAlertStatusUpdateResponse from(OperationAlert operationAlert) {
+        return new OperationAlertStatusUpdateResponse(
+                operationAlert.getOperationAlertId(),
+                operationAlert.getStatus(),
+                operationAlert.getAdminMemo(),
+                operationAlert.getResolvedBy(),
+                operationAlert.getResolvedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/entity/OperationAlert.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/entity/OperationAlert.java
@@ -1,0 +1,120 @@
+package com.wanted.codebombalms.domain.admin.operationalert.entity;
+
+import com.wanted.codebombalms.domain.admin.automationrule.entity.AutomationRule;
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationTargetType;
+import com.wanted.codebombalms.domain.admin.operationalert.enums.OperationAlertStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "operation_alert")
+@Getter
+@NoArgsConstructor
+public class OperationAlert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "operation_alert_id")
+    private Long operationAlertId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "operation_rule_id", nullable = false)
+    private AutomationRule automationRule;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private OperationTargetType targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "detected_value", nullable = false, precision = 10, scale = 2)
+    private BigDecimal detectedValue;
+
+    @Column(name = "threshold_value_snapshot", nullable = false, precision = 10, scale = 2)
+    private BigDecimal thresholdValueSnapshot;
+
+    @Column(name = "assignee_id")
+    private Long assigneeId;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @Column(name = "recommended_action", length = 500)
+    private String recommendedAction;
+
+    @Column(name = "first_detected_at", nullable = false)
+    private LocalDateTime firstDetectedAt;
+
+    @Column(name = "last_detected_at", nullable = false)
+    private LocalDateTime lastDetectedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private OperationAlertStatus status;
+
+    @Column(name = "resolved_by")
+    private Long resolvedBy;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    @Column(name = "admin_memo", length = 500)
+    private String adminMemo;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+
+        this.createdAt = now;
+
+        if (this.firstDetectedAt == null) {
+            this.firstDetectedAt = now;
+        }
+
+        if (this.lastDetectedAt == null) {
+            this.lastDetectedAt = now;
+        }
+
+        if (this.status == null) {
+            this.status = OperationAlertStatus.OPEN;
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void process(
+            OperationAlertStatus status,
+            Long resolvedBy,
+            String adminMemo
+    ) {
+        this.status = status;
+        this.resolvedBy = resolvedBy;
+        this.resolvedAt = LocalDateTime.now();
+        this.adminMemo = adminMemo;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateDetectedValue(BigDecimal detectedValue, String reason, String recommendedAction) {
+        this.detectedValue = detectedValue;
+        this.reason = reason;
+        this.recommendedAction = recommendedAction;
+        this.lastDetectedAt = LocalDateTime.now();
+    }
+
+
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/enums/OperationAlertStatus.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/enums/OperationAlertStatus.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.domain.admin.operationalert.enums;
+
+public enum OperationAlertStatus {
+    OPEN,       // 미처리
+    RESOLVED,   // 처리 완료
+    IGNORED     // 조치 불필요 / 무시
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/exception/OperationAlertErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/exception/OperationAlertErrorCode.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.domain.admin.operationalert.exception;
+
+import com.wanted.codebombalms.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OperationAlertErrorCode implements ErrorCode {
+
+    INVALID_SEARCH_CONDITION(400, "OA-001", "알림 조회 조건이 올바르지 않습니다."),
+    INVALID_PAGE_REQUEST(400, "OA-002", "페이지 요청 값이 올바르지 않습니다."),
+    OPERATION_ALERT_NOT_FOUND(404, "OA-003", "운영 알림을 찾을 수 없습니다."),
+    INVALID_STATUS_UPDATE_REQUEST(400, "OA-004", "운영 알림 상태 변경 요청이 올바르지 않습니다."),
+    ALREADY_PROCESSED_ALERT(400, "OA-005", "이미 처리된 운영 알림입니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/repository/OperationAlertRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/repository/OperationAlertRepository.java
@@ -1,0 +1,34 @@
+package com.wanted.codebombalms.domain.admin.operationalert.repository;
+
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationTargetType;
+import com.wanted.codebombalms.domain.admin.operationalert.entity.OperationAlert;
+import com.wanted.codebombalms.domain.admin.operationalert.enums.OperationAlertStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OperationAlertRepository extends JpaRepository<OperationAlert, Long> {
+
+    @Query(
+            value = """
+                    select oa
+                    from OperationAlert oa
+                    join fetch oa.automationRule ar
+                    where (:targetType is null or oa.targetType = :targetType)
+                      and (:status is null or oa.status = :status)
+                    """,
+            countQuery = """
+                    select count(oa)
+                    from OperationAlert oa
+                    where (:targetType is null or oa.targetType = :targetType)
+                      and (:status is null or oa.status = :status)
+                    """
+    )
+    Page<OperationAlert> findOperationAlerts(
+            @Param("targetType") OperationTargetType targetType,
+            @Param("status") OperationAlertStatus status,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/service/OperationAlertService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operationalert/service/OperationAlertService.java
@@ -1,0 +1,89 @@
+package com.wanted.codebombalms.domain.admin.operationalert.service;
+
+import com.wanted.codebombalms.domain.admin.automationrule.enums.OperationTargetType;
+import com.wanted.codebombalms.domain.admin.operationalert.dto.request.OperationAlertStatusUpdateRequest;
+import com.wanted.codebombalms.domain.admin.operationalert.dto.response.OperationAlertListResponse;
+import com.wanted.codebombalms.domain.admin.operationalert.dto.response.OperationAlertStatusUpdateResponse;
+import com.wanted.codebombalms.domain.admin.operationalert.entity.OperationAlert;
+import com.wanted.codebombalms.domain.admin.operationalert.enums.OperationAlertStatus;
+import com.wanted.codebombalms.domain.admin.operationalert.exception.OperationAlertErrorCode;
+import com.wanted.codebombalms.domain.admin.operationalert.repository.OperationAlertRepository;
+import com.wanted.codebombalms.global.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OperationAlertService {
+
+    private final OperationAlertRepository operationAlertRepository;
+
+    public OperationAlertListResponse findOperationAlerts(
+            OperationTargetType targetType,
+            OperationAlertStatus status,
+            int page,
+            int size
+    ) {
+        if (page < 0 || size <= 0 || size > 100) {
+            throw new ValidationException(OperationAlertErrorCode.INVALID_PAGE_REQUEST);
+        }
+
+        PageRequest pageRequest = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "lastDetectedAt")
+                        .and(Sort.by(Sort.Direction.DESC, "operationAlertId"))
+        );
+
+        Page<OperationAlert> operationAlerts =
+                operationAlertRepository.findOperationAlerts(targetType, status, pageRequest);
+
+        return OperationAlertListResponse.from(operationAlerts);
+    }
+
+    @Transactional
+    public OperationAlertStatusUpdateResponse updateOperationAlertStatus(
+            Long operationAlertId,
+            OperationAlertStatusUpdateRequest request
+    ) {
+        validateStatusUpdateRequest(request);
+
+        OperationAlert operationAlert = operationAlertRepository.findById(operationAlertId)
+                .orElseThrow(() -> new NotFoundException(OperationAlertErrorCode.OPERATION_ALERT_NOT_FOUND));
+
+        if (operationAlert.getStatus() != OperationAlertStatus.OPEN) {
+            throw new ValidationException(OperationAlertErrorCode.ALREADY_PROCESSED_ALERT);
+        }
+
+        operationAlert.process(
+                request.getStatus(),
+                request.getResolvedBy(),
+                request.getAdminMemo()
+        );
+
+        return OperationAlertStatusUpdateResponse.from(operationAlert);
+    }
+
+    private void validateStatusUpdateRequest(OperationAlertStatusUpdateRequest request) {
+        if (request == null
+                || request.getStatus() == null
+                || request.getResolvedBy() == null) {
+            throw new ValidationException(OperationAlertErrorCode.INVALID_STATUS_UPDATE_REQUEST);
+        }
+
+        if (request.getStatus() != OperationAlertStatus.RESOLVED
+                && request.getStatus() != OperationAlertStatus.IGNORED) {
+            throw new ValidationException(OperationAlertErrorCode.INVALID_STATUS_UPDATE_REQUEST);
+        }
+
+        if (request.getAdminMemo() != null && request.getAdminMemo().length() > 500) {
+            throw new ValidationException(OperationAlertErrorCode.INVALID_STATUS_UPDATE_REQUEST);
+        }
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #137 
- Closes #138 

---

## 🛠️ 기능 관련 작업 내용

- 관리자 운영 알림 조회 기능을 구현했습니다.
- 운영 알림을 targetType, status 기준으로 필터링할 수 있도록 수정했습니다.
- 운영 알림 목록 조회에 페이징 정보를 추가했습니다.
     - page, size, totalElements, totalPages, first, last, hasNext, hasPrevious
- 운영 알림 상세 조회 기능을 구현했습니다.
- 운영 알림 상세 조회 시 대상 유형에 따라 강좌, 학생, 문제 정보를 함께 조회하도록 구성했습니다.
- 관리자가 운영 알림을 RESOLVED 또는 IGNORED 상태로 처리할 수 있는 상태 변경 API를 추가했습니다.
- 운영 알림 처리 시 adminMemo, resolvedBy, resolvedAt이 저장되도록 구현했습니다.
- 운영 알림 상태값을 OPEN, RESOLVED, IGNORED 기준으로 정리했습니다.
- 자동화 규칙과 운영 알림 엔티티의 생성일, 수정일 처리 로직을 추가했습니다.



---

## ♻️ 패키지 변경 사항
- admin/automationrule/entity/AutomationRule : 자동화 규칙 엔티티 추가 및 날짜 처리 로직 추가
- admin/automationrule/enums/OperationRuleCode : 운영 자동화 규칙 코드 enum 추가
- admin/automationrule/enums/OperationTargetType : 알림 대상 유형 enum 추가
- admin/automationrule/enums/OperationSeverity : 알림 심각도 enum 추가
- admin/operationalert/controller/OperationAlertController : 운영 알림 목록 조회, 상세 조회, 상태 변경 API 추가
- admin/operationalert/service/OperationAlertService : 운영 알림 조회, 상세 조회, 상태 변경 비즈니스 로직 추가
- admin/operationalert/service/OperationAlertTargetReader : 알림 대상 유형별 상세 정보 조회 로직 추가
- admin/operationalert/repository/OperationAlertRepository : 운영 알림 조회 및 상세 조회 쿼리 추가
- admin/operationalert/entity/OperationAlert : 운영 알림 엔티티 추가 및 처리 상태 변경 메서드 추가
- admin/operationalert/enums/OperationAlertStatus : 운영 알림 상태값 OPEN, RESOLVED, IGNORED로 정리
- admin/operationalert/dto/response/OperationAlertListResponse : 페이징 응답 필드 추가
- admin/operationalert/dto/response/OperationAlertResponse : 운영 알림 목록 응답 DTO 추가
- admin/operationalert/dto/response/OperationAlertDetailResponse : 운영 알림 상세 응답 DTO 추가
- admin/operationalert/dto/response/OperationAlertTargetResponse : 알림 대상 상세 응답 DTO 추가
- admin/operationalert/dto/request/OperationAlertStatusUpdateRequest : 운영 알림 상태 변경 요청 DTO 추가
- admin/operationalert/dto/response/OperationAlertStatusUpdateResponse : 운영 알림 상태 변경 응답 DTO 추가
- admin/operationalert/exception/OperationAlertErrorCode : 운영 알림 관련 에러 코드 추가
변경된 패키지, 클래스, HTML 파일 등을 작성해주세요.



---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
