### PR TITLE
[UPDATE] Auth 도메인 단위 테스트 5종 신규 작성

### DIFF
--- a/src/test/java/com/wanted/codebombalms/auth/application/service/DuplicateCheckServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/DuplicateCheckServiceTest.java
@@ -1,0 +1,84 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DuplicateCheckService 단위 테스트")
+class DuplicateCheckServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private DuplicateCheckService duplicateCheckService;
+
+    @Test
+    @DisplayName("사용 가능한 이메일이면 true를 반환한다.")
+    void 이메일_사용_가능() {
+        // given
+        String email = "new@example.com";
+        given(userRepository.existsByEmail(email)).willReturn(false);
+
+        // when
+        boolean result = duplicateCheckService.isEmailAvailable(email);
+
+        // then
+        assertTrue(result);
+        verify(userRepository).existsByEmail(email);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 이메일이면 false를 반환한다.")
+    void 이메일_중복() {
+        // given
+        String email = "existing@example.com";
+        given(userRepository.existsByEmail(email)).willReturn(true);
+
+        // when
+        boolean result = duplicateCheckService.isEmailAvailable(email);
+
+        // then
+        assertFalse(result);
+        verify(userRepository).existsByEmail(email);
+    }
+
+    @Test
+    @DisplayName("사용 가능한 닉네임이면 true를 반환한다.")
+    void 닉네임_사용_가능() {
+        // given
+        String nickname = "새닉네임";
+        given(userRepository.existsByNickname(nickname)).willReturn(false);
+
+        // when
+        boolean result = duplicateCheckService.isNicknameAvailable(nickname);
+
+        // then
+        assertTrue(result);
+        verify(userRepository).existsByNickname(nickname);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 닉네임이면 false를 반환한다.")
+    void 닉네임_중복() {
+        // given
+        String nickname = "기존닉네임";
+        given(userRepository.existsByNickname(nickname)).willReturn(true);
+
+        // when
+        boolean result = duplicateCheckService.isNicknameAvailable(nickname);
+
+        // then
+        assertFalse(result);
+        verify(userRepository).existsByNickname(nickname);
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -1,0 +1,164 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.command.LoginCommand;
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LoginService 단위 테스트")
+class LoginServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private LoginService loginService;
+
+    private LoginCommand command;
+
+    @BeforeEach
+    void setUp() {
+        command = new LoginCommand("test@example.com", "Test1234!");
+    }
+
+    @Test
+    @DisplayName("정상 로그인 시 TokenPair를 반환하고 새 Refresh Token을 저장한다.")
+    void 로그인_성공() {
+        // given
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+        given(jwtTokenProvider.generateAccessToken(1L, UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
+        given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
+
+        // when
+        TokenPair pair = loginService.login(command);
+
+        // then
+        assertEquals("ACCESS_TOKEN", pair.accessToken());
+        assertEquals("REFRESH_TOKEN", pair.refreshToken());
+        verify(refreshTokenRepository).deleteByUserId(1L);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("이메일이 없으면 UnauthorizedException(AUTH_LOGIN_FAIL)을 던진다.")
+    void 이메일_없음_예외() {
+        // given
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.empty());
+
+        // when & then
+        UnauthorizedException ex = assertThrows(
+                UnauthorizedException.class,
+                () -> loginService.login(command)
+        );
+        assertEquals(AuthErrorCode.AUTH_LOGIN_FAIL, ex.getErrorCode());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("비밀번호가 불일치하면 UnauthorizedException(AUTH_LOGIN_FAIL)을 던진다.")
+    void 비밀번호_불일치_예외() {
+        // given
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(false);
+
+        // when & then
+        UnauthorizedException ex = assertThrows(
+                UnauthorizedException.class,
+                () -> loginService.login(command)
+        );
+        assertEquals(AuthErrorCode.AUTH_LOGIN_FAIL, ex.getErrorCode());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("잠긴 계정이면 ForbiddenException(USER_ACCOUNT_LOCKED)을 던진다.")
+    void 계정_잠금_예외() {
+        // given
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", true);  // isLocked=true
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+
+        // when & then
+        ForbiddenException ex = assertThrows(
+                ForbiddenException.class,
+                () -> loginService.login(command)
+        );
+        assertEquals(UserErrorCode.USER_ACCOUNT_LOCKED, ex.getErrorCode());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("로그인 시 기존 Refresh Token을 전부 삭제하고 새 토큰을 저장한다 (단일 세션 강제).")
+    void 단일_세션_강제() {
+        // given
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+        given(jwtTokenProvider.generateAccessToken(1L, UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
+        given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
+
+        // when
+        loginService.login(command);
+
+        // then — 삭제 후 저장 순서 검증
+        var inOrder = inOrder(refreshTokenRepository);
+        inOrder.verify(refreshTokenRepository).deleteByUserId(1L);
+        inOrder.verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    // ===== 테스트 헬퍼 =====
+
+    private User createUser(Long userId, String email, String encodedPassword, boolean isLocked) {
+        return User.restore(
+                userId,
+                UserRole.STUDENT,
+                email,
+                encodedPassword,
+                "홍길동",
+                "길동이",
+                "010-1234-5678",
+                AuthProvider.LOCAL,
+                null,
+                false,        // emailVerified
+                isLocked,
+                null,         // bio
+                null,         // career
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null          // deletedAt
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LogoutServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LogoutServiceTest.java
@@ -1,0 +1,35 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LogoutService 단위 테스트")
+class LogoutServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private LogoutService logoutService;
+
+    @Test
+    @DisplayName("로그아웃 시 해당 유저의 Refresh Token을 전부 삭제한다.")
+    void 로그아웃_성공() {
+        // given
+        Long userId = 1L;
+
+        // when
+        logoutService.logout(userId);
+
+        // then
+        verify(refreshTokenRepository).deleteByUserId(userId);
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
@@ -1,0 +1,122 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.command.SignupCommand;
+import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SignupService 단위 테스트")
+class SignupServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private SignupService signupService;
+
+    private SignupCommand command;
+
+    @BeforeEach
+    void setUp() {
+        command = new SignupCommand(
+                "test@example.com",
+                "Test1234!",
+                "홍길동",
+                "길동이",
+                "010-1234-5678"
+        );
+    }
+
+    @Test
+    @DisplayName("정상 회원가입 시 User를 저장하고 userId를 반환한다.")
+    void 회원가입_성공() {
+        // given
+        given(userRepository.existsByEmail(command.email())).willReturn(false);
+        given(userRepository.existsByNickname(command.nickname())).willReturn(false);
+        given(passwordEncoder.encode(command.rawpassword())).willReturn("encoded_password");
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User u = invocation.getArgument(0);
+            return User.restore(
+                    1L, u.getRole(), u.getEmail(), u.getPassword(),
+                    u.getName(), u.getNickname(), u.getPhone(),
+                    u.getProvider(), null, false, false, null, null,
+                    null, null, null
+            );
+        });
+
+        // when
+        Long userId = signupService.signup(command);
+
+        // then
+        assertEquals(1L, userId);
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이메일이 중복되면 ConflictException(USER_EMAIL_DUPLICATED)을 던진다.")
+    void 이메일_중복_예외() {
+        // given
+        given(userRepository.existsByEmail(command.email())).willReturn(true);
+
+        // when & then
+        ConflictException ex = assertThrows(
+                ConflictException.class,
+                () -> signupService.signup(command)
+        );
+        assertEquals(UserErrorCode.USER_EMAIL_DUPLICATED, ex.getErrorCode());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("닉네임이 중복되면 ConflictException(USER_NICKNAME_DUPLICATED)을 던진다.")
+    void 닉네임_중복_예외() {
+        // given
+        given(userRepository.existsByEmail(command.email())).willReturn(false);
+        given(userRepository.existsByNickname(command.nickname())).willReturn(true);
+
+        // when & then
+        ConflictException ex = assertThrows(
+                ConflictException.class,
+                () -> signupService.signup(command)
+        );
+        assertEquals(UserErrorCode.USER_NICKNAME_DUPLICATED, ex.getErrorCode());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 시 비밀번호를 BCrypt로 인코딩한 후 저장한다.")
+    void 비밀번호_BCrypt_인코딩() {
+        // given
+        given(userRepository.existsByEmail(command.email())).willReturn(false);
+        given(userRepository.existsByNickname(command.nickname())).willReturn(false);
+        given(passwordEncoder.encode(command.rawpassword())).willReturn("encoded_password");
+        given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        signupService.signup(command);
+
+        // then
+        verify(passwordEncoder).encode("Test1234!");
+        verify(userRepository).save(argThat(user ->
+                user.getPassword().equals("encoded_password")
+        ));
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/TokenReissueServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/TokenReissueServiceTest.java
@@ -1,0 +1,184 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TokenReissueService 단위 테스트")
+class TokenReissueServiceTest {
+
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private TokenReissueService tokenReissueService;
+
+    private static final String OLD_TOKEN = "OLD_REFRESH_TOKEN";
+
+    @BeforeEach
+    void setUp() {
+        // validateRefreshToken 은 void — 기본 mock 동작이 "아무것도 안 함" 이라 stub 불필요
+    }
+
+    @Test
+    @DisplayName("정상 재발급 시 새 TokenPair를 반환하고 기존 RT를 삭제 후 새 RT를 저장한다 (RTR).")
+    void 재발급_성공() {
+        // given
+        RefreshToken stored = createValidRefreshToken(1L, OLD_TOKEN);
+        User user = createUser(1L, false);
+
+        given(refreshTokenRepository.findByToken(OLD_TOKEN)).willReturn(Optional.of(stored));
+        given(userRepository.findByUserId(1L)).willReturn(Optional.of(user));
+        given(jwtTokenProvider.generateAccessToken(1L, UserRole.STUDENT)).willReturn("NEW_ACCESS");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("NEW_REFRESH");
+        given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
+
+        // when
+        TokenPair pair = tokenReissueService.reissue(OLD_TOKEN);
+
+        // then
+        assertEquals("NEW_ACCESS", pair.accessToken());
+        assertEquals("NEW_REFRESH", pair.refreshToken());
+
+        // RTR — 삭제 후 저장 순서
+        var inOrder = inOrder(refreshTokenRepository);
+        inOrder.verify(refreshTokenRepository).deleteByUserId(1L);
+        inOrder.verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("DB에 없는 Refresh Token이면 UnauthorizedException(REFRESH_TOKEN_INVALID)을 던진다.")
+    void DB_토큰_없음_예외() {
+        // given
+        given(refreshTokenRepository.findByToken(OLD_TOKEN)).willReturn(Optional.empty());
+
+        // when & then
+        UnauthorizedException ex = assertThrows(
+                UnauthorizedException.class,
+                () -> tokenReissueService.reissue(OLD_TOKEN)
+        );
+        assertEquals(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID, ex.getErrorCode());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("DB의 Refresh Token이 만료되었으면 UnauthorizedException(REFRESH_TOKEN_EXPIRED)을 던진다.")
+    void DB_토큰_만료_예외() {
+        // given
+        RefreshToken expired = createExpiredRefreshToken(1L, OLD_TOKEN);
+        given(refreshTokenRepository.findByToken(OLD_TOKEN)).willReturn(Optional.of(expired));
+
+        // when & then
+        UnauthorizedException ex = assertThrows(
+                UnauthorizedException.class,
+                () -> tokenReissueService.reissue(OLD_TOKEN)
+        );
+        assertEquals(AuthErrorCode.AUTH_REFRESH_TOKEN_EXPIRED, ex.getErrorCode());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않으면 NotFoundException(USER_NOT_FOUND)을 던진다.")
+    void 유저_없음_예외() {
+        // given
+        RefreshToken stored = createValidRefreshToken(1L, OLD_TOKEN);
+        given(refreshTokenRepository.findByToken(OLD_TOKEN)).willReturn(Optional.of(stored));
+        given(userRepository.findByUserId(1L)).willReturn(Optional.empty());
+
+        // when & then
+        NotFoundException ex = assertThrows(
+                NotFoundException.class,
+                () -> tokenReissueService.reissue(OLD_TOKEN)
+        );
+        assertEquals(UserErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("잠긴 계정이면 ForbiddenException(USER_ACCOUNT_LOCKED)을 던진다.")
+    void 계정_잠금_예외() {
+        // given
+        RefreshToken stored = createValidRefreshToken(1L, OLD_TOKEN);
+        User lockedUser = createUser(1L, true);
+        given(refreshTokenRepository.findByToken(OLD_TOKEN)).willReturn(Optional.of(stored));
+        given(userRepository.findByUserId(1L)).willReturn(Optional.of(lockedUser));
+
+        // when & then
+        ForbiddenException ex = assertThrows(
+                ForbiddenException.class,
+                () -> tokenReissueService.reissue(OLD_TOKEN)
+        );
+        assertEquals(UserErrorCode.USER_ACCOUNT_LOCKED, ex.getErrorCode());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    // ===== 테스트 헬퍼 =====
+
+    private RefreshToken createValidRefreshToken(Long userId, String token) {
+        return RefreshToken.restore(
+                1L,
+                userId,
+                token,
+                LocalDateTime.now().plusHours(1),    // 미래 = 유효
+                LocalDateTime.now().minusMinutes(10)
+        );
+    }
+
+    private RefreshToken createExpiredRefreshToken(Long userId, String token) {
+        return RefreshToken.restore(
+                1L,
+                userId,
+                token,
+                LocalDateTime.now().minusHours(1),   // 과거 = 만료
+                LocalDateTime.now().minusDays(7)
+        );
+    }
+
+    private User createUser(Long userId, boolean isLocked) {
+        return User.restore(
+                userId,
+                UserRole.STUDENT,
+                "test@example.com",
+                "ENCODED_PW",
+                "홍길동",
+                "길동이",
+                "010-1234-5678",
+                AuthProvider.LOCAL,
+                null,
+                false,
+                isLocked,
+                null,
+                null,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] 🪛 UPDATE

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

앞서 개발한 Auth 도메인 Service 5종에 대한 단위 테스트를 신규 작성했습니다. 


---

## ♻️ 패키지 변경 사항

src/test/com/wanted/codebombalms/auth/application/service

/SignupServiceTest : 회원가입 단위 테스트 4 시나리오 신규 작성
/service/DuplicateCheckServiceTest : 이메일/닉네임 중복 확인 단위 테스트 4 시나리오 신규 작성
/service/LoginServiceTest : 로그인 단위 테스트 5 시나리오 신규 작성 (단일 세션 강제 순서 검증 포함)
/service/LogoutServiceTest : 로그아웃 단위 테스트 1 시나리오 신규 작성
/service/TokenReissueServiceTest : 토큰 재발급(RTR) 단위 테스트 5 시나리오 신규 작성

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
