### PR TITLE
[Ref] CleanCode 리팩토링 / 스웨거 /

### DIFF
--- a/docs/CONVENTION.md
+++ b/docs/CONVENTION.md
@@ -1,0 +1,208 @@
+# API 응답 / 예외 처리 / 에러코드 컨벤션
+
+`ref/global2` 브랜치에서 도입된 글로벌 공통 구조에 대한 팀 컨벤션 문서입니다.
+
+---
+
+## 1. 에러코드 네이밍
+
+### 포맷
+```
+{DOMAIN}-{NNN}          // 단일 도메인
+{DOMAIN}-{SUBDOMAIN}-{NNN}  // 하위 도메인 있는 경우
+```
+
+### 코드표
+
+| 도메인 | 접두어 | 예시 |
+|--------|--------|------|
+| `course` | `CRS` | `CRS-001` |
+| `lecture` | `LCT` | `LCT-001` |
+| `enrollment` | `ENR` | `ENR-001` |
+| `auth` | `AUT` | `AUT-001` |
+| `user` | `USR` | `USR-001` |
+| `submission` | `SUB` | `SUB-001` |
+| `problems` (공통) | `PRB` | `PRB-001` |
+| `problems.problem` | `PRB-PBL` | `PRB-PBL-001` |
+| `problems.set` | `PRB-SET` | `PRB-SET-001` |
+| `problems.category` | `PRB-CAT` | `PRB-CAT-001` |
+| `problems.hint` | `PRB-HNT` | `PRB-HNT-001` |
+| `problems.dataset` | `PRB-DAT` | `PRB-DAT-001` |
+| `problems.progress` | `PRB-PRG` | `PRB-PRG-001` |
+| `problems.result` | `PRB-RES` | `PRB-RES-001` |
+| `admin.operation.rule` | `ADM-ARL` | `ADM-ARL-001` |
+| `admin.operation.alert` | `ADM-ALT` | `ADM-ALT-001` |
+
+### 에러코드 추가 방법
+1. 해당 도메인의 `XxxErrorCode` enum에 상수 추가
+2. 코드 문자열은 위 코드표 prefix + 시퀀스 번호 순서대로
+3. **개별 Exception 클래스 신규 생성 금지** — 공통 예외 타입 사용
+
+```java
+// Good
+throw new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND);
+
+// Bad — 개별 클래스 만들지 말 것
+throw new CourseNotFoundException();
+```
+
+---
+
+## 2. 예외 처리 구조
+
+### 공통 예외 타입 (global.domain.common.error.exception)
+
+| 클래스 | HTTP Status | 용도 |
+|--------|-------------|------|
+| `NotFoundException` | 404 | 리소스 없음 |
+| `ValidationException` | 400 | 입력값 검증 실패 |
+| `UnauthorizedException` | 401 | 인증 실패 |
+| `ForbiddenException` | 403 | 권한 없음 |
+| `ConflictException` | 409 | 중복 / 충돌 |
+
+### 사용 예시
+
+```java
+// 조회 실패
+courseRepository.findById(id)
+    .orElseThrow(() -> new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
+
+// 중복
+if (exists) throw new ConflictException(EnrollmentErrorCode.DUPLICATE_ENROLLMENT);
+
+// 입력값 검증
+if (title == null) throw new ValidationException(ProblemErrorCode.PROBLEM_SET_TITLE_REQUIRED);
+```
+
+### 에러 응답 포맷 (ApiErrorResponse)
+
+```json
+{
+  "timestamp": "2026-05-21T10:00:00Z",
+  "status": 404,
+  "code": "CRS-001",
+  "message": "존재하지 않는 강좌입니다.",
+  "path": "/api/v1/courses/999"
+}
+```
+
+---
+
+## 3. 성공 응답 포맷 (ApiResponse)
+
+### 새 컨트롤러 — ApiResponse 사용
+
+```java
+// 조회 / 수정 (200)
+return ResponseEntity.ok(ApiResponse.success(
+    CourseResponseCode.RETRIEVED,
+    CourseResponseMessage.RETRIEVED,
+    response
+));
+
+// 생성 (201)
+return ResponseEntity.status(201).body(ApiResponse.created(
+    CourseResponseCode.CREATED,
+    CourseResponseMessage.CREATED,
+    response
+));
+
+// 삭제 (204) — ApiResponse 사용하지 않음
+return ResponseEntity.noContent().build();
+```
+
+### 기존 컨트롤러 — ResponseDTO 유지 (점진적 마이그레이션)
+
+기존 컨트롤러는 `ResponseDTO` 패턴 그대로 유지. 새 컨트롤러 작성 시부터 `ApiResponse` 적용.
+
+### ResponseCode / ResponseMessage 파일 위치 및 구조
+
+**각 컨트롤러 패키지에** `XxxResponseCode.java` + `XxxResponseMessage.java` 두 파일을 함께 둔다.
+
+```
+domain/course/controller/
+├── CourseController.java
+├── CourseResponseCode.java     ← 성공 코드 상수
+└── CourseResponseMessage.java  ← 성공 메시지 상수
+```
+
+**작성 규칙:**
+- 상수명은 동사 없이 행위 결과로 표현: `RETRIEVED`, `CREATED`, `UPDATED`, `DELETED`
+- 코드 문자열 포맷: `{DOMAIN}-{ACTION}` (예: `COURSE-RETRIEVED`)
+- 생성자 `private` — 인스턴스화 금지
+
+**예시 (CourseResponseCode / CourseResponseMessage):**
+
+```java
+public class CourseResponseCode {
+    private CourseResponseCode() {}
+
+    public static final String RETRIEVED = "COURSE-RETRIEVED";
+    public static final String CREATED   = "COURSE-CREATED";
+    public static final String UPDATED   = "COURSE-UPDATED";
+    public static final String DELETED   = "COURSE-DELETED";
+}
+
+public class CourseResponseMessage {
+    private CourseResponseMessage() {}
+
+    public static final String RETRIEVED = "강좌 조회에 성공했습니다.";
+    public static final String CREATED   = "강좌가 생성되었습니다.";
+    public static final String UPDATED   = "강좌가 수정되었습니다.";
+    public static final String DELETED   = "강좌가 삭제되었습니다.";
+}
+```
+
+### 도메인별 코드/메시지 파일 현황
+
+| 도메인 | ResponseCode | ResponseMessage |
+|--------|-------------|-----------------|
+| course | `CourseResponseCode` | `CourseResponseMessage` |
+| lecture | `LectureResponseCode` | `LectureResponseMessage` |
+| enrollment | `EnrollmentResponseCode` | `EnrollmentResponseMessage` |
+| submission | `SubmissionResponseCode` | `SubmissionResponseMessage` |
+| problems.set | `ProblemSetResponseCode` | `ProblemSetResponseMessage` |
+| problems.category | `ProblemCategoryResponseCode` | `ProblemCategoryResponseMessage` |
+| problems.dataset | `ProblemDatasetResponseCode` | `ProblemDatasetResponseMessage` |
+| problems.hint | `ProblemHintResponseCode` | `ProblemHintResponseMessage` |
+| problems.problem | `ProblemResponseCode` | `ProblemResponseMessage` |
+| problems.progress | `ProgressResponseCode` | `ProgressResponseMessage` |
+| problems.result | `ResultResponseCode` | `ResultResponseMessage` |
+| admin.operation.rule | `AutomationRuleResponseCode` | `AutomationRuleResponseMessage` |
+| admin.operation.alert | `OperationAlertResponseCode` | `OperationAlertResponseMessage` |
+
+### 성공 응답 포맷
+
+```json
+{
+  "timestamp": "2026-05-21T10:00:00Z",
+  "status": 200,
+  "code": "COURSE-RETRIEVED",
+  "message": "강좌 조회에 성공했습니다.",
+  "data": { ... }
+}
+```
+
+---
+
+## 4. Swagger 작성 가이드
+
+의존성: `springdoc-openapi-starter-webmvc-ui:2.8.6`
+Swagger UI: `http://localhost:8080/swagger-ui/index.html`
+
+### 새 엔드포인트 작성 예시
+
+```java
+@Operation(summary = "강좌 단건 조회")
+@ApiResponses({
+    @ApiResponse(responseCode = "200", description = "조회 성공"),
+    @ApiResponse(responseCode = "404", description = "CRS-001: 존재하지 않는 강좌")
+})
+@GetMapping("/{courseId}")
+public ResponseEntity<ApiResponse<CourseDetailResponse>> findCourse(@PathVariable Long courseId) { ... }
+```
+
+### 규칙
+- 공통 에러(`401`, `403`, `500`)는 생략 가능 — `GlobalExceptionHandler`에서 자동 처리
+- 도메인별 에러만 `@ApiResponse`로 명시
+- `description`에 에러코드 포함: `"CRS-001: 존재하지 않는 강좌"`

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operation/alert/presentation/api/OperationAlertResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operation/alert/presentation/api/OperationAlertResponseCode.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.admin.operation.alert.presentation.api;
+
+public class OperationAlertResponseCode {
+
+    private OperationAlertResponseCode() {}
+
+    public static final String RETRIEVED      = "OPERATION-ALERT-RETRIEVED";
+    public static final String STATUS_UPDATED = "OPERATION-ALERT-STATUS-UPDATED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operation/alert/presentation/api/OperationAlertResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operation/alert/presentation/api/OperationAlertResponseMessage.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.admin.operation.alert.presentation.api;
+
+public class OperationAlertResponseMessage {
+
+    private OperationAlertResponseMessage() {}
+
+    public static final String RETRIEVED      = "운영 알림 조회에 성공했습니다.";
+    public static final String STATUS_UPDATED = "운영 알림 상태가 변경되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operation/rule/presentation/api/AutomationRuleResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operation/rule/presentation/api/AutomationRuleResponseCode.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.admin.operation.rule.presentation.api;
+
+public class AutomationRuleResponseCode {
+
+    private AutomationRuleResponseCode() {}
+
+    public static final String RETRIEVED = "AUTOMATION-RULE-RETRIEVED";
+    public static final String CREATED   = "AUTOMATION-RULE-CREATED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/admin/operation/rule/presentation/api/AutomationRuleResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/admin/operation/rule/presentation/api/AutomationRuleResponseMessage.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.admin.operation.rule.presentation.api;
+
+public class AutomationRuleResponseMessage {
+
+    private AutomationRuleResponseMessage() {}
+
+    public static final String RETRIEVED = "자동화 규칙 조회에 성공했습니다.";
+    public static final String CREATED   = "자동화 규칙이 등록되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/course/controller/CourseResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/course/controller/CourseResponseCode.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.course.controller;
+
+public class CourseResponseCode {
+
+    private CourseResponseCode() {}
+
+    public static final String RETRIEVED = "COURSE-RETRIEVED";
+    public static final String CREATED   = "COURSE-CREATED";
+    public static final String UPDATED   = "COURSE-UPDATED";
+    public static final String DELETED   = "COURSE-DELETED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/course/controller/CourseResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/course/controller/CourseResponseMessage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.course.controller;
+
+public class CourseResponseMessage {
+
+    private CourseResponseMessage() {}
+
+    public static final String RETRIEVED = "강좌 조회에 성공했습니다.";
+    public static final String CREATED   = "강좌가 생성되었습니다.";
+    public static final String UPDATED   = "강좌가 수정되었습니다.";
+    public static final String DELETED   = "강좌가 삭제되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/enrollment/controller/EnrollmentResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/enrollment/controller/EnrollmentResponseCode.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.domain.enrollment.controller;
+
+public class EnrollmentResponseCode {
+
+    private EnrollmentResponseCode() {}
+
+    public static final String RETRIEVED = "ENROLLMENT-RETRIEVED";
+    public static final String CREATED   = "ENROLLMENT-CREATED";
+    public static final String CANCELED  = "ENROLLMENT-CANCELED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/enrollment/controller/EnrollmentResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/enrollment/controller/EnrollmentResponseMessage.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.domain.enrollment.controller;
+
+public class EnrollmentResponseMessage {
+
+    private EnrollmentResponseMessage() {}
+
+    public static final String RETRIEVED = "수강 목록 조회에 성공했습니다.";
+    public static final String CREATED   = "수강 신청이 완료되었습니다.";
+    public static final String CANCELED  = "수강 신청이 취소되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/lecture/controller/LectureResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/lecture/controller/LectureResponseCode.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.lecture.controller;
+
+public class LectureResponseCode {
+
+    private LectureResponseCode() {}
+
+    public static final String RETRIEVED = "LECTURE-RETRIEVED";
+    public static final String CREATED   = "LECTURE-CREATED";
+    public static final String UPDATED   = "LECTURE-UPDATED";
+    public static final String DELETED   = "LECTURE-DELETED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/lecture/controller/LectureResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/lecture/controller/LectureResponseMessage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.lecture.controller;
+
+public class LectureResponseMessage {
+
+    private LectureResponseMessage() {}
+
+    public static final String RETRIEVED = "강의 조회에 성공했습니다.";
+    public static final String CREATED   = "강의가 생성되었습니다.";
+    public static final String UPDATED   = "강의가 수정되었습니다.";
+    public static final String DELETED   = "강의가 삭제되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/lecture/exception/LectureErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/lecture/exception/LectureErrorCode.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.domain.lecture.exception;
+
+import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LectureErrorCode implements ErrorCode {
+
+    // 조회
+    LECTURE_NOT_FOUND("LCT-001", "존재하지 않는 강의입니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/category/controller/ProblemCategoryResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/category/controller/ProblemCategoryResponseCode.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.problems.category.controller;
+
+public class ProblemCategoryResponseCode {
+
+    private ProblemCategoryResponseCode() {}
+
+    public static final String RETRIEVED = "PROBLEM-CATEGORY-RETRIEVED";
+    public static final String CREATED   = "PROBLEM-CATEGORY-CREATED";
+    public static final String UPDATED   = "PROBLEM-CATEGORY-UPDATED";
+    public static final String DELETED   = "PROBLEM-CATEGORY-DELETED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/category/controller/ProblemCategoryResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/category/controller/ProblemCategoryResponseMessage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.problems.category.controller;
+
+public class ProblemCategoryResponseMessage {
+
+    private ProblemCategoryResponseMessage() {}
+
+    public static final String RETRIEVED = "문제 분야 조회에 성공했습니다.";
+    public static final String CREATED   = "문제 분야가 생성되었습니다.";
+    public static final String UPDATED   = "문제 분야가 수정되었습니다.";
+    public static final String DELETED   = "문제 분야가 삭제되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/controller/ProblemDatasetResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/controller/ProblemDatasetResponseCode.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.domain.problems.dataset.controller;
+
+public class ProblemDatasetResponseCode {
+
+    private ProblemDatasetResponseCode() {}
+
+    public static final String UPLOADED   = "PROBLEM-DATASET-UPLOADED";
+    public static final String CONNECTED  = "PROBLEM-DATASET-CONNECTED";
+    public static final String RETRIEVED  = "PROBLEM-DATASET-RETRIEVED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/dataset/controller/ProblemDatasetResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/dataset/controller/ProblemDatasetResponseMessage.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.domain.problems.dataset.controller;
+
+public class ProblemDatasetResponseMessage {
+
+    private ProblemDatasetResponseMessage() {}
+
+    public static final String UPLOADED   = "데이터셋이 업로드되었습니다.";
+    public static final String CONNECTED  = "데이터셋이 문제에 연결되었습니다.";
+    public static final String RETRIEVED  = "데이터셋 조회에 성공했습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/hint/controller/ProblemHintResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/hint/controller/ProblemHintResponseCode.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.domain.problems.hint.controller;
+
+public class ProblemHintResponseCode {
+
+    private ProblemHintResponseCode() {}
+
+    public static final String RETRIEVED = "PROBLEM-HINT-RETRIEVED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/hint/controller/ProblemHintResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/hint/controller/ProblemHintResponseMessage.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.domain.problems.hint.controller;
+
+public class ProblemHintResponseMessage {
+
+    private ProblemHintResponseMessage() {}
+
+    public static final String RETRIEVED = "힌트 조회에 성공했습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemResponseCode.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.problems.problem.controller;
+
+public class ProblemResponseCode {
+
+    private ProblemResponseCode() {}
+
+    public static final String RETRIEVED = "PROBLEM-RETRIEVED";
+    public static final String CREATED   = "PROBLEM-CREATED";
+    public static final String UPDATED   = "PROBLEM-UPDATED";
+    public static final String DELETED   = "PROBLEM-DELETED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/problem/controller/ProblemResponseMessage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.domain.problems.problem.controller;
+
+public class ProblemResponseMessage {
+
+    private ProblemResponseMessage() {}
+
+    public static final String RETRIEVED = "문제 조회에 성공했습니다.";
+    public static final String CREATED   = "문제가 생성되었습니다.";
+    public static final String UPDATED   = "문제가 수정되었습니다.";
+    public static final String DELETED   = "문제가 삭제되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/progress/controller/ProgressResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/progress/controller/ProgressResponseCode.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.problems.progress.controller;
+
+public class ProgressResponseCode {
+
+    private ProgressResponseCode() {}
+
+    public static final String RETRIEVED = "PROGRESS-RETRIEVED";
+    public static final String UPDATED   = "PROGRESS-UPDATED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/progress/controller/ProgressResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/progress/controller/ProgressResponseMessage.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.problems.progress.controller;
+
+public class ProgressResponseMessage {
+
+    private ProgressResponseMessage() {}
+
+    public static final String RETRIEVED = "학습 진도 조회에 성공했습니다.";
+    public static final String UPDATED   = "학습 진도가 업데이트되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/result/controller/ResultResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/result/controller/ResultResponseCode.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.domain.problems.result.controller;
+
+public class ResultResponseCode {
+
+    private ResultResponseCode() {}
+
+    public static final String RETRIEVED = "RESULT-RETRIEVED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/result/controller/ResultResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/result/controller/ResultResponseMessage.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.domain.problems.result.controller;
+
+public class ResultResponseMessage {
+
+    private ResultResponseMessage() {}
+
+    public static final String RETRIEVED = "결과 조회에 성공했습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/controller/ProblemSetResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/controller/ProblemSetResponseCode.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.domain.problems.set.controller;
+
+public class ProblemSetResponseCode {
+
+    private ProblemSetResponseCode() {}
+
+    public static final String RETRIEVED = "PROBLEM-SET-RETRIEVED";
+    public static final String CREATED   = "PROBLEM-SET-CREATED";
+    public static final String UPDATED   = "PROBLEM-SET-UPDATED";
+    public static final String DELETED   = "PROBLEM-SET-DELETED";
+    public static final String ENTERED   = "PROBLEM-SET-ENTERED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/problems/set/controller/ProblemSetResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/problems/set/controller/ProblemSetResponseMessage.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.domain.problems.set.controller;
+
+public class ProblemSetResponseMessage {
+
+    private ProblemSetResponseMessage() {}
+
+    public static final String RETRIEVED = "문제 세트 조회에 성공했습니다.";
+    public static final String CREATED   = "문제 세트가 생성되었습니다.";
+    public static final String UPDATED   = "문제 세트가 수정되었습니다.";
+    public static final String DELETED   = "문제 세트가 삭제되었습니다.";
+    public static final String ENTERED   = "문제 세트에 입장했습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/submission/controller/SubmissionResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/domain/submission/controller/SubmissionResponseCode.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.submission.controller;
+
+public class SubmissionResponseCode {
+
+    private SubmissionResponseCode() {}
+
+    public static final String SUBMITTED = "SUBMISSION-SUBMITTED";
+    public static final String RETRIEVED = "SUBMISSION-RETRIEVED";
+}

--- a/src/main/java/com/wanted/codebombalms/domain/submission/controller/SubmissionResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/domain/submission/controller/SubmissionResponseMessage.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.domain.submission.controller;
+
+public class SubmissionResponseMessage {
+
+    private SubmissionResponseMessage() {}
+
+    public static final String SUBMITTED = "답안이 제출되었습니다.";
+    public static final String RETRIEVED = "제출 내역 조회에 성공했습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.global.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("CodeBomba LMS API")
+                        .version("v1")
+                        .description("LMS 백엔드 API 문서"));
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [v] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #202

---

## 🛠️ 기능 관련 작업 내용

- 에러코드 prefix를 2글자에서 3글자로 통일하고 하위 도메인 분리 컨벤션 적용 (예: `PRB-CAT-001`)
- 도메인별 개별 Exception 클래스를 삭제하고 공통 예외 타입(`NotFoundException`, `ValidationException` 등)으로 전환
- 글로벌 공통 응답 포맷 `ApiResponse<T>` / `ApiErrorResponse` 정의
- Swagger(springdoc-openapi) 설정 추가
- 팀 컨벤션 문서(`docs/CONVENTION.md`) 작성

---

## ♻️ 패키지 변경 사항

**에러코드 컨벤션 변경:**
- `domain/course/exception/CourseErrorCode` : CR → CRS
- `domain/lecture/exception/LectureErrorCode` : LC → LCT
- `domain/enrollment/exception/EnrollmentErrorCode` : EN → ENR
- `domain/auth/domain/exception/AuthErrorCode` : AU → AUT
- `domain/user/domain/exception/UserErrorCode` : US → USR
- `domain/submission/exception/SubmissionErrorCode` : SB → SUB
- `domain/problems/exception/ProblemErrorCode` : PR → PRB-PBL / PRB-SET / PRB-CAT / PRB-HNT / PRB-DAT (하위 도메인 분리)
- `domain/admin/operation/rule/domain/exception/AutomationRuleErrorCode` : AR → ADM-ARL
- `domain/admin/operation/alert/domain/exception/OperationAlertErrorCode` : OA → ADM-ALT

**예외 처리 구조 정리:**
- `domain/course/exception/CourseNotFoundException` : 삭제
- `domain/enrollment/exception/DuplicateEnrollmentException` : 삭제
- `domain/enrollment/exception/EnrollmentNotFoundException` : 삭제
- `domain/lecture/exception/LectureNotFoundException` : 삭제
- `domain/problems/category/exception/CategoryNotFoundException` : 삭제
- `domain/problems/problem/exception/ProblemNotFound` : 삭제
- `domain/problems/set/exception/SetNotFoundException` : 삭제
- `global/domain/common/error/exception/` : NotFoundException / ValidationException / ConflictException / UnauthorizedException / ForbiddenException 공통 예외 타입 정의

**글로벌 응답 포맷:**
- `global/presentation/api/common/ApiResponse` : 성공 응답 공통 포맷 (200 / 201)
- `global/presentation/api/common/ApiErrorResponse` : 에러 응답 공통 포맷
- `global/presentation/api/common/GlobalExceptionHandler` : DomainException 핸들링

**보안 핸들러 동기화:**
- `global/infrastructure/config/security/CustomAccessDeniedHandler` : AU-015 → AUT-015
- `global/infrastructure/config/security/CustomAuthenticationEntryPoint` : AU-002 → AUT-002

**신규:**
- `global/infrastructure/config/SwaggerConfig` : Swagger 설정 추가
- `docs/CONVENTION.md` : 에러코드 / 응답 포맷 / 예외 처리 / Swagger 팀 컨벤션 문서

---

## 체크리스트

- [v] 팀에서 정한 컨벤션을 준수했습니다.
- [v] 정상적으로 동작합니다.
- [v] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.