### PR TITLE
[Feat] 로그인 API api/v1/auth/login 구현

### DIFF
--- a/src/main/java/com/wanted/codebombalms/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/auth/controller/AuthController.java
@@ -1,11 +1,16 @@
 package com.wanted.codebombalms.domain.auth.controller;
 
+import com.wanted.codebombalms.domain.auth.dto.TokenPair;
+import com.wanted.codebombalms.domain.auth.dto.request.LoginRequest;
 import com.wanted.codebombalms.domain.auth.dto.request.SignupRequest;
 import com.wanted.codebombalms.domain.auth.service.AuthService;
 import com.wanted.codebombalms.global.common.ResponseDTO;
+import com.wanted.codebombalms.global.jwt.JwtTokenProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/signup")
     public ResponseEntity<ResponseDTO> signup(@Valid @RequestBody SignupRequest request) {
@@ -26,5 +32,40 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(new ResponseDTO(HttpStatus.CREATED, "회원가입 성공", null));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ResponseDTO> login(@Valid @RequestBody LoginRequest request) {
+        TokenPair tokens = authService.login(request);
+
+        ResponseCookie accessTokenCookie = createAccessTokenCookie(tokens.accessToken());
+        ResponseCookie refreshTokenCookie = createRefreshTokenCookie(tokens.refreshToken());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+                .body(new ResponseDTO(HttpStatus.OK, "로그인 성공", null));
+    }
+
+    // ===== 쿠키 생성 헬퍼 =====
+    private ResponseCookie createAccessTokenCookie(String token) {
+        return ResponseCookie.from("accessToken", token)
+                .httpOnly(true)
+                .secure(false)  // 로컬 개발 환경, 운영 시 true
+                .path("/")
+                .maxAge(jwtTokenProvider.getAccessExpiration() / 1000)
+                .sameSite("Lax")
+                .build();
+    }
+
+    private ResponseCookie createRefreshTokenCookie(String token) {
+        return ResponseCookie.from("refreshToken", token)
+                .httpOnly(true)
+                .secure(false)  // 로컬 개발 환경, 운영 시 true
+                .path("/")
+                .maxAge(jwtTokenProvider.getRefreshExpiration() / 1000)
+                .sameSite("Lax")
+                .build();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/domain/auth/dto/TokenPair.java
+++ b/src/main/java/com/wanted/codebombalms/domain/auth/dto/TokenPair.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.domain.auth.dto;
+
+public record TokenPair(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/wanted/codebombalms/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,44 @@
+package com.wanted.codebombalms.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long refreshTokenId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static RefreshToken create(Long userId, String token, LocalDateTime expiresAt) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.userId = userId;
+        refreshToken.token = token;
+        refreshToken.expiresAt = expiresAt;
+        return refreshToken;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.domain.auth.repository;
+
+import com.wanted.codebombalms.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/domain/auth/service/AuthService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/auth/service/AuthService.java
@@ -1,21 +1,33 @@
 package com.wanted.codebombalms.domain.auth.service;
 
+import com.wanted.codebombalms.domain.auth.dto.TokenPair;
+import com.wanted.codebombalms.domain.auth.dto.request.LoginRequest;
 import com.wanted.codebombalms.domain.auth.dto.request.SignupRequest;
+import com.wanted.codebombalms.domain.auth.entity.RefreshToken;
+import com.wanted.codebombalms.domain.auth.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.domain.user.entity.User;
+import com.wanted.codebombalms.domain.user.exception.AuthErrorCode;
 import com.wanted.codebombalms.domain.user.exception.UserErrorCode;
 import com.wanted.codebombalms.domain.user.repository.UserRepository;
 import com.wanted.codebombalms.global.error.exception.ConflictException;
+import com.wanted.codebombalms.global.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public void signup(SignupRequest request) {
@@ -38,5 +50,36 @@ public class AuthService {
         );
 
         userRepository.save(user);
+    }
+
+    @Transactional
+    public TokenPair login(LoginRequest request) {
+        // 1. 이메일로 회원 조회 (없으면 AUTH_LOGIN_FAIL)
+        User user = userRepository.findByEmailAndDeletedAtIsNull(request.getEmail())
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
+
+        // 2. 비밀번호 검증 (틀리면 AUTH_LOGIN_FAIL)
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL);
+        }
+
+        // 3. 계정 잠금 여부 확인
+        if (user.isLocked()) {
+            throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
+        }
+
+        // 4. JWT 발급
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getRole());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
+
+        // 5. Refresh Token DB 저장
+        LocalDateTime expiresAt = LocalDateTime.now()
+                .plusNanos(jwtTokenProvider.getRefreshExpiration() * 1_000_000L);
+
+        refreshTokenRepository.save(
+                RefreshToken.create(user.getUserId(), refreshToken, expiresAt)
+        );
+
+        return new TokenPair(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/wanted/codebombalms/global/jwt/JwtTokenProvider.java
@@ -64,4 +64,14 @@ public class JwtTokenProvider {
         }
     }
 
+    public long getAccessExpiration() {
+        return accessExpiration;
+    }
+
+    public long getRefreshExpiration() {
+        return refreshExpiration;
+    }
+
+
+
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #100 

---

## 🛠️ 기능 관련 작업 내용

로그인 API (`POST /api/v1/auth/login`) 를 구현했습니다.
- `RefreshToken` 엔티티 + `RefreshTokenRepository` 신규 작성
  - `refresh_tokens` 테이블 매핑 (userId, token, expiresAt, createdAt)
  - 정적 팩토리 `RefreshToken.create()` 제공
  - `findByToken`, `deleteByUserId` 메서드 (재발급/로그아웃 대비)
- `LoginRequest` DTO 작성 — `@NotBlank @Email` + 비밀번호 형식 검증은 의도적으로 생략 (보안: 응답 메시지 통일)
- `TokenPair` record 추가 — Service→Controller 토큰 전달 내부 DTO
- `JwtTokenProvider` 에 `getAccessExpiration()`, `getRefreshExpiration()` getter 추가
- `AuthService.login()` 구현
  - 이메일로 회원 조회 (없으면 `AUTH_LOGIN_FAIL`)
  - BCrypt 비밀번호 검증 (틀리면 `AUTH_LOGIN_FAIL` — 이메일 존재 여부 노출 방지)
  - `is_locked` 확인 (`USER_ACCOUNT_LOCKED`)
  - Access Token (1시간), Refresh Token (2주) 발급
  - Refresh Token DB 저장
- `AuthController.login()` 구현 — HttpOnly 쿠키 2개로 토큰 전달
테스트 결과 (Postman):
- ✅ 정상 로그인 → `200 OK`, `Set-Cookie: accessToken`, `Set-Cookie: refreshToken`
- ✅ 로그인 실패 시 동일 메시지 (`AUTH_LOGIN_FAIL`) 통일
보안 결정 사항:
- 이메일 없음 / 비밀번호 불일치 모두 동일하게 `AUTH_LOGIN_FAIL` 응답 (이메일 존재 여부 정보 노출 방지)
- 쿠키 `secure=false` 는 로컬 개발용 — 운영 배포 시 환경별 분기 필요 

---

## ♻️ 패키지 변경 사항

변경된 패키지, 클래스, HTML 파일 등을 작성해주세요.

예시:
- `domain/auth/entity/RefreshToken` : Refresh Token 엔티티 신규 작성
- `domain/auth/repository/RefreshTokenRepository` : Refresh Token 레포지토리 신규 작성
- `domain/auth/dto/request/LoginRequest` : 로그인 요청 DTO 신규 작성
- `domain/auth/dto/TokenPair` : 내부 토큰 전달용 record 신규 작성
- `domain/auth/service/AuthService` : `login()` 메서드 추가
- `domain/auth/controller/AuthController` : `login()` 엔드포인트 + 쿠키 생성 헬퍼 추가
- `global/jwt/JwtTokenProvider` : 만료 시간 getter 추가 (`getAccessExpiration`, `getRefreshExpiration`)
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
