### PR TITLE
[Ref] operation entity 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/domain/model/AutomationRule.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/domain/model/AutomationRule.java
@@ -13,42 +13,33 @@ public class AutomationRule {
     private final Long operationRuleId;
     private final Long createdBy;
     private final OperationRuleCode ruleCode;
-    private final String ruleName;
-    private final OperationTargetType targetType;
     private final BigDecimal thresholdValue;
     private final Integer minSampleCount;
     private final OperationSeverity severity;
     private final boolean enabled;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
-    private final LocalDateTime deletedAt;
 
     private AutomationRule(
             Long operationRuleId,
             Long createdBy,
             OperationRuleCode ruleCode,
-            String ruleName,
-            OperationTargetType targetType,
             BigDecimal thresholdValue,
             Integer minSampleCount,
             OperationSeverity severity,
             boolean enabled,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            LocalDateTime deletedAt
+            LocalDateTime updatedAt
     ) {
         this.operationRuleId = operationRuleId;
         this.createdBy = createdBy;
         this.ruleCode = ruleCode;
-        this.ruleName = ruleName;
-        this.targetType = targetType;
         this.thresholdValue = thresholdValue;
         this.minSampleCount = minSampleCount;
         this.severity = severity;
         this.enabled = enabled;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-        this.deletedAt = deletedAt;
     }
 
     public static AutomationRule create(
@@ -68,13 +59,10 @@ public class AutomationRule {
                 null,
                 createdBy,
                 ruleCode,
-                ruleCode.getLabel(),
-                ruleCode.getTargetType(),
                 thresholdValue,
                 normalizeMinSampleCount(ruleCode, minSampleCount),
                 resolvedSeverity,
                 resolvedEnabled,
-                null,
                 null,
                 null
         );
@@ -84,29 +72,23 @@ public class AutomationRule {
             Long operationRuleId,
             Long createdBy,
             OperationRuleCode ruleCode,
-            String ruleName,
-            OperationTargetType targetType,
             BigDecimal thresholdValue,
             Integer minSampleCount,
             OperationSeverity severity,
             boolean enabled,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            LocalDateTime deletedAt
+            LocalDateTime updatedAt
     ) {
         return new AutomationRule(
                 operationRuleId,
                 createdBy,
                 ruleCode,
-                ruleName,
-                targetType,
                 thresholdValue,
                 minSampleCount,
                 severity,
                 enabled,
                 createdAt,
-                updatedAt,
-                deletedAt
+                updatedAt
         );
     }
 
@@ -138,18 +120,6 @@ public class AutomationRule {
         }
     }
 
-    public String buildRuleContent() {
-        return switch (ruleCode) {
-            case COURSE_LOW_ENROLLMENT ->
-                    "수강생 수가 " + thresholdValue.stripTrailingZeros().toPlainString() + "명 이하인 강좌를 탐지합니다.";
-            case USER_INACTIVE_NO_COURSE ->
-                    "마지막 로그인 후 " + thresholdValue.stripTrailingZeros().toPlainString() + "일 이상 지났고 수강 중인 강좌가 없는 학생을 탐지합니다.";
-            case PROBLEM_HIGH_WRONG_RATE ->
-                    "제출 수가 " + minSampleCount + "회 이상이고 오답률이 "
-                            + thresholdValue.stripTrailingZeros().toPlainString() + "% 이상인 문제를 탐지합니다.";
-        };
-    }
-
     public Long getOperationRuleId() {
         return operationRuleId;
     }
@@ -163,11 +133,11 @@ public class AutomationRule {
     }
 
     public String getRuleName() {
-        return ruleName;
+        return ruleCode.getLabel();
     }
 
     public OperationTargetType getTargetType() {
-        return targetType;
+        return ruleCode.getTargetType();
     }
 
     public BigDecimal getThresholdValue() {
@@ -194,7 +164,4 @@ public class AutomationRule {
         return updatedAt;
     }
 
-    public LocalDateTime getDeletedAt() {
-        return deletedAt;
-    }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleJpaEntity.java
@@ -1,7 +1,6 @@
 package com.wanted.codebombalms.admin.operation.rule.infrastructure.persistence;
 
 import com.wanted.codebombalms.admin.operation.common.domain.model.OperationSeverity;
-import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
 import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -11,7 +10,12 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "automation_rule")
+@Table(
+        name = "automation_rule",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_automation_rule_code", columnNames = "rule_code")
+        }
+)
 @Getter
 @NoArgsConstructor
 public class AutomationRuleJpaEntity {
@@ -21,19 +25,12 @@ public class AutomationRuleJpaEntity {
     @Column(name = "operation_rule_id")
     private Long operationRuleId;
 
-    @Column(name = "created_by", nullable = false)
+    @Column(name = "created_by")
     private Long createdBy;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "rule_code", nullable = false)
     private OperationRuleCode ruleCode;
-
-    @Column(name = "rule_name", nullable = false, length = 100)
-    private String ruleName;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "target_type", nullable = false)
-    private OperationTargetType targetType;
 
     @Column(name = "threshold_value", nullable = false, precision = 10, scale = 2)
     private BigDecimal thresholdValue;
@@ -54,35 +51,26 @@ public class AutomationRuleJpaEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
     public AutomationRuleJpaEntity(
             Long operationRuleId,
             Long createdBy,
             OperationRuleCode ruleCode,
-            String ruleName,
-            OperationTargetType targetType,
             BigDecimal thresholdValue,
             Integer minSampleCount,
             OperationSeverity severity,
             boolean enabled,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            LocalDateTime deletedAt
+            LocalDateTime updatedAt
     ) {
         this.operationRuleId = operationRuleId;
         this.createdBy = createdBy;
         this.ruleCode = ruleCode;
-        this.ruleName = ruleName;
-        this.targetType = targetType;
         this.thresholdValue = thresholdValue;
         this.minSampleCount = minSampleCount;
         this.severity = severity;
         this.enabled = enabled;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-        this.deletedAt = deletedAt;
     }
 
     @PrePersist

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleMapper.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleMapper.java
@@ -12,15 +12,12 @@ public class AutomationRuleMapper {
                 entity.getOperationRuleId(),
                 entity.getCreatedBy(),
                 entity.getRuleCode(),
-                entity.getRuleName(),
-                entity.getTargetType(),
                 entity.getThresholdValue(),
                 entity.getMinSampleCount(),
                 entity.getSeverity(),
                 entity.isEnabled(),
                 entity.getCreatedAt(),
-                entity.getUpdatedAt(),
-                entity.getDeletedAt()
+                entity.getUpdatedAt()
         );
     }
 
@@ -29,15 +26,12 @@ public class AutomationRuleMapper {
                 domain.getOperationRuleId(),
                 domain.getCreatedBy(),
                 domain.getRuleCode(),
-                domain.getRuleName(),
-                domain.getTargetType(),
                 domain.getThresholdValue(),
                 domain.getMinSampleCount(),
                 domain.getSeverity(),
                 domain.isEnabled(),
                 domain.getCreatedAt(),
-                domain.getUpdatedAt(),
-                domain.getDeletedAt()
+                domain.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleRepositoryAdapter.java
@@ -7,6 +7,8 @@ import com.wanted.codebombalms.admin.operation.rule.domain.repository.Automation
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,21 +35,39 @@ public class AutomationRuleRepositoryAdapter implements AutomationRuleRepository
     @Override
     public List<AutomationRule> findAllActive(OperationTargetType targetType) {
         List<AutomationRuleJpaEntity> entities = targetType == null
-                ? springDataRepository.findByDeletedAtIsNullOrderByCreatedAtDesc()
-                : springDataRepository.findByTargetTypeAndDeletedAtIsNullOrderByCreatedAtDesc(targetType);
+                ? springDataRepository.findAllByOrderByOperationRuleIdAsc()
+                : springDataRepository.findByRuleCodeIn(findRuleCodesByTargetType(targetType));
 
         return entities.stream()
                 .map(AutomationRuleMapper::toDomain)
+                .sorted(Comparator.comparingInt(rule -> getDisplayOrder(rule.getRuleCode())))
                 .toList();
     }
 
     @Override
     public boolean existsActiveByRuleCode(OperationRuleCode ruleCode) {
-        return springDataRepository.existsByRuleCodeAndDeletedAtIsNull(ruleCode);
+        return springDataRepository.existsByRuleCode(ruleCode);
     }
 
     @Override
     public List<OperationRuleCode> findActiveRuleCodes() {
-        return springDataRepository.findRuleCodesByDeletedAtIsNull();
+        return springDataRepository.findAllByOrderByOperationRuleIdAsc()
+                .stream()
+                .map(AutomationRuleJpaEntity::getRuleCode)
+                .toList();
+    }
+
+    private List<OperationRuleCode> findRuleCodesByTargetType(OperationTargetType targetType) {
+        return Arrays.stream(OperationRuleCode.values())
+                .filter(ruleCode -> ruleCode.getTargetType() == targetType)
+                .toList();
+    }
+
+    private int getDisplayOrder(OperationRuleCode ruleCode) {
+        return switch (ruleCode) {
+            case COURSE_LOW_ENROLLMENT -> 1;
+            case PROBLEM_HIGH_WRONG_RATE -> 2;
+            case USER_INACTIVE_NO_COURSE -> 3;
+        };
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/SpringDataAutomationRuleRepository.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/SpringDataAutomationRuleRepository.java
@@ -1,20 +1,15 @@
 package com.wanted.codebombalms.admin.operation.rule.infrastructure.persistence;
 
-import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
 import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface SpringDataAutomationRuleRepository extends JpaRepository<AutomationRuleJpaEntity, Long> {
 
-    List<AutomationRuleJpaEntity> findByDeletedAtIsNullOrderByCreatedAtDesc();
+    List<AutomationRuleJpaEntity> findAllByOrderByOperationRuleIdAsc();
 
-    List<AutomationRuleJpaEntity> findByTargetTypeAndDeletedAtIsNullOrderByCreatedAtDesc(OperationTargetType targetType);
+    boolean existsByRuleCode(OperationRuleCode ruleCode);
 
-    boolean existsByRuleCodeAndDeletedAtIsNull(OperationRuleCode ruleCode);
-
-    @Query("select ar.ruleCode from AutomationRuleJpaEntity ar where ar.deletedAt is null")
-    List<OperationRuleCode> findRuleCodesByDeletedAtIsNull();
+    List<AutomationRuleJpaEntity> findByRuleCodeIn(List<OperationRuleCode> ruleCodes);
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/presentation/api/response/AutomationRuleResponse.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/presentation/api/response/AutomationRuleResponse.java
@@ -20,15 +20,17 @@ public class AutomationRuleResponse {
     private OperationRuleCode ruleCode;
     private String ruleName;
     private OperationTargetType targetType;
-    private String ruleContent;
     private BigDecimal thresholdValue;
     private String thresholdLabel;
     private String thresholdUnit;
+    private BigDecimal thresholdMin;
+    private BigDecimal thresholdMax;
     private Integer minSampleCount;
+    private boolean requiresMinSampleCount;
+    private String minSampleCountLabel;
+    private String minSampleCountUnit;
     private OperationSeverity severity;
     private boolean enabled;
-    private Long createdBy;
-    private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public static AutomationRuleResponse from(AutomationRule rule) {
@@ -39,15 +41,17 @@ public class AutomationRuleResponse {
                 rule.getRuleCode(),
                 rule.getRuleName(),
                 rule.getTargetType(),
-                rule.buildRuleContent(),
                 rule.getThresholdValue(),
                 ruleCode.getThresholdLabel(),
                 ruleCode.getThresholdUnit(),
+                ruleCode.getThresholdMin(),
+                ruleCode.getThresholdMax(),
                 rule.getMinSampleCount(),
+                ruleCode.isRequiresMinSampleCount(),
+                ruleCode.getMinSampleCountLabel(),
+                ruleCode.getMinSampleCountUnit(),
                 rule.getSeverity(),
                 rule.isEnabled(),
-                rule.getCreatedBy(),
-                rule.getCreatedAt(),
                 rule.getUpdatedAt()
         );
     }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #209 

---

## 🛠️ 기능 관련 작업 내용


예시:
- 강사 코스 등록 기능을 구현했습니다.
- 과제 제출 시 빈 내용 검증 로직을 추가했습니다.
- 코스 상세 화면의 버튼 디자인을 main.html 기준으로 통일했습니다.

---

## ♻️ 패키지 변경 사항

automationRuleJpaEntity.java
-> ruleName, targetType, deletedAt 제거
-> createtby nullable로 변경
-> rule_code unique constraint 반영

automationrule.java
-> db에서 빠진 ruleName, targetType은 저장 값이 아니라 ruleCode enum에서 파생되도록 변경

AutomationRuleMapper.java
-> 제거된 칼럼 매핑 삭제

SpringDataAutomationRuleRepository
-> deleted_at, target_type 기준 쿼리 제거
-> rule_code 기준 존재 확인/조회로 변경

AutomationRuleRepositoryAdapter.java
-> targetType 필터는 DB 칼럼이 아니라 OperationRuleCode.getTargetType() 기반으로 처리 
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
