### PR TITLE
[Feat] LoginHistory 엔티티 구성

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/command/LoginCommand.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/command/LoginCommand.java
@@ -2,6 +2,6 @@ package com.wanted.codebombalms.auth.application.command;
 
 public record LoginCommand(
         String email,
-        String rawPassword
+        String rawpassword
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -4,7 +4,9 @@ import com.wanted.codebombalms.auth.application.command.LoginCommand;
 import com.wanted.codebombalms.auth.application.dto.TokenPair;
 import com.wanted.codebombalms.auth.application.usecase.LoginUseCase;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
@@ -12,6 +14,7 @@ import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -24,18 +27,19 @@ public class LoginService implements LoginUseCase {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final LoginHistoryRepository loginHistoryRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public TokenPair login(LoginCommand command) {
+    public TokenPair login(LoginCommand command, HttpServletRequest request) {
 
-        // 1. 이메일로 회원 조회 — 이메일 없음 / 비번 불일치 모두 동일 에러 (보안)
+        // 1. 이메일로 회원 조회
         User user = userRepository.findByEmail(command.email())
                 .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
 
         // 2. 비밀번호 검증
-        if (!passwordEncoder.matches(command.rawPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(command.rawpassword(), user.getPassword())) {
             throw new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL);
         }
 
@@ -44,7 +48,7 @@ public class LoginService implements LoginUseCase {
             throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
         }
 
-        // 4. 단일 세션 강제 — 기존 RT 전부 삭제
+        // 4. 단일 세션 강제
         refreshTokenRepository.deleteByUserId(user.getUserId());
 
         // 5. 토큰 발급
@@ -56,6 +60,28 @@ public class LoginService implements LoginUseCase {
                 RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration())
         );
 
+        // 7. 로그인 이력 기록
+        loginHistoryRepository.save(
+                LoginHistory.record(
+                        user.getUserId(),
+                        extractIpAddress(request),
+                        request.getHeader("User-Agent"),
+                        null,
+                        null,
+                        null,
+                        false
+                )
+        );
+
         return new TokenPair(accessToken, refreshToken);
+    }
+
+    /** 프록시 환경(X-Forwarded-For) 고려한 클라이언트 IP 추출 */
+    private String extractIpAddress(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();   // 첫 번째 IP가 원본 클라이언트
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
@@ -2,8 +2,9 @@ package com.wanted.codebombalms.auth.application.usecase;
 
 import com.wanted.codebombalms.auth.application.command.LoginCommand;
 import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface LoginUseCase {
 
-    TokenPair login(LoginCommand command);
+    TokenPair login(LoginCommand command, HttpServletRequest request);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/domain/model/LoginHistory.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/model/LoginHistory.java
@@ -1,0 +1,77 @@
+package com.wanted.codebombalms.auth.domain.model;
+
+import java.time.LocalDateTime;
+
+public class LoginHistory {
+
+    private Long loginHistoryId;
+    private Long userId;
+    private String ipAddress;
+    private String userAgent;
+    private String deviceFp;
+    private String country;
+    private String city;
+    private boolean suspicious;
+    private LocalDateTime createdAt;
+
+    private LoginHistory() {}
+
+    // ===== Getter =====
+    public Long getLoginHistoryId()    { return loginHistoryId; }
+    public Long getUserId()            { return userId; }
+    public String getIpAddress()       { return ipAddress; }
+    public String getUserAgent()       { return userAgent; }
+    public String getDeviceFp()        { return deviceFp; }
+    public String getCountry()         { return country; }
+    public String getCity()            { return city; }
+    public boolean isSuspicious()      { return suspicious; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+
+    // ===== 정적 팩토리 — 신규 기록 =====
+
+    public static LoginHistory record(
+            Long userId,
+            String ipAddress,
+            String userAgent,
+            String deviceFp,
+            String country,
+            String city,
+            boolean suspicious
+    ) {
+        LoginHistory history = new LoginHistory();
+        history.userId      = userId;
+        history.ipAddress   = ipAddress;
+        history.userAgent   = userAgent;
+        history.deviceFp    = deviceFp;
+        history.country     = country;
+        history.city        = city;
+        history.suspicious  = suspicious;
+        return history;
+    }
+
+    // ===== 영속성 복원 — Adapter 전용 =====
+
+    public static LoginHistory restore(
+            Long loginHistoryId,
+            Long userId,
+            String ipAddress,
+            String userAgent,
+            String deviceFp,
+            String country,
+            String city,
+            boolean suspicious,
+            LocalDateTime createdAt
+    ) {
+        LoginHistory history = new LoginHistory();
+        history.loginHistoryId = loginHistoryId;
+        history.userId         = userId;
+        history.ipAddress      = ipAddress;
+        history.userAgent      = userAgent;
+        history.deviceFp       = deviceFp;
+        history.country        = country;
+        history.city           = city;
+        history.suspicious     = suspicious;
+        history.createdAt      = createdAt;
+        return history;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/model/RefreshToken.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/model/RefreshToken.java
@@ -35,14 +35,14 @@ public class RefreshToken {
             Long refreshTokenId,
             Long userId,
             String token,
-            LocalDateTime expiresAt,
+            LocalDateTime expiredAt,
             LocalDateTime createdAt
     ) {
         RefreshToken rt = new RefreshToken();
         rt.refreshTokenId = refreshTokenId;
         rt.userId         = userId;
         rt.token          = token;
-        rt.expiredAt      = expiresAt;
+        rt.expiredAt      = expiredAt;
         rt.createdAt      = createdAt;
         return rt;
     }

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/LoginHistoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/LoginHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.auth.domain.repository;
+
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+
+import java.util.Optional;
+
+public interface LoginHistoryRepository {
+
+    LoginHistory save(LoginHistory loginHistory);
+
+    Optional<LoginHistory> findLatestByUserId(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryJpaEntity.java
@@ -1,0 +1,78 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "login_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class LoginHistoryJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "login_history_id")
+    private Long loginHistoryId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "user_agent", columnDefinition = "TEXT")
+    private String userAgent;
+
+    @Column(name = "device_fp", length = 64)
+    private String deviceFp;
+
+    @Column(name = "country", length = 50)
+    private String country;
+
+    @Column(name = "city", length = 50)
+    private String city;
+
+    @Column(name = "is_suspicious", nullable = false)
+    private boolean suspicious;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+
+    public static LoginHistoryJpaEntity from(LoginHistory loginHistory) {
+        LoginHistoryJpaEntity e = new LoginHistoryJpaEntity();
+        e.loginHistoryId = loginHistory.getLoginHistoryId();
+        e.userId         = loginHistory.getUserId();
+        e.ipAddress      = loginHistory.getIpAddress();
+        e.userAgent      = loginHistory.getUserAgent();
+        e.deviceFp       = loginHistory.getDeviceFp();
+        e.country        = loginHistory.getCountry();
+        e.city           = loginHistory.getCity();
+        e.suspicious     = loginHistory.isSuspicious();
+        return e;
+    }
+
+
+    public LoginHistory toDomain() {
+        return LoginHistory.restore(
+                loginHistoryId,
+                userId,
+                ipAddress,
+                userAgent,
+                deviceFp,
+                country,
+                city,
+                suspicious,
+                createdAt
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class LoginHistoryRepositoryAdapter implements LoginHistoryRepository {
+
+    private final SpringDataLoginHistoryRepository springDataLoginHistoryRepository;
+
+    @Override
+    public LoginHistory save(LoginHistory loginHistory) {
+        LoginHistoryJpaEntity entity = LoginHistoryJpaEntity.from(loginHistory);
+        return springDataLoginHistoryRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public Optional<LoginHistory> findLatestByUserId(Long userId) {
+        return springDataLoginHistoryRepository
+                .findTopByUserIdOrderByCreatedAtDesc(userId)
+                .map(LoginHistoryJpaEntity::toDomain);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RefreshTokenJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RefreshTokenJpaEntity.java
@@ -29,7 +29,7 @@ public class RefreshTokenJpaEntity {
     private String token;
 
     @Column(name = "expired_at", nullable = false)
-    private LocalDateTime expiresAt;
+    private LocalDateTime expiredAt;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -42,7 +42,7 @@ public class RefreshTokenJpaEntity {
         e.refreshTokenId = refreshToken.getRefreshTokenId();
         e.userId         = refreshToken.getUserId();
         e.token          = refreshToken.getToken();
-        e.expiresAt      = refreshToken.getExpiredAt();
+        e.expiredAt      = refreshToken.getExpiredAt();
         return e;
     }
 
@@ -53,7 +53,7 @@ public class RefreshTokenJpaEntity {
                 refreshTokenId,
                 userId,
                 token,
-                expiresAt,
+                expiredAt,
                 createdAt
         );
     }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataLoginHistoryRepository extends JpaRepository<LoginHistoryJpaEntity, Long> {
+    
+    Optional<LoginHistoryJpaEntity> findTopByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.auth.presentation.api.dto.request.LoginRequest;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,9 +27,10 @@ public class LoginController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Void>> login(
             @Valid @RequestBody LoginRequest request,
+            HttpServletRequest httpRequest,
             HttpServletResponse response
     ) {
-        TokenPair pair = loginUseCase.login(request.toCommand());
+        TokenPair pair = loginUseCase.login(request.toCommand(), httpRequest);
 
         // 쿠키 2개 설정
         response.addCookie(createCookie(

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -3,7 +3,9 @@ package com.wanted.codebombalms.auth.application.service;
 import com.wanted.codebombalms.auth.application.command.LoginCommand;
 import com.wanted.codebombalms.auth.application.dto.TokenPair;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
@@ -13,6 +15,7 @@ import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,8 +39,10 @@ class LoginServiceTest {
 
     @Mock private UserRepository userRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private LoginHistoryRepository loginHistoryRepository;   // ⭐ 추가
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private HttpServletRequest httpRequest;                  // ⭐ 추가
 
     @InjectMocks
     private LoginService loginService;
@@ -50,7 +55,7 @@ class LoginServiceTest {
     }
 
     @Test
-    @DisplayName("정상 로그인 시 TokenPair를 반환하고 새 Refresh Token을 저장한다.")
+    @DisplayName("정상 로그인 시 TokenPair를 반환하고 새 Refresh Token + LoginHistory를 저장한다.")
     void 로그인_성공() {
         // given
         User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
@@ -61,13 +66,14 @@ class LoginServiceTest {
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
         // when
-        TokenPair pair = loginService.login(command);
+        TokenPair pair = loginService.login(command, httpRequest);   // ⭐ httpRequest 전달
 
         // then
         assertEquals("ACCESS_TOKEN", pair.accessToken());
         assertEquals("REFRESH_TOKEN", pair.refreshToken());
         verify(refreshTokenRepository).deleteByUserId(1L);
         verify(refreshTokenRepository).save(any(RefreshToken.class));
+        verify(loginHistoryRepository).save(any(LoginHistory.class));   // ⭐ 추가
     }
 
     @Test
@@ -79,10 +85,11 @@ class LoginServiceTest {
         // when & then
         UnauthorizedException ex = assertThrows(
                 UnauthorizedException.class,
-                () -> loginService.login(command)
+                () -> loginService.login(command, httpRequest)   // ⭐
         );
         assertEquals(AuthErrorCode.AUTH_LOGIN_FAIL, ex.getErrorCode());
         verify(refreshTokenRepository, never()).save(any());
+        verify(loginHistoryRepository, never()).save(any());            // ⭐ 추가
     }
 
     @Test
@@ -96,27 +103,29 @@ class LoginServiceTest {
         // when & then
         UnauthorizedException ex = assertThrows(
                 UnauthorizedException.class,
-                () -> loginService.login(command)
+                () -> loginService.login(command, httpRequest)   // ⭐
         );
         assertEquals(AuthErrorCode.AUTH_LOGIN_FAIL, ex.getErrorCode());
         verify(refreshTokenRepository, never()).save(any());
+        verify(loginHistoryRepository, never()).save(any());            // ⭐ 추가
     }
 
     @Test
     @DisplayName("잠긴 계정이면 ForbiddenException(USER_ACCOUNT_LOCKED)을 던진다.")
     void 계정_잠금_예외() {
         // given
-        User user = createUser(1L, "test@example.com", "ENCODED_PW", true);  // isLocked=true
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", true);
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
 
         // when & then
         ForbiddenException ex = assertThrows(
                 ForbiddenException.class,
-                () -> loginService.login(command)
+                () -> loginService.login(command, httpRequest)   // ⭐
         );
         assertEquals(UserErrorCode.USER_ACCOUNT_LOCKED, ex.getErrorCode());
         verify(refreshTokenRepository, never()).save(any());
+        verify(loginHistoryRepository, never()).save(any());            // ⭐ 추가
     }
 
     @Test
@@ -131,7 +140,7 @@ class LoginServiceTest {
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
         // when
-        loginService.login(command);
+        loginService.login(command, httpRequest);   // ⭐
 
         // then — 삭제 후 저장 순서 검증
         var inOrder = inOrder(refreshTokenRepository);
@@ -152,13 +161,13 @@ class LoginServiceTest {
                 "010-1234-5678",
                 AuthProvider.LOCAL,
                 null,
-                false,        // emailVerified
+                false,
                 isLocked,
-                null,         // bio
-                null,         // career
+                null,
+                null,
                 LocalDateTime.now(),
                 LocalDateTime.now(),
-                null          // deletedAt
+                null
         );
     }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE

---

## 📌 작업한 이슈

---

## 🛠️ 기능 관련 작업 내용

1. LoginHistory 엔티티 구현 
LoginHistory 를 클린 아키텍처 패턴으로 구현했습니다.


last_login_at 조회 방법
LocalDateTime lastLoginAt = loginHistoryRepository
        .findLatestByUserId(userId)
        .map(LoginHistory::getCreatedAt)
        .orElse(null);
→ LoginHistory.createdAt 이 곧 마지막 로그인 시각입니다.

3. 명명 컨벤션 갱신

---

## ♻️ 패키지 변경 사항

LoginHistory 
auth/domain/model/LoginHistory : 순수 도메인 모델 신규 생성
auth/domain/repository/LoginHistoryRepository : Output Port 신규 생성 (save, findLatestByUserId)
auth/infrastructure/persistence/LoginHistoryJpaEntity : JPA 영속성 엔티티 신규 생성, from / toDomain 변환 메서드 포함
auth/infrastructure/persistence/SpringDataLoginHistoryRepository : Spring Data JPA 신규 생성 (findTopByUserIdOrderByCreatedAtDesc)
auth/infrastructure/persistence/LoginHistoryRepositoryAdapter : Port 구현체 신규 생성

auth  시그니처 / 명명 갱신
auth/application/usecase/LoginUseCase : login(LoginCommand, HttpServletRequest) 시그니처 변경
auth/application/service/LoginService : LoginHistoryRepository 의존성 추가, 로그인 성공 시 LoginHistory 기록 hook 추가, extractIpAddress 헬퍼 추가 (X-Forwarded-For 우선)
auth/application/command/LoginCommand : rawPassword → rawpassword
auth/presentation/api/LoginController : HttpServletRequest httpRequest 파라미터 추가 후 UseCase 위임
auth/domain/model/RefreshToken : expiresAt → expiredAt (필드, getter, restore 파라미터, isExpired 참조 모두 일관 적용)
auth/infrastructure/persistence/RefreshTokenJpaEntity : 동일 명명 갱신, @Column(name = "expires_at") → @Column(name = "expired_at")
테스트
src/test/.../auth/application/service/LoginServiceTest : LoginHistoryRepository mock 추가, HttpServletRequest mock 추가, 5개 시나리오 모두 새 시그니처 + LoginHistory 저장/미저장 검증 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
