### PR TITLE
[FEAT] 코드 실행형 문제 상세 조회 및  코드 문제 테스트 crud 기능구현

### DIFF
--- a/http/problem-set.http
+++ b/http/problem-set.http
@@ -1,22 +1,4 @@
 @baseUrl = http://localhost:8080
-
-# =====================================================
-# M1 문제 도메인 테스트용 변수
-# =====================================================
-# 더미 데이터 기준:
-# - category_id = 2001, 2002, 2003
-# - problem_set_id = 2001, 2002, 2003
-# - problem_id = 2001 ~ 2009
-# - hint_id = 2001 ~ 2009
-#
-# 수정 테스트 기본 대상:
-# - 문제 세트: 2001
-# - 소문제: 2001
-# - 힌트: 2001
-#
-# 현재 SecurityConfig가 permitAll이면 accessToken은 없어도 됩니다.
-# 다시 인증이 켜지면 실제 로그인 토큰으로 바꾸고 Cookie 헤더를 사용하세요.
-
 @categoryId = 2001
 @problemSetId = 2001
 @userId = 3
@@ -26,29 +8,37 @@
 @updateProblemId = 2001
 @updateHintId = 2001
 
+# =====================================================
+# 문제 세트 조회
+# =====================================================
 
 ### 1. 문제 세트 목록 조회 - 분야별 문제 세트 조회
 # 기대 결과:
-# - categoryId=2001인 "비즈니스 기초" 분야의 문제 세트가 조회됩니다.
-# - 더미 데이터 기준 "비즈니스 모델 이해 입문" 문제 세트가 포함되어야 합니다.
+# - 200 OK
+# - categoryId에 속한 ACTIVE 문제 세트만 조회됩니다.
+# - 응답에 difficulty 값이 포함됩니다.
 GET {{baseUrl}}/api/v1/problem-sets?categoryId={{categoryId}}
 Accept: application/json
 
 
 ### 2. 문제 세트 상세 진입 - 현재 풀 문제 조회
 # 기대 결과:
-# - userId=3 사용자가 problemSetId=2001 문제 세트에 진입합니다.
-# - 진행 상태가 없으면 1번 소문제부터 조회됩니다.
-# - 이미 완료된 문제 세트라면 결과 화면 또는 완료 응답 흐름으로 이동할 수 있습니다.
+# - 200 OK
+# - 사용자의 progress 기준으로 현재 문제를 조회합니다.
+# - 정답은 응답에 포함되지 않습니다.
 GET {{baseUrl}}/api/v1/problem-sets/{{problemSetId}}?userId={{userId}}
 Accept: application/json
 
 
+# =====================================================
+# 문제 세트 등록
+# =====================================================
+
 ### 3. 문제 세트 등록 성공 - 기존 카테고리 사용
 # 기대 결과:
-# - categoryName이 이미 있으면 기존 ACTIVE 카테고리를 사용합니다.
+# - 201 Created
+# - problem_set.difficulty = EASY
 # - problem_set 1건, problem 2건, problem_hint 2건이 저장됩니다.
-# - 응답 상태는 201 Created입니다.
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
@@ -56,7 +46,8 @@ Cookie: accessToken={{accessToken}}
 
 {
   "title": "고객 분석 기초 문제 세트",
-  "categoryName": "테스트 데이터 분석",
+  "categoryName": "비즈니스 기초",
+  "difficulty": "EASY",
   "description": "고객 세그먼트와 재방문 지표를 이해하는 문제 세트입니다.",
   "dataFileName": "customer_analysis.csv",
   "problems": [
@@ -64,37 +55,38 @@ Cookie: accessToken={{accessToken}}
       "title": "고객 세그먼트 목적",
       "content": "고객 세그먼트를 나누는 이유를 한 문장으로 작성하세요.",
       "point": 10,
-      "startCode": "df = pd.read_csv(\"data/customer_analysis.csv\")",
-      "answer": "고객 특성에 맞는 서비스를 제공하기 위해서",
-      "hint": "모든 고객이 같은 요구를 가진 것은 아닙니다.",
-      "explanation": "고객 세그먼트는 고객을 특성별로 나누어 더 적절한 서비스 전략을 세우기 위해 사용합니다."
+      "startCode": null,
+      "answer": "고객 특성에 맞는 서비스를 제공하기 위해",
+      "hint": "모든 고객이 같은 문제를 가진 것은 아닙니다.",
+      "explanation": "고객 세그먼트는 고객을 특성별로 나누어 적절한 서비스 전략을 세우기 위해 사용합니다."
     },
     {
       "title": "재방문 지표",
       "content": "사용자가 서비스를 다시 이용하는지 확인하는 대표 지표를 작성하세요.",
       "point": 10,
-      "startCode": "df = pd.read_csv(\"data/customer_analysis.csv\")",
+      "startCode": null,
       "answer": "재방문율",
       "hint": "사용자가 다시 돌아오는지를 보는 지표입니다.",
-      "explanation": "재방문율은 사용자가 서비스를 다시 이용하는지 확인할 수 있는 중요한 지표입니다."
+      "explanation": "재방문율은 사용자가 서비스를 다시 이용하는지 확인할 수 있는 지표입니다."
     }
   ]
 }
 
 
-### 4. 문제 세트 등록 성공 - 새로운 카테고리 자동 생성
+### 4. 문제 세트 등록 성공 - 새 카테고리 자동 생성
 # 기대 결과:
-# - "Python 실습 테스트" 카테고리가 없으면 새로 생성됩니다.
-# - 이미 있으면 기존 ACTIVE 카테고리를 재사용합니다.
-# - M2 코드 실행형 확장을 고려해 startCode 값도 함께 보냅니다.
+# - 201 Created
+# - categoryName이 없으면 새 ACTIVE 카테고리가 생성됩니다.
+# - problem_set.difficulty = MEDIUM
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
 Cookie: accessToken={{accessToken}}
 
 {
-  "title": "M2 코드 실행형 준비 문제 세트",
+  "title": "M2 코드 실행 준비 문제 세트",
   "categoryName": "Python 실습 테스트",
+  "difficulty": "MEDIUM",
   "description": "M2 코드 실행형 문제를 고려한 테스트 문제 세트입니다.",
   "dataFileName": "employee_performance.csv",
   "problems": [
@@ -111,29 +103,30 @@ Cookie: accessToken={{accessToken}}
 }
 
 
-### 5. 문제 세트 등록 성공 - 힌트 없이 등록
+### 5. 문제 세트 등록 실패 - 잘못된 난이도
 # 기대 결과:
-# - problem_set과 problem은 저장됩니다.
-# - hint가 빈 문자열이므로 problem_hint는 저장되지 않습니다.
+# - 400 PROBLEM_INVALID_INPUT
+# - difficulty는 EASY, MEDIUM, HARD 중 하나여야 합니다.
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
 Cookie: accessToken={{accessToken}}
 
 {
-  "title": "힌트 없는 단답형 문제 세트",
-  "categoryName": "SQL",
-  "description": "힌트가 없어도 등록 가능한지 확인하는 문제 세트입니다.",
+  "title": "잘못된 난이도 문제 세트",
+  "categoryName": "비즈니스 기초",
+  "difficulty": "상",
+  "description": "난이도 검증 실패를 확인하는 요청입니다.",
   "dataFileName": null,
   "problems": [
     {
-      "title": "SELECT 키워드",
-      "content": "SQL에서 데이터를 조회할 때 사용하는 대표 키워드를 작성하세요.",
-      "point": 5,
+      "title": "난이도 검증 문제",
+      "content": "난이도 값이 잘못되면 실패해야 합니다.",
+      "point": 10,
       "startCode": null,
-      "answer": "SELECT",
-      "hint": "",
-      "explanation": "SELECT는 테이블에서 데이터를 조회할 때 사용하는 SQL 키워드입니다."
+      "answer": "EASY",
+      "hint": "허용 값은 EASY, MEDIUM, HARD입니다.",
+      "explanation": "표시값 상/중/하는 프론트에서 EASY/MEDIUM/HARD로 변환해 보내야 합니다."
     }
   ]
 }
@@ -141,8 +134,7 @@ Cookie: accessToken={{accessToken}}
 
 ### 6. 문제 세트 등록 실패 - 소문제 없음
 # 기대 결과:
-# - problems가 빈 배열이므로 실패해야 합니다.
-# - 현재 예외 포맷 정책에 따라 400 또는 공통 에러 응답이 내려올 수 있습니다.
+# - 400 PROBLEM_REQUIRED
 POST {{baseUrl}}/api/v1/problems
 Accept: application/json
 Content-Type: application/json
@@ -150,23 +142,23 @@ Cookie: accessToken={{accessToken}}
 
 {
   "title": "소문제 없는 문제 세트",
-  "categoryName": "테스트 데이터 분석",
+  "categoryName": "비즈니스 기초",
+  "difficulty": "EASY",
   "description": "소문제가 없으므로 실패해야 하는 요청입니다.",
   "dataFileName": null,
   "problems": []
 }
 
 
-### 7. 문제 세트 수정 성공 - 기존 소문제와 기존 힌트 수정
-# 실행 전 DB 확인:
-# SELECT * FROM problem_set WHERE problem_set_id = 2001;
-# SELECT * FROM problem WHERE problem_id = 2001;
-# SELECT * FROM problem_hint WHERE hint_id = 2001;
-#
+# =====================================================
+# 문제 세트 수정
+# =====================================================
+
+### 7. 문제 세트 수정 성공 - 난이도 수정 포함
 # 기대 결과:
-# - problem_set의 제목/설명/카테고리가 수정됩니다.
-# - problem_id=2001 소문제의 제목/내용/정답/해설/점수가 수정됩니다.
-# - hint_id=2001 힌트 내용이 수정됩니다.
+# - 200 OK
+# - problem_set.difficulty = HARD
+# - 기존 problem과 hint가 함께 수정됩니다.
 PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
 Accept: application/json
 Content-Type: application/json
@@ -174,8 +166,9 @@ Cookie: accessToken={{accessToken}}
 
 {
   "title": "비즈니스 모델 이해 입문 - 수정",
-  "categoryName": "테스트 데이터 분석",
-  "description": "고객 세그먼트와 수익 모델을 다시 점검하는 수정된 문제 세트입니다.",
+  "categoryName": "비즈니스 기초",
+  "difficulty": "HARD",
+  "description": "고객 세그먼트와 수익 모델을 다시 평가하는 수정용 문제 세트입니다.",
   "dataFileName": "business_basic.csv",
   "problems": [
     {
@@ -184,115 +177,48 @@ Cookie: accessToken={{accessToken}}
       "content": "서비스 설계에서 고객 세그먼트를 나누는 이유를 정확히 작성하세요.",
       "point": 20,
       "startCode": null,
-      "answer": "고객 특성에 맞는 서비스를 제공하기 위해서",
+      "answer": "고객 특성에 맞는 서비스를 제공하기 위해",
       "hintId": {{updateHintId}},
-      "hint": "모든 고객이 같은 문제와 요구를 가진 것은 아닙니다.",
-      "explanation": "고객 세그먼트는 고객을 특성별로 나누어 더 적절한 서비스와 전략을 제공하기 위해 사용합니다."
-    }
-  ]
-}
-
-
-### 8. 문제 세트 수정 성공 - 기존 소문제 수정 + 새 소문제와 새 힌트 추가
-# 기대 결과:
-# - 첫 번째 항목은 기존 problem_id=2001, hint_id=2001을 수정합니다.
-# - 두 번째 항목은 problemId가 null이므로 새 소문제가 추가됩니다.
-# - 두 번째 항목은 hintId가 null이므로 새 힌트가 추가됩니다.
-# - problem_set.total_problem_count가 요청한 problems 개수에 맞게 갱신됩니다.
-PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
-Accept: application/json
-Content-Type: application/json
-Cookie: accessToken={{accessToken}}
-
-{
-  "title": "비즈니스 모델 이해 입문 - 확장",
-  "categoryName": "테스트 데이터 분석",
-  "description": "기존 소문제 수정과 새 소문제 추가를 함께 확인하는 요청입니다.",
-  "dataFileName": "business_basic.csv",
-  "problems": [
-    {
-      "problemId": 2001,
-      "title": "고객 세그먼트 식별 - 최종 수정",
-      "content": "서비스 설계에서 고객 세그먼트를 나누는 핵심 이유를 작성하세요.",
-      "point": 20,
-      "startCode": null,
-      "answer": "고객 특성에 맞는 서비스를 제공하기 위해서",
-      "hintId": 2001,
       "hint": "고객마다 필요한 서비스와 메시지가 다를 수 있습니다.",
-      "explanation": "고객 세그먼트를 나누면 사용자 특성에 맞는 서비스 전략을 세울 수 있습니다."
-    },
-    {
-      "problemId": 2002,
-      "title": "수익 모델 구분",
-      "content": "정기적으로 반복 결제가 발생하는 수익 모델을 무엇이라고 부르는지 작성하세요.",
-      "point": 10,
-      "startCode": null,
-      "answer": "구독형 수익 모델",
-      "hintId": 2002,
-      "hint": "넷플릭스나 SaaS 요금제를 떠올려보세요.",
-      "explanation": "구독형 수익 모델은 사용자가 일정 주기마다 비용을 지불하고 서비스를 이용하는 방식입니다."
-    },
-    {
-      "problemId": 2003,
-      "title": "핵심 지표 선택",
-      "content": "초기 서비스에서 재방문을 확인하는 주요 지표를 작성하세요.",
-      "point": 10,
-      "startCode": null,
-      "answer": "재방문율",
-      "hintId": 2003,
-      "hint": "사용자가 다시 방문하는지를 확인하는 지표입니다.",
-      "explanation": "재방문율은 사용자가 서비스를 다시 이용하는지 확인할 수 있는 중요한 지표입니다."
-    },
-    {
-      "problemId": null,
-      "title": "전환율 이해",
-      "content": "사용자가 목표 행동을 완료한 비율을 무엇이라고 부르는지 작성하세요.",
-      "point": 10,
-      "startCode": null,
-      "answer": "전환율",
-      "hintId": null,
-      "hint": "방문자가 구매나 가입 같은 목표 행동을 했는지 보는 지표입니다.",
-      "explanation": "전환율은 전체 사용자 중 목표 행동을 완료한 사용자의 비율입니다."
+      "explanation": "고객 세그먼트는 고객의 특성에 맞는 서비스 전략을 세우기 위해 사용합니다."
     }
   ]
 }
 
 
-
-### 9. 문제 세트 수정 성공 - 힌트 없이 수정
+### 8. 문제 세트 수정 실패 - 잘못된 난이도
 # 기대 결과:
-# - 소문제는 수정됩니다.
-# - hint가 빈 문자열이므로 힌트 수정/생성은 건너뜁니다.
-# - 기존 힌트가 빈 값으로 덮어쓰기 되지 않아야 합니다.
+# - 400 PROBLEM_INVALID_INPUT
 PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
 Accept: application/json
 Content-Type: application/json
 Cookie: accessToken={{accessToken}}
 
 {
-  "title": "힌트 수정 없이 문제 세트 수정",
-  "categoryName": "테스트 데이터 분석",
-  "description": "힌트가 비어 있을 때 힌트 처리를 건너뛰는지 확인합니다.",
+  "title": "잘못된 난이도 수정 요청",
+  "categoryName": "비즈니스 기초",
+  "difficulty": "어려움",
+  "description": "난이도 값이 잘못되었으므로 실패해야 합니다.",
   "dataFileName": null,
   "problems": [
     {
       "problemId": {{updateProblemId}},
-      "title": "힌트 없이 수정되는 소문제",
-      "content": "힌트 없이도 소문제 정보만 수정되는지 확인합니다.",
+      "title": "난이도 수정 검증",
+      "content": "난이도 값이 잘못되면 실패해야 합니다.",
       "point": 10,
       "startCode": null,
-      "answer": "정답",
+      "answer": "HARD",
       "hintId": null,
-      "hint": "",
-      "explanation": "hint가 비어 있으면 힌트 생성과 수정은 수행하지 않습니다."
+      "hint": "허용 값은 EASY, MEDIUM, HARD입니다.",
+      "explanation": "프론트 표시값은 백엔드 코드값으로 변환해야 합니다."
     }
   ]
 }
 
 
-### 10. 문제 세트 수정 실패 - 존재하지 않는 문제 세트
+### 9. 문제 세트 수정 실패 - 존재하지 않는 문제 세트
 # 기대 결과:
-# - problemSetId=999999가 없으므로 실패해야 합니다.
+# - 404 PROBLEM_SET_NOT_FOUND
 PUT {{baseUrl}}/api/v1/problems/999999
 Accept: application/json
 Content-Type: application/json
@@ -300,7 +226,8 @@ Cookie: accessToken={{accessToken}}
 
 {
   "title": "존재하지 않는 문제 세트 수정",
-  "categoryName": "테스트 데이터 분석",
+  "categoryName": "비즈니스 기초",
+  "difficulty": "EASY",
   "description": "실패해야 하는 요청입니다.",
   "dataFileName": null,
   "problems": [
@@ -319,154 +246,40 @@ Cookie: accessToken={{accessToken}}
 }
 
 
-### 11. 문제 세트 수정 실패 - 카테고리 없음
+# =====================================================
+# 문제 세트 삭제 / 비활성화
+# =====================================================
+
+### 10. 문제 세트 삭제 성공 - 제출 기록 없는 문제 세트 비활성화
 # 기대 결과:
-# - categoryName이 비어 있으므로 실패해야 합니다.
-PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
-Accept: application/json
-Content-Type: application/json
-Cookie: accessToken={{accessToken}}
-
-{
-  "title": "카테고리 없는 수정 요청",
-  "categoryName": "",
-  "description": "실패해야 하는 요청입니다.",
-  "dataFileName": null,
-  "problems": [
-    {
-      "problemId": {{updateProblemId}},
-      "title": "소문제",
-      "content": "내용",
-      "point": 10,
-      "startCode": null,
-      "answer": "정답",
-      "hintId": null,
-      "hint": "힌트",
-      "explanation": "해설"
-    }
-  ]
-}
-
-
-### 12. 문제 세트 수정 실패 - 소문제 없음
-# 기대 결과:
-# - problems가 빈 배열이므로 실패해야 합니다.
-PUT {{baseUrl}}/api/v1/problems/{{updateProblemSetId}}
-Accept: application/json
-Content-Type: application/json
-Cookie: accessToken={{accessToken}}
-
-{
-  "title": "소문제 없는 수정 요청",
-  "categoryName": "테스트 데이터 분석",
-  "description": "실패해야 하는 요청입니다.",
-  "dataFileName": null,
-  "problems": []
-}
-
-
-### 13. 수정 후 DB 확인용 쿼리
-# 아래 쿼리는 MySQL Workbench에서 실행하세요.
-#
-# SELECT * FROM problem_set WHERE problem_set_id = 2001;
-#
-# SELECT *
-# FROM problem
-# WHERE problem_set_id = 2001
-# ORDER BY problem_order;
-#
-# SELECT h.*
-# FROM problem_hint h
-# JOIN problem p ON h.problem_id = p.problem_id
-# WHERE p.problem_set_id = 2001
-# ORDER BY h.hint_id;
-
-
-### 14. 문제 세트 삭제 성공 - 제출 기록이 없는 문제 세트 비활성화
-# 목적:
-# - 제출 기록이 없는 문제 세트를 삭제 요청했을 때 바로 비활성화되는지 확인합니다.
-#
-# 실행 전 확인:
-# - problem_set_id=2003에 제출 기록이 없어야 합니다.
-# - 제출 기록이 있으면 409 PROBLEM_HAS_SUBMISSION이 나올 수 있습니다.
-#
-# 기대 결과:
-# - HTTP 200
+# - 200 OK
 # - problem_set.status = INACTIVE
-# - 해당 problem_set에 속한 problem.status = INACTIVE
-#
-# DB 확인:
-# SELECT problem_set_id, title, status
-# FROM problem_set
-# WHERE problem_set_id = 2003;
-#
-# SELECT problem_id, problem_set_id, title, status
-# FROM problem
-# WHERE problem_set_id = 2003
-# ORDER BY problem_order;
+# - 연결된 problem.status = INACTIVE
 DELETE {{baseUrl}}/api/v1/problems/2003
 Accept: application/json
 Cookie: accessToken={{accessToken}}
 
 
-### 15. 문제 세트 삭제 실패 - 제출 기록이 있어 확인이 필요한 경우
-# 목적:
-# - 제출 기록이 있는 문제 세트는 바로 비활성화하지 않고 409로 막는지 확인합니다.
-# - 프론트는 이 응답을 보고 "제출 기록이 있습니다. 그래도 비활성화하시겠습니까?" 경고창을 띄우면 됩니다.
-#
-# 실행 전 확인:
-# - problem_set_id=2001에 submission 기록이 있어야 합니다.
-#
+### 11. 문제 세트 삭제 실패 - 제출 기록 존재
 # 기대 결과:
-# - HTTP 409
-# - errorCode = PROBLEM_HAS_SUBMISSION
-# - message = 제출 기록이 존재합니다.
+# - 409 PROBLEM_HAS_SUBMISSION
 DELETE {{baseUrl}}/api/v1/problems/2001
 Accept: application/json
 Cookie: accessToken={{accessToken}}
 
 
-### 16. 문제 세트 삭제 성공 - 제출 기록이 있지만 확인 후 강제 비활성화
-# 목적:
-# - 프론트 경고창에서 확인 버튼을 누른 뒤 force=true로 다시 요청하는 상황을 확인합니다.
-#
+### 12. 문제 세트 강제 삭제 성공 - 제출 기록이 있어도 비활성화
 # 기대 결과:
-# - HTTP 200
-# - problem_set.status = INACTIVE
-# - 해당 problem_set에 속한 problem.status = INACTIVE
-#
-# DB 확인:
-# SELECT problem_set_id, title, status
-# FROM problem_set
-# WHERE problem_set_id = 2001;
-#
-# SELECT problem_id, problem_set_id, title, status
-# FROM problem
-# WHERE problem_set_id = 2001
-# ORDER BY problem_order;
+# - 200 OK
+# - force=true이면 제출 기록이 있어도 problem_set과 problem이 INACTIVE 처리됩니다.
 DELETE {{baseUrl}}/api/v1/problems/2001?force=true
 Accept: application/json
 Cookie: accessToken={{accessToken}}
 
 
-### 17. 문제 세트 삭제 실패 - 존재하지 않는 문제 세트
-# 목적:
-# - 존재하지 않는 문제 세트를 삭제하려고 할 때 404가 내려오는지 확인합니다.
-#
+### 13. 문제 세트 삭제 실패 - 존재하지 않는 문제 세트
 # 기대 결과:
-# - HTTP 404
-# - errorCode = PROBLEM_SET_NOT_FOUND
+# - 404 PROBLEM_SET_NOT_FOUND
 DELETE {{baseUrl}}/api/v1/problems/999999
 Accept: application/json
 Cookie: accessToken={{accessToken}}
-
-
-### 18. 삭제 후 목록 조회 - 비활성화된 문제 세트가 목록에서 빠지는지 확인
-# 목적:
-# - 삭제된 문제 세트가 문제 세트 목록 조회에서 보이지 않는지 확인합니다.
-#
-# 기대 결과:
-# - status = ACTIVE인 문제 세트만 조회됩니다.
-# - 2001 또는 2003을 삭제했다면 해당 문제 세트는 목록에 나오지 않아야 합니다.
-GET {{baseUrl}}/api/v1/problem-sets?categoryId={{categoryId}}
-Accept: application/json

--- a/http/problem-test-case.http
+++ b/http/problem-test-case.http
@@ -1,0 +1,147 @@
+@baseUrl = http://localhost:8080
+@codeProblemId = 3001
+@textProblemId = 2005
+@notFoundProblemId = 999999
+@testCaseId = 3001
+@notFoundTestCaseId = 999999
+
+### 1. 테스트케이스 목록 조회 성공
+# 기대 결과:
+# - 200 OK
+# - ACTIVE 테스트케이스가 testOrder 순서대로 조회됩니다.
+GET {{baseUrl}}/api/v1/problems/{{codeProblemId}}/test-cases
+Accept: application/json
+
+
+### 2. 테스트케이스 등록 실패 - 이미 등록된 테스트케이스 존재
+# 기대 결과:
+# - 409 PROBLEM_TEST_CASE_ALREADY_EXISTS
+POST {{baseUrl}}/api/v1/problems/{{codeProblemId}}/test-cases
+Accept: application/json
+Content-Type: application/json
+
+{
+  "testCode": "assert result == df.shape",
+  "expectedResult": "df.shape",
+  "testOrder": 1,
+  "score": 10,
+  "isHidden": true,
+  "timeoutMs": 3000
+}
+
+
+### 3. 테스트케이스 수정 성공
+# 기대 결과:
+# - 200 OK
+# - data.isHidden 값이 false로 변경됩니다.
+PUT {{baseUrl}}/api/v1/test-cases/{{testCaseId}}
+Accept: application/json
+Content-Type: application/json
+
+{
+  "testCode": "assert isinstance(result, tuple)",
+  "expectedResult": "tuple",
+  "testOrder": 1,
+  "score": 10,
+  "isHidden": false,
+  "timeoutMs": 3000
+}
+
+
+### 4. 테스트케이스 삭제 성공
+# 기대 결과:
+# - 200 OK
+# - 실제 삭제가 아니라 data.status 값이 INACTIVE로 변경됩니다.
+DELETE {{baseUrl}}/api/v1/test-cases/{{testCaseId}}
+Accept: application/json
+
+
+### 5. 기존 테스트케이스 삭제 후 새 테스트케이스 등록 성공
+# 기대 결과:
+# - 먼저 4번 요청을 실행해야 합니다.
+# - 201 Created
+# - data.testCaseId 값이 반환됩니다.
+POST {{baseUrl}}/api/v1/problems/{{codeProblemId}}/test-cases
+Accept: application/json
+Content-Type: application/json
+
+{
+  "testCode": "assert result == df.shape",
+  "expectedResult": "df.shape",
+  "testOrder": 1,
+  "score": 10,
+  "isHidden": true,
+  "timeoutMs": 3000
+}
+
+> {%
+    client.global.set("createdTestCaseId", response.body.data.testCaseId);
+%}
+
+
+### 6. 테스트케이스 등록 실패 - 존재하지 않는 문제
+# 기대 결과:
+# - 404 PROBLEM_NOT_FOUND
+POST {{baseUrl}}/api/v1/problems/{{notFoundProblemId}}/test-cases
+Accept: application/json
+Content-Type: application/json
+
+{
+  "testCode": "assert result == df.shape",
+  "expectedResult": "df.shape",
+  "testOrder": 1,
+  "score": 10,
+  "isHidden": false,
+  "timeoutMs": 3000
+}
+
+
+### 7. 테스트케이스 등록 실패 - TEXT 문제에는 테스트케이스 등록 불가
+# 기대 결과:
+# - 400 PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE
+POST {{baseUrl}}/api/v1/problems/{{textProblemId}}/test-cases
+Accept: application/json
+Content-Type: application/json
+
+{
+  "testCode": "assert result == df.shape",
+  "expectedResult": "df.shape",
+  "testOrder": 1,
+  "score": 10,
+  "isHidden": false,
+  "timeoutMs": 3000
+}
+
+
+### 8. 테스트케이스 등록 실패 - 잘못된 입력값
+# 기대 결과:
+# - 400 PROBLEM_TEST_CASE_INVALID_INPUT
+POST {{baseUrl}}/api/v1/problems/{{codeProblemId}}/test-cases
+Accept: application/json
+Content-Type: application/json
+
+{
+  "testCode": "",
+  "expectedResult": "df.shape",
+  "testOrder": 0,
+  "score": 10,
+  "isHidden": false,
+  "timeoutMs": 3000
+}
+
+
+### 9. 테스트케이스 수정 실패 - 존재하지 않는 테스트케이스
+# 기대 결과:
+# - 404 PROBLEM_TEST_CASE_NOT_FOUND
+PUT {{baseUrl}}/api/v1/test-cases/{{notFoundTestCaseId}}
+Accept: application/json
+Content-Type: application/json
+
+{
+  "testCode": "assert result == df.shape",
+  "expectedResult": "df.shape",
+  "testOrder": 1,
+  "score": 10,
+  "isHidden": false,
+  "timeoutMs": 3000
+}

--- a/http/submission.http
+++ b/http/submission.http
@@ -1,25 +1,68 @@
 @baseUrl = http://localhost:8080
 @userId = 3
-@problemId = 2001
+@codeProblemId = 3001
 
-### 문제 답안 제출 - 정답 예시
-# 주의: userId의 현재 progress가 problemId=1을 풀 수 있는 상태여야 합니다.
-POST {{baseUrl}}/api/v1/problems/{{problemId}}/submissions
+### 1. 코드 답안 제출 성공 예시
+# 사전 조건:
+# - codeProblemId 문제에 ACTIVE 테스트케이스가 1개 이상 있어야 합니다.
+# - userId의 진행 상태가 해당 문제를 풀 수 있는 상태여야 합니다.
+# - 현재 임시 채점기는 코드에 result 변수가 있으면 통과로 판단합니다.
+POST {{baseUrl}}/api/v1/problems/{{codeProblemId}}/submissions
 Accept: application/json
 Content-Type: application/json
 
 {
   "userId": {{userId}},
-  "submittedAnswer": "2"
+  "code": "import pandas as pd\n\ndf = pd.read_csv(\"data/employee_performance.csv\")\nresult = df.shape"
 }
 
-### 문제 답안 제출 - 오답 예시
-# 주의: 이미 완료된 문제 세트이거나 현재 열린 문제가 아니면 실패할 수 있습니다.
-POST {{baseUrl}}/api/v1/problems/{{problemId}}/submissions
+### 2. 코드 답안 제출 실패 예시 - result 변수 없음
+POST {{baseUrl}}/api/v1/problems/{{codeProblemId}}/submissions
 Accept: application/json
 Content-Type: application/json
 
 {
   "userId": {{userId}},
-  "submittedAnswer": "1"
+  "code": "import pandas as pd\n\ndf = pd.read_csv(\"data/employee_performance.csv\")\nprint(df.shape)"
+}
+
+### 3. 코드 답안 제출 실패 예시 - 빈 코드
+POST {{baseUrl}}/api/v1/problems/{{codeProblemId}}/submissions
+Accept: application/json
+Content-Type: application/json
+
+{
+  "userId": {{userId}},
+  "code": ""
+}
+
+### 4. 코드 채점 결과 조회
+# 사전 조건:
+# - 1번 또는 2번 요청으로 생성된 submissionId를 아래 값에 넣어주세요.
+@submissionId = 3007
+
+GET {{baseUrl}}/api/v1/code-submissions/{{submissionId}}
+Accept: application/json
+
+### 5. 코드 제출 기록 목록 조회
+GET {{baseUrl}}/api/v1/code-problems/{{codeProblemId}}/submissions?page=1&size=10
+Accept: application/json
+
+### 6. 코드 실행 성공 예시
+# 제출 저장 없이 실행 결과만 확인합니다.
+POST {{baseUrl}}/api/v1/code-problems/{{codeProblemId}}/executions
+Accept: application/json
+Content-Type: application/json
+
+{
+  "code": "import pandas as pd\n\ndf = pd.read_csv(\"data/employee_performance.csv\")\nresult = df.shape"
+}
+
+### 7. 코드 실행 실패 예시 - result 변수 없음
+POST {{baseUrl}}/api/v1/code-problems/{{codeProblemId}}/executions
+Accept: application/json
+Content-Type: application/json
+
+{
+  "code": "import pandas as pd\n\ndf = pd.read_csv(\"data/employee_performance.csv\")\nprint(df.shape)"
 }

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/ApiResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/ApiResponseMessage.java
@@ -4,7 +4,7 @@ public class ApiResponseMessage {
 
     private ApiResponseMessage() {}
 
-    public static final String SUCCESS = "Request completed successfully.";
-    public static final String CREATED = "Resource created successfully.";
+    public static final String SUCCESS = "요청이 성공적으로 처리되었습니다.";
+    public static final String CREATED = "리소스가 성공적으로 생성되었습니다.";
     public static final String AUTH_SIGNUP_COMPLETED = "회원가입이 완료되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
@@ -43,6 +43,19 @@ public enum ProblemErrorCode implements ErrorCode {
     PROBLEM_DATASET_INVALID_FILE("PRB-DAT-004", "CSV 파일만 업로드할 수 있습니다."),
     PROBLEM_DATASET_UPLOAD_FAILED("PRB-DAT-005", "데이터셋 업로드에 실패했습니다."),
 
+    // 테스트 코드 (PRB-TC)
+    PROBLEM_TEST_CASE_NOT_FOUND("PRB-TC-001", "테스트케이스를 찾을 수 없습니다."),
+    PROBLEM_TEST_CASE_INVALID_INPUT("PRB-TC-002", "테스트케이스 입력값이 올바르지 않습니다."),
+    PROBLEM_TEST_CASE_ALREADY_EXISTS("PRB-TC-003", "이미 등록된 테스트케이스가 있습니다."),
+    PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE("PRB-TC-004", "코드 문제에만 테스트케이스를 등록할 수 있습니다."),
+
+    // 코드 실행 (PRB-EXE)
+    PROBLEM_CODE_INVALID_INPUT("PRB-EXE-001", "코드 값이 비어 있습니다."),
+    PROBLEM_CODE_EXECUTION_FAILED("PRB-EXE-002", "코드 실행에 실패했습니다."),
+
+    // 난이도 코드
+    PROBLEM_INVALID_INPUT("PRB-INP-001", "문제 난이도 값이 올바르지 않습니다."),
+
     // 공통 (PRB)
     INVALID_INPUT("PRB-001", "필수값이 누락되었습니다."),
     SERVER_ERROR("PRB-002", "문제 도메인 처리 중 서버 오류가 발생했습니다.");

--- a/src/main/java/com/wanted/codebombalms/problems/execution/application/command/ExecuteCodeCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/application/command/ExecuteCodeCommand.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.execution.application.command;
+
+public record ExecuteCodeCommand(
+        String code
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/application/policy/CodeExecutionPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/application/policy/CodeExecutionPolicy.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.problems.execution.application.policy;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CodeExecutionPolicy {
+
+    public void validate(String code) {
+        if (code == null || code.isBlank()) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_CODE_INVALID_INPUT);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/application/port/LoadCodeProblemPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/application/port/LoadCodeProblemPort.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.problems.execution.application.port;
+
+public interface LoadCodeProblemPort {
+
+    CodeProblemForExecution loadCodeProblem(Long problemId);
+
+    record CodeProblemForExecution(
+            Long problemId,
+            String problemType
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/application/port/RunCodePort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/application/port/RunCodePort.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.problems.execution.application.port;
+
+public interface RunCodePort {
+
+    CodeRunResult run(String code);
+
+    record CodeRunResult(
+            String output,
+            String errorMessage,
+            Long executionTimeMs,
+            Boolean success
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/application/service/CodeExecutionService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/application/service/CodeExecutionService.java
@@ -1,0 +1,43 @@
+package com.wanted.codebombalms.problems.execution.application.service;
+
+import com.wanted.codebombalms.problems.execution.application.command.ExecuteCodeCommand;
+import com.wanted.codebombalms.problems.execution.application.policy.CodeExecutionPolicy;
+import com.wanted.codebombalms.problems.execution.application.port.LoadCodeProblemPort;
+import com.wanted.codebombalms.problems.execution.application.port.RunCodePort;
+import com.wanted.codebombalms.problems.execution.application.usecase.CodeExecutionUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CodeExecutionService implements CodeExecutionUseCase {
+
+    private final LoadCodeProblemPort loadCodeProblemPort;
+    private final RunCodePort runCodePort;
+    private final CodeExecutionPolicy codeExecutionPolicy;
+
+    public CodeExecutionService(
+            LoadCodeProblemPort loadCodeProblemPort,
+            RunCodePort runCodePort,
+            CodeExecutionPolicy codeExecutionPolicy
+    ) {
+        this.loadCodeProblemPort = loadCodeProblemPort;
+        this.runCodePort = runCodePort;
+        this.codeExecutionPolicy = codeExecutionPolicy;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CodeExecutionView handle(Long problemId, ExecuteCodeCommand command) {
+        codeExecutionPolicy.validate(command.code());
+        var problem = loadCodeProblemPort.loadCodeProblem(problemId);
+        var result = runCodePort.run(command.code());
+
+        return new CodeExecutionView(
+                problem.problemId(),
+                result.output(),
+                result.errorMessage(),
+                result.executionTimeMs(),
+                result.success()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/application/usecase/CodeExecutionUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/application/usecase/CodeExecutionUseCase.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.problems.execution.application.usecase;
+
+import com.wanted.codebombalms.problems.execution.application.command.ExecuteCodeCommand;
+
+public interface CodeExecutionUseCase {
+
+    CodeExecutionView handle(Long problemId, ExecuteCodeCommand command);
+
+    record CodeExecutionView(
+            Long problemId,
+            String output,
+            String errorMessage,
+            Long executionTimeMs,
+            Boolean success
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/problem/CodeProblemForExecutionAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/problem/CodeProblemForExecutionAdapter.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.problems.execution.infrastructure.problem;
+
+import com.wanted.codebombalms.problems.execution.application.port.LoadCodeProblemPort;
+import com.wanted.codebombalms.problems.problem.application.service.ProblemQueryService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CodeProblemForExecutionAdapter implements LoadCodeProblemPort {
+
+    private final ProblemQueryService problemQueryService;
+
+    public CodeProblemForExecutionAdapter(ProblemQueryService problemQueryService) {
+        this.problemQueryService = problemQueryService;
+    }
+
+    @Override
+    public CodeProblemForExecution loadCodeProblem(Long problemId) {
+        var problem = problemQueryService.findProblem(problemId);
+
+        return new CodeProblemForExecution(
+                problem.getProblemId(),
+                problem.getProblemType()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/runner/MockCodeRunnerAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/runner/MockCodeRunnerAdapter.java
@@ -1,0 +1,38 @@
+package com.wanted.codebombalms.problems.execution.infrastructure.runner;
+
+import com.wanted.codebombalms.problems.execution.application.port.RunCodePort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MockCodeRunnerAdapter implements RunCodePort {
+
+    private static final long MOCK_EXECUTION_TIME_MS = 1L;
+
+    @Override
+    public CodeRunResult run(String code) {
+        if (code.contains("raise") || code.contains("error")) {
+            return new CodeRunResult(
+                    null,
+                    "코드 실행 중 오류가 발생했습니다.",
+                    MOCK_EXECUTION_TIME_MS,
+                    false
+            );
+        }
+
+        if (!code.contains("result")) {
+            return new CodeRunResult(
+                    null,
+                    "result 변수가 정의되지 않았습니다.",
+                    MOCK_EXECUTION_TIME_MS,
+                    false
+            );
+        }
+
+        return new CodeRunResult(
+                "실행 결과를 확인했습니다.",
+                null,
+                MOCK_EXECUTION_TIME_MS,
+                true
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/presentation/api/CodeExecutionController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/presentation/api/CodeExecutionController.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.problems.execution.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import com.wanted.codebombalms.problems.execution.application.command.ExecuteCodeCommand;
+import com.wanted.codebombalms.problems.execution.application.usecase.CodeExecutionUseCase;
+import com.wanted.codebombalms.problems.execution.presentation.api.request.CodeExecutionRequest;
+import com.wanted.codebombalms.problems.execution.presentation.api.response.CodeExecutionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CodeExecutionController {
+
+    private final CodeExecutionUseCase codeExecutionUseCase;
+
+    public CodeExecutionController(CodeExecutionUseCase codeExecutionUseCase) {
+        this.codeExecutionUseCase = codeExecutionUseCase;
+    }
+
+    @PostMapping("/api/v1/code-problems/{problemId}/executions")
+    public ResponseEntity<ApiResponse<CodeExecutionResponse>> executeCode(
+            @PathVariable Long problemId,
+            @RequestBody CodeExecutionRequest request
+    ) {
+        var command = new ExecuteCodeCommand(request.getCode());
+        var response = new CodeExecutionResponse(
+                codeExecutionUseCase.handle(problemId, command)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "코드 실행 성공",
+                response
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/presentation/api/request/CodeExecutionRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/presentation/api/request/CodeExecutionRequest.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.problems.execution.presentation.api.request;
+
+public class CodeExecutionRequest {
+
+    private String code;
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/presentation/api/response/CodeExecutionResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/presentation/api/response/CodeExecutionResponse.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.problems.execution.presentation.api.response;
+
+import com.wanted.codebombalms.problems.execution.application.usecase.CodeExecutionUseCase.CodeExecutionView;
+
+public record CodeExecutionResponse(
+        Long problemId,
+        String output,
+        String errorMessage,
+        Long executionTimeMs,
+        Boolean isSuccess
+) {
+
+    public CodeExecutionResponse(CodeExecutionView result) {
+        this(
+                result.problemId(),
+                result.output(),
+                result.errorMessage(),
+                result.executionTimeMs(),
+                result.success()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/command/RegisterProblemSetCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/command/RegisterProblemSetCommand.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record RegisterProblemSetCommand(
         String title,
         String categoryName,
+        String difficulty,
         String description,
         String dataFileName,
         List<ProblemCreateCommand> problems

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/command/UpdateProblemSetCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/command/UpdateProblemSetCommand.java
@@ -6,6 +6,7 @@ public record UpdateProblemSetCommand(
         Long problemSetId,
         String title,
         String categoryName,
+        String difficulty,
         String description,
         String dataFileName,
         List<ProblemUpdateCommand> problems

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/policy/ProblemSetCommandValidationPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/policy/ProblemSetCommandValidationPolicy.java
@@ -8,16 +8,23 @@ import com.wanted.codebombalms.problems.set.application.command.UpdateProblemSet
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 public class ProblemSetCommandValidationPolicy {
 
     public void validate(RegisterProblemSetCommand command) {
-        validateProblemSet(command.title(), command.categoryName(), command.problems());
+        validateProblemSet(
+                command.title(),
+                command.categoryName(),
+                command.difficulty(),
+                command.problems()
+        );
         command.problems().forEach(this::validate);
     }
 
     public void validate(UpdateProblemSetCommand command) {
-        validateProblemSet(command.title(), command.categoryName(), command.problems());
+        validateProblemSet(command.title(), command.categoryName(), command.difficulty(), command.problems());
         command.problems().forEach(this::validate);
     }
 
@@ -33,12 +40,28 @@ public class ProblemSetCommandValidationPolicy {
         requireNotBlank(command.answer(), ProblemErrorCode.PROBLEM_ANSWER_REQUIRED);
     }
 
-    private void validateProblemSet(String title, String categoryName, java.util.List<?> problems) {
+    private void validateProblemSet(
+            String title,
+            String categoryName,
+            String difficulty,
+            java.util.List<?> problems
+    ) {
         requireNotBlank(title, ProblemErrorCode.PROBLEM_SET_TITLE_REQUIRED);
         requireNotBlank(categoryName, ProblemErrorCode.PROBLEM_CATEGORY_REQUIRED);
+        validateDifficulty(difficulty);
         requireNotEmpty(problems, ProblemErrorCode.PROBLEM_REQUIRED);
     }
+    private void validateDifficulty(String difficulty) {
+        if (difficulty == null || difficulty.isBlank()) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
 
+        if (!difficulty.equals("EASY")
+                && !difficulty.equals("MEDIUM")
+                && !difficulty.equals("HARD")) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+    }
     private void requireNotBlank(String value, ProblemErrorCode errorCode) {
         if (value == null || value.isBlank()) {
             throw new ValidationException(errorCode);

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetRegistrationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetRegistrationService.java
@@ -55,6 +55,7 @@ public class ProblemSetRegistrationService implements RegisterProblemSetUseCase 
         return new ProblemSetRegistration(
                 command.title(),
                 command.categoryName(),
+                command.difficulty(),
                 command.description(),
                 problems
         );

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetUpdateService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetUpdateService.java
@@ -53,6 +53,7 @@ public class ProblemSetUpdateService implements UpdateProblemSetUseCase {
                 command.problemSetId(),
                 command.title(),
                 command.categoryName(),
+                command.difficulty(),
                 command.description(),
                 problems
         );

--- a/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetModification.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetModification.java
@@ -6,6 +6,7 @@ public record ProblemSetModification(
         Long problemSetId,
         String title,
         String categoryName,
+        String difficulty,
         String description,
         List<ProblemModification> problems
 ) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetRegistration.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetRegistration.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record ProblemSetRegistration(
         String title,
         String categoryName,
+        String difficulty,
         String description,
         List<ProblemRegistration> problems
 ) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetJpaEntity.java
@@ -74,11 +74,13 @@ public class ProblemSetJpaEntity {
     public void update(
             ProblemCategoryJpaEntity category,
             String title,
-            String description
+            String description,
+            String difficulty
     ) {
         this.category = category;
         this.title = title;
         this.description = description;
+        this.difficulty = difficulty;
     }
 
     public void updateTotalProblemCount(Integer totalProblemCount) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetManagementPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetManagementPersistenceAdapter.java
@@ -50,7 +50,7 @@ public class ProblemSetManagementPersistenceAdapter implements ProblemSetManagem
                 category,
                 registration.title(),
                 registration.description(),
-                "EASY",
+                registration.difficulty(),
                 registration.problems().size(),
                 createdBy
         );
@@ -87,7 +87,8 @@ public class ProblemSetManagementPersistenceAdapter implements ProblemSetManagem
         problemSet.update(
                 category,
                 modification.title(),
-                modification.description()
+                modification.description(),
+                modification.difficulty()
         );
 
         int updatedProblemCount = 0;

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/api/ProblemManageController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/api/ProblemManageController.java
@@ -95,6 +95,7 @@ public class ProblemManageController {
         return new RegisterProblemSetCommand(
                 request.title(),
                 request.categoryName(),
+                request.difficulty(),
                 request.description(),
                 request.dataFileName(),
                 problems
@@ -125,6 +126,7 @@ public class ProblemManageController {
                 problemSetId,
                 request.title(),
                 request.categoryName(),
+                request.difficulty(),
                 request.description(),
                 request.dataFileName(),
                 problems

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/api/request/ProblemSetCreateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/api/request/ProblemSetCreateRequest.java
@@ -6,6 +6,7 @@ public record ProblemSetCreateRequest(
         String title,
         String categoryName,
         String description,
+        String difficulty,
         String dataFileName,
         List<ProblemCreateRequest> problems
 ) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/api/request/ProblemSetUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/api/request/ProblemSetUpdateRequest.java
@@ -6,6 +6,7 @@ public record ProblemSetUpdateRequest(
         String title,
         String categoryName,
         String description,
+        String difficulty,
         String dataFileName,
         List<ProblemUpdateRequest> problems
 ) {

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/command/CreateProblemTestCaseCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/command/CreateProblemTestCaseCommand.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.problems.testcase.application.command;
+
+public record CreateProblemTestCaseCommand(
+        Long problemId,
+        String testCode,
+        String expectedResult,
+        Integer testOrder,
+        Integer score,
+        Boolean hidden,
+        Integer timeoutMs
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/command/UpdateProblemTestCaseCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/command/UpdateProblemTestCaseCommand.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.problems.testcase.application.command;
+
+public record UpdateProblemTestCaseCommand(
+        Long testCaseId,
+        String testCode,
+        String expectedResult,
+        Integer testOrder,
+        Integer score,
+        Boolean hidden,
+        Integer timeoutMs
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/policy/ProblemTestCasePolicy.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/policy/ProblemTestCasePolicy.java
@@ -1,0 +1,61 @@
+package com.wanted.codebombalms.problems.testcase.application.policy;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.testcase.application.port.LoadTestCaseProblemPort;
+import com.wanted.codebombalms.problems.testcase.domain.repository.ProblemTestCaseRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProblemTestCasePolicy {
+
+    private static final String CODE_PROBLEM_TYPE = "CODE";
+
+    private final LoadTestCaseProblemPort loadTestCaseProblemPort;
+    private final ProblemTestCaseRepository problemTestCaseRepository;
+
+    public ProblemTestCasePolicy(
+            LoadTestCaseProblemPort loadTestCaseProblemPort,
+            ProblemTestCaseRepository problemTestCaseRepository
+    ) {
+        this.loadTestCaseProblemPort = loadTestCaseProblemPort;
+        this.problemTestCaseRepository = problemTestCaseRepository;
+    }
+
+    public void validateCreatable(Long problemId, Integer testCaseScore) {
+        var problem = validateCodeProblem(problemId);
+
+        validateSameScore(problem.score(), testCaseScore);
+
+        if (problemTestCaseRepository.existsActiveByProblemId(problemId)) {
+            throw new ConflictException(ProblemErrorCode.PROBLEM_TEST_CASE_ALREADY_EXISTS);
+        }
+    }
+
+    public void validateReadable(Long problemId) {
+        validateCodeProblem(problemId);
+    }
+
+    public void validateUpdatable(Long problemId, Integer testCaseScore) {
+        var problem = validateCodeProblem(problemId);
+
+        validateSameScore(problem.score(), testCaseScore);
+    }
+
+    private LoadTestCaseProblemPort.TestCaseProblemView validateCodeProblem(Long problemId) {
+        var problem = loadTestCaseProblemPort.loadByProblemId(problemId);
+
+        if (!CODE_PROBLEM_TYPE.equals(problem.problemType())) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE);
+        }
+
+        return problem;
+    }
+
+    private void validateSameScore(Integer problemScore, Integer testCaseScore) {
+        if (testCaseScore == null || !testCaseScore.equals(problemScore)) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_INPUT);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/port/LoadTestCaseProblemPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/port/LoadTestCaseProblemPort.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.problems.testcase.application.port;
+
+public interface LoadTestCaseProblemPort {
+
+    TestCaseProblemView loadByProblemId(Long problemId);
+
+    record TestCaseProblemView(
+            Long problemId,
+            String problemType,
+            Integer score
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/query/GetProblemTestCasesQuery.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/query/GetProblemTestCasesQuery.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.testcase.application.query;
+
+public record GetProblemTestCasesQuery(
+        Long problemId
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/service/ProblemTestCaseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/service/ProblemTestCaseCommandService.java
@@ -1,0 +1,91 @@
+package com.wanted.codebombalms.problems.testcase.application.service;
+
+
+import com.wanted.codebombalms.problems.testcase.application.command.CreateProblemTestCaseCommand;
+import com.wanted.codebombalms.problems.testcase.application.command.UpdateProblemTestCaseCommand;
+import com.wanted.codebombalms.problems.testcase.application.policy.ProblemTestCasePolicy;
+import com.wanted.codebombalms.problems.testcase.application.usecase.ProblemTestCaseCommandUseCase;
+import com.wanted.codebombalms.problems.testcase.domain.model.ProblemTestCase;
+import com.wanted.codebombalms.problems.testcase.domain.repository.ProblemTestCaseRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ProblemTestCaseCommandService implements ProblemTestCaseCommandUseCase {
+
+    private final ProblemTestCasePolicy problemTestCasePolicy;
+    private final ProblemTestCaseRepository problemTestCaseRepository;
+
+    public ProblemTestCaseCommandService(
+            ProblemTestCasePolicy problemTestCasePolicy,
+            ProblemTestCaseRepository problemTestCaseRepository
+    ) {
+        this.problemTestCasePolicy = problemTestCasePolicy;
+        this.problemTestCaseRepository = problemTestCaseRepository;
+    }
+
+    @Override
+    @Transactional
+    public TestCaseView handle(CreateProblemTestCaseCommand command) {
+        problemTestCasePolicy.validateCreatable(command.problemId(),command.score());
+
+        ProblemTestCase testCase = ProblemTestCase.create(
+                command.problemId(),
+                command.testCode(),
+                command.expectedResult(),
+                command.testOrder(),
+                command.score(),
+                command.hidden(),
+                command.timeoutMs()
+        );
+
+        return toView(problemTestCaseRepository.save(testCase));
+    }
+
+    @Override
+    @Transactional
+    public ProblemTestCaseCommandUseCase.TestCaseView handle(UpdateProblemTestCaseCommand command) {
+        ProblemTestCase existingTestCase = problemTestCaseRepository.findActiveById(command.testCaseId());
+
+        problemTestCasePolicy.validateUpdatable(
+                existingTestCase.getProblemId(),
+                command.score()
+        );
+
+        ProblemTestCase updatedTestCase = ProblemTestCase.restore(
+                existingTestCase.getTestCaseId(),
+                existingTestCase.getProblemId(),
+                command.testCode(),
+                command.expectedResult(),
+                command.testOrder(),
+                command.score(),
+                command.hidden(),
+                command.timeoutMs(),
+                existingTestCase.getStatus()
+        );
+
+        return toView(problemTestCaseRepository.save(updatedTestCase));
+    }
+
+    @Override
+    @Transactional
+    public ProblemTestCaseCommandUseCase.TestCaseView delete(Long testCaseId) {
+        return toView(problemTestCaseRepository.deactivate(testCaseId));
+    }
+
+    private ProblemTestCaseCommandUseCase.TestCaseView toView(ProblemTestCase testCase) {
+        return new ProblemTestCaseCommandUseCase.TestCaseView(
+                testCase.getTestCaseId(),
+                testCase.getProblemId(),
+                testCase.getTestCode(),
+                testCase.getExpectedResult(),
+                testCase.getTestOrder(),
+                testCase.getScore(),
+                testCase.getHidden(),
+                testCase.getTimeoutMs(),
+                testCase.getStatus()
+        );
+    }
+
+
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/service/ProblemTestCaseQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/service/ProblemTestCaseQueryService.java
@@ -1,0 +1,52 @@
+package com.wanted.codebombalms.problems.testcase.application.service;
+
+import com.wanted.codebombalms.problems.testcase.application.policy.ProblemTestCasePolicy;
+import com.wanted.codebombalms.problems.testcase.application.query.GetProblemTestCasesQuery;
+import com.wanted.codebombalms.problems.testcase.application.usecase.ProblemTestCaseCommandUseCase;
+import com.wanted.codebombalms.problems.testcase.application.usecase.ProblemTestCaseQueryUseCase;
+import com.wanted.codebombalms.problems.testcase.domain.model.ProblemTestCase;
+import com.wanted.codebombalms.problems.testcase.domain.repository.ProblemTestCaseRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Service
+public class ProblemTestCaseQueryService implements ProblemTestCaseQueryUseCase {
+
+    private final ProblemTestCasePolicy problemTestCasePolicy;
+    private final ProblemTestCaseRepository problemTestCaseRepository;
+
+    public ProblemTestCaseQueryService(
+            ProblemTestCasePolicy problemTestCasePolicy,
+            ProblemTestCaseRepository problemTestCaseRepository
+    ) {
+        this.problemTestCasePolicy = problemTestCasePolicy;
+        this.problemTestCaseRepository = problemTestCaseRepository;
+    }
+
+    @Override
+    public List<ProblemTestCaseCommandUseCase.TestCaseView> handle(GetProblemTestCasesQuery query) {
+        problemTestCasePolicy.validateReadable(query.problemId());
+
+        return problemTestCaseRepository.findActiveByProblemId(query.problemId())
+                .stream()
+                .map(this::toView)
+                .toList();
+    }
+
+    private ProblemTestCaseCommandUseCase.TestCaseView toView(ProblemTestCase testCase) {
+        return new ProblemTestCaseCommandUseCase.TestCaseView(
+                testCase.getTestCaseId(),
+                testCase.getProblemId(),
+                testCase.getTestCode(),
+                testCase.getExpectedResult(),
+                testCase.getTestOrder(),
+                testCase.getScore(),
+                testCase.getHidden(),
+                testCase.getTimeoutMs(),
+                testCase.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/usecase/ProblemTestCaseCommandUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/usecase/ProblemTestCaseCommandUseCase.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms.problems.testcase.application.usecase;
+
+import com.wanted.codebombalms.problems.testcase.application.command.CreateProblemTestCaseCommand;
+import com.wanted.codebombalms.problems.testcase.application.command.UpdateProblemTestCaseCommand;
+
+public interface ProblemTestCaseCommandUseCase {
+
+    TestCaseView handle(CreateProblemTestCaseCommand command);
+
+    TestCaseView handle(UpdateProblemTestCaseCommand command);
+
+    TestCaseView delete(Long testCaseId);
+
+    record TestCaseView(
+            Long testCaseId,
+            Long problemId,
+            String testCode,
+            String expectedResult,
+            Integer testOrder,
+            Integer score,
+            Boolean hidden,
+            Integer timeoutMs,
+            String status
+    ) {
+    }
+}
+

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/usecase/ProblemTestCaseQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/usecase/ProblemTestCaseQueryUseCase.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.testcase.application.usecase;
+
+import com.wanted.codebombalms.problems.testcase.application.query.GetProblemTestCasesQuery;
+import com.wanted.codebombalms.problems.testcase.application.usecase.ProblemTestCaseCommandUseCase.TestCaseView;
+
+import java.util.List;
+
+public interface ProblemTestCaseQueryUseCase {
+
+    List<TestCaseView> handle(GetProblemTestCasesQuery query);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/domain/model/ProblemTestCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/domain/model/ProblemTestCase.java
@@ -1,0 +1,154 @@
+package com.wanted.codebombalms.problems.testcase.domain.model;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+
+public class ProblemTestCase {
+
+    private static final String ACTIVE = "ACTIVE";
+    private static final int DEFAULT_TIMEOUT_MS = 3000;
+
+    private final Long testCaseId;
+    private final Long problemId;
+    private final String testCode;
+    private final String expectedResult;
+    private final Integer testOrder;
+    private final Integer score;
+    private final Boolean hidden;
+    private final Integer timeoutMs;
+    private final String status;
+
+    private ProblemTestCase(
+            Long testCaseId,
+            Long problemId,
+            String testCode,
+            String expectedResult,
+            Integer testOrder,
+            Integer score,
+            Boolean hidden,
+            Integer timeoutMs,
+            String status
+    ) {
+        validate(problemId, testCode, testOrder, score, hidden, status);
+
+        this.testCaseId = testCaseId;
+        this.problemId = problemId;
+        this.testCode = testCode;
+        this.expectedResult = expectedResult;
+        this.testOrder = testOrder;
+        this.score = score;
+        this.hidden = hidden;
+        this.timeoutMs = timeoutMs == null ? DEFAULT_TIMEOUT_MS : timeoutMs;
+        this.status = status;
+    }
+
+    public static ProblemTestCase create(
+            Long problemId,
+            String testCode,
+            String expectedResult,
+            Integer testOrder,
+            Integer score,
+            Boolean hidden,
+            Integer timeoutMs
+    ) {
+        return new ProblemTestCase(
+                null,
+                problemId,
+                testCode,
+                expectedResult,
+                testOrder,
+                score,
+                hidden,
+                timeoutMs,
+                ACTIVE
+        );
+    }
+
+    public static ProblemTestCase restore(
+            Long testCaseId,
+            Long problemId,
+            String testCode,
+            String expectedResult,
+            Integer testOrder,
+            Integer score,
+            Boolean hidden,
+            Integer timeoutMs,
+            String status
+    ) {
+        return new ProblemTestCase(
+                testCaseId,
+                problemId,
+                testCode,
+                expectedResult,
+                testOrder,
+                score,
+                hidden,
+                timeoutMs,
+                status
+        );
+    }
+
+    private void validate(
+            Long problemId,
+            String testCode,
+            Integer testOrder,
+            Integer score,
+            Boolean hidden,
+            String status
+    ) {
+        if (problemId == null) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_NOT_FOUND);
+        }
+        if (testCode == null || testCode.isBlank()) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_INPUT);
+        }
+        if (testOrder == null || testOrder < 1) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_INPUT);
+        }
+        if (score == null || score < 0) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_INPUT);
+        }
+        if (hidden == null) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_INPUT);
+        }
+        if (status == null || status.isBlank()) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_INPUT);
+        }
+    }
+
+    public Long getTestCaseId() {
+        return testCaseId;
+    }
+
+    public Long getProblemId() {
+        return problemId;
+    }
+
+    public String getTestCode() {
+        return testCode;
+    }
+
+    public String getExpectedResult() {
+        return expectedResult;
+    }
+
+    public Integer getTestOrder() {
+        return testOrder;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    public Boolean getHidden() {
+        return hidden;
+    }
+
+    public Integer getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/domain/repository/ProblemTestCaseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/domain/repository/ProblemTestCaseRepository.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.problems.testcase.domain.repository;
+
+import com.wanted.codebombalms.problems.testcase.domain.model.ProblemTestCase;
+
+import java.util.List;
+
+public interface ProblemTestCaseRepository {
+    ProblemTestCase save(ProblemTestCase testCase);
+
+    List<ProblemTestCase> findActiveByProblemId(Long problemId);
+
+    ProblemTestCase findActiveById(Long testCaseId);
+
+    boolean existsActiveByProblemId(Long problemId);
+
+    ProblemTestCase deactivate(Long testCaseId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCaseJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCaseJpaEntity.java
@@ -1,0 +1,146 @@
+package com.wanted.codebombalms.problems.testcase.infrastructure.persistence;
+
+import com.wanted.codebombalms.problems.problem.infrastructure.persistence.ProblemJpaEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "problem_test_case")
+public class ProblemTestCaseJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long testCaseId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_id", nullable = false)
+    private ProblemJpaEntity problem;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String testCode;
+
+    @Column(columnDefinition = "TEXT")
+    private String expectedResult;
+
+    @Column(nullable = false)
+    private Integer testOrder;
+
+    @Column(nullable = false)
+    private Integer score;
+
+    @Column(name = "is_hidden", nullable = false)
+    private Boolean hidden;
+
+    @Column(nullable = false)
+    private Integer timeoutMs;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ProblemTestCaseJpaEntity() {
+    }
+
+    public static ProblemTestCaseJpaEntity create(
+            ProblemJpaEntity problem,
+            String testCode,
+            String expectedResult,
+            Integer testOrder,
+            Integer score,
+            Boolean hidden,
+            Integer timeoutMs
+    ) {
+        ProblemTestCaseJpaEntity testCase = new ProblemTestCaseJpaEntity();
+        testCase.problem = problem;
+        testCase.testCode = testCode;
+        testCase.expectedResult = expectedResult;
+        testCase.testOrder = testOrder;
+        testCase.score = score;
+        testCase.hidden = hidden;
+        testCase.timeoutMs = timeoutMs;
+        testCase.status = "ACTIVE";
+        testCase.createdAt = LocalDateTime.now();
+        testCase.updatedAt = testCase.createdAt;
+        return testCase;
+    }
+
+    public void update(
+            String testCode,
+            String expectedResult,
+            Integer testOrder,
+            Integer score,
+            Boolean hidden,
+            Integer timeoutMs
+    ) {
+        this.testCode = testCode;
+        this.expectedResult = expectedResult;
+        this.testOrder = testOrder;
+        this.score = score;
+        this.hidden = hidden;
+        this.timeoutMs = timeoutMs;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void deactivate() {
+        this.status = "INACTIVE";
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getTestCaseId() {
+        return testCaseId;
+    }
+
+    public ProblemJpaEntity getProblem() {
+        return problem;
+    }
+
+    public String getTestCode() {
+        return testCode;
+    }
+
+    public String getExpectedResult() {
+        return expectedResult;
+    }
+
+    public Integer getTestOrder() {
+        return testOrder;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    public Boolean getHidden() {
+        return hidden;
+    }
+
+    public Integer getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCasePersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCasePersistenceAdapter.java
@@ -1,0 +1,119 @@
+package com.wanted.codebombalms.problems.testcase.infrastructure.persistence;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.problem.infrastructure.persistence.ProblemJpaEntity;
+import com.wanted.codebombalms.problems.problem.infrastructure.persistence.SpringDataProblemRepository;
+import com.wanted.codebombalms.problems.testcase.application.port.LoadTestCaseProblemPort;
+import com.wanted.codebombalms.problems.testcase.domain.model.ProblemTestCase;
+import com.wanted.codebombalms.problems.testcase.domain.repository.ProblemTestCaseRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ProblemTestCasePersistenceAdapter implements ProblemTestCaseRepository, LoadTestCaseProblemPort {
+
+    private static final String ACTIVE = "ACTIVE";
+
+    private final SpringDataProblemTestCaseRepository testCaseRepository;
+    private final SpringDataProblemRepository problemRepository;
+
+    public ProblemTestCasePersistenceAdapter(
+            SpringDataProblemTestCaseRepository testCaseRepository,
+            SpringDataProblemRepository problemRepository
+    ) {
+        this.testCaseRepository = testCaseRepository;
+        this.problemRepository = problemRepository;
+    }
+
+    @Override
+    public ProblemTestCase save(ProblemTestCase testCase) {
+        if (testCase.getTestCaseId() == null) {
+            ProblemJpaEntity problem = loadProblem(testCase.getProblemId());
+
+            return toDomain(testCaseRepository.save(ProblemTestCaseJpaEntity.create(
+                    problem,
+                    testCase.getTestCode(),
+                    testCase.getExpectedResult(),
+                    testCase.getTestOrder(),
+                    testCase.getScore(),
+                    testCase.getHidden(),
+                    testCase.getTimeoutMs()
+            )));
+        }
+
+        ProblemTestCaseJpaEntity entity = loadActiveTestCase(testCase.getTestCaseId());
+        entity.update(
+                testCase.getTestCode(),
+                testCase.getExpectedResult(),
+                testCase.getTestOrder(),
+                testCase.getScore(),
+                testCase.getHidden(),
+                testCase.getTimeoutMs()
+        );
+
+        return toDomain(entity);
+    }
+
+    @Override
+    public List<ProblemTestCase> findActiveByProblemId(Long problemId) {
+        return testCaseRepository.findByProblem_ProblemIdAndStatusOrderByTestOrderAsc(problemId, ACTIVE)
+                .stream()
+                .map(this::toDomain)
+                .toList();
+    }
+
+    @Override
+    public ProblemTestCase findActiveById(Long testCaseId) {
+        return toDomain(loadActiveTestCase(testCaseId));
+    }
+
+    @Override
+    public boolean existsActiveByProblemId(Long problemId) {
+        return testCaseRepository.existsByProblem_ProblemIdAndStatus(problemId, ACTIVE);
+    }
+
+    @Override
+    public ProblemTestCase deactivate(Long testCaseId) {
+        ProblemTestCaseJpaEntity testCase = loadActiveTestCase(testCaseId);
+        testCase.deactivate();
+
+        return toDomain(testCase);
+    }
+
+    @Override
+    public LoadTestCaseProblemPort.TestCaseProblemView loadByProblemId(Long problemId) {
+        ProblemJpaEntity problem = loadProblem(problemId);
+
+        return new LoadTestCaseProblemPort.TestCaseProblemView(
+                problem.getProblemId(),
+                problem.getProblemType(),
+                problem.getScore()
+        );
+    }
+
+    private ProblemJpaEntity loadProblem(Long problemId) {
+        return problemRepository.findById(problemId)
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND));
+    }
+
+    private ProblemTestCaseJpaEntity loadActiveTestCase(Long testCaseId) {
+        return testCaseRepository.findByTestCaseIdAndStatus(testCaseId, ACTIVE)
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_TEST_CASE_NOT_FOUND));
+    }
+
+    private ProblemTestCase toDomain(ProblemTestCaseJpaEntity entity) {
+        return ProblemTestCase.restore(
+                entity.getTestCaseId(),
+                entity.getProblem().getProblemId(),
+                entity.getTestCode(),
+                entity.getExpectedResult(),
+                entity.getTestOrder(),
+                entity.getScore(),
+                entity.getHidden(),
+                entity.getTimeoutMs(),
+                entity.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/SpringDataProblemTestCaseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/SpringDataProblemTestCaseRepository.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.problems.testcase.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringDataProblemTestCaseRepository extends JpaRepository<ProblemTestCaseJpaEntity, Long> {
+    List<ProblemTestCaseJpaEntity> findByProblem_ProblemIdAndStatusOrderByTestOrderAsc(
+            Long problemId,
+            String status
+    );
+
+    boolean existsByProblem_ProblemIdAndStatus(
+            Long problemId,
+            String status
+    );
+
+    Optional<ProblemTestCaseJpaEntity> findByTestCaseIdAndStatus(
+            Long testCaseId,
+            String status
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/ProblemTestCaseController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/ProblemTestCaseController.java
@@ -1,0 +1,113 @@
+package com.wanted.codebombalms.problems.testcase.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.problems.testcase.application.command.CreateProblemTestCaseCommand;
+import com.wanted.codebombalms.problems.testcase.application.command.UpdateProblemTestCaseCommand;
+import com.wanted.codebombalms.problems.testcase.application.query.GetProblemTestCasesQuery;
+import com.wanted.codebombalms.problems.testcase.application.usecase.ProblemTestCaseCommandUseCase;
+import com.wanted.codebombalms.problems.testcase.application.usecase.ProblemTestCaseQueryUseCase;
+import com.wanted.codebombalms.problems.testcase.presentation.api.request.CreateProblemTestCaseRequest;
+import com.wanted.codebombalms.problems.testcase.presentation.api.request.UpdateProblemTestCaseRequest;
+import com.wanted.codebombalms.problems.testcase.presentation.api.response.ProblemTestCaseResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class ProblemTestCaseController {
+
+    private final ProblemTestCaseCommandUseCase commandUseCase;
+    private final ProblemTestCaseQueryUseCase queryUseCase;
+
+    public ProblemTestCaseController(
+            ProblemTestCaseCommandUseCase commandUseCase,
+            ProblemTestCaseQueryUseCase queryUseCase
+    ) {
+        this.commandUseCase = commandUseCase;
+        this.queryUseCase = queryUseCase;
+    }
+
+    @PostMapping("/api/v1/problems/{problemId}/test-cases")
+    public ResponseEntity<ApiResponse<ProblemTestCaseResponse>> createTestCase(
+            @PathVariable Long problemId,
+            @RequestBody CreateProblemTestCaseRequest request
+    ) {
+        var view = commandUseCase.handle(new CreateProblemTestCaseCommand(
+                problemId,
+                request.testCode(),
+                request.expectedResult(),
+                request.testOrder(),
+                request.score(),
+                request.isHidden(),
+                request.timeoutMs()
+        ));
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        ApiResponseCode.CREATED,
+                        ApiResponseMessage.CREATED,
+                        ProblemTestCaseResponse.from(view)
+                ));
+    }
+
+    @GetMapping("/api/v1/problems/{problemId}/test-cases")
+    public ResponseEntity<ApiResponse<List<ProblemTestCaseResponse>>> findTestCases(
+            @PathVariable Long problemId
+    ) {
+        List<ProblemTestCaseResponse> responses = queryUseCase.handle(new GetProblemTestCasesQuery(problemId))
+                .stream()
+                .map(ProblemTestCaseResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                responses
+        ));
+    }
+
+    @PutMapping("/api/v1/test-cases/{testCaseId}")
+    public ResponseEntity<ApiResponse<ProblemTestCaseResponse>> updateTestCase(
+            @PathVariable Long testCaseId,
+            @RequestBody UpdateProblemTestCaseRequest request
+    ) {
+        var view = commandUseCase.handle(new UpdateProblemTestCaseCommand(
+                testCaseId,
+                request.testCode(),
+                request.expectedResult(),
+                request.testOrder(),
+                request.score(),
+                request.isHidden(),
+                request.timeoutMs()
+        ));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                ProblemTestCaseResponse.from(view)
+        ));
+    }
+
+    @DeleteMapping("/api/v1/test-cases/{testCaseId}")
+    public ResponseEntity<ApiResponse<ProblemTestCaseResponse>> deleteTestCase(
+            @PathVariable Long testCaseId
+    ) {
+        var view = commandUseCase.delete(testCaseId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                ProblemTestCaseResponse.from(view)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/request/CreateProblemTestCaseRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/request/CreateProblemTestCaseRequest.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.testcase.presentation.api.request;
+
+public record CreateProblemTestCaseRequest(
+        String testCode,
+        String expectedResult,
+        Integer testOrder,
+        Integer score,
+        Boolean isHidden,
+        Integer timeoutMs
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/request/UpdateProblemTestCaseRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/request/UpdateProblemTestCaseRequest.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.testcase.presentation.api.request;
+
+public record UpdateProblemTestCaseRequest(
+        String testCode,
+        String expectedResult,
+        Integer testOrder,
+        Integer score,
+        Boolean isHidden,
+        Integer timeoutMs
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/response/ProblemTestCaseResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/api/response/ProblemTestCaseResponse.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.problems.testcase.presentation.api.response;
+
+import com.wanted.codebombalms.problems.testcase.application.usecase.ProblemTestCaseCommandUseCase;
+
+public record ProblemTestCaseResponse(
+        Long testCaseId,
+        Long problemId,
+        String testCode,
+        String expectedResult,
+        Integer testOrder,
+        Integer score,
+        Boolean isHidden,
+        Integer timeoutMs,
+        String status
+) {
+
+    public static ProblemTestCaseResponse from(ProblemTestCaseCommandUseCase.TestCaseView view) {
+        return new ProblemTestCaseResponse(
+                view.testCaseId(),
+                view.problemId(),
+                view.testCode(),
+                view.expectedResult(),
+                view.testOrder(),
+                view.score(),
+                view.hidden(),
+                view.timeoutMs(),
+                view.status()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/command/SubmitCodeCommand.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/command/SubmitCodeCommand.java
@@ -1,7 +1,7 @@
 package com.wanted.codebombalms.submission.application.command;
 
-public record SubmitAnswerCommand(
+public record SubmitCodeCommand(
         Long userId,
-        String submittedAnswer
+        String code
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/submission/application/policy/SubmissionCodePolicy.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/policy/SubmissionCodePolicy.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.submission.application.policy;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.submission.exception.SubmissionErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SubmissionCodePolicy {
+
+    public void validate(String code) {
+        if (code == null || code.isBlank()) {
+            throw new ValidationException(SubmissionErrorCode.INVALID_CODE);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/port/LoadTestCasesForGradingPort.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/port/LoadTestCasesForGradingPort.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.submission.application.port;
+
+import java.util.List;
+
+public interface LoadTestCasesForGradingPort {
+
+    List<TestCaseForGrading> loadActiveTestCases(Long problemId);
+
+    record TestCaseForGrading(
+            Long testCaseId,
+            String testCode,
+            String expectedResult,
+            Integer score,
+            Boolean hidden,
+            Integer timeoutMs
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionCommandPort.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionCommandPort.java
@@ -1,10 +1,15 @@
 package com.wanted.codebombalms.submission.application.port;
 
-import com.wanted.codebombalms.submission.domain.model.TextSubmission;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmission;
+import com.wanted.codebombalms.submission.domain.model.SubmissionTestResult;
+
+import java.util.List;
 
 public interface SubmissionCommandPort {
 
     int countAttempts(Long userId, Long problemId);
 
-    void saveTextSubmission(TextSubmission submission);
+    Long saveCodeSubmission(CodeSubmission submission);
+
+    void saveTestResults(Long submissionId, List<SubmissionTestResult> testResults);
 }

--- a/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionListQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionListQueryPort.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.submission.application.port;
+
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionPage;
+
+public interface SubmissionListQueryPort {
+
+    CodeSubmissionPage findCodeSubmissions(Long problemId, int page, int size);
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionResultQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionResultQueryPort.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.submission.application.port;
+
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionResult;
+
+public interface SubmissionResultQueryPort {
+
+    CodeSubmissionResult getCodeSubmissionResult(Long submissionId);
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/CodeGradingService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/CodeGradingService.java
@@ -1,0 +1,88 @@
+package com.wanted.codebombalms.submission.application.service;
+
+import com.wanted.codebombalms.submission.application.port.LoadTestCasesForGradingPort.TestCaseForGrading;
+import com.wanted.codebombalms.submission.domain.model.SubmissionTestResult;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CodeGradingService {
+
+    private static final String SUCCESS = "SUCCESS";
+    private static final String WRONG_ANSWER = "WRONG_ANSWER";
+    private static final String GRADING_FAILED = "GRADING_FAILED";
+    private static final int MOCK_EXECUTION_TIME_MS = 1;
+
+    public CodeGradingResult grade(String code, List<TestCaseForGrading> testCases) {
+        if (testCases == null || testCases.isEmpty()) {
+            return new CodeGradingResult(
+                    false,
+                    0,
+                    0,
+                    0,
+                    GRADING_FAILED,
+                    "채점 기준 테스트케이스가 없습니다.",
+                    List.of()
+            );
+        }
+
+        if (!code.contains("result")) {
+            List<SubmissionTestResult> failedResults = testCases.stream()
+                    .map(testCase -> new SubmissionTestResult(
+                            testCase.testCaseId(),
+                            false,
+                            null,
+                            "result 변수가 정의되지 않았습니다.",
+                            MOCK_EXECUTION_TIME_MS,
+                            0
+                    ))
+                    .toList();
+
+            return new CodeGradingResult(
+                    false,
+                    0,
+                    testCases.size(),
+                    0,
+                    WRONG_ANSWER,
+                    "result 변수가 정의되지 않았습니다.",
+                    failedResults
+            );
+        }
+
+        int earnedScore = testCases.stream()
+                .mapToInt(testCase -> testCase.score() == null ? 0 : testCase.score())
+                .sum();
+        List<SubmissionTestResult> passedResults = testCases.stream()
+                .map(testCase -> new SubmissionTestResult(
+                        testCase.testCaseId(),
+                        true,
+                        testCase.expectedResult(),
+                        null,
+                        MOCK_EXECUTION_TIME_MS,
+                        testCase.score() == null ? 0 : testCase.score()
+                ))
+                .toList();
+
+        return new CodeGradingResult(
+                true,
+                testCases.size(),
+                testCases.size(),
+                earnedScore,
+                SUCCESS,
+                null,
+                passedResults
+        );
+    }
+
+    public record CodeGradingResult(
+            Boolean correct,
+            Integer passedTestCount,
+            Integer totalTestCount,
+            Integer earnedScore,
+            String executionStatus,
+            String errorMessage,
+            List<SubmissionTestResult> testResults
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/CodeSubmissionListQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/CodeSubmissionListQueryService.java
@@ -1,0 +1,68 @@
+package com.wanted.codebombalms.submission.application.service;
+
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.submission.application.port.LoadProblemForSubmissionPort;
+import com.wanted.codebombalms.submission.application.port.SubmissionListQueryPort;
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionListQueryUseCase;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionListItem;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionPage;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CodeSubmissionListQueryService implements CodeSubmissionListQueryUseCase {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_SIZE = 10;
+
+    private final LoadProblemForSubmissionPort loadProblemForSubmissionPort;
+    private final SubmissionListQueryPort submissionListQueryPort;
+
+    public CodeSubmissionListQueryService(
+            LoadProblemForSubmissionPort loadProblemForSubmissionPort,
+            SubmissionListQueryPort submissionListQueryPort
+    ) {
+        this.loadProblemForSubmissionPort = loadProblemForSubmissionPort;
+        this.submissionListQueryPort = submissionListQueryPort;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CodeSubmissionPageView handle(Long problemId, int page, int size) {
+        if (problemId == null) {
+            throw new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND);
+        }
+
+        loadProblemForSubmissionPort.loadProblem(problemId);
+
+        int safePage = page < 1 ? DEFAULT_PAGE : page;
+        int safeSize = size < 1 ? DEFAULT_SIZE : size;
+        CodeSubmissionPage result = submissionListQueryPort.findCodeSubmissions(problemId, safePage, safeSize);
+
+        return new CodeSubmissionPageView(
+                result.submissions()
+                        .stream()
+                        .map(this::toItemView)
+                        .toList(),
+                new PageInfoView(
+                        result.currentPage(),
+                        result.totalPage(),
+                        result.totalCount()
+                )
+        );
+    }
+
+    private CodeSubmissionListItemView toItemView(CodeSubmissionListItem item) {
+        return new CodeSubmissionListItemView(
+                item.submissionId(),
+                item.problemId(),
+                item.correct(),
+                item.earnedScore(),
+                item.passedTestCount(),
+                item.totalTestCount(),
+                item.executionStatus(),
+                item.submittedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/CodeSubmissionResultQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/CodeSubmissionResultQueryService.java
@@ -1,0 +1,64 @@
+package com.wanted.codebombalms.submission.application.service;
+
+import com.wanted.codebombalms.submission.application.port.SubmissionResultQueryPort;
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionResultQueryUseCase;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionResult;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionTestCaseResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CodeSubmissionResultQueryService implements CodeSubmissionResultQueryUseCase {
+
+    private final SubmissionResultQueryPort submissionResultQueryPort;
+
+    public CodeSubmissionResultQueryService(SubmissionResultQueryPort submissionResultQueryPort) {
+        this.submissionResultQueryPort = submissionResultQueryPort;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CodeSubmissionResultView handle(Long submissionId) {
+        CodeSubmissionResult result = submissionResultQueryPort.getCodeSubmissionResult(submissionId);
+
+        return new CodeSubmissionResultView(
+                result.submissionId(),
+                result.problemId(),
+                result.correct(),
+                result.earnedScore(),
+                result.passedTestCount(),
+                result.totalTestCount(),
+                result.executionStatus(),
+                result.errorMessage(),
+                result.submittedAt(),
+                result.testCaseResults()
+                        .stream()
+                        .map(this::toView)
+                        .toList()
+        );
+    }
+
+    private TestCaseResultView toView(CodeSubmissionTestCaseResult result) {
+        if (Boolean.TRUE.equals(result.hidden())) {
+            return new TestCaseResultView(
+                    result.testCaseId(),
+                    result.passed(),
+                    true,
+                    null,
+                    null,
+                    null,
+                    result.score()
+            );
+        }
+
+        return new TestCaseResultView(
+                result.testCaseId(),
+                result.passed(),
+                false,
+                result.actualOutput(),
+                result.errorMessage(),
+                result.executionTimeMs(),
+                result.score()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
@@ -1,19 +1,16 @@
 package com.wanted.codebombalms.submission.application.service;
 
-import com.wanted.codebombalms.submission.application.command.SubmitAnswerCommand;
-import com.wanted.codebombalms.submission.application.policy.SubmissionAnswerPolicy;
+import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
+import com.wanted.codebombalms.submission.application.policy.SubmissionCodePolicy;
 import com.wanted.codebombalms.submission.application.policy.SubmissionAttemptPolicy;
-import com.wanted.codebombalms.submission.application.policy.SubmissionScorePolicy;
 import com.wanted.codebombalms.submission.application.port.LoadProblemForSubmissionPort;
 import com.wanted.codebombalms.submission.application.port.LoadProblemForSubmissionPort.ProblemForSubmission;
+import com.wanted.codebombalms.submission.application.port.LoadTestCasesForGradingPort;
 import com.wanted.codebombalms.submission.application.port.ProblemProgressPort;
 import com.wanted.codebombalms.submission.application.port.ProblemSetCompletionEventPort;
 import com.wanted.codebombalms.submission.application.port.SubmissionCommandPort;
 import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase;
-import com.wanted.codebombalms.submission.domain.model.TextSubmission;
-import com.wanted.codebombalms.submission.exception.SubmissionErrorCode;
-import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
-import lombok.RequiredArgsConstructor;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmission;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,38 +19,38 @@ public class SubmissionService implements SubmissionCommandUseCase {
 
     private final SubmissionCommandPort submissionCommandPort;
     private final LoadProblemForSubmissionPort loadProblemForSubmissionPort;
+    private final LoadTestCasesForGradingPort loadTestCasesForGradingPort;
     private final ProblemProgressPort problemProgressPort;
     private final ProblemSetCompletionEventPort problemSetCompletionEventPort;
-    private final AnswerGradingService answerGradingService;
+    private final CodeGradingService codeGradingService;
     private final SubmissionAttemptPolicy submissionAttemptPolicy;
-    private final SubmissionAnswerPolicy submissionAnswerPolicy;
-    private final SubmissionScorePolicy submissionScorePolicy;
+    private final SubmissionCodePolicy submissionCodePolicy;
 
 
     public SubmissionService(
             SubmissionCommandPort submissionCommandPort,
             LoadProblemForSubmissionPort loadProblemForSubmissionPort,
+            LoadTestCasesForGradingPort loadTestCasesForGradingPort,
             ProblemProgressPort problemProgressPort,
             ProblemSetCompletionEventPort problemSetCompletionEventPort,
-            AnswerGradingService answerGradingService,
+            CodeGradingService codeGradingService,
             SubmissionAttemptPolicy submissionAttemptPolicy,
-            SubmissionScorePolicy submissionScorePolicy,
-            SubmissionAnswerPolicy submissionAnswerPolicy
+            SubmissionCodePolicy submissionCodePolicy
     ) {
         this.submissionCommandPort = submissionCommandPort;
         this.loadProblemForSubmissionPort = loadProblemForSubmissionPort;
+        this.loadTestCasesForGradingPort = loadTestCasesForGradingPort;
         this.problemProgressPort = problemProgressPort;
         this.problemSetCompletionEventPort = problemSetCompletionEventPort;
-        this.answerGradingService = answerGradingService;
+        this.codeGradingService = codeGradingService;
         this.submissionAttemptPolicy = submissionAttemptPolicy;
-        this.submissionScorePolicy = submissionScorePolicy;
-        this.submissionAnswerPolicy = submissionAnswerPolicy;
+        this.submissionCodePolicy = submissionCodePolicy;
     }
 
     @Override
     @Transactional
-    public SubmissionView handle(Long problemId, SubmitAnswerCommand command) {
-        submissionAnswerPolicy.validate(command.submittedAnswer());
+    public SubmissionView handle(Long problemId, SubmitCodeCommand command) {
+        submissionCodePolicy.validate(command.code());
 
         ProblemForSubmission problem = loadProblemForSubmissionPort.loadProblem(problemId);
         Long problemSetId = problem.problemSetId();
@@ -72,14 +69,10 @@ public class SubmissionService implements SubmissionCommandUseCase {
                 previousAttemptCount
         );
 
-        boolean isCorrect = answerGradingService.gradeTextAnswer(
-                problem.answer(),
-                command.submittedAnswer()
-        );
-        int earnedScore = submissionScorePolicy.calculateEarnedScore(
-                isCorrect,
-                problem.score()
-        );
+        var testCases = loadTestCasesForGradingPort.loadActiveTestCases(problemId);
+        var gradingResult = codeGradingService.grade(command.code(), testCases);
+
+        boolean isCorrect = gradingResult.correct();
         int attemptNo = previousAttemptCount + 1;
         int remainingAttemptCount = submissionAttemptPolicy.calculateRemainingAttemptCount(
                 problem.attemptLimit(),
@@ -91,14 +84,19 @@ public class SubmissionService implements SubmissionCommandUseCase {
                 isCorrect
         );
 
-        submissionCommandPort.saveTextSubmission(new TextSubmission(
+        Long submissionId = submissionCommandPort.saveCodeSubmission(new CodeSubmission(
                 command.userId(),
                 problem.problemId(),
-                command.submittedAnswer(),
+                command.code(),
                 isCorrect,
-                earnedScore,
-                attemptNo
+                gradingResult.earnedScore(),
+                attemptNo,
+                gradingResult.passedTestCount(),
+                gradingResult.totalTestCount(),
+                gradingResult.executionStatus(),
+                gradingResult.errorMessage()
         ));
+        submissionCommandPort.saveTestResults(submissionId, gradingResult.testResults());
 
         Long nextProblemId = null;
         boolean isProblemSetCompleted = false;
@@ -127,8 +125,14 @@ public class SubmissionService implements SubmissionCommandUseCase {
         }
 
         return new SubmissionView(
+                submissionId,
                 problem.problemId(),
                 isCorrect,
+                gradingResult.earnedScore(),
+                gradingResult.passedTestCount(),
+                gradingResult.totalTestCount(),
+                gradingResult.executionStatus(),
+                gradingResult.errorMessage(),
                 attemptNo,
                 remainingAttemptCount,
                 canRetry,

--- a/src/main/java/com/wanted/codebombalms/submission/application/usecase/CodeSubmissionListQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/usecase/CodeSubmissionListQueryUseCase.java
@@ -1,0 +1,34 @@
+package com.wanted.codebombalms.submission.application.usecase;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CodeSubmissionListQueryUseCase {
+
+    CodeSubmissionPageView handle(Long problemId, int page, int size);
+
+    record CodeSubmissionPageView(
+            List<CodeSubmissionListItemView> submissions,
+            PageInfoView pageInfo
+    ) {
+    }
+
+    record CodeSubmissionListItemView(
+            Long submissionId,
+            Long problemId,
+            Boolean correct,
+            Integer earnedScore,
+            Integer passedTestCount,
+            Integer totalTestCount,
+            String executionStatus,
+            LocalDateTime submittedAt
+    ) {
+    }
+
+    record PageInfoView(
+            int currentPage,
+            int totalPage,
+            long totalCount
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/usecase/CodeSubmissionResultQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/usecase/CodeSubmissionResultQueryUseCase.java
@@ -1,0 +1,34 @@
+package com.wanted.codebombalms.submission.application.usecase;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CodeSubmissionResultQueryUseCase {
+
+    CodeSubmissionResultView handle(Long submissionId);
+
+    record CodeSubmissionResultView(
+            Long submissionId,
+            Long problemId,
+            Boolean correct,
+            Integer earnedScore,
+            Integer passedTestCount,
+            Integer totalTestCount,
+            String executionStatus,
+            String errorMessage,
+            LocalDateTime submittedAt,
+            List<TestCaseResultView> testCaseResults
+    ) {
+    }
+
+    record TestCaseResultView(
+            Long testCaseId,
+            Boolean passed,
+            Boolean hidden,
+            String actualOutput,
+            String errorMessage,
+            Integer executionTimeMs,
+            Integer score
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/usecase/SubmissionCommandUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/usecase/SubmissionCommandUseCase.java
@@ -1,14 +1,20 @@
 package com.wanted.codebombalms.submission.application.usecase;
 
-import com.wanted.codebombalms.submission.application.command.SubmitAnswerCommand;
+import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
 
 public interface SubmissionCommandUseCase {
 
-    SubmissionView handle(Long problemId, SubmitAnswerCommand command);
+    SubmissionView handle(Long problemId, SubmitCodeCommand command);
 
     record SubmissionView(
+            Long submissionId,
             Long problemId,
             Boolean correct,
+            Integer earnedScore,
+            Integer passedTestCount,
+            Integer totalTestCount,
+            String executionStatus,
+            String errorMessage,
             Integer attemptNo,
             Integer remainingAttemptCount,
             Boolean canRetry,

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmission.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmission.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.submission.domain.model;
+
+public record CodeSubmission(
+        Long userId,
+        Long problemId,
+        String submittedCode,
+        Boolean correct,
+        Integer earnedScore,
+        Integer attemptNo,
+        Integer passedTestCount,
+        Integer totalTestCount,
+        String executionStatus,
+        String errorMessage
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionListItem.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionListItem.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.submission.domain.model;
+
+import java.time.LocalDateTime;
+
+public record CodeSubmissionListItem(
+        Long submissionId,
+        Long problemId,
+        Boolean correct,
+        Integer earnedScore,
+        Integer passedTestCount,
+        Integer totalTestCount,
+        String executionStatus,
+        LocalDateTime submittedAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionPage.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionPage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.submission.domain.model;
+
+import java.util.List;
+
+public record CodeSubmissionPage(
+        List<CodeSubmissionListItem> submissions,
+        int currentPage,
+        int totalPage,
+        long totalCount
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionResult.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionResult.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.submission.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CodeSubmissionResult(
+        Long submissionId,
+        Long problemId,
+        Boolean correct,
+        Integer earnedScore,
+        Integer passedTestCount,
+        Integer totalTestCount,
+        String executionStatus,
+        String errorMessage,
+        LocalDateTime submittedAt,
+        List<CodeSubmissionTestCaseResult> testCaseResults
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionTestCaseResult.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/CodeSubmissionTestCaseResult.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.submission.domain.model;
+
+public record CodeSubmissionTestCaseResult(
+        Long testCaseId,
+        Boolean passed,
+        Boolean hidden,
+        String actualOutput,
+        String errorMessage,
+        Integer executionTimeMs,
+        Integer score
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/SubmissionTestResult.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/SubmissionTestResult.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.submission.domain.model;
+
+public record SubmissionTestResult(
+        Long testCaseId,
+        Boolean passed,
+        String actualOutput,
+        String errorMessage,
+        Integer executionTimeMs,
+        Integer score
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/submission/exception/SubmissionErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/submission/exception/SubmissionErrorCode.java
@@ -8,12 +8,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SubmissionErrorCode implements ErrorCode {
 
-    // 답안
-    INVALID_ANSWER("SUB-001", "답안 값이 비어 있습니다."),
-
-    // 재시도 / 제출 제한
-    PROBLEM_NOT_RETRIABLE("SUB-002", "재시도할 수 없는 문제입니다."),
-    ATTEMPT_LIMIT_EXCEEDED("SUB-003", "제출 가능 횟수를 초과했습니다.");
+    INVALID_CODE("SUB-001", "코드 값이 비어 있습니다."),
+    INVALID_ANSWER("SUB-002", "답안 값이 비어 있습니다."),
+    PROBLEM_NOT_RETRIABLE("SUB-003", "재시도할 수 없는 문제입니다."),
+    ATTEMPT_LIMIT_EXCEEDED("SUB-004", "제출 가능한 횟수를 초과했습니다."),
+    SUBMISSION_NOT_FOUND("SUB-005", "제출 기록을 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionRepository.java
@@ -1,6 +1,8 @@
 package com.wanted.codebombalms.submission.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -14,4 +16,9 @@ public interface SpringDataSubmissionRepository extends JpaRepository<Submission
     );
 
     boolean existsByProblem_ProblemSet_ProblemSetId(Long problemSetId);
+
+    Page<SubmissionJpaEntity> findByProblem_ProblemIdAndSubmittedCodeIsNotNullOrderBySubmittedAtDesc(
+            Long problemId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.submission.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpringDataSubmissionTestResultRepository extends JpaRepository<SubmissionTestResultJpaEntity, Long> {
+
+    List<SubmissionTestResultJpaEntity> findBySubmission_SubmissionIdOrderByTestCase_TestOrderAsc(Long submissionId);
+}

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionCommandPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionCommandPersistenceAdapter.java
@@ -3,23 +3,34 @@ package com.wanted.codebombalms.submission.infrastructure.persistence;
 import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.problems.problem.infrastructure.persistence.ProblemJpaEntity;
 import com.wanted.codebombalms.problems.problem.infrastructure.persistence.SpringDataProblemRepository;
-import com.wanted.codebombalms.submission.domain.model.TextSubmission;
+import com.wanted.codebombalms.problems.testcase.infrastructure.persistence.ProblemTestCaseJpaEntity;
+import com.wanted.codebombalms.problems.testcase.infrastructure.persistence.SpringDataProblemTestCaseRepository;
 import com.wanted.codebombalms.submission.application.port.SubmissionCommandPort;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmission;
+import com.wanted.codebombalms.submission.domain.model.SubmissionTestResult;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class SubmissionCommandPersistenceAdapter implements SubmissionCommandPort {
 
     private final SpringDataSubmissionRepository submissionRepository;
+    private final SpringDataSubmissionTestResultRepository submissionTestResultRepository;
     private final SpringDataProblemRepository problemRepository;
+    private final SpringDataProblemTestCaseRepository problemTestCaseRepository;
 
     public SubmissionCommandPersistenceAdapter(
             SpringDataSubmissionRepository submissionRepository,
-            SpringDataProblemRepository problemRepository
+            SpringDataSubmissionTestResultRepository submissionTestResultRepository,
+            SpringDataProblemRepository problemRepository,
+            SpringDataProblemTestCaseRepository problemTestCaseRepository
     ) {
         this.submissionRepository = submissionRepository;
+        this.submissionTestResultRepository = submissionTestResultRepository;
         this.problemRepository = problemRepository;
+        this.problemTestCaseRepository = problemTestCaseRepository;
     }
 
     @Override
@@ -28,19 +39,53 @@ public class SubmissionCommandPersistenceAdapter implements SubmissionCommandPor
     }
 
     @Override
-    public void saveTextSubmission(TextSubmission submission) {
+    public Long saveCodeSubmission(CodeSubmission submission) {
         ProblemJpaEntity problem = problemRepository.findById(submission.problemId())
                 .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND));
 
         SubmissionJpaEntity submissionEntity = new SubmissionJpaEntity(
                 submission.userId(),
                 problem,
-                submission.submittedAnswer(),
+                submission.submittedCode(),
                 submission.correct(),
                 submission.earnedScore(),
-                submission.attemptNo()
+                submission.attemptNo(),
+                submission.passedTestCount(),
+                submission.totalTestCount(),
+                submission.executionStatus(),
+                submission.errorMessage()
         );
 
-        submissionRepository.save(submissionEntity);
+        return submissionRepository.save(submissionEntity).getSubmissionId();
+    }
+
+    @Override
+    public void saveTestResults(Long submissionId, List<SubmissionTestResult> testResults) {
+        SubmissionJpaEntity submission = submissionRepository.findById(submissionId)
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND));
+
+        List<SubmissionTestResultJpaEntity> entities = testResults.stream()
+                .map(testResult -> toEntity(submission, testResult))
+                .toList();
+
+        submissionTestResultRepository.saveAll(entities);
+    }
+
+    private SubmissionTestResultJpaEntity toEntity(
+            SubmissionJpaEntity submission,
+            SubmissionTestResult testResult
+    ) {
+        ProblemTestCaseJpaEntity testCase = problemTestCaseRepository.findById(testResult.testCaseId())
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_TEST_CASE_NOT_FOUND));
+
+        return new SubmissionTestResultJpaEntity(
+                submission,
+                testCase,
+                testResult.passed(),
+                testResult.actualOutput(),
+                testResult.errorMessage(),
+                testResult.executionTimeMs(),
+                testResult.score()
+        );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionJpaEntity.java
@@ -30,6 +30,9 @@ public class SubmissionJpaEntity {
     @Column(columnDefinition = "TEXT")
     private String submittedAnswer;
 
+    @Column(columnDefinition = "TEXT")
+    private String submittedCode;
+
     private Boolean isCorrect;
 
     @Column(nullable = false)
@@ -37,6 +40,17 @@ public class SubmissionJpaEntity {
 
     @Column(nullable = false)
     private Integer attemptNo;
+
+    @Column(nullable = false)
+    private Integer passedTestCount;
+
+    @Column(nullable = false)
+    private Integer totalTestCount;
+
+    private String executionStatus;
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
 
     @Column(nullable = false)
     private LocalDateTime submittedAt;
@@ -55,9 +69,40 @@ public class SubmissionJpaEntity {
         this.userId = userId;
         this.problem = problem;
         this.submittedAnswer = submittedAnswer;
+        this.submittedCode = null;
         this.isCorrect = isCorrect;
         this.earnedScore = earnedScore;
         this.attemptNo = attemptNo;
+        this.passedTestCount = 0;
+        this.totalTestCount = 0;
+        this.executionStatus = null;
+        this.errorMessage = null;
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public SubmissionJpaEntity(
+            Long userId,
+            ProblemJpaEntity problem,
+            String submittedCode,
+            Boolean isCorrect,
+            Integer earnedScore,
+            Integer attemptNo,
+            Integer passedTestCount,
+            Integer totalTestCount,
+            String executionStatus,
+            String errorMessage
+    ) {
+        this.userId = userId;
+        this.problem = problem;
+        this.submittedAnswer = null;
+        this.submittedCode = submittedCode;
+        this.isCorrect = isCorrect;
+        this.earnedScore = earnedScore;
+        this.attemptNo = attemptNo;
+        this.passedTestCount = passedTestCount;
+        this.totalTestCount = totalTestCount;
+        this.executionStatus = executionStatus;
+        this.errorMessage = errorMessage;
         this.submittedAt = LocalDateTime.now();
     }
 
@@ -77,6 +122,10 @@ public class SubmissionJpaEntity {
         return submittedAnswer;
     }
 
+    public String getSubmittedCode() {
+        return submittedCode;
+    }
+
     public Boolean getCorrect() {
         return isCorrect;
     }
@@ -87,6 +136,22 @@ public class SubmissionJpaEntity {
 
     public Integer getAttemptNo() {
         return attemptNo;
+    }
+
+    public Integer getPassedTestCount() {
+        return passedTestCount;
+    }
+
+    public Integer getTotalTestCount() {
+        return totalTestCount;
+    }
+
+    public String getExecutionStatus() {
+        return executionStatus;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
     }
 
     public LocalDateTime getSubmittedAt() {

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionListQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionListQueryPersistenceAdapter.java
@@ -1,0 +1,48 @@
+package com.wanted.codebombalms.submission.infrastructure.persistence;
+
+import com.wanted.codebombalms.submission.application.port.SubmissionListQueryPort;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionListItem;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionPage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SubmissionListQueryPersistenceAdapter implements SubmissionListQueryPort {
+
+    private final SpringDataSubmissionRepository submissionRepository;
+
+    public SubmissionListQueryPersistenceAdapter(SpringDataSubmissionRepository submissionRepository) {
+        this.submissionRepository = submissionRepository;
+    }
+
+    @Override
+    public CodeSubmissionPage findCodeSubmissions(Long problemId, int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+        Page<SubmissionJpaEntity> result = submissionRepository
+                .findByProblem_ProblemIdAndSubmittedCodeIsNotNullOrderBySubmittedAtDesc(problemId, pageRequest);
+
+        return new CodeSubmissionPage(
+                result.getContent()
+                        .stream()
+                        .map(this::toListItem)
+                        .toList(),
+                result.getNumber() + 1,
+                result.getTotalPages(),
+                result.getTotalElements()
+        );
+    }
+
+    private CodeSubmissionListItem toListItem(SubmissionJpaEntity submission) {
+        return new CodeSubmissionListItem(
+                submission.getSubmissionId(),
+                submission.getProblem().getProblemId(),
+                submission.getCorrect(),
+                submission.getEarnedScore(),
+                submission.getPassedTestCount(),
+                submission.getTotalTestCount(),
+                submission.getExecutionStatus(),
+                submission.getSubmittedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionResultQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionResultQueryPersistenceAdapter.java
@@ -1,0 +1,62 @@
+package com.wanted.codebombalms.submission.infrastructure.persistence;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.submission.application.port.SubmissionResultQueryPort;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionResult;
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionTestCaseResult;
+import com.wanted.codebombalms.submission.exception.SubmissionErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SubmissionResultQueryPersistenceAdapter implements SubmissionResultQueryPort {
+
+    private final SpringDataSubmissionRepository submissionRepository;
+    private final SpringDataSubmissionTestResultRepository submissionTestResultRepository;
+
+    public SubmissionResultQueryPersistenceAdapter(
+            SpringDataSubmissionRepository submissionRepository,
+            SpringDataSubmissionTestResultRepository submissionTestResultRepository
+    ) {
+        this.submissionRepository = submissionRepository;
+        this.submissionTestResultRepository = submissionTestResultRepository;
+    }
+
+    @Override
+    public CodeSubmissionResult getCodeSubmissionResult(Long submissionId) {
+        SubmissionJpaEntity submission = submissionRepository.findById(submissionId)
+                .orElseThrow(() -> new NotFoundException(SubmissionErrorCode.SUBMISSION_NOT_FOUND));
+
+        List<CodeSubmissionTestCaseResult> testCaseResults = submissionTestResultRepository
+                .findBySubmission_SubmissionIdOrderByTestCase_TestOrderAsc(submissionId)
+                .stream()
+                .map(this::toTestCaseResult)
+                .toList();
+
+        return new CodeSubmissionResult(
+                submission.getSubmissionId(),
+                submission.getProblem().getProblemId(),
+                submission.getCorrect(),
+                submission.getEarnedScore(),
+                submission.getPassedTestCount(),
+                submission.getTotalTestCount(),
+                submission.getExecutionStatus(),
+                submission.getErrorMessage(),
+                submission.getSubmittedAt(),
+                testCaseResults
+        );
+    }
+
+    private CodeSubmissionTestCaseResult toTestCaseResult(SubmissionTestResultJpaEntity result) {
+        return new CodeSubmissionTestCaseResult(
+                result.getTestCase().getTestCaseId(),
+                result.getPassed(),
+                result.getTestCase().getHidden(),
+                result.getActualOutput(),
+                result.getErrorMessage(),
+                result.getExecutionTimeMs(),
+                result.getScore()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionTestResultJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionTestResultJpaEntity.java
@@ -1,0 +1,106 @@
+package com.wanted.codebombalms.submission.infrastructure.persistence;
+
+import com.wanted.codebombalms.problems.testcase.infrastructure.persistence.ProblemTestCaseJpaEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "submission_test_result")
+public class SubmissionTestResultJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long submissionTestResultId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "submission_id", nullable = false)
+    private SubmissionJpaEntity submission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_case_id", nullable = false)
+    private ProblemTestCaseJpaEntity testCase;
+
+    @Column(name = "is_passed", nullable = false)
+    private Boolean passed;
+
+    @Column(columnDefinition = "TEXT")
+    private String actualOutput;
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    private Integer executionTimeMs;
+
+    @Column(nullable = false)
+    private Integer score;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    protected SubmissionTestResultJpaEntity() {
+    }
+
+    public SubmissionTestResultJpaEntity(
+            SubmissionJpaEntity submission,
+            ProblemTestCaseJpaEntity testCase,
+            Boolean passed,
+            String actualOutput,
+            String errorMessage,
+            Integer executionTimeMs,
+            Integer score
+    ) {
+        this.submission = submission;
+        this.testCase = testCase;
+        this.passed = passed;
+        this.actualOutput = actualOutput;
+        this.errorMessage = errorMessage;
+        this.executionTimeMs = executionTimeMs;
+        this.score = score;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getSubmissionTestResultId() {
+        return submissionTestResultId;
+    }
+
+    public SubmissionJpaEntity getSubmission() {
+        return submission;
+    }
+
+    public ProblemTestCaseJpaEntity getTestCase() {
+        return testCase;
+    }
+
+    public Boolean getPassed() {
+        return passed;
+    }
+
+    public String getActualOutput() {
+        return actualOutput;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Integer getExecutionTimeMs() {
+        return executionTimeMs;
+    }
+
+    public Integer getScore() {
+        return score;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/testcase/TestCaseForGradingAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/testcase/TestCaseForGradingAdapter.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.submission.infrastructure.testcase;
+
+import com.wanted.codebombalms.problems.testcase.domain.model.ProblemTestCase;
+import com.wanted.codebombalms.problems.testcase.domain.repository.ProblemTestCaseRepository;
+import com.wanted.codebombalms.submission.application.port.LoadTestCasesForGradingPort;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class TestCaseForGradingAdapter implements LoadTestCasesForGradingPort {
+
+    private final ProblemTestCaseRepository problemTestCaseRepository;
+
+    public TestCaseForGradingAdapter(ProblemTestCaseRepository problemTestCaseRepository) {
+        this.problemTestCaseRepository = problemTestCaseRepository;
+    }
+
+    @Override
+    public List<TestCaseForGrading> loadActiveTestCases(Long problemId) {
+        return problemTestCaseRepository.findActiveByProblemId(problemId)
+                .stream()
+                .map(this::toTestCaseForGrading)
+                .toList();
+    }
+
+    private TestCaseForGrading toTestCaseForGrading(ProblemTestCase testCase) {
+        return new TestCaseForGrading(
+                testCase.getTestCaseId(),
+                testCase.getTestCode(),
+                testCase.getExpectedResult(),
+                testCase.getScore(),
+                testCase.getHidden(),
+                testCase.getTimeoutMs()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/SubmissionController.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/SubmissionController.java
@@ -1,35 +1,49 @@
 package com.wanted.codebombalms.submission.presentation.api;
 
-import com.wanted.codebombalms.submission.application.command.SubmitAnswerCommand;
-import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase;
-import com.wanted.codebombalms.submission.presentation.api.request.SubmissionRequest;
-import com.wanted.codebombalms.submission.presentation.api.response.SubmissionResponse;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionListQueryUseCase;
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionResultQueryUseCase;
+import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase;
+import com.wanted.codebombalms.submission.presentation.api.request.SubmissionRequest;
+import com.wanted.codebombalms.submission.presentation.api.response.CodeSubmissionListResponse;
+import com.wanted.codebombalms.submission.presentation.api.response.CodeSubmissionResultResponse;
+import com.wanted.codebombalms.submission.presentation.api.response.SubmissionResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class SubmissionController {
 
     private final SubmissionCommandUseCase submissionCommandUseCase;
+    private final CodeSubmissionResultQueryUseCase codeSubmissionResultQueryUseCase;
+    private final CodeSubmissionListQueryUseCase codeSubmissionListQueryUseCase;
 
-    public SubmissionController(SubmissionCommandUseCase submissionCommandUseCase) {
+    public SubmissionController(
+            SubmissionCommandUseCase submissionCommandUseCase,
+            CodeSubmissionResultQueryUseCase codeSubmissionResultQueryUseCase,
+            CodeSubmissionListQueryUseCase codeSubmissionListQueryUseCase
+    ) {
         this.submissionCommandUseCase = submissionCommandUseCase;
+        this.codeSubmissionResultQueryUseCase = codeSubmissionResultQueryUseCase;
+        this.codeSubmissionListQueryUseCase = codeSubmissionListQueryUseCase;
     }
 
     @PostMapping("/api/v1/problems/{problemId}/submissions")
-    public ResponseEntity<ApiResponse<SubmissionResponse>> submitAnswer(
+    public ResponseEntity<ApiResponse<SubmissionResponse>> submitCode(
             @PathVariable Long problemId,
             @RequestBody SubmissionRequest request
     ) {
-        var command = new SubmitAnswerCommand(
+        var command = new SubmitCodeCommand(
                 request.getUserId(),
-                request.getSubmittedAnswer()
+                request.getCode()
         );
         var response = new SubmissionResponse(
                 submissionCommandUseCase.handle(problemId, command)
@@ -38,6 +52,38 @@ public class SubmissionController {
         return ResponseEntity.ok(ApiResponse.success(
                 ApiResponseCode.SUCCESS,
                 ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+
+    @GetMapping("/api/v1/code-submissions/{submissionId}")
+    public ResponseEntity<ApiResponse<CodeSubmissionResultResponse>> getCodeSubmissionResult(
+            @PathVariable Long submissionId
+    ) {
+        var response = new CodeSubmissionResultResponse(
+                codeSubmissionResultQueryUseCase.handle(submissionId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "코드 채점 결과 조회 성공",
+                response
+        ));
+    }
+
+    @GetMapping("/api/v1/code-problems/{problemId}/submissions")
+    public ResponseEntity<ApiResponse<CodeSubmissionListResponse>> getCodeSubmissions(
+            @PathVariable Long problemId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        var response = new CodeSubmissionListResponse(
+                codeSubmissionListQueryUseCase.handle(problemId, page, size)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "코드 제출 기록 조회 성공",
                 response
         ));
     }

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/request/SubmissionRequest.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/request/SubmissionRequest.java
@@ -3,13 +3,13 @@ package com.wanted.codebombalms.submission.presentation.api.request;
 public class SubmissionRequest {
 
     private Long userId;
-    private String submittedAnswer;
+    private String code;
 
     public Long getUserId() {
         return userId;
     }
 
-    public String getSubmittedAnswer() {
-        return submittedAnswer;
+    public String getCode() {
+        return code;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/CodeSubmissionListItemResponse.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/CodeSubmissionListItemResponse.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.submission.presentation.api.response;
+
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionListQueryUseCase.CodeSubmissionListItemView;
+
+import java.time.LocalDateTime;
+
+public record CodeSubmissionListItemResponse(
+        Long submissionId,
+        Long problemId,
+        Boolean isCorrect,
+        Integer earnedScore,
+        Integer passedTestCount,
+        Integer totalTestCount,
+        String executionStatus,
+        LocalDateTime submittedAt
+) {
+
+    public CodeSubmissionListItemResponse(CodeSubmissionListItemView item) {
+        this(
+                item.submissionId(),
+                item.problemId(),
+                item.correct(),
+                item.earnedScore(),
+                item.passedTestCount(),
+                item.totalTestCount(),
+                item.executionStatus(),
+                item.submittedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/CodeSubmissionListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/CodeSubmissionListResponse.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.submission.presentation.api.response;
+
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionListQueryUseCase.CodeSubmissionPageView;
+
+import java.util.List;
+
+public record CodeSubmissionListResponse(
+        List<CodeSubmissionListItemResponse> submissions,
+        PageInfoResponse pageInfo
+) {
+
+    public CodeSubmissionListResponse(CodeSubmissionPageView result) {
+        this(
+                result.submissions()
+                        .stream()
+                        .map(CodeSubmissionListItemResponse::new)
+                        .toList(),
+                new PageInfoResponse(result.pageInfo())
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/CodeSubmissionResultResponse.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/CodeSubmissionResultResponse.java
@@ -1,0 +1,38 @@
+package com.wanted.codebombalms.submission.presentation.api.response;
+
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionResultQueryUseCase.CodeSubmissionResultView;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CodeSubmissionResultResponse(
+        Long submissionId,
+        Long problemId,
+        Boolean isCorrect,
+        Integer earnedScore,
+        Integer passedTestCount,
+        Integer totalTestCount,
+        String executionStatus,
+        String errorMessage,
+        LocalDateTime submittedAt,
+        List<TestCaseResultResponse> testCaseResults
+) {
+
+    public CodeSubmissionResultResponse(CodeSubmissionResultView result) {
+        this(
+                result.submissionId(),
+                result.problemId(),
+                result.correct(),
+                result.earnedScore(),
+                result.passedTestCount(),
+                result.totalTestCount(),
+                result.executionStatus(),
+                result.errorMessage(),
+                result.submittedAt(),
+                result.testCaseResults()
+                        .stream()
+                        .map(TestCaseResultResponse::new)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/PageInfoResponse.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/PageInfoResponse.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.submission.presentation.api.response;
+
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionListQueryUseCase.PageInfoView;
+
+public record PageInfoResponse(
+        int currentPage,
+        int totalPage,
+        long totalCount
+) {
+
+    public PageInfoResponse(PageInfoView pageInfo) {
+        this(
+                pageInfo.currentPage(),
+                pageInfo.totalPage(),
+                pageInfo.totalCount()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/SubmissionResponse.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/SubmissionResponse.java
@@ -3,8 +3,14 @@ package com.wanted.codebombalms.submission.presentation.api.response;
 import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase.SubmissionView;
 
 public record SubmissionResponse(
+        Long submissionId,
         Long problemId,
         Boolean isCorrect,
+        Integer earnedScore,
+        Integer passedTestCount,
+        Integer totalTestCount,
+        String executionStatus,
+        String errorMessage,
         Integer attemptNo,
         Integer remainingAttemptCount,
         Boolean canRetry,
@@ -15,8 +21,14 @@ public record SubmissionResponse(
 
     public SubmissionResponse(SubmissionView result) {
         this(
+                result.submissionId(),
                 result.problemId(),
                 result.correct(),
+                result.earnedScore(),
+                result.passedTestCount(),
+                result.totalTestCount(),
+                result.executionStatus(),
+                result.errorMessage(),
                 result.attemptNo(),
                 result.remainingAttemptCount(),
                 result.canRetry(),

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/TestCaseResultResponse.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/api/response/TestCaseResultResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.submission.presentation.api.response;
+
+import com.wanted.codebombalms.submission.application.usecase.CodeSubmissionResultQueryUseCase.TestCaseResultView;
+
+public record TestCaseResultResponse(
+        Long testCaseId,
+        Boolean isPassed,
+        Boolean isHidden,
+        String actualOutput,
+        String errorMessage,
+        Integer executionTimeMs,
+        Integer score
+) {
+
+    public TestCaseResultResponse(TestCaseResultView result) {
+        this(
+                result.testCaseId(),
+                result.passed(),
+                result.hidden(),
+                result.actualOutput(),
+                result.errorMessage(),
+                result.executionTimeMs(),
+                result.score()
+        );
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #147 
- Closes #146 

---

## 🛠️ 기능 관련 작업 내용

- 코드 실행형 문제의 테스트케이스 CRUD 기능을 구현했습니다.
- 코드 실행 요청 API를 구현했습니다.
  - 제출 저장 없이 코드 실행 결과만 반환합니다.
  - 현재는 실제 Python 실행기가 아닌 Mock Runner 기반입니다.
- 코드 답안 제출 API를 코드 제출 흐름으로 확장했습니다.
  - `submittedAnswer` 대신 `code`를 입력받도록 변경했습니다.
  - 테스트케이스 기준으로 임시 채점 결과를 계산합니다.
  - 제출 기록을 `submission`에 저장합니다.
  - 테스트케이스별 채점 결과를 `submission_test_result`에 저장합니다.
- 코드 채점 결과 단건 조회 API를 구현했습니다.
  - 히든 테스트케이스는 상세 실행 결과를 노출하지 않도록 처리했습니다.
- 코드 제출 기록 목록 조회 API를 구현했습니다.
  - 문제 ID 기준 제출 기록을 페이징 조회할 수 있습니다.
- 코드 실행 API 응답에서 실제 저장 ID가 아닌 `executionId`를 제거했습니다.
- 제출/채점 관련 코드를 클린 아키텍처 흐름에 맞게 UseCase, Port, Adapter 구조로 정리했습니다.

---

## ♻️ 패키지 변경 사항

- `problems/testcase` : 테스트케이스 등록, 조회, 수정, 삭제 기능 추가
- `problems/execution/presentation/api/CodeExecutionController` : 코드 실행 요청 API 추가
- `problems/execution/application/usecase/CodeExecutionUseCase` : 코드 실행 UseCase 추가
- `problems/execution/application/service/CodeExecutionService` : 코드 실행 흐름 처리 추가
- `problems/execution/application/port/RunCodePort` : 코드 실행기 교체를 위한 Port 추가
- `problems/execution/infrastructure/runner/MockCodeRunnerAdapter` : 임시 코드 실행 Adapter 추가
- `submission/presentation/api/SubmissionController` : 코드 제출, 결과 조회, 제출 목록 조회 API 추가
- `submission/application/usecase` : 코드 제출 결과 및 목록 조회 UseCase 추가
- `submission/application/service` : 코드 제출, 임시 채점, 결과 조회 흐름 추가
- `submission/application/port` : 제출 저장, 테스트 결과 저장, 결과 조회, 목록 조회 Port 추가
- `submission/domain/model` : 코드 제출, 테스트케이스별 결과, 제출 결과 조회 모델 추가
- `submission/infrastructure/persistence` : `submission`, `submission_test_result` 저장 및 조회 Adapter 추가
- `http/submission.http` : 코드 실행, 제출, 결과 조회, 목록 조회 테스트 API 예시 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.

---

## 리뷰어 참고 사항

현재 코드 실행 및 채점은 실제 Python 샌드박스 실행기가 아닌 Mock Runner 기반입니다.

후속 작업에서 `RunCodePort` 구현체를 교체하는 방식으로 실제 Python 실행기를 연결할 예정입니다.

```text
현재:
RunCodePort
-> MockCodeRunnerAdapter

추후:
RunCodePort
-> PythonCodeRunnerAdapter
-> Docker 또는 별도 Python 실행 환경