### PR TITLE
[Feat] 관리자알림삭제

### DIFF
--- a/http/automationalert.http
+++ b/http/automationalert.http
@@ -1,5 +1,7 @@
 @baseUrl = http://localhost:8080
 @operationAlertId = 1
+@deletableOperationAlertId = 2
+@openOperationAlertId = 1
 
 ### =========================================================
 ### 운영 알림 목록 조회 - 전체
@@ -218,3 +220,33 @@ Content-Type: application/json
 
 {
 }
+
+
+### =========================================================
+### 운영 알림 삭제 - 성공
+### RESOLVED 또는 IGNORED 상태 알림에만 사용
+### 기대 결과: deletedAt 값 반환, 이후 목록 조회에서 제외
+### =========================================================
+DELETE {{baseUrl}}/api/v1/admin/operation-alerts/{{deletableOperationAlertId}}
+
+
+### =========================================================
+### 운영 알림 삭제 - OPEN 상태 삭제 불가
+### 기대 결과: CANNOT_DELETE_OPEN_ALERT
+### =========================================================
+DELETE {{baseUrl}}/api/v1/admin/operation-alerts/{{openOperationAlertId}}
+
+
+### =========================================================
+### 운영 알림 삭제 - 이미 삭제된 알림 재삭제
+### 위 성공 요청을 먼저 실행한 뒤 다시 실행
+### 기대 결과: OPERATION_ALERT_NOT_FOUND
+### =========================================================
+DELETE {{baseUrl}}/api/v1/admin/operation-alerts/{{deletableOperationAlertId}}
+
+
+### =========================================================
+### 운영 알림 삭제 후 목록 조회 확인
+### deleted_at이 채워진 알림은 조회 결과에서 제외되어야 함
+### =========================================================
+GET {{baseUrl}}/api/v1/admin/operation-alerts?page=1&size=20

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/application/service/OperationAlertCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/application/service/OperationAlertCommandService.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.admin.operation.alert.application.service;
 
 import com.wanted.codebombalms.admin.operation.alert.application.command.UpdateOperationAlertStatusCommand;
+import com.wanted.codebombalms.admin.operation.alert.application.usecase.DeleteOperationAlertUseCase;
 import com.wanted.codebombalms.admin.operation.alert.application.usecase.UpdateOperationAlertStatusUseCase;
 import com.wanted.codebombalms.admin.operation.alert.domain.exception.OperationAlertErrorCode;
 import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlert;
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class OperationAlertCommandService implements UpdateOperationAlertStatusUseCase {
+public class OperationAlertCommandService implements UpdateOperationAlertStatusUseCase, DeleteOperationAlertUseCase {
 
     private final OperationAlertRepository operationAlertRepository;
 
@@ -36,6 +37,21 @@ public class OperationAlertCommandService implements UpdateOperationAlertStatusU
         return operationAlertRepository.save(operationAlert);
     }
 
+    //DeleteOperationAlertUseCase를 구현
+    // operationAlertId 검증 후 삭제되지 않은 알림을 조회하고
+    // 도메인의 delete(LocalDateTime.now())를 호출한 뒤 저장
+    @Override
+    public OperationAlert delete(Long operationAlertId) {
+        validateDeleteRequest(operationAlertId);
+
+        OperationAlert operationAlert = operationAlertRepository.findById(operationAlertId)
+                .orElseThrow(() -> new NotFoundException(OperationAlertErrorCode.OPERATION_ALERT_NOT_FOUND));
+
+        operationAlert.delete(LocalDateTime.now());
+
+        return operationAlertRepository.save(operationAlert);
+    }
+
     private void validateCommand(UpdateOperationAlertStatusCommand command) {
         if (command == null
                 || command.operationAlertId() == null
@@ -44,5 +60,11 @@ public class OperationAlertCommandService implements UpdateOperationAlertStatusU
             throw new ValidationException(OperationAlertErrorCode.INVALID_STATUS_UPDATE_REQUEST);
         }
 
+    }
+
+    private void validateDeleteRequest(Long operationAlertId) {
+        if (operationAlertId == null) {
+            throw new ValidationException(OperationAlertErrorCode.INVALID_DELETE_REQUEST);
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/application/usecase/DeleteOperationAlertUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/application/usecase/DeleteOperationAlertUseCase.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.admin.operation.alert.application.usecase;
+
+import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlert;
+
+//soft delete 전용 유스케이스 인터페이스를 새로 추가
+public interface DeleteOperationAlertUseCase {
+
+    OperationAlert delete(Long operationAlertId);
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/exception/OperationAlertErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/exception/OperationAlertErrorCode.java
@@ -15,7 +15,11 @@ public enum OperationAlertErrorCode implements ErrorCode {
 
     // 상태 변경
     INVALID_STATUS_UPDATE_REQUEST("ADM-ALT-004", "운영 알림 상태 변경 요청이 올바르지 않습니다."),
-    ALREADY_PROCESSED_ALERT("ADM-ALT-005", "이미 처리된 운영 알림입니다.");
+    ALREADY_PROCESSED_ALERT("ADM-ALT-005", "이미 처리된 운영 알림입니다."),
+
+    // 삭제
+    INVALID_DELETE_REQUEST("ADM-ALT-006", "운영 알림 삭제 요청이 올바르지 않습니다."),
+    CANNOT_DELETE_OPEN_ALERT("ADM-ALT-007", "OPEN 상태의 운영 알림은 삭제할 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/model/OperationAlert.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/model/OperationAlert.java
@@ -26,6 +26,7 @@ public class OperationAlert {
     private String adminMemo;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
 
     private OperationAlert(
             Long operationAlertId,
@@ -44,7 +45,8 @@ public class OperationAlert {
             LocalDateTime resolvedAt,
             String adminMemo,
             LocalDateTime createdAt,
-            LocalDateTime updatedAt
+            LocalDateTime updatedAt,
+            LocalDateTime deletedAt
     ) {
         this.operationAlertId = operationAlertId;
         this.operationRuleId = operationRuleId;
@@ -63,6 +65,7 @@ public class OperationAlert {
         this.adminMemo = adminMemo;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
     }
 
     public static OperationAlert restore(
@@ -84,6 +87,48 @@ public class OperationAlert {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
+        return restore(
+                operationAlertId,
+                operationRuleId,
+                targetType,
+                targetId,
+                detectedValue,
+                thresholdValueSnapshot,
+                assigneeId,
+                reason,
+                recommendedAction,
+                firstDetectedAt,
+                lastDetectedAt,
+                status,
+                resolvedBy,
+                resolvedAt,
+                adminMemo,
+                createdAt,
+                updatedAt,
+                null
+        );
+    }
+
+    public static OperationAlert restore(
+            Long operationAlertId,
+            Long operationRuleId,
+            OperationTargetType targetType,
+            Long targetId,
+            BigDecimal detectedValue,
+            BigDecimal thresholdValueSnapshot,
+            Long assigneeId,
+            String reason,
+            String recommendedAction,
+            LocalDateTime firstDetectedAt,
+            LocalDateTime lastDetectedAt,
+            OperationAlertStatus status,
+            Long resolvedBy,
+            LocalDateTime resolvedAt,
+            String adminMemo,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            LocalDateTime deletedAt
+    ) {
         return new OperationAlert(
                 operationAlertId,
                 operationRuleId,
@@ -101,7 +146,8 @@ public class OperationAlert {
                 resolvedAt,
                 adminMemo,
                 createdAt,
-                updatedAt
+                updatedAt,
+                deletedAt
         );
     }
 
@@ -131,6 +177,15 @@ public class OperationAlert {
         this.recommendedAction = recommendedAction;
         this.lastDetectedAt = detectedAt;
         this.updatedAt = detectedAt;
+    }
+
+    public void delete(LocalDateTime deletedAt) {
+        if (this.status == OperationAlertStatus.OPEN) {
+            throw new ValidationException(OperationAlertErrorCode.CANNOT_DELETE_OPEN_ALERT);
+        }
+
+        this.deletedAt = deletedAt;
+        this.updatedAt = deletedAt;
     }
 
     public Long getOperationAlertId() {
@@ -199,5 +254,9 @@ public class OperationAlert {
 
     public LocalDateTime getUpdatedAt() {
         return updatedAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertJpaEntity.java
@@ -70,6 +70,9 @@ public class OperationAlertJpaEntity {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public OperationAlertJpaEntity(
             Long operationAlertId,
             Long operationRuleId,
@@ -89,6 +92,48 @@ public class OperationAlertJpaEntity {
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
+        this(
+                operationAlertId,
+                operationRuleId,
+                targetType,
+                targetId,
+                detectedValue,
+                thresholdValueSnapshot,
+                assigneeId,
+                reason,
+                recommendedAction,
+                firstDetectedAt,
+                lastDetectedAt,
+                status,
+                resolvedBy,
+                resolvedAt,
+                adminMemo,
+                createdAt,
+                updatedAt,
+                null
+        );
+    }
+
+    public OperationAlertJpaEntity(
+            Long operationAlertId,
+            Long operationRuleId,
+            OperationTargetType targetType,
+            Long targetId,
+            BigDecimal detectedValue,
+            BigDecimal thresholdValueSnapshot,
+            Long assigneeId,
+            String reason,
+            String recommendedAction,
+            LocalDateTime firstDetectedAt,
+            LocalDateTime lastDetectedAt,
+            OperationAlertStatus status,
+            Long resolvedBy,
+            LocalDateTime resolvedAt,
+            String adminMemo,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt,
+            LocalDateTime deletedAt
+    ) {
         this.operationAlertId = operationAlertId;
         this.operationRuleId = operationRuleId;
         this.targetType = targetType;
@@ -106,6 +151,7 @@ public class OperationAlertJpaEntity {
         this.adminMemo = adminMemo;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
     }
 
     @PrePersist

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertMapper.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertMapper.java
@@ -25,7 +25,8 @@ public class OperationAlertMapper {
                 entity.getResolvedAt(),
                 entity.getAdminMemo(),
                 entity.getCreatedAt(),
-                entity.getUpdatedAt()
+                entity.getUpdatedAt(),
+                entity.getDeletedAt()
         );
     }
 
@@ -47,7 +48,8 @@ public class OperationAlertMapper {
                 domain.getResolvedAt(),
                 domain.getAdminMemo(),
                 domain.getCreatedAt(),
-                domain.getUpdatedAt()
+                domain.getUpdatedAt(),
+                domain.getDeletedAt()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertRepositoryAdapter.java
@@ -15,7 +15,7 @@ public class OperationAlertRepositoryAdapter implements OperationAlertRepository
 
     @Override
     public Optional<OperationAlert> findById(Long operationAlertId) {
-        return springDataRepository.findById(operationAlertId)
+        return springDataRepository.findByOperationAlertIdAndDeletedAtIsNull(operationAlertId)
                 .map(OperationAlertMapper::toDomain);
     }
 

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/SpringDataOperationAlertRepository.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/SpringDataOperationAlertRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface SpringDataOperationAlertRepository
         extends JpaRepository<OperationAlertJpaEntity, Long> {
 
@@ -31,7 +33,8 @@ public interface SpringDataOperationAlertRepository
                     from OperationAlertJpaEntity oa
                     join AutomationRuleJpaEntity ar
                         on ar.operationRuleId = oa.operationRuleId
-                    where (:targetType is null or oa.targetType = :targetType)
+                    where oa.deletedAt is null
+                      and (:targetType is null or oa.targetType = :targetType)
                       and (:status is null or oa.status = :status)
                     """,
             countQuery = """
@@ -39,7 +42,8 @@ public interface SpringDataOperationAlertRepository
                     from OperationAlertJpaEntity oa
                     join AutomationRuleJpaEntity ar
                         on ar.operationRuleId = oa.operationRuleId
-                    where (:targetType is null or oa.targetType = :targetType)
+                    where oa.deletedAt is null
+                      and (:targetType is null or oa.targetType = :targetType)
                       and (:status is null or oa.status = :status)
                     """
     )
@@ -48,4 +52,6 @@ public interface SpringDataOperationAlertRepository
             @Param("status") OperationAlertStatus status,
             Pageable pageable
     );
+
+    Optional<OperationAlertJpaEntity> findByOperationAlertIdAndDeletedAtIsNull(Long operationAlertId);
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/OperationAlertController.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/OperationAlertController.java
@@ -1,10 +1,12 @@
 package com.wanted.codebombalms.admin.operation.alert.presentation.api;
 
 import com.wanted.codebombalms.admin.operation.alert.application.query.GetOperationAlertsQuery;
+import com.wanted.codebombalms.admin.operation.alert.application.usecase.DeleteOperationAlertUseCase;
 import com.wanted.codebombalms.admin.operation.alert.application.usecase.GetOperationAlertsUseCase;
 import com.wanted.codebombalms.admin.operation.alert.application.usecase.UpdateOperationAlertStatusUseCase;
 import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlertStatus;
 import com.wanted.codebombalms.admin.operation.alert.presentation.api.request.OperationAlertStatusUpdateRequest;
+import com.wanted.codebombalms.admin.operation.alert.presentation.api.response.OperationAlertDeleteResponse;
 import com.wanted.codebombalms.admin.operation.alert.presentation.api.response.OperationAlertListResponse;
 import com.wanted.codebombalms.admin.operation.alert.presentation.api.response.OperationAlertStatusUpdateResponse;
 import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
@@ -22,6 +24,7 @@ public class OperationAlertController {
 
     private final GetOperationAlertsUseCase getOperationAlertsUseCase;
     private final UpdateOperationAlertStatusUseCase updateOperationAlertStatusUseCase;
+    private final DeleteOperationAlertUseCase deleteOperationAlertUseCase;
 
 
     //알람 목록 조회
@@ -58,6 +61,20 @@ public class OperationAlertController {
                 OperationAlertResponseCode.UPDATED,
                 OperationAlertResponseMessage.UPDATED,
                 OperationAlertStatusUpdateResponse.from(result)
+        ));
+    }
+
+    //알람 삭제
+    @DeleteMapping("/{operationAlertId}")
+    public ResponseEntity<ApiResponse<OperationAlertDeleteResponse>> deleteOperationAlert(
+            @PathVariable Long operationAlertId
+    ) {
+        var result = deleteOperationAlertUseCase.delete(operationAlertId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                OperationAlertResponseCode.DELETED,
+                OperationAlertResponseMessage.DELETED,
+                OperationAlertDeleteResponse.from(result)
         ));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/OperationAlertResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/OperationAlertResponseCode.java
@@ -6,4 +6,5 @@ public class OperationAlertResponseCode {
 
     public static final String RETRIEVED = "OPERATION_ALERT-RETRIEVED";
     public static final String UPDATED   = "OPERATION_ALERT-UPDATED";
+    public static final String DELETED   = "OPERATION_ALERT-DELETED";
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/OperationAlertResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/OperationAlertResponseMessage.java
@@ -6,4 +6,5 @@ public class OperationAlertResponseMessage {
 
     public static final String RETRIEVED = "운영 알림 조회에 성공했습니다.";
     public static final String UPDATED   = "운영 알림 상태가 변경되었습니다.";
+    public static final String DELETED   = "운영 알림이 삭제되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/response/OperationAlertDeleteResponse.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/presentation/api/response/OperationAlertDeleteResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.admin.operation.alert.presentation.api.response;
+
+import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlert;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+//삭제 응답 DTO
+// operationAlertId, deletedAt을 반환
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OperationAlertDeleteResponse {
+
+    private Long operationAlertId;
+    private LocalDateTime deletedAt;
+
+    public static OperationAlertDeleteResponse from(OperationAlert operationAlert) {
+        return new OperationAlertDeleteResponse(
+                operationAlert.getOperationAlertId(),
+                operationAlert.getDeletedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentJpaEntity.java
@@ -30,8 +30,6 @@ public class EnrollmentJpaEntity {
     @Column(name = "user_id", nullable = false)
     private Long studentId;
 
-    @Column(name = "instructor_id")
-    private Long instructorId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
@@ -46,7 +44,6 @@ public class EnrollmentJpaEntity {
     public EnrollmentJpaEntity(CourseJpaEntity course, Long studentId, EnrollmentStatus status) {
         this.course = course;
         this.studentId = studentId;
-        this.instructorId = course.getInstructorId();
         this.status = status;
     }
 
@@ -65,7 +62,6 @@ public class EnrollmentJpaEntity {
     public void apply(Enrollment enrollment, CourseJpaEntity course) {
         this.course = course;
         this.studentId = enrollment.getStudentId();
-        this.instructorId = course.getInstructorId();
         this.status = enrollment.getStatus();
         this.canceledAt = enrollment.getCanceledAt();
     }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #141

---

## 🛠️ 기능 관련 작업 내용

- 관리자 운영 알림 soft delete 기능을 구현했습니다.
- `DELETE /api/v1/admin/operation-alerts/{operationAlertId}` API를 추가했습니다.
- `OPEN` 상태의 운영 알림은 삭제할 수 없도록 도메인 검증 로직을 추가했습니다.
- 삭제된 운영 알림은 목록 조회 및 단건 조회 대상에서 제외되도록 조회 조건을 수정했습니다.
- 운영 알림 엔티티와 도메인 모델에 `deletedAt` 필드를 추가했습니다.
- 운영 알림 삭제 API 테스트용 HTTP 요청 예시를 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `admin/operation/alert/presentation/api/OperationAlertController` : 운영 알림 삭제 API 추가
- `admin/operation/alert/application/usecase/DeleteOperationAlertUseCase` : 운영 알림 삭제 유스케이스 추가
- `admin/operation/alert/application/service/OperationAlertCommandService` : 운영 알림 soft delete 처리 로직 추가
- `admin/operation/alert/domain/model/OperationAlert` : `deletedAt` 필드 및 삭제 도메인 규칙 추가
- `admin/operation/alert/domain/exception/OperationAlertErrorCode` : 삭제 요청 검증 및 OPEN 상태 삭제 불가 에러 코드 추가
- `admin/operation/alert/infrastructure/persistence/OperationAlertJpaEntity` : `deleted_at` 컬럼 매핑 추가
- `admin/operation/alert/infrastructure/persistence/OperationAlertMapper` : `deletedAt` 도메인/엔티티 매핑 추가
- `admin/operation/alert/infrastructure/persistence/SpringDataOperationAlertRepository` : 삭제되지 않은 알림만 조회하도록 조건 추가
- `admin/operation/alert/infrastructure/persistence/OperationAlertRepositoryAdapter` : 삭제되지 않은 알림만 단건 조회하도록 수정
- `admin/operation/alert/presentation/api/response/OperationAlertDeleteResponse` : 운영 알림 삭제 응답 DTO 추가
- `admin/operation/alert/presentation/api/OperationAlertResponseCode` : 삭제 성공 응답 코드 추가
- `admin/operation/alert/presentation/api/OperationAlertResponseMessage` : 삭제 성공 응답 메시지 추가
- `http/automationalert.http` : 운영 알림 삭제 API 테스트 요청 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.