### PR TITLE
[Feat] automation alarm + gcs 등록

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ application-*.properties
 application-*.yml
 *.env
 .env*
+/secrets/
+/src/main/resources/gcs/
 
 ### Logs ###
 *.log

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
     //챗봇
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    //구글 클라우드
+    implementation 'com.google.cloud:google-cloud-storage:2.68.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     implementation 'com.google.cloud:google-cloud-storage:2.68.0'
 }
 
+//성공한 테스트에서도 System.out이 보이도록 showStandardStreams = true 추가
 tasks.named('test') {
     useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/model/OperationAlert.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/model/OperationAlert.java
@@ -68,6 +68,40 @@ public class OperationAlert {
         this.deletedAt = deletedAt;
     }
 
+    // 자동 규칙 탐지 결과를 OPEN 상태의 운영 알림으로 생성한다.
+    public static OperationAlert create(
+            Long operationRuleId,
+            OperationTargetType targetType,
+            Long targetId,
+            BigDecimal detectedValue,
+            BigDecimal thresholdValueSnapshot,
+            Long assigneeId,
+            String reason,
+            String recommendedAction,
+            LocalDateTime detectedAt
+    ) {
+        return new OperationAlert(
+                null,
+                operationRuleId,
+                targetType,
+                targetId,
+                detectedValue,
+                thresholdValueSnapshot,
+                assigneeId,
+                reason,
+                recommendedAction,
+                detectedAt,
+                detectedAt,
+                OperationAlertStatus.OPEN,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
     public static OperationAlert restore(
             Long operationAlertId,
             Long operationRuleId,

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/repository/OperationAlertRepository.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/domain/repository/OperationAlertRepository.java
@@ -1,12 +1,20 @@
 package com.wanted.codebombalms.admin.operation.alert.domain.repository;
 
 import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlert;
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
 
 import java.util.Optional;
 
 public interface OperationAlertRepository {
 
     Optional<OperationAlert> findById(Long operationAlertId);
+
+    // 같은 규칙과 대상에 대해 아직 처리되지 않은 알림을 조회한다.
+    Optional<OperationAlert> findOpenByRuleIdAndTarget(
+            Long operationRuleId,
+            OperationTargetType targetType,
+            Long targetId
+    );
 
     OperationAlert save(OperationAlert operationAlert);
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertRepositoryAdapter.java
@@ -1,6 +1,8 @@
 package com.wanted.codebombalms.admin.operation.alert.infrastructure.persistence;
 
 import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlert;
+import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlertStatus;
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
 import com.wanted.codebombalms.admin.operation.alert.domain.repository.OperationAlertRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,6 +18,23 @@ public class OperationAlertRepositoryAdapter implements OperationAlertRepository
     @Override
     public Optional<OperationAlert> findById(Long operationAlertId) {
         return springDataRepository.findByOperationAlertIdAndDeletedAtIsNull(operationAlertId)
+                .map(OperationAlertMapper::toDomain);
+    }
+
+    // 같은 규칙과 대상에 대해 아직 처리되지 않은 알림을 조회한다.
+    @Override
+    public Optional<OperationAlert> findOpenByRuleIdAndTarget(
+            Long operationRuleId,
+            OperationTargetType targetType,
+            Long targetId
+    ) {
+        return springDataRepository
+                .findByOperationRuleIdAndTargetTypeAndTargetIdAndStatusAndDeletedAtIsNull(
+                        operationRuleId,
+                        targetType,
+                        targetId,
+                        OperationAlertStatus.OPEN
+                )
                 .map(OperationAlertMapper::toDomain);
     }
 

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/SpringDataOperationAlertRepository.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/SpringDataOperationAlertRepository.java
@@ -54,4 +54,12 @@ public interface SpringDataOperationAlertRepository
     );
 
     Optional<OperationAlertJpaEntity> findByOperationAlertIdAndDeletedAtIsNull(Long operationAlertId);
+
+    // 같은 규칙과 대상에 대해 삭제되지 않은 특정 상태의 알림을 조회한다.
+    Optional<OperationAlertJpaEntity> findByOperationRuleIdAndTargetTypeAndTargetIdAndStatusAndDeletedAtIsNull(
+            Long operationRuleId,
+            OperationTargetType targetType,
+            Long targetId,
+            OperationAlertStatus status
+    );
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/handler/CourseLowEnrollmentRuleHandler.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/handler/CourseLowEnrollmentRuleHandler.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.admin.operation.automation.application.handler;
+
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+import com.wanted.codebombalms.admin.operation.automation.application.port.CourseOperationMetricPort;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+// 수강생 수가 기준 이하인 강좌를 탐지하는 규칙 핸들러다.
+public class CourseLowEnrollmentRuleHandler implements OperationRuleHandler {
+
+    private final CourseOperationMetricPort courseOperationMetricPort;
+
+    @Override
+    public OperationRuleCode supports() {
+        return OperationRuleCode.COURSE_LOW_ENROLLMENT;
+    }
+
+    @Override
+    public List<OperationRuleDetectionResult> detect(AutomationRule rule) {
+        return courseOperationMetricPort.findLowEnrollmentCourses(rule.getThresholdValue());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/handler/OperationRuleHandler.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/handler/OperationRuleHandler.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.admin.operation.automation.application.handler;
+
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
+
+import java.util.List;
+
+// 규칙 코드별 탐지 로직을 실행하는 전략 인터페이스다.
+public interface OperationRuleHandler {
+
+    OperationRuleCode supports();
+
+    List<OperationRuleDetectionResult> detect(AutomationRule rule);
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/handler/ProblemHighWrongRateRuleHandler.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/handler/ProblemHighWrongRateRuleHandler.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.admin.operation.automation.application.handler;
+
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+import com.wanted.codebombalms.admin.operation.automation.application.port.ProblemOperationMetricPort;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+// 제출 수와 오답률 기준을 만족하는 문제를 탐지하는 규칙 핸들러다.
+public class ProblemHighWrongRateRuleHandler implements OperationRuleHandler {
+
+    private final ProblemOperationMetricPort problemOperationMetricPort;
+
+    @Override
+    public OperationRuleCode supports() {
+        return OperationRuleCode.PROBLEM_HIGH_WRONG_RATE;
+    }
+
+    @Override
+    public List<OperationRuleDetectionResult> detect(AutomationRule rule) {
+        return problemOperationMetricPort.findHighWrongRateProblems(
+                rule.getThresholdValue(),
+                rule.getMinSampleCount()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/model/OperationRuleDetectionResult.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/model/OperationRuleDetectionResult.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.admin.operation.automation.application.model;
+
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+
+import java.math.BigDecimal;
+
+// 운영 규칙 실행으로 탐지된 알림 후보 정보를 담는다.
+public record OperationRuleDetectionResult(
+        OperationTargetType targetType,
+        Long targetId,
+        BigDecimal detectedValue,
+        String reason,
+        String recommendedAction
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/policy/OperationAlertUpsertPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/policy/OperationAlertUpsertPolicy.java
@@ -1,0 +1,58 @@
+package com.wanted.codebombalms.admin.operation.automation.application.policy;
+
+import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlert;
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+// 탐지 결과를 기존 OPEN 알림 갱신 또는 신규 알림 생성으로 결정한다.
+public class OperationAlertUpsertPolicy {
+
+    public OperationAlert resolve(
+            AutomationRule rule,
+            OperationRuleDetectionResult result,
+            Optional<OperationAlert> existingAlert,
+            LocalDateTime detectedAt
+    ) {
+        return existingAlert
+                .map(alert -> update(alert, result, detectedAt))
+                .orElseGet(() -> create(rule, result, detectedAt));
+    }
+
+    private OperationAlert update(
+            OperationAlert alert,
+            OperationRuleDetectionResult result,
+            LocalDateTime detectedAt
+    ) {
+        alert.updateDetectedValue(
+                result.detectedValue(),
+                result.reason(),
+                result.recommendedAction(),
+                detectedAt
+        );
+
+        return alert;
+    }
+
+    private OperationAlert create(
+            AutomationRule rule,
+            OperationRuleDetectionResult result,
+            LocalDateTime detectedAt
+    ) {
+        return OperationAlert.create(
+                rule.getOperationRuleId(),
+                result.targetType(),
+                result.targetId(),
+                result.detectedValue(),
+                rule.getThresholdValue(),
+                null,
+                result.reason(),
+                result.recommendedAction(),
+                detectedAt
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/policy/OperationRuleExecutionPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/policy/OperationRuleExecutionPolicy.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.admin.operation.automation.application.policy;
+
+import com.wanted.codebombalms.admin.operation.automation.application.handler.OperationRuleHandler;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
+import org.springframework.stereotype.Component;
+
+@Component
+// 자동 규칙이 현재 실행 가능한 상태인지 판단한다.
+public class OperationRuleExecutionPolicy {
+
+    public boolean canExecute(AutomationRule rule, OperationRuleHandler handler) {
+        return rule != null
+                && rule.isEnabled()
+                && handler != null;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/port/CourseOperationMetricPort.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/port/CourseOperationMetricPort.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.admin.operation.automation.application.port;
+
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+// 강좌 도메인의 운영 지표를 자동 규칙 실행에 제공한다.
+public interface CourseOperationMetricPort {
+
+    List<OperationRuleDetectionResult> findLowEnrollmentCourses(BigDecimal threshold);
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/port/ProblemOperationMetricPort.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/port/ProblemOperationMetricPort.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.admin.operation.automation.application.port;
+
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+// 문제 도메인의 운영 지표를 자동 규칙 실행에 제공한다.
+public interface ProblemOperationMetricPort {
+
+    List<OperationRuleDetectionResult> findHighWrongRateProblems(
+            BigDecimal wrongRateThreshold,
+            Integer minSampleCount
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java
@@ -1,0 +1,90 @@
+package com.wanted.codebombalms.admin.operation.automation.application.service;
+
+import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlert;
+import com.wanted.codebombalms.admin.operation.alert.domain.repository.OperationAlertRepository;
+import com.wanted.codebombalms.admin.operation.automation.application.handler.OperationRuleHandler;
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+import com.wanted.codebombalms.admin.operation.automation.application.policy.OperationAlertUpsertPolicy;
+import com.wanted.codebombalms.admin.operation.automation.application.policy.OperationRuleExecutionPolicy;
+import com.wanted.codebombalms.admin.operation.automation.application.usecase.RunOperationRuleUseCase;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
+import com.wanted.codebombalms.admin.operation.rule.domain.repository.AutomationRuleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+// 활성화된 자동 규칙을 실행하고 탐지 결과를 운영 알림으로 반영한다.
+public class OperationRuleExecutionService implements RunOperationRuleUseCase {
+
+    private final AutomationRuleRepository automationRuleRepository;
+    private final OperationAlertRepository operationAlertRepository;
+    private final Map<OperationRuleCode, OperationRuleHandler> handlers;
+    private final OperationRuleExecutionPolicy operationRuleExecutionPolicy;
+    private final OperationAlertUpsertPolicy operationAlertUpsertPolicy;
+    private final Clock clock;
+
+    public OperationRuleExecutionService(
+            AutomationRuleRepository automationRuleRepository,
+            OperationAlertRepository operationAlertRepository,
+            List<OperationRuleHandler> handlers,
+            OperationRuleExecutionPolicy operationRuleExecutionPolicy,
+            OperationAlertUpsertPolicy operationAlertUpsertPolicy,
+            Clock clock
+    ) {
+        this.automationRuleRepository = automationRuleRepository;
+        this.operationAlertRepository = operationAlertRepository;
+        this.operationRuleExecutionPolicy = operationRuleExecutionPolicy;
+        this.operationAlertUpsertPolicy = operationAlertUpsertPolicy;
+        this.clock = clock;
+        this.handlers = handlers.stream()
+                .collect(Collectors.toMap(
+                        OperationRuleHandler::supports,
+                        Function.identity(),
+                        (left, right) -> left,
+                        () -> new EnumMap<>(OperationRuleCode.class)
+                ));
+    }
+
+    @Override
+    public void run() {
+        automationRuleRepository.findEnabled()
+                .forEach(this::executeRule);
+    }
+
+    private void executeRule(AutomationRule rule) {
+        OperationRuleHandler handler = handlers.get(rule.getRuleCode());
+        if (!operationRuleExecutionPolicy.canExecute(rule, handler)) {
+            return;
+        }
+
+        handler.detect(rule)
+                .forEach(result -> saveAlert(rule, result));
+    }
+
+    private void saveAlert(AutomationRule rule, OperationRuleDetectionResult result) {
+        LocalDateTime detectedAt = LocalDateTime.now(clock);
+
+        OperationAlert operationAlert = operationAlertUpsertPolicy.resolve(
+                rule,
+                result,
+                operationAlertRepository.findOpenByRuleIdAndTarget(
+                        rule.getOperationRuleId(),
+                        result.targetType(),
+                        result.targetId()
+                ),
+                detectedAt
+        );
+
+        operationAlertRepository.save(operationAlert);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/usecase/RunOperationRuleUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/usecase/RunOperationRuleUseCase.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.admin.operation.automation.application.usecase;
+
+// 스케줄러 또는 수동 트리거가 운영 자동 규칙 실행을 요청하는 진입점이다.
+public interface RunOperationRuleUseCase {
+
+    void run();
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/CourseOperationMetricAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/CourseOperationMetricAdapter.java
@@ -1,0 +1,61 @@
+package com.wanted.codebombalms.admin.operation.automation.infrastructure.adapter;
+
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+import com.wanted.codebombalms.admin.operation.automation.application.port.CourseOperationMetricPort;
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+// 강좌와 수강신청 데이터를 조회해 수강생 부족 강좌 지표를 만든다.
+public class CourseOperationMetricAdapter implements CourseOperationMetricPort {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public List<OperationRuleDetectionResult> findLowEnrollmentCourses(BigDecimal threshold) {
+        long maxEnrollmentCount = threshold.longValue();
+
+        return entityManager.createQuery("""
+                        select c.courseId, count(e.enrollmentId)
+                        from CourseJpaEntity c
+                        left join EnrollmentJpaEntity e
+                            on e.course = c
+                            and e.status = :activeEnrollmentStatus
+                        where c.deletedAt is null
+                          and c.status = :activeCourseStatus
+                        group by c.courseId
+                        having count(e.enrollmentId) <= :maxEnrollmentCount
+                        """, Object[].class)
+                .setParameter("activeEnrollmentStatus", EnrollmentStatus.ACTIVE)
+                .setParameter("activeCourseStatus", CourseStatus.ACTIVE)
+                .setParameter("maxEnrollmentCount", maxEnrollmentCount)
+                .getResultList()
+                .stream()
+                .map(row -> toResult((Long) row[0], (Long) row[1], threshold))
+                .toList();
+    }
+
+    private OperationRuleDetectionResult toResult(
+            Long courseId,
+            Long enrollmentCount,
+            BigDecimal threshold
+    ) {
+        return new OperationRuleDetectionResult(
+                OperationTargetType.COURSE,
+                courseId,
+                BigDecimal.valueOf(enrollmentCount),
+                "수강생 수가 기준 이하입니다. 현재 수강생 수: " + enrollmentCount + "명",
+                "강좌 노출, 홍보 상태, 커리큘럼 구성을 점검하세요. 기준값: " + threshold + "명"
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/ProblemOperationMetricAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/ProblemOperationMetricAdapter.java
@@ -1,0 +1,79 @@
+package com.wanted.codebombalms.admin.operation.automation.infrastructure.adapter;
+
+import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
+import com.wanted.codebombalms.admin.operation.automation.application.port.ProblemOperationMetricPort;
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+// 문제와 제출 데이터를 조회해 오답률 높은 문제 지표를 만든다.
+public class ProblemOperationMetricAdapter implements ProblemOperationMetricPort {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public List<OperationRuleDetectionResult> findHighWrongRateProblems(
+            BigDecimal wrongRateThreshold,
+            Integer minSampleCount
+    ) {
+        return entityManager.createQuery("""
+                        select p.problemId,
+                               count(s.submissionId),
+                               sum(case when s.isCorrect = false then 1 else 0 end)
+                        from ProblemJpaEntity p
+                        join SubmissionJpaEntity s on s.problem = p
+                        where p.status = 'ACTIVE'
+                        group by p.problemId
+                        having count(s.submissionId) >= :minSampleCount
+                        """, Object[].class)
+                .setParameter("minSampleCount", minSampleCount.longValue())
+                .getResultList()
+                .stream()
+                .map(this::toMetric)
+                .filter(metric -> metric.wrongRate().compareTo(wrongRateThreshold) >= 0)
+                .map(metric -> toResult(metric, wrongRateThreshold, minSampleCount))
+                .toList();
+    }
+
+    private ProblemWrongRateMetric toMetric(Object[] row) {
+        Long problemId = (Long) row[0];
+        Long submissionCount = (Long) row[1];
+        Long wrongCount = (Long) row[2];
+        BigDecimal wrongRate = BigDecimal.valueOf(wrongCount)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(submissionCount), 2, RoundingMode.HALF_UP);
+
+        return new ProblemWrongRateMetric(problemId, submissionCount, wrongCount, wrongRate);
+    }
+
+    private OperationRuleDetectionResult toResult(
+            ProblemWrongRateMetric metric,
+            BigDecimal wrongRateThreshold,
+            Integer minSampleCount
+    ) {
+        return new OperationRuleDetectionResult(
+                OperationTargetType.PROBLEM,
+                metric.problemId(),
+                metric.wrongRate(),
+                "오답률이 기준 이상입니다. 현재 오답률: " + metric.wrongRate() + "%, 제출 수: " + metric.submissionCount() + "회",
+                "문제 설명, 정답, 테스트 케이스를 점검하세요. 기준값: " + wrongRateThreshold + "%, 최소 제출 수: " + minSampleCount + "회"
+        );
+    }
+
+    private record ProblemWrongRateMetric(
+            Long problemId,
+            Long submissionCount,
+            Long wrongCount,
+            BigDecimal wrongRate
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/config/OperationAutomationClockConfig.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/config/OperationAutomationClockConfig.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.admin.operation.automation.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+// 운영 자동 알림에서 사용할 기준 시간대를 제공한다.
+public class OperationAutomationClockConfig {
+
+    @Bean
+    public Clock operationAutomationClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/scheduler/OperationRuleScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/scheduler/OperationRuleScheduler.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.admin.operation.automation.infrastructure.scheduler;
+
+import com.wanted.codebombalms.admin.operation.automation.application.usecase.RunOperationRuleUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+// 매일 오전 9시에 운영 자동 규칙 실행 유스케이스를 호출한다.
+public class OperationRuleScheduler {
+
+    private final RunOperationRuleUseCase runOperationRuleUseCase;
+
+    @Scheduled(cron = "0 0 9 * * *", zone = "Asia/Seoul")
+    public void runDailyOperationRules() {
+        runOperationRuleUseCase.run();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/domain/repository/AutomationRuleRepository.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/domain/repository/AutomationRuleRepository.java
@@ -15,6 +15,9 @@ public interface AutomationRuleRepository {
 
     List<AutomationRule> findAllActive(OperationTargetType targetType);
 
+    // 스케줄러가 실행할 활성화된 자동 규칙만 조회한다.
+    List<AutomationRule> findEnabled();
+
     boolean existsActiveByRuleCode(OperationRuleCode ruleCode);
 
     List<OperationRuleCode> findActiveRuleCodes();

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/AutomationRuleRepositoryAdapter.java
@@ -44,6 +44,15 @@ public class AutomationRuleRepositoryAdapter implements AutomationRuleRepository
                 .toList();
     }
 
+    // 스케줄러가 실행할 활성화된 자동 규칙만 조회한다.
+    @Override
+    public List<AutomationRule> findEnabled() {
+        return springDataRepository.findByEnabledTrueOrderByOperationRuleIdAsc()
+                .stream()
+                .map(AutomationRuleMapper::toDomain)
+                .toList();
+    }
+
     @Override
     public boolean existsActiveByRuleCode(OperationRuleCode ruleCode) {
         return springDataRepository.existsByRuleCode(ruleCode);

--- a/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/SpringDataAutomationRuleRepository.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/rule/infrastructure/persistence/SpringDataAutomationRuleRepository.java
@@ -9,6 +9,9 @@ public interface SpringDataAutomationRuleRepository extends JpaRepository<Automa
 
     List<AutomationRuleJpaEntity> findAllByOrderByOperationRuleIdAsc();
 
+    // 활성화된 자동 규칙을 등록 순서대로 조회한다.
+    List<AutomationRuleJpaEntity> findByEnabledTrueOrderByOperationRuleIdAsc();
+
     boolean existsByRuleCode(OperationRuleCode ruleCode);
 
     List<AutomationRuleJpaEntity> findByRuleCodeIn(List<OperationRuleCode> ruleCodes);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,10 @@ fastapi:
 
 chat:
   max-history-messages: 20
+
+gcp:
+  project-id: ${GCP_PROJECT_ID:project-9eb65e0d-55b9-4a40-878}
+  storage:
+    bucket: ${GCP_STORAGE_BUCKET:codebombalms}
+  credentials:
+    location: ${GCP_CREDENTIALS_LOCATION:file:./secrets/gcp-storage-key.json}

--- a/src/test/java/com/wanted/codebombalms/admin/operation/automation/OperationRuleSchedulerIntegrationTest.java
+++ b/src/test/java/com/wanted/codebombalms/admin/operation/automation/OperationRuleSchedulerIntegrationTest.java
@@ -1,0 +1,289 @@
+package com.wanted.codebombalms.admin.operation.automation;
+
+import com.wanted.codebombalms.admin.operation.alert.domain.model.OperationAlertStatus;
+import com.wanted.codebombalms.admin.operation.alert.infrastructure.persistence.OperationAlertJpaEntity;
+import com.wanted.codebombalms.admin.operation.alert.infrastructure.persistence.SpringDataOperationAlertRepository;
+import com.wanted.codebombalms.admin.operation.automation.application.usecase.RunOperationRuleUseCase;
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationSeverity;
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
+import com.wanted.codebombalms.admin.operation.rule.domain.repository.AutomationRuleRepository;
+import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.course.infrastructure.persistence.CourseJpaEntity;
+import com.wanted.codebombalms.problems.category.infrastructure.persistence.ProblemCategoryJpaEntity;
+import com.wanted.codebombalms.problems.problem.infrastructure.persistence.ProblemJpaEntity;
+import com.wanted.codebombalms.problems.set.infrastructure.persistence.ProblemSetJpaEntity;
+import com.wanted.codebombalms.submission.infrastructure.persistence.SubmissionJpaEntity;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("운영 자동 알림 스케줄러 통합 테스트")
+// 운영 자동 규칙 실행 전후의 알림 생성 상태 변화를 검증한다.
+class OperationRuleSchedulerIntegrationTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Autowired
+    private AutomationRuleRepository automationRuleRepository;
+
+    @Autowired
+    private SpringDataOperationAlertRepository operationAlertRepository;
+
+    @Autowired
+    private RunOperationRuleUseCase runOperationRuleUseCase;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private MutableClock mutableClock;
+
+    @Test
+    @DisplayName("08시 59분에는 알림이 없고 09시 규칙 실행 후 강좌/문제 알림이 생성된다.")
+    void operationRuleSchedulerCreatesAlertsAtNine() {
+        // given
+        LocalDateTime beforeScheduleTime = LocalDateTime.of(2026, 5, 24, 8, 59);
+        LocalDateTime scheduleTime = beforeScheduleTime.plusMinutes(1);
+        mutableClock.setTime(beforeScheduleTime);
+
+        seedRules();
+        seedCourseForLowEnrollmentAlert();
+        seedProblemForHighWrongRateAlert();
+        entityManager.flush();
+        entityManager.clear();
+
+        // 1. 등록된 규칙 조회
+        List<AutomationRule> registeredRules = automationRuleRepository.findAllActive(null);
+        printRules(registeredRules);
+        assertEquals(2, registeredRules.size());
+        assertTrue(registeredRules.stream()
+                .anyMatch(rule -> rule.getRuleCode() == OperationRuleCode.COURSE_LOW_ENROLLMENT));
+        assertTrue(registeredRules.stream()
+                .anyMatch(rule -> rule.getRuleCode() == OperationRuleCode.PROBLEM_HIGH_WRONG_RATE));
+
+        // 2. 현재 시간이 08시 59분이라고 가정하고 알람 조회
+        List<OperationAlertJpaEntity> alertsAtBeforeScheduleTime = operationAlertRepository.findAll();
+        printAlerts("08:59 before scheduler", alertsAtBeforeScheduleTime);
+        assertEquals(0, alertsAtBeforeScheduleTime.size());
+
+        // 3. 1분 뒤에 스케줄러가 실행하는 유스케이스를 호출하고 알람 조회
+        mutableClock.setTime(scheduleTime);
+        runOperationRuleUseCase.run();
+        entityManager.flush();
+        entityManager.clear();
+
+        List<OperationAlertJpaEntity> alertsAfterScheduleTime = operationAlertRepository.findAll()
+                .stream()
+                .sorted(Comparator.comparing(OperationAlertJpaEntity::getTargetType))
+                .toList();
+        printAlerts("09:00 after scheduler", alertsAfterScheduleTime);
+
+        assertEquals(2, alertsAfterScheduleTime.size());
+        assertCreatedAlert(
+                alertsAfterScheduleTime.get(0),
+                OperationTargetType.COURSE,
+                BigDecimal.ZERO,
+                scheduleTime
+        );
+        assertCreatedAlert(
+                alertsAfterScheduleTime.get(1),
+                OperationTargetType.PROBLEM,
+                BigDecimal.valueOf(66.67),
+                scheduleTime
+        );
+    }
+
+    private void printRules(List<AutomationRule> rules) {
+        System.out.println();
+        System.out.println("========== registered operation rules ==========");
+        System.out.println("rule count = " + rules.size());
+        rules.forEach(rule -> System.out.println(
+                "ruleId=" + rule.getOperationRuleId()
+                        + ", ruleCode=" + rule.getRuleCode()
+                        + ", targetType=" + rule.getTargetType()
+                        + ", threshold=" + rule.getThresholdValue()
+                        + ", minSampleCount=" + rule.getMinSampleCount()
+                        + ", severity=" + rule.getSeverity()
+                        + ", enabled=" + rule.isEnabled()
+        ));
+        System.out.println("================================================");
+        System.out.println();
+    }
+
+    private void printAlerts(String label, List<OperationAlertJpaEntity> alerts) {
+        System.out.println();
+        System.out.println("========== " + label + " ==========");
+        System.out.println("alert count = " + alerts.size());
+        alerts.forEach(alert -> System.out.println(
+                "alertId=" + alert.getOperationAlertId()
+                        + ", ruleId=" + alert.getOperationRuleId()
+                        + ", targetType=" + alert.getTargetType()
+                        + ", targetId=" + alert.getTargetId()
+                        + ", detectedValue=" + alert.getDetectedValue()
+                        + ", thresholdSnapshot=" + alert.getThresholdValueSnapshot()
+                        + ", status=" + alert.getStatus()
+                        + ", firstDetectedAt=" + alert.getFirstDetectedAt()
+                        + ", lastDetectedAt=" + alert.getLastDetectedAt()
+                        + ", reason=" + alert.getReason()
+                        + ", recommendedAction=" + alert.getRecommendedAction()
+        ));
+        System.out.println("========================================");
+        System.out.println();
+    }
+
+    private void seedRules() {
+        automationRuleRepository.save(AutomationRule.create(
+                1L,
+                OperationRuleCode.COURSE_LOW_ENROLLMENT,
+                BigDecimal.ZERO,
+                null,
+                OperationSeverity.MEDIUM,
+                true
+        ));
+        automationRuleRepository.save(AutomationRule.create(
+                1L,
+                OperationRuleCode.PROBLEM_HIGH_WRONG_RATE,
+                BigDecimal.valueOf(50),
+                3,
+                OperationSeverity.HIGH,
+                true
+        ));
+    }
+
+    private void seedCourseForLowEnrollmentAlert() {
+        entityManager.persist(new CourseJpaEntity(
+                10L,
+                "수강생이 없는 운영 점검 강좌",
+                "운영 자동 알림 테스트용 강좌입니다.",
+                "course.png",
+                CourseStatus.ACTIVE
+        ));
+    }
+
+    private void seedProblemForHighWrongRateAlert() {
+        ProblemCategoryJpaEntity category = new ProblemCategoryJpaEntity("Java", "Java 문제");
+        entityManager.persist(category);
+
+        ProblemSetJpaEntity problemSet = new ProblemSetJpaEntity(
+                category,
+                "오답률 점검 문제 세트",
+                "운영 자동 알림 테스트용 문제 세트입니다.",
+                "EASY",
+                1,
+                1L
+        );
+        entityManager.persist(problemSet);
+
+        ProblemJpaEntity problem = new ProblemJpaEntity(
+                problemSet,
+                "오답률 높은 문제",
+                "1 + 1은?",
+                "2",
+                "기본 덧셈 문제입니다.",
+                10,
+                1
+        );
+        entityManager.persist(problem);
+
+        entityManager.persist(createSubmission(1L, problem, false, 1));
+        entityManager.persist(createSubmission(2L, problem, false, 1));
+        entityManager.persist(createSubmission(3L, problem, true, 1));
+    }
+
+    private SubmissionJpaEntity createSubmission(
+            Long userId,
+            ProblemJpaEntity problem,
+            Boolean correct,
+            Integer attemptNo
+    ) {
+        return new SubmissionJpaEntity(
+                userId,
+                problem,
+                "answer",
+                correct,
+                correct ? 10 : 0,
+                attemptNo
+        );
+    }
+
+    private void assertCreatedAlert(
+            OperationAlertJpaEntity alert,
+            OperationTargetType targetType,
+            BigDecimal detectedValue,
+            LocalDateTime detectedAt
+    ) {
+        assertEquals(targetType, alert.getTargetType());
+        assertEquals(OperationAlertStatus.OPEN, alert.getStatus());
+        assertEquals(0, detectedValue.compareTo(alert.getDetectedValue()));
+        assertEquals(detectedAt, alert.getFirstDetectedAt());
+        assertEquals(detectedAt, alert.getLastDetectedAt());
+    }
+
+    @TestConfiguration
+    static class TestClockConfig {
+
+        @Bean
+        @Primary
+        MutableClock mutableClock() {
+            return new MutableClock(
+                    LocalDateTime.of(2026, 5, 24, 8, 59)
+                            .atZone(SEOUL_ZONE)
+                            .toInstant(),
+                    SEOUL_ZONE
+            );
+        }
+    }
+
+    static class MutableClock extends Clock {
+
+        private Instant instant;
+        private final ZoneId zone;
+
+        MutableClock(Instant instant, ZoneId zone) {
+            this.instant = instant;
+            this.zone = zone;
+        }
+
+        void setTime(LocalDateTime time) {
+            this.instant = time.atZone(zone).toInstant();
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return new MutableClock(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}


### PR DESCRIPTION
🚨 Pull Request 유형
해당하는 항목에 체크해주세요.

⭐ FEATURE
🪛 UPDATE
🐞 BUGFIX
♻️ REFACTOR
📌 작업한 이슈
Closes #229
Closes #142
🛠️ 기능 관련 작업 내용
규칙에 의한 운영 알림 자동 등록 기능을 구현했습니다.

매일 오전 9시(Asia/Seoul)에 enabled 상태의 자동 규칙을 실행하는 스케줄러를 추가했습니다.
COURSE_LOW_ENROLLMENT 규칙 실행 시 수강생 수가 기준 이하인 강좌를 탐지해 운영 알림을 등록합니다.
PROBLEM_HIGH_WRONG_RATE 규칙 실행 시 최소 제출 수 이상이면서 오답률이 기준 이상인 문제를 탐지해 운영 알림을 등록합니다.
동일한 규칙과 대상에 대해 OPEN 상태의 알림이 이미 있으면 새로 생성하지 않고 탐지값, 사유, 권장 조치, 마지막 탐지 시간을 갱신하도록 처리했습니다.
USER_INACTIVE_NO_COURSE 규칙은 현재 user 도메인에 마지막 로그인 시간이 없어 이번 스케줄러 실행 대상에서는 제외했습니다.
테스트에서 08:59 알림 조회, 09:00 규칙 실행 후 알림 조회 흐름을 검증하고 콘솔에서 엔티티 상태 변화를 확인할 수 있도록 했습니다.
♻️ 패키지 변경 사항
admin/

admin/operation/automation/application/usecase/RunOperationRuleUseCase : 운영 자동 규칙 실행 진입점 추가
admin/operation/automation/application/service/OperationRuleExecutionService : enabled 규칙 조회, handler 실행, 알림 저장 흐름 구현
admin/operation/automation/application/handler/OperationRuleHandler : 규칙별 실행 전략 인터페이스 추가
admin/operation/automation/application/handler/CourseLowEnrollmentRuleHandler : 수강생 부족 강좌 탐지 handler 추가
admin/operation/automation/application/handler/ProblemHighWrongRateRuleHandler : 오답률 높은 문제 탐지 handler 추가
admin/operation/automation/application/port/CourseOperationMetricPort : 강좌 운영 지표 조회 port 추가
admin/operation/automation/application/port/ProblemOperationMetricPort : 문제 운영 지표 조회 port 추가
admin/operation/automation/application/policy/OperationRuleExecutionPolicy : 규칙 실행 가능 여부 판단 정책 추가
admin/operation/automation/application/policy/OperationAlertUpsertPolicy : 기존 OPEN 알림 갱신 또는 신규 알림 생성 정책 추가
admin/operation/automation/infrastructure/adapter/CourseOperationMetricAdapter : 강좌/수강신청 데이터 기반 수강생 부족 지표 조회 구현
admin/operation/automation/infrastructure/adapter/ProblemOperationMetricAdapter : 문제/제출 데이터 기반 오답률 지표 조회 구현
admin/operation/automation/infrastructure/scheduler/OperationRuleScheduler : 매일 오전 9시 자동 규칙 실행 스케줄러 추가
admin/operation/automation/infrastructure/config/OperationAutomationClockConfig : 자동 알림 기준 시간대 Clock bean 추가
admin/operation/alert/domain/model/OperationAlert : 자동 규칙 탐지 결과로 OPEN 알림을 생성하는 factory 메서드 추가
admin/operation/alert/domain/repository/OperationAlertRepository : 동일 규칙/대상 OPEN 알림 조회 메서드 추가
admin/operation/alert/infrastructure/persistence/* : OPEN 알림 중복 방지 조회 구현 추가
admin/operation/rule/domain/repository/AutomationRuleRepository : enabled 규칙 조회 메서드 추가
admin/operation/rule/infrastructure/persistence/* : enabled 규칙 조회 구현 추가
src/test/java/com/wanted/codebombalms/admin/operation/automation/OperationRuleSchedulerIntegrationTest : 자동 규칙 실행 전후 알림 생성 상태 변화 통합 테스트 추가
build.gradle : 테스트 실행 시 표준 출력 로그가 보이도록 설정 추가
체크리스트
팀에서 정한 컨벤션을 준수했습니다.
정상적으로 동작합니다.
불필요한 코드를 최소화했습니다.
팀원들과 변경 내용을 공유했습니다.