### PR TITLE
[FEAT] 문제와 문제 데이터셋 연결 및 등록 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ application-*.yml
 *.log
 logs/
 
+### Uploaded Files ###
+uploads/
+
 ### macOS ###
 .DS_Store
 

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/controller/ProblemDatasetController.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/controller/ProblemDatasetController.java
@@ -1,0 +1,49 @@
+package com.wanted.codebombalms.domain.problems.dataset.controller;
+
+
+import com.wanted.codebombalms.domain.problems.dataset.dto.request.ProblemDatasetConnectRequest;
+import com.wanted.codebombalms.domain.problems.dataset.dto.response.ProblemDatasetConnectResponse;
+import com.wanted.codebombalms.domain.problems.dataset.dto.response.ProblemDatasetUploadResponse;
+import com.wanted.codebombalms.domain.problems.dataset.service.ProblemDatasetService;
+import com.wanted.codebombalms.global.common.ResponseDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class ProblemDatasetController {
+    private final ProblemDatasetService problemDatasetService;
+
+    @PostMapping("/api/v1/problems/{problemId}/datasets")
+    public ResponseEntity<ResponseDTO> connectDataset(
+            @PathVariable Long problemId,
+            @Valid @RequestBody ProblemDatasetConnectRequest request
+    ) {
+        ProblemDatasetConnectResponse response =
+                problemDatasetService.connectDataset(problemId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ResponseDTO(HttpStatus.CREATED, "문제-데이터셋 연결 성공", response));
+    }
+
+    @PostMapping(
+            value = "/api/v1/problem-datasets",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<ResponseDTO> uploadDataset(
+            @RequestPart("datasetFile") MultipartFile datasetFile
+    ) {
+        ProblemDatasetUploadResponse response =
+                problemDatasetService.uploadDataset(datasetFile);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ResponseDTO(HttpStatus.CREATED, "데이터셋 업로드 성공", response));
+    }
+
+
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/dto/request/ProblemDatasetConnectRequest.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/dto/request/ProblemDatasetConnectRequest.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.problems.dataset.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ProblemDatasetConnectRequest(
+        @NotNull(message = "데이터셋 ID는 필수입니다.")
+        Long datasetId
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/dto/response/ProblemDatasetConnectResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/dto/response/ProblemDatasetConnectResponse.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.domain.problems.dataset.dto.response;
+
+public record ProblemDatasetConnectResponse(
+        Long problemId,
+        Long datasetId,
+        String startCode
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/dto/response/ProblemDatasetUploadResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/dto/response/ProblemDatasetUploadResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.domain.problems.dataset.dto.response;
+
+import com.wanted.codebombalms.domain.problems.dataset.entitiy.ProblemDataset;
+
+public record ProblemDatasetUploadResponse(
+        Long datasetId,
+        String originalFileName,
+        String storedFileName,
+        String fileUrl,
+        String filePath,
+        String status
+) {
+    public ProblemDatasetUploadResponse(ProblemDataset dataset) {
+        this(
+                dataset.getDatasetId(),
+                dataset.getOriginalFileName(),
+                dataset.getStoredFileName(),
+                dataset.getFileUrl(),
+                dataset.getFilePath(),
+                dataset.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/entitiy/ProblemDataset.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/entitiy/ProblemDataset.java
@@ -1,0 +1,71 @@
+package com.wanted.codebombalms.domain.problems.dataset.entitiy;
+
+import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class ProblemDataset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long datasetId;
+
+
+    private String originalFileName;
+
+    private String storedFileName;
+
+    private  String fileUrl;
+
+    private String filePath;
+
+    private Long fileSize;
+
+    @Column(nullable = false)
+    private String status;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+
+    public static ProblemDataset createUploaded(
+            String originalFileName,
+            String storedFileName,
+            String fileUrl,
+            String filePath,
+            Long fileSize
+    ) {
+        ProblemDataset dataset = new ProblemDataset();
+        dataset.originalFileName = originalFileName;
+        dataset.storedFileName = storedFileName;
+        dataset.fileUrl = fileUrl;
+        dataset.filePath = filePath;
+        dataset.fileSize = fileSize;
+        dataset.status = "ACTIVE";
+        dataset.createdAt = LocalDateTime.now();
+        dataset.updatedAt = dataset.createdAt;
+        return dataset;
+    }
+
+    public void connectProblem(Problem problem) {
+        this.problem = problem;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getDatasetId() { return datasetId; }
+    public Problem getProblem() { return problem; }
+    public String getOriginalFileName() { return originalFileName; }
+    public String getStoredFileName() { return storedFileName; }
+    public String getFileUrl() { return fileUrl; }
+    public String getFilePath() { return filePath; }
+    public String getStatus() { return status; }
+
+    protected ProblemDataset() {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/problem-dataset.http
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/problem-dataset.http
@@ -1,0 +1,133 @@
+@baseUrl = http://localhost:8080
+@problemId = 3001
+@connectedDatasetId = 3001
+@textProblemId = 2001
+@notFoundProblemId = 999999
+@notFoundDatasetId = 999999
+@problemSetId = 3001
+@userId = 3
+
+### 1. 데이터셋 업로드 성공
+# 기대 결과:
+# - 201 Created
+# - data.datasetId가 반환됩니다.
+# - problem_id는 NULL로 저장됩니다.
+POST {{baseUrl}}/api/v1/problem-datasets
+Accept: application/json
+Content-Type: multipart/form-data; boundary=datasetBoundary
+
+--datasetBoundary
+Content-Disposition: form-data; name="datasetFile"; filename="employee_performance.csv"
+Content-Type: text/csv
+
+employee_id,department,performance_score
+1,Sales,90
+2,HR,85
+--datasetBoundary--
+
+> {%
+    client.global.set("uploadedDatasetId", response.body.data.datasetId);
+%}
+
+
+### 2. 데이터셋 업로드 실패 - CSV가 아닌 파일
+# 기대 결과:
+# - 400 PROBLEM_DATASET_INVALID_FILE
+POST {{baseUrl}}/api/v1/problem-datasets
+Accept: application/json
+Content-Type: multipart/form-data; boundary=invalidDatasetBoundary
+
+--invalidDatasetBoundary
+Content-Disposition: form-data; name="datasetFile"; filename="employee_performance.txt"
+Content-Type: text/plain
+
+not,csv,file
+--invalidDatasetBoundary--
+
+
+### 3. 문제-데이터셋 연결 성공 - 1번에서 업로드한 데이터셋 사용
+# 사전 조건:
+# - 1번 요청을 먼저 실행해야 합니다.
+# 기대 결과:
+# - 201 Created
+POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
+Accept: application/json
+Content-Type: application/json
+
+{
+  "datasetId": {{uploadedDatasetId}}
+}
+
+
+### 4. 문제-데이터셋 중복 연결 실패
+# 사전 조건:
+# - 더미데이터 기준 dataset_id = 3001은 이미 problem_id = 3001에 연결되어 있습니다.
+# 기대 결과:
+# - 409 PROBLEM_DATASET_ALREADY_CONNECTED
+POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
+Accept: application/json
+Content-Type: application/json
+
+{
+  "datasetId": {{connectedDatasetId}}
+}
+
+
+### 5. 문제 세트 진입 시 startCode 확인
+# 사전 조건:
+# - problem_set_id = 3001은 CODE 문제 세트입니다.
+# - 현재 문제에 ACTIVE 데이터셋이 연결되어 있으면 problem.startCode가 내려와야 합니다.
+# 기대 결과:
+# - problem.startCode = import pandas as pd\n\ndf = pd.read_csv("data/employee_performance.csv")
+GET {{baseUrl}}/api/v1/problem-sets/{{problemSetId}}?userId={{userId}}
+Accept: application/json
+
+
+### 6. 존재하지 않는 문제 실패
+# 기대 결과:
+# - 404 PROBLEM_NOT_FOUND
+POST {{baseUrl}}/api/v1/problems/{{notFoundProblemId}}/datasets
+Accept: application/json
+Content-Type: application/json
+
+{
+  "datasetId": {{connectedDatasetId}}
+}
+
+
+### 7. 존재하지 않는 데이터셋 실패
+# 기대 결과:
+# - 404 PROBLEM_DATASET_NOT_FOUND
+POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
+Accept: application/json
+Content-Type: application/json
+
+{
+  "datasetId": {{notFoundDatasetId}}
+}
+
+
+### 8. 코드 문제가 아닌 문제에 데이터셋 연결 실패
+# 사전 조건:
+# - 1번 요청으로 업로드한 미연결 datasetId를 사용합니다.
+# - problem_id = 2001 문제는 TEXT 타입입니다.
+# 기대 결과:
+# - 400 PROBLEM_DATASET_INVALID_PROBLEM_TYPE
+POST {{baseUrl}}/api/v1/problems/{{textProblemId}}/datasets
+Accept: application/json
+Content-Type: application/json
+
+{
+  "datasetId": {{uploadedDatasetId}}
+}
+
+
+### 9. datasetId 누락 실패
+# 기대 결과:
+# - 400 VALIDATION_FAILED
+POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
+Accept: application/json
+Content-Type: application/json
+
+{
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/repository/ProblemDatasetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/repository/ProblemDatasetRepository.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.domain.problems.dataset.repository;
+
+
+import com.wanted.codebombalms.domain.problems.dataset.entitiy.ProblemDataset;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+
+public interface ProblemDatasetRepository extends JpaRepository<ProblemDataset, Long> {
+    Optional<ProblemDataset> findFirstByProblem_ProblemIdAndStatus(Long problemId, String status);
+
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/service/ProblemDatasetReader.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/service/ProblemDatasetReader.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.domain.problems.dataset.service;
+
+import com.wanted.codebombalms.domain.problems.dataset.repository.ProblemDatasetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemDatasetReader {
+
+    private final ProblemDatasetRepository problemDatasetRepository;
+
+    @Transactional(readOnly = true)
+    public String findStartCodeByProblemId(Long problemId) {
+        return problemDatasetRepository.findFirstByProblem_ProblemIdAndStatus(problemId, "ACTIVE")
+                .map(dataset -> "import pandas as pd\n\n"
+                        + "df = pd.read_csv(\"" + dataset.getFilePath() + "\")")
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/service/ProblemDatasetService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/service/ProblemDatasetService.java
@@ -1,0 +1,91 @@
+package com.wanted.codebombalms.domain.problems.dataset.service;
+
+import com.wanted.codebombalms.domain.problems.dataset.dto.request.ProblemDatasetConnectRequest;
+import com.wanted.codebombalms.domain.problems.dataset.dto.response.ProblemDatasetConnectResponse;
+import com.wanted.codebombalms.domain.problems.dataset.dto.response.ProblemDatasetUploadResponse;
+import com.wanted.codebombalms.domain.problems.dataset.entitiy.ProblemDataset;
+import com.wanted.codebombalms.domain.problems.dataset.repository.ProblemDatasetRepository;
+import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
+import com.wanted.codebombalms.domain.problems.problem.service.ProblemService;
+import com.wanted.codebombalms.domain.problems.dataset.storage.DatasetFileStorage;
+import com.wanted.codebombalms.domain.problems.dataset.storage.StoredDatasetFile;
+import com.wanted.codebombalms.global.error.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+public class ProblemDatasetService {
+    private final ProblemDatasetRepository problemDatasetRepository;
+    private final ProblemService problemService;
+    private final DatasetFileStorage datasetFileStorage;
+
+    @Transactional
+    public ProblemDatasetConnectResponse connectDataset(
+            Long problemId,
+            ProblemDatasetConnectRequest request
+    ) {
+        Problem problem = problemService.findProblemEntity(problemId);
+
+        ProblemDataset dataset = problemDatasetRepository.findById(request.datasetId())
+                .orElseThrow(() -> new ValidationException(ProblemErrorCode.PROBLEM_DATASET_NOT_FOUND));
+
+        if (dataset.getProblem() != null) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_ALREADY_CONNECTED);
+        }
+
+        if (!"CODE".equals(problem.getProblemType())) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_INVALID_PROBLEM_TYPE);
+        }
+
+        dataset.connectProblem(problem);
+
+        String startCode = "import pandas as pd\n\n"
+                + "df = pd.read_csv(\"" + dataset.getFilePath() + "\")";
+
+        return new ProblemDatasetConnectResponse(
+                problem.getProblemId(),
+                dataset.getDatasetId(),
+                startCode
+        );
+    }
+
+    @Transactional
+    public ProblemDatasetUploadResponse uploadDataset(MultipartFile datasetFile) {
+        validateDatasetFile(datasetFile);
+
+        try {
+            StoredDatasetFile storedFile = datasetFileStorage.store(datasetFile);
+
+            ProblemDataset dataset = ProblemDataset.createUploaded(
+                    storedFile.originalFileName(),
+                    storedFile.storedFileName(),
+                    storedFile.fileUrl(),
+                    storedFile.filePath(),
+                    storedFile.fileSize()
+            );
+
+            ProblemDataset savedDataset = problemDatasetRepository.save(dataset);
+
+            return new ProblemDatasetUploadResponse(savedDataset);
+        } catch (Exception e) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED);
+        }
+    }
+
+    private void validateDatasetFile(MultipartFile datasetFile) {
+        if (datasetFile == null || datasetFile.isEmpty()) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE);
+        }
+
+        String originalFileName = datasetFile.getOriginalFilename();
+
+        if (originalFileName == null || !originalFileName.toLowerCase().endsWith(".csv")) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE);
+        }
+    }
+
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/DatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/DatasetFileStorage.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.problems.dataset.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface DatasetFileStorage {
+    StoredDatasetFile store(MultipartFile file) throws IOException;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/DatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/DatasetFileStorage.java
@@ -1,4 +1,4 @@
-package com.wanted.codebombalms.domain.problems.dataset.service;
+package com.wanted.codebombalms.domain.problems.dataset.storage;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/LocalDatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/LocalDatasetFileStorage.java
@@ -1,4 +1,4 @@
-package com.wanted.codebombalms.domain.problems.dataset.service;
+package com.wanted.codebombalms.domain.problems.dataset.storage;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/LocalDatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/LocalDatasetFileStorage.java
@@ -1,0 +1,38 @@
+package com.wanted.codebombalms.domain.problems.dataset.service;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+@Component
+public class LocalDatasetFileStorage implements DatasetFileStorage {
+
+    private static final String UPLOAD_DIR = "uploads/datasets";
+
+    @Override
+    public StoredDatasetFile store(MultipartFile file) throws IOException {
+        String originalFileName = file.getOriginalFilename();
+        String storedFileName = UUID.randomUUID() + "_" + originalFileName;
+
+        Path uploadPath = Path.of(UPLOAD_DIR);
+        Files.createDirectories(uploadPath);
+
+        Path targetPath = uploadPath.resolve(storedFileName);
+        file.transferTo(targetPath);
+
+        String fileUrl = "/" + UPLOAD_DIR + "/" + storedFileName;
+        String filePath = "data/" + originalFileName;
+
+        return new StoredDatasetFile(
+                originalFileName,
+                storedFileName,
+                fileUrl,
+                filePath,
+                file.getSize()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/StoredDatasetFile.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/storage/StoredDatasetFile.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.domain.problems.dataset.storage;
+
+public record StoredDatasetFile(
+        String originalFileName,
+        String storedFileName,
+        String fileUrl,
+        String filePath,
+        Long fileSize
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/exception/ProblemErrorCode.java
@@ -26,7 +26,14 @@ public enum ProblemErrorCode implements ErrorCode {
     PROBLEM_CONTENT_REQUIRED(400, "PROBLEM_INVALID_INPUT", "소문제 내용은 필수입니다."),
     PROBLEM_ANSWER_REQUIRED(400, "PROBLEM_INVALID_INPUT", "소문제 정답은 필수입니다."),
     PROBLEM_HAS_SUBMISSION(409, "PROBLEM_HAS_SUBMISSION", "제출 기록이 존재합니다."),
-    SERVER_ERROR(500, "PROBLEM_SERVER_ERROR", "문제 도메인 처리 중 서버 오류가 발생했습니다.");
+    SERVER_ERROR(500, "PROBLEM_SERVER_ERROR", "문제 도메인 처리 중 서버 오류가 발생했습니다."),
+    PROBLEM_DATASET_NOT_FOUND(404, "PROBLEM_DATASET_NOT_FOUND", "데이터셋을 찾을 수 없습니다."),
+    PROBLEM_DATASET_ALREADY_CONNECTED(409, "PROBLEM_DATASET_ALREADY_CONNECTED", "이미 문제에 연결된 데이터셋입니다."),
+    PROBLEM_DATASET_INVALID_PROBLEM_TYPE(400, "PROBLEM_DATASET_INVALID_PROBLEM_TYPE", "코드 실행형 문제에만 데이터셋을 연결할 수 있습니다."),
+    PROBLEM_DATASET_INVALID_FILE(400, "PROBLEM_DATASET_INVALID_FILE", "CSV 파일만 업로드할 수 있습니다."),
+    PROBLEM_DATASET_UPLOAD_FAILED(500, "PROBLEM_DATASET_UPLOAD_FAILED", "데이터셋 업로드에 실패했습니다.");
+
+
 
     private final int status;
     private final String code;

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/dto/response/ProblemResponse.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/dto/response/ProblemResponse.java
@@ -7,7 +7,8 @@ public record ProblemResponse(
         Integer problemNumber,
         String title,
         String content,
-        String problemType
+        String problemType,
+        String startCode
 ) {
     public ProblemResponse(Problem problem) {
         this(
@@ -15,7 +16,18 @@ public record ProblemResponse(
                 problem.getProblemOrder(),
                 problem.getTitle(),
                 problem.getContent(),
-                problem.getProblemType()
+                problem.getProblemType(),
+                null
+        );
+    }
+    public ProblemResponse withStartCode(String startCode) {
+        return new ProblemResponse(
+                problemId,
+                problemNumber,
+                title,
+                content,
+                problemType,
+                startCode
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/service/ProblemService.java
@@ -8,8 +8,6 @@ import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemCreateRequest;
 import com.wanted.codebombalms.domain.problems.set.dto.request.ProblemUpdateRequest;
 import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
-import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
-import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -131,6 +129,7 @@ public class ProblemService {
 
         return problem;
     }
+
 
 
 }

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/service/ProblemSetService.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.domain.problems.set.service;
 
 import com.wanted.codebombalms.domain.problems.category.entity.ProblemCategory;
 import com.wanted.codebombalms.domain.problems.category.service.ProblemCategoryService;
+import com.wanted.codebombalms.domain.problems.dataset.service.ProblemDatasetReader;
 import com.wanted.codebombalms.domain.problems.hint.service.ProblemHintService;
 import com.wanted.codebombalms.domain.problems.problem.dto.response.ProblemResponse;
 import com.wanted.codebombalms.domain.problems.problem.entitiy.Problem;
@@ -16,13 +17,14 @@ import com.wanted.codebombalms.domain.problems.set.entity.ProblemSet;
 import com.wanted.codebombalms.domain.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.global.error.exception.NotFoundException;
 import com.wanted.codebombalms.domain.problems.set.repository.ProblemSetRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.IntStream;
 
 @Service
+@RequiredArgsConstructor
 public class ProblemSetService {
 
     private final ProblemSetRepository problemSetRepository;
@@ -30,20 +32,7 @@ public class ProblemSetService {
     private final ProblemService problemService;
     private final ProgressService progressService;
     private final ProblemHintService problemHintService;
-
-    public ProblemSetService(
-            ProblemSetRepository problemSetRepository,
-            ProblemCategoryService problemCategoryService,
-            ProblemService problemService,
-            ProgressService progressService,
-            ProblemHintService problemHintService
-    ) {
-        this.problemSetRepository = problemSetRepository;
-        this.problemCategoryService = problemCategoryService;
-        this.problemService = problemService;
-        this.progressService = progressService;
-        this.problemHintService = problemHintService;
-    }
+    private final ProblemDatasetReader problemDatasetReader;
 
     public List<ProblemSetListResponse> findActiveSetsByCategory(Long categoryId) {
         if (!problemCategoryService.existsActiveCategory(categoryId)) {
@@ -70,6 +59,10 @@ public class ProblemSetService {
                 ? problemService.findLastProblem(problemSetId).orElse(null)
                 : problemService.findCurrentProblem(problemSetId, currentProblemNumber);
 
+        if (currentProblem != null) {
+            String startCode = problemDatasetReader.findStartCodeByProblemId(currentProblem.problemId());
+            currentProblem = currentProblem.withStartCode(startCode);
+        }
         return new ProblemSetEnterResponse(
                 problemSet.getProblemSetId(),
                 problemSet.getTitle(),


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #144 
- Closes #145 

---

## 🛠️ 기능 관련 작업 내용

- 코드 실행형 문제에 사용할 데이터셋 업로드 API를 구현했습니다.
- `MultipartFile` 기반 CSV 업로드를 처리하고, 업로드된 파일 정보를 `problem_dataset` 테이블에 저장하도록 구현했습니다.
- 업로드 시 원본 파일명, 저장 파일명, 파일 URL, 실행 환경 파일 경로, 파일 크기, 상태값을 저장하도록 처리했습니다.
- 빈 파일 또는 CSV가 아닌 파일 업로드 시 `PROBLEM_DATASET_INVALID_FILE` 예외가 발생하도록 검증 로직을 추가했습니다.
- 파일 저장 실패 시 `PROBLEM_DATASET_UPLOAD_FAILED` 예외가 발생하도록 처리했습니다.
- 문제와 데이터셋을 연결하는 API를 구현했습니다.
- 문제 ID 기준 문제 존재 여부와 데이터셋 ID 기준 데이터셋 존재 여부를 검증하도록 구현했습니다.
- 이미 문제에 연결된 데이터셋은 중복 연결되지 않도록 `PROBLEM_DATASET_ALREADY_CONNECTED` 예외를 추가했습니다.
- 코드 실행형 문제에만 데이터셋을 연결할 수 있도록 문제 타입 검증을 추가했습니다.
- 문제 세트 진입 시 연결된 데이터셋의 `filePath`를 기반으로 `df = pd.read_csv("data/파일명.csv")` 형태의 기본 실행 코드를 응답에 포함하도록 구현했습니다.
- 데이터셋 조회 책임을 `ProblemDatasetReader`로 분리하여 문제 세트 진입 로직에서 Repository 직접 의존을 피하도록 개선했습니다.
- 로컬 저장 구현체인 `LocalDatasetFileStorage`를 추가하고, 추후 Google Cloud Storage 연동 시 `DatasetFileStorage` 구현체를 교체/추가할 수 있도록 구조를 분리했습니다.

---

## ♻️ 패키지 변경 사항

- `domain/problems/dataset/controller/ProblemDatasetController` : 데이터셋 업로드 API 및 문제-데이터셋 연결 API 추가
- `domain/problems/dataset/service/ProblemDatasetService` : 데이터셋 업로드, 파일 검증, 문제-데이터셋 연결 비즈니스 로직 추가
- `domain/problems/dataset/service/ProblemDatasetReader` : 문제 상세 조회 시 데이터셋 기반 시작 코드 조회 로직 추가
- `domain/problems/dataset/storage/DatasetFileStorage` : 데이터셋 파일 저장 추상화 인터페이스 추가
- `domain/problems/dataset/storage/LocalDatasetFileStorage` : 로컬 데이터셋 파일 저장 구현체 추가
- `domain/problems/dataset/storage/StoredDatasetFile` : 저장된 파일 정보 전달용 record 추가
- `domain/problems/dataset/repository/ProblemDatasetRepository` : 데이터셋 JPA Repository 및 ACTIVE 데이터셋 조회 메서드 추가
- `domain/problems/dataset/entitiy/ProblemDataset` : 데이터셋 엔티티 매핑, 업로드 생성 메서드, 문제 연결 메서드 추가
- `domain/problems/dataset/dto/request/ProblemDatasetConnectRequest` : 문제-데이터셋 연결 요청 DTO 추가
- `domain/problems/dataset/dto/response/ProblemDatasetConnectResponse` : 문제-데이터셋 연결 응답 DTO 추가
- `domain/problems/dataset/dto/response/ProblemDatasetUploadResponse` : 데이터셋 업로드 응답 DTO 추가
- `domain/problems/problem/dto/response/ProblemResponse` : 문제 상세 응답에 `startCode` 필드 추가
- `domain/problems/set/service/ProblemSetService` : 문제 세트 진입 시 데이터셋 시작 코드 포함 처리 추가
- `domain/problems/exception/ProblemErrorCode` : 데이터셋 관련 예외 코드 추가
- `.gitignore` : 로컬 업로드 파일 경로 `uploads/` 제외 추가
- `domain/problems/dataset/problem-dataset.http` : 데이터셋 업로드/연결 API 테스트 요청 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.

---

## 리뷰어 참고 사항

- 현재 데이터셋 파일 저장은 M2 초기 단계 기준으로 로컬 저장 방식(`LocalDatasetFileStorage`)으로 구현했습니다.
- 추후 Google Cloud Storage 연동 시 `DatasetFileStorage` 구현체로 `GcsDatasetFileStorage`를 추가하면 Service 로직 변경을 최소화할 수 있습니다.
- 문제와 데이터셋 연결은 `problem_dataset.problem_id`가 `NULL`인 업로드 데이터셋을 대상으로 수행됩니다.
- 이미 문제에 연결된 데이터셋은 중복 연결되지 않도록 처리했습니다.
- 문제 세트 진입 응답의 `startCode`는 연결된 ACTIVE 데이터셋의 `filePath`를 기준으로 생성됩니다.
- `.http` 파일로 업로드 성공, CSV 형식 오류, 연결 성공, 중복 연결, 존재하지 않는 문제/데이터셋, 필수값 누락 케이스를 확인했습니다.
- `compileJava` 성공 확인했습니다.