### PR TITLE
Feat/login logout clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main, develop, clenCodeDevelop ]
+    branches: [ main, develop, cleanCodeDevelop ]
 
 jobs:
   build:

--- a/http/auth.http
+++ b/http/auth.http
@@ -84,3 +84,44 @@ GET http://localhost:8080/api/v1/auth/check/nickname?nickname=완전새로운닉
 
 ### 10. 닉네임 중복 확인 — 이미 사용 중 (1번에서 가입한 닉네임)
 GET http://localhost:8080/api/v1/auth/check/nickname?nickname=길동이
+
+
+
+### 11. 로그인 성공 — 쿠키 2개 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "test1@example.com",
+  "password": "Test1234!"
+}
+
+### 12. 로그인 실패 — 비번 틀림
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "test1@example.com",
+  "password": "WrongPass1!"
+}
+
+### 13. 로그인 실패 — 없는 이메일
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "ghost@example.com",
+  "password": "Test1234!"
+}
+
+### 14. 토큰 재발급 — 쿠키 자동 전송 (11번 이후 실행)
+POST http://localhost:8080/api/v1/auth/reissue
+
+### 15. 로그아웃 (14번 또는 11번 이후 실행)
+POST http://localhost:8080/api/v1/auth/logout
+
+### 16. 로그아웃 후 다시 로그아웃 — 401 (쿠키 없음)
+POST http://localhost:8080/api/v1/auth/logout
+
+### 17. 로그아웃 후 재발급 시도 — 401 (DB에 RT 없음)
+POST http://localhost:8080/api/v1/auth/reissue

--- a/src/main/java/com/wanted/codebombalms/auth/application/command/LoginCommand.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/command/LoginCommand.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.auth.application.command;
+
+public record LoginCommand(
+        String email,
+        String rawPassword
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/dto/TokenPair.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/dto/TokenPair.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.auth.application.dto;
+
+public record TokenPair(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -1,0 +1,61 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.command.LoginCommand;
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.usecase.LoginUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LoginService implements LoginUseCase {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public TokenPair login(LoginCommand command) {
+
+        // 1. 이메일로 회원 조회 — 이메일 없음 / 비번 불일치 모두 동일 에러 (보안)
+        User user = userRepository.findByEmail(command.email())
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(command.rawPassword(), user.getPassword())) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL);
+        }
+
+        // 3. 계정 잠금 확인
+        if (user.isLocked()) {
+            throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
+        }
+
+        // 4. 단일 세션 강제 — 기존 RT 전부 삭제
+        refreshTokenRepository.deleteByUserId(user.getUserId());
+
+        // 5. 토큰 발급
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getRole());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
+
+        // 6. RT 저장
+        refreshTokenRepository.save(
+                RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration())
+        );
+
+        return new TokenPair(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LogoutService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LogoutService.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.usecase.LogoutUseCase;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LogoutService implements LogoutUseCase {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void logout(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/TokenReissueService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/TokenReissueService.java
@@ -1,0 +1,64 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.usecase.TokenReissueUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TokenReissueService implements TokenReissueUseCase {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public TokenPair reissue(String refreshToken) {
+
+        // 1. JWT 자체 유효성 검증 (만료 / 위변조)
+        jwtTokenProvider.validateRefreshToken(refreshToken);
+
+        // 2. DB 에 등록된 토큰인지 확인
+        RefreshToken stored = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID));
+
+        // 3. DB 만료 확인 (이중 안전망)
+        if (stored.isExpired()) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
+        }
+
+        // 4. 유저 조회 + 상태 확인
+        Long userId = stored.getUserId();
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.isLocked()) {
+            throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
+        }
+
+        // 5. 새 토큰 발급
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getRole());
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
+
+        // 6. RTR — 기존 RT 삭제 + 새 RT 저장 (1회용)
+        refreshTokenRepository.deleteByUserId(user.getUserId());
+        refreshTokenRepository.save(
+                RefreshToken.issue(user.getUserId(), newRefreshToken, jwtTokenProvider.getRefreshExpiration())
+        );
+
+        return new TokenPair(newAccessToken, newRefreshToken);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+import com.wanted.codebombalms.auth.application.command.LoginCommand;
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+
+public interface LoginUseCase {
+
+    TokenPair login(LoginCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/LogoutUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/LogoutUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+public interface LogoutUseCase {
+    
+    void logout(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/TokenReissueUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/TokenReissueUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+
+public interface TokenReissueUseCase {
+
+    TokenPair reissue(String refreshToken);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/exception/AuthErrorCode.java
@@ -35,7 +35,8 @@ public enum AuthErrorCode implements ErrorCode {
 
     // 기타
     AUTH_EMAIL_SEND_TOO_MANY("AUT-014", "이메일 발송 횟수를 초과했습니다."),
-    AUTH_FORBIDDEN("AUT-015", "접근 권한이 없습니다.");
+    AUTH_FORBIDDEN("AUT-015", "접근 권한이 없습니다."),
+    AUTH_REQUIRED("AUT-016", "인증이 필요합니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/auth/domain/model/RefreshToken.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/model/RefreshToken.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.auth.domain.model;
+
+import java.time.LocalDateTime;
+
+public class RefreshToken {
+
+    private Long refreshTokenId;
+    private Long userId;
+    private String token;
+    private LocalDateTime expiresAt;
+    private LocalDateTime createdAt;
+
+    private RefreshToken() {}
+
+    // ===== Getter =====
+    public Long getRefreshTokenId()      { return refreshTokenId; }
+    public Long getUserId()              { return userId; }
+    public String getToken()             { return token; }
+    public LocalDateTime getExpiresAt()  { return expiresAt; }
+    public LocalDateTime getCreatedAt()  { return createdAt; }
+
+    // ===== 정적 팩토리 — 신규 발급 =====
+
+    public static RefreshToken issue(Long userId, String token, long ttlMillis) {
+        RefreshToken rt = new RefreshToken();
+        rt.userId    = userId;
+        rt.token     = token;
+        rt.expiresAt = LocalDateTime.now().plusNanos(ttlMillis * 1_000_000);
+        return rt;
+    }
+
+    // ===== 영속성 복원 — Adapter 전용 =====
+
+    public static RefreshToken restore(
+            Long refreshTokenId,
+            Long userId,
+            String token,
+            LocalDateTime expiresAt,
+            LocalDateTime createdAt
+    ) {
+        RefreshToken rt = new RefreshToken();
+        rt.refreshTokenId = refreshTokenId;
+        rt.userId         = userId;
+        rt.token          = token;
+        rt.expiresAt      = expiresAt;
+        rt.createdAt      = createdAt;
+        return rt;
+    }
+
+    // ===== 도메인 행위 =====
+
+    // 만료 여부 확인
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.auth.domain.repository;
+
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+
+    // 토큰 문자열로 조회
+    Optional<RefreshToken> findByToken(String token);
+
+    // 특정 유저의 모든 Refresh Token 삭제 (로그아웃 / 단일 세션 강제)
+    void deleteByUserId(Long userId);
+
+    // 저장
+    RefreshToken save(RefreshToken refreshToken);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RefreshTokenJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RefreshTokenJpaEntity.java
@@ -1,0 +1,60 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class RefreshTokenJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long refreshTokenId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "token", nullable = false, length = 512)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // ===== 도메인 → 엔티티 (저장용) =====
+
+    public static RefreshTokenJpaEntity from(RefreshToken refreshToken) {
+        RefreshTokenJpaEntity e = new RefreshTokenJpaEntity();
+        e.refreshTokenId = refreshToken.getRefreshTokenId();
+        e.userId         = refreshToken.getUserId();
+        e.token          = refreshToken.getToken();
+        e.expiresAt      = refreshToken.getExpiresAt();
+        return e;
+    }
+
+    // ===== 엔티티 → 도메인 (조회용) =====
+
+    public RefreshToken toDomain() {
+        return RefreshToken.restore(
+                refreshTokenId,
+                userId,
+                token,
+                expiresAt,
+                createdAt
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RefreshTokenRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RefreshTokenRepositoryAdapter.java
@@ -1,0 +1,32 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
+
+    private final SpringDataRefreshTokenRepository springDataRefreshTokenRepository;
+
+    @Override
+    public Optional<RefreshToken> findByToken(String token) {
+        return springDataRefreshTokenRepository.findByToken(token)
+                .map(RefreshTokenJpaEntity::toDomain);
+    }
+
+    @Override
+    public void deleteByUserId(Long userId) {
+        springDataRefreshTokenRepository.deleteByUserId(userId);
+    }
+
+    @Override
+    public RefreshToken save(RefreshToken refreshToken) {
+        RefreshTokenJpaEntity entity = RefreshTokenJpaEntity.from(refreshToken);
+        return springDataRefreshTokenRepository.save(entity).toDomain();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataRefreshTokenRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataRefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataRefreshTokenRepository extends JpaRepository<RefreshTokenJpaEntity, Long> {
+
+    Optional<RefreshTokenJpaEntity> findByToken(String token);
+
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
@@ -8,4 +8,7 @@ public class AuthResponseCode {
 
     public static final String EMAIL_AVAILABILITY_CHECKED = "AUTH-EMAIL-AVAILABILITY-CHECKED";
     public static final String NICKNAME_AVAILABILITY_CHECKED = "AUTH-NICKNAME-AVAILABILITY-CHECKED";
+    public static final String LOGIN_COMPLETED = "AUTH-LOGIN-COMPLETED";
+    public static final String LOGOUT_COMPLETED = "AUTH-LOGOUT-COMPLETED";
+    public static final String TOKEN_REISSUED = "AUTH-TOKEN-REISSUED";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
@@ -8,4 +8,7 @@ public class AuthResponseMessage {
 
     public static final String EMAIL_AVAILABILITY_CHECKED = "이메일 사용 가능 여부를 확인했습니다.";
     public static final String NICKNAME_AVAILABILITY_CHECKED = "닉네임 사용 가능 여부를 확인했습니다.";
+    public static final String LOGIN_COMPLETED = "로그인되었습니다.";
+    public static final String LOGOUT_COMPLETED = "로그아웃되었습니다.";
+    public static final String TOKEN_REISSUED = "토큰이 재발급되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
@@ -1,0 +1,60 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.usecase.LoginUseCase;
+import com.wanted.codebombalms.auth.presentation.api.dto.request.LoginRequest;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class LoginController {
+
+    private final LoginUseCase loginUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Void>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        TokenPair pair = loginUseCase.login(request.toCommand());
+
+        // 쿠키 2개 설정
+        response.addCookie(createCookie(
+                "accessToken",
+                pair.accessToken(),
+                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
+        ));
+        response.addCookie(createCookie(
+                "refreshToken",
+                pair.refreshToken(),
+                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
+        ));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.LOGIN_COMPLETED,
+                AuthResponseMessage.LOGIN_COMPLETED
+        ));
+    }
+
+    private Cookie createCookie(String name, String value, int maxAgeSeconds) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);   // 운영 배포 시 true 로
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAgeSeconds);
+        cookie.setAttribute("SameSite", "Lax");
+        return cookie;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/LogoutController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/LogoutController.java
@@ -1,0 +1,50 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.usecase.LogoutUseCase;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class LogoutController {
+
+    private final LogoutUseCase logoutUseCase;
+
+    @PostMapping("/logout")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal Long userId,
+            HttpServletResponse response
+    ) {
+        // 1. DB의 Refresh Token 삭제
+        logoutUseCase.logout(userId);
+
+        // 2. 쿠키 만료
+        response.addCookie(createExpiredCookie("accessToken"));
+        response.addCookie(createExpiredCookie("refreshToken"));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.LOGOUT_COMPLETED,
+                AuthResponseMessage.LOGOUT_COMPLETED
+        ));
+    }
+
+    private Cookie createExpiredCookie(String name) {
+        Cookie cookie = new Cookie(name, "");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);   // ← 즉시 만료
+        cookie.setAttribute("SameSite", "Lax");
+        return cookie;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/TokenReissueController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/TokenReissueController.java
@@ -1,0 +1,75 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.usecase.TokenReissueUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class TokenReissueController {
+
+    private final TokenReissueUseCase tokenReissueUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<Void>> reissue(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        // 1. 쿠키에서 refreshToken 추출
+        String refreshToken = extractCookie(request, "refreshToken")
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID));
+
+        // 2. 재발급 수행
+        TokenPair pair = tokenReissueUseCase.reissue(refreshToken);
+
+        // 3. 새 쿠키 2개 발급 (기존 쿠키 덮어쓰기)
+        response.addCookie(createCookie(
+                "accessToken",
+                pair.accessToken(),
+                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
+        ));
+        response.addCookie(createCookie(
+                "refreshToken",
+                pair.refreshToken(),
+                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
+        ));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.TOKEN_REISSUED,
+                AuthResponseMessage.TOKEN_REISSUED
+        ));
+    }
+
+    private java.util.Optional<String> extractCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return java.util.Optional.empty();
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals(name)) {
+                return java.util.Optional.of(cookie.getValue());
+            }
+        }
+        return java.util.Optional.empty();
+    }
+
+    private Cookie createCookie(String name, String value, int maxAgeSeconds) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        cookie.setPath("/");
+        cookie.setMaxAge(maxAgeSeconds);
+        cookie.setAttribute("SameSite", "Lax");
+        return cookie;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/LoginRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.request;
+
+import com.wanted.codebombalms.auth.application.command.LoginCommand;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+
+    public LoginCommand toCommand() {
+        return new LoginCommand(email, password);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -44,4 +44,25 @@ public class GlobalExceptionHandler {
     private boolean isDev() {
         return Arrays.asList(env.getActiveProfiles()).contains("local");
     }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ApiErrorResponse> handleAuthorizationDenied(
+            AuthorizationDeniedException e, HttpServletRequest request) {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        boolean isAuthenticated = auth != null
+                && auth.isAuthenticated()
+                && !(auth instanceof AnonymousAuthenticationToken);
+
+        if (!isAuthenticated) {
+            log.warn("[401] 인증되지 않은 요청 - path: {}", request.getRequestURI());
+            return ResponseEntity.status(401)
+                    .body(ApiErrorResponse.of(401, "AUT-016", "인증이 필요합니다.", request.getRequestURI()));
+        } else {
+            log.warn("[403] 권한 부족 - path: {}", request.getRequestURI());
+            return ResponseEntity.status(403)
+                    .body(ApiErrorResponse.of(403, "AUT-015", "접근 권한이 없습니다.", request.getRequestURI()));
+        }
+    }
 }
+


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #195 
- Closes #196 

---

## 🛠️ 기능 관련 작업 내용

로그인 / 로그아웃 / 토큰 재발급 API 3종을 클린 아키텍처 패턴으로 구현했습니다. [#193](https://github.com/wanted-Tsarbomba-module03-Project/Tsarbomba-Backend-module03-LMS/issues/193) 에서 삭제됐던 RefreshToken 도 도메인 모델 + Port + Adapter 구조로 재구성.

- 신규 API
POST /api/v1/auth/login — 이메일/비밀번호 로그인 후 HttpOnly 쿠키 2개(accessToken, refreshToken) 발급
POST /api/v1/auth/logout — @PreAuthorize("isAuthenticated()") 로 인증 강제, DB의 Refresh Token 전체 삭제 + 쿠키 만료
POST /api/v1/auth/reissue — 쿠키의 Refresh Token 으로 새 토큰 쌍 발급 (RTR — Refresh Token Rotation)
RefreshToken 클린 아키텍처 셋업
RefreshToken 순수 도메인 모델 — issue(userId, token, ttlMillis), restore(...), isExpired() 행위 보유, JPA / Spring 의존 없음
RefreshTokenRepository Port 인터페이스 — findByToken, deleteByUserId, save 3개 메서드
RefreshTokenJpaEntity JPA 매핑 전담 — from(RefreshToken), toDomain() 변환 메서드 보유
RefreshTokenRepositoryAdapter — Port 구현, SpringDataRefreshTokenRepository 감쌈
TokenPair record — Service → Controller 로 Access/Refresh 토큰 한 쌍을 전달하기 위한 application DTO
보안 / 정책 ([#100](https://github.com/wanted-Tsarbomba-module03-Project/Tsarbomba-Backend-module03-LMS/issues/100) [#101](https://github.com/wanted-Tsarbomba-module03-Project/Tsarbomba-Backend-module03-LMS/issues/101) 정책 유지)
이메일 없음 / 비밀번호 불일치 모두 동일한 AUT-001 응답 — 이메일 존재 여부 노출 방지
단일 세션 강제 — 로그인 시점에 기존 Refresh Token 전부 삭제 후 새로 발급, 멀티 디바이스 차단
RTR — 재발급 시 기존 Refresh Token 즉시 무효화 + 새 RT 저장, 탈취 시 1회 사용 후 거부
HttpOnly 쿠키 + SameSite=Lax, Secure=false (로컬 개발 — 운영 시 환경별 분기 필요)
계정 잠금 확인 — User.isLocked() 가 true 면 로그인 / 재발급 모두 403 USR-007
동작 흐름
로그인: 이메일 조회 → BCrypt 비번 검증 → 잠금 계정 차단 → 기존 RT 전체 삭제 → 새 토큰 발급 → 새 RT DB 저장 → HttpOnly 쿠키 2개 발급
로그아웃: @PreAuthorize 로 인증 강제 → Service 가 해당 유저 RT 전체 삭제 → 쿠키 Max-Age=0 만료
재발급(RTR): JWT 유효성 검증 → DB 토큰 존재 확인 → 유저 잠금 여부 확인 → 새 토큰 발급 → 기존 RT DB 삭제 + 새 RT 저장 → 새 쿠키 덮어쓰기
메서드 레벨 보안 핸들러 복구
컨벤션 마이그레이션 시 누락됐던 AuthorizationDeniedException 핸들러를 GlobalExceptionHandler 에 복구 ([#101](https://github.com/wanted-Tsarbomba-module03-Project/Tsarbomba-Backend-module03-LMS/issues/101) 패턴 그대로)
인증 안 됨 → 401 AUT-016 "인증이 필요합니다."
인증은 됐지만 권한 부족 → 403 AUT-015 "접근 권한이 없습니다."
AuthErrorCode.AUTH_REQUIRED("AUT-016") 신규 추가
향후 다른 도메인에서도 @PreAuthorize("hasRole('ADMIN')") 등 메서드 레벨 보안 사용 시 동일하게 적용됨

검증 (http/auth.http 11~17번)
정상 로그인 → 200 + 쿠키 2개 발급
비번 틀림 → 401 AUT-001
없는 이메일 → 401 AUT-001 (이메일 노출 방지)
토큰 재발급 → 200 + 새 쿠키 2개 발급
로그아웃 → 200 + 쿠키 만료
로그아웃 후 재로그아웃 → 401 AUT-016
로그아웃 후 재발급 → 401 AUT-004

---

## ♻️ 패키지 변경 사항

변경된 패키지, 클래스, HTML 파일 등을 작성해주세요.

예시:
auth/domain/model/RefreshToken : 순수 도메인 모델 신규 생성
auth/domain/repository/RefreshTokenRepository : Port 인터페이스 신규 생성
auth/infrastructure/persistence/RefreshTokenJpaEntity : JPA 영속성 엔티티 신규 생성, from / toDomain 변환 메서드 포함
auth/infrastructure/persistence/SpringDataRefreshTokenRepository : Spring Data JPA 신규 생성 (findByToken, deleteByUserId)
auth/infrastructure/persistence/RefreshTokenRepositoryAdapter : Port 구현체 신규 생성
auth/application/dto/TokenPair : Service → Controller 토큰 전달용 record 신규 생성
auth/application/command/LoginCommand : 로그인 입력 모델 신규 생성
auth/application/usecase/LoginUseCase : 로그인 유스케이스 인터페이스 신규 생성
auth/application/usecase/LogoutUseCase : 로그아웃 유스케이스 인터페이스 신규 생성 (입력값 단순해서 Command 없이 Long userId 직접)
auth/application/usecase/TokenReissueUseCase : 재발급 유스케이스 인터페이스 신규 생성 (입력값 단순해서 Command 없이 String refreshToken 직접)
auth/application/service/LoginService : 로그인 비즈니스 로직 신규 작성 (이메일/비번 검증, 단일 세션 강제, 토큰 발급, RT 저장)
auth/application/service/LogoutService : DB 의 RT 전체 삭제만 담당
auth/application/service/TokenReissueService : RTR 비즈니스 로직 신규 작성
auth/presentation/api/dto/request/LoginRequest : Bean Validation 적용 DTO 신규 생성 (@Email, @NotBlank)
auth/presentation/api/LoginController : POST /api/v1/auth/login 엔드포인트 + 쿠키 발급 헬퍼 createCookie 추가
auth/presentation/api/LogoutController : POST /api/v1/auth/logout 엔드포인트 + 쿠키 만료 헬퍼 createExpiredCookie 추가
auth/presentation/api/TokenReissueController : POST /api/v1/auth/reissue 엔드포인트 + 쿠키 추출/갱신 헬퍼
auth/presentation/api/AuthResponseCode : LOGIN_COMPLETED, LOGOUT_COMPLETED, TOKEN_REISSUED 상수 3개 추가
auth/presentation/api/AuthResponseMessage : 동일 키 한국어 메시지 3개 추가
auth/domain/exception/AuthErrorCode : AUTH_REQUIRED("AUT-016", "인증이 필요합니다.") 추가

공통 영역
global/presentation/api/common/GlobalExceptionHandler : AuthorizationDeniedException 핸들러 추가. SecurityContextHolder 의 인증 상태에 따라 401(AUT-016) / 403(AUT-015) 으로 분기. 컨벤션 마이그 시 누락된 [#101](https://github.com/wanted-Tsarbomba-module03-Project/Tsarbomba-Backend-module03-LMS/issues/101) 패턴을 복구한 것이며, 추후 다른 도메인에서 @PreAuthorize 사용 시에도 동일하게 적용됨
.github/workflows/ci.yml : pull_request.branches 트리거 목록의 오타 수정 (clenCodeDevelop → cleanCodeDevelop). 그동안 cleanCodeDevelop base PR 에 CI 가 트리거되지 않던 문제 해결

테스트
http/auth.http : 로그인/로그아웃/재발급 검증용 11~17번 케이스 추가
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
