### PR TITLE
[FEAT] 문제 데이터셋 GCS 업로드 및 공개 URL 기반 시작 코드 연동

### DIFF
--- a/http/problem-dataset.http
+++ b/http/problem-dataset.http
@@ -1,103 +1,98 @@
 @baseUrl = http://localhost:8080
+@datasetId = 3008
 @problemId = 3001
-@connectedDatasetId = 3001
-@textProblemId = 2001
-@notFoundProblemId = 999999
 @notFoundDatasetId = 999999
-@problemSetId = 3001
-@userId = 3
+@notFoundProblemId = 999999
 
-### 1. 데이터셋 업로드 성공
-# 기대 결과:
-# - 201 Created
-# - data.datasetId가 반환됩니다.
-# - problem_id는 NULL로 저장됩니다.
+# =====================================================
+# GCS 데이터셋 업로드 확인
+# =====================================================
+
+### 1. 데이터셋 업로드 성공 - GCS 저장 확인
+# 확인할 것:
+# - 응답 fileUrl이 https://storage.googleapis.com/codebombalms/problem_dataset/... 형태인지 확인
+# - 응답 filePath가 problem_dataset/... 형태인지 확인
+# - GCS 콘솔 codebombalms > problem_dataset 폴더에 파일이 생겼는지 확인
+# - DB problem_dataset 테이블에 original_file_name, stored_file_name, file_url, file_path가 저장됐는지 확인
 POST {{baseUrl}}/api/v1/problem-datasets
 Accept: application/json
-Content-Type: multipart/form-data; boundary=datasetBoundary
+Content-Type: multipart/form-data; boundary=boundary
 
---datasetBoundary
+--boundary
 Content-Disposition: form-data; name="datasetFile"; filename="employee_performance.csv"
 Content-Type: text/csv
 
-employee_id,department,performance_score
-1,Sales,90
-2,HR,85
---datasetBoundary--
-
-> {%
-    client.global.set("uploadedDatasetId", response.body.data.datasetId);
-%}
+< ../uploads/datasets/employee_performance_202605.csv
+--boundary--
 
 
-### 2. 데이터셋 업로드 실패 - CSV가 아닌 파일
+### 2. 데이터셋 업로드 실패 - 빈 파일
+# 빈 CSV 파일이 있으면 경로를 맞춰 테스트하세요.
 # 기대 결과:
-# - 400 PROBLEM_DATASET_INVALID_FILE
+# - 400 Bad Request
+# - PROBLEM_DATASET_INVALID_FILE
 POST {{baseUrl}}/api/v1/problem-datasets
 Accept: application/json
-Content-Type: multipart/form-data; boundary=invalidDatasetBoundary
+Content-Type: multipart/form-data; boundary=boundary
 
---invalidDatasetBoundary
-Content-Disposition: form-data; name="datasetFile"; filename="employee_performance.txt"
+--boundary
+Content-Disposition: form-data; name="datasetFile"; filename="empty.csv"
+Content-Type: text/csv
+
+< ../uploads/datasets/empty.csv
+--boundary--
+
+
+### 3. 데이터셋 업로드 실패 - CSV가 아닌 파일
+# 기대 결과:
+# - 400 Bad Request
+# - PROBLEM_DATASET_INVALID_FILE
+POST {{baseUrl}}/api/v1/problem-datasets
+Accept: application/json
+Content-Type: multipart/form-data; boundary=boundary
+
+--boundary
+Content-Disposition: form-data; name="datasetFile"; filename="not_csv.txt"
 Content-Type: text/plain
 
-not,csv,file
---invalidDatasetBoundary--
+< ../uploads/datasets/not_csv.txt
+--boundary--
 
 
-### 3. 문제-데이터셋 연결 성공 - 1번에서 업로드한 데이터셋 사용
+# =====================================================
+# 데이터셋 연결 확인
+# =====================================================
+
+### 4. 문제-데이터셋 연결 성공
 # 사전 조건:
-# - 1번 요청을 먼저 실행해야 합니다.
-# 기대 결과:
-# - 201 Created
+# - problemId = 3001 문제가 존재해야 합니다.
+# - datasetId는 업로드 성공 응답의 datasetId로 바꿔서 실행하세요.
 POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
 Accept: application/json
 Content-Type: application/json
 
 {
-  "datasetId": {{uploadedDatasetId}}
+  "datasetId": {{datasetId}}
 }
 
 
-### 4. 문제-데이터셋 중복 연결 실패
-# 사전 조건:
-# - 더미데이터 기준 dataset_id = 3001은 이미 problem_id = 3001에 연결되어 있습니다.
+### 5. 문제-데이터셋 연결 실패 - 존재하지 않는 문제
 # 기대 결과:
-# - 409 PROBLEM_DATASET_ALREADY_CONNECTED
-POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
-Accept: application/json
-Content-Type: application/json
-
-{
-  "datasetId": {{connectedDatasetId}}
-}
-
-
-### 5. 문제 세트 진입 시 startCode 확인
-# 사전 조건:
-# - problem_set_id = 3001은 CODE 문제 세트입니다.
-# - 현재 문제에 ACTIVE 데이터셋이 연결되어 있으면 problem.startCode가 내려와야 합니다.
-# 기대 결과:
-# - problem.startCode = import pandas as pd\n\ndf = pd.read_csv("data/employee_performance.csv")
-GET {{baseUrl}}/api/v1/problem-sets/{{problemSetId}}?userId={{userId}}
-Accept: application/json
-
-
-### 6. 존재하지 않는 문제 실패
-# 기대 결과:
-# - 404 PROBLEM_NOT_FOUND
+# - 404 Not Found
+# - PROBLEM_NOT_FOUND
 POST {{baseUrl}}/api/v1/problems/{{notFoundProblemId}}/datasets
 Accept: application/json
 Content-Type: application/json
 
 {
-  "datasetId": {{connectedDatasetId}}
+  "datasetId": {{datasetId}}
 }
 
 
-### 7. 존재하지 않는 데이터셋 실패
+### 6. 문제-데이터셋 연결 실패 - 존재하지 않는 데이터셋
 # 기대 결과:
-# - 404 PROBLEM_DATASET_NOT_FOUND
+# - 404 Not Found
+# - PROBLEM_DATASET_NOT_FOUND
 POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
 Accept: application/json
 Content-Type: application/json
@@ -107,27 +102,40 @@ Content-Type: application/json
 }
 
 
-### 8. 코드 문제가 아닌 문제에 데이터셋 연결 실패
-# 사전 조건:
-# - 1번 요청으로 업로드한 미연결 datasetId를 사용합니다.
-# - problem_id = 2001 문제는 TEXT 타입입니다.
+### 7. 문제-데이터셋 연결 실패 - 이미 연결된 데이터셋
+# 4번을 성공시킨 뒤 같은 요청을 다시 실행하세요.
 # 기대 결과:
-# - 400 PROBLEM_DATASET_INVALID_PROBLEM_TYPE
-POST {{baseUrl}}/api/v1/problems/{{textProblemId}}/datasets
-Accept: application/json
-Content-Type: application/json
-
-{
-  "datasetId": {{uploadedDatasetId}}
-}
-
-
-### 9. datasetId 누락 실패
-# 기대 결과:
-# - 400 VALIDATION_FAILED
+# - 409 Conflict
+# - PROBLEM_DATASET_ALREADY_CONNECTED
 POST {{baseUrl}}/api/v1/problems/{{problemId}}/datasets
 Accept: application/json
 Content-Type: application/json
 
 {
+  "datasetId": {{datasetId}}
+}
+
+
+### =====================================================
+### 코드 문제 상세 / 시작 코드 확인
+### =====================================================
+
+### 8. 문제 세트 진입 시 시작 코드 확인
+# 확인할 것:
+# - data.problem.startCode에 pd.read_csv("problem_dataset/...") 또는 관련 경로가 내려오는지 확인
+# - data.problem.point가 내려오는지 확인
+GET {{baseUrl}}/api/v1/problem-sets/3001?userId=3
+Accept: application/json
+
+
+### 9. 코드 실행 요청 - GCS 업로드 파일 경로 기반
+# 주의:
+# - 현재 버킷은 비공개이므로 fileUrl을 pandas가 바로 읽는 방식은 실패할 수 있습니다.
+# - 현재 로컬 실행기는 filePath를 직접 읽는 구조일 수 있으니, 이 요청은 실행 환경 정책에 맞춰 조정하세요.
+POST {{baseUrl}}/api/v1/code-problems/3001/executions
+Accept: application/json
+Content-Type: application/json
+
+{
+  "code": "import pandas as pd\n\ndf = pd.read_csv(\"problem_dataset/employee_performance_202605.csv\")\nresult = df.shape\nprint(result)"
 }

--- a/http/submission.http
+++ b/http/submission.http
@@ -136,7 +136,7 @@ Content-Type: application/json
 }
 
 ### 12. 코드 실행 실패 예시 - 연결된 데이터셋 없음
-# 사전 조건:
+# 사전 조건:s
 # - codeProblemWithoutDatasetId를 실제 존재하는 CODE 문제 ID로 바꾸세요.
 # - 해당 문제에는 ACTIVE problem_dataset이 없어야 합니다.
 # 기대 결과:

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/application/port/StoreDatasetFilePort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/application/port/StoreDatasetFilePort.java
@@ -8,4 +8,6 @@ import java.io.IOException;
 public interface StoreDatasetFilePort {
 
     StoredDatasetFile store(UploadProblemDatasetCommand command) throws IOException;
+
+    void delete(String filePath);
 }

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/application/service/ProblemDatasetCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/application/service/ProblemDatasetCommandService.java
@@ -43,7 +43,7 @@ public class ProblemDatasetCommandService implements
         return new ConnectProblemDatasetView(
                 connection.getProblemId(),
                 connection.getDatasetId(),
-                startCode(connection.getFilePath())
+                startCode(connection.getFileUrl())
         );
     }
 
@@ -52,8 +52,10 @@ public class ProblemDatasetCommandService implements
     public UploadProblemDatasetView handle(UploadProblemDatasetCommand command) {
         validationPolicy.validate(command);
 
+        StoredDatasetFile storedFile = null;
+
         try {
-            StoredDatasetFile storedFile = storeDatasetFilePort.store(command);
+            storedFile = storeDatasetFilePort.store(command);
             ProblemDataset dataset = problemDatasetRepository.saveUploadedDataset(storedFile);
 
             return new UploadProblemDatasetView(
@@ -65,13 +67,17 @@ public class ProblemDatasetCommandService implements
                     dataset.getStatus()
             );
         } catch (Exception e) {
+            if (storedFile != null) {
+                storeDatasetFilePort.delete(storedFile.getFilePath());
+            }
+
             log.warn("Dataset upload failed. originalFileName={}", command.originalFileName(), e);
             throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED);
         }
     }
 
-    private String startCode(String filePath) {
+    private String startCode(String fileUrl) {
         return "import pandas as pd\n\n"
-                + "df = pd.read_csv(\"" + filePath + "\")";
+                + "df = pd.read_csv(\"" + fileUrl + "\")";
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/domain/model/ProblemDatasetConnection.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/domain/model/ProblemDatasetConnection.java
@@ -7,22 +7,22 @@ public class ProblemDatasetConnection {
 
     private final Long problemId;
     private final Long datasetId;
-    private final String filePath;
+    private final String fileUrl;
 
-    private ProblemDatasetConnection(Long problemId, Long datasetId, String filePath) {
+    private ProblemDatasetConnection(Long problemId, Long datasetId, String fileUrl) {
         if (problemId == null) {
             throw new ValidationException(ProblemErrorCode.PROBLEM_NOT_FOUND);
         }
         if (datasetId == null) {
             throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_NOT_FOUND);
         }
-        if (filePath == null || filePath.isBlank()) {
+        if (fileUrl == null || fileUrl.isBlank()) {
             throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE);
         }
 
         this.problemId = problemId;
         this.datasetId = datasetId;
-        this.filePath = filePath;
+        this.fileUrl = fileUrl;
     }
 
     public static ProblemDatasetConnection connect(Long problemId, Long datasetId, String filePath) {
@@ -37,7 +37,7 @@ public class ProblemDatasetConnection {
         return datasetId;
     }
 
-    public String getFilePath() {
-        return filePath;
+    public String getFileUrl() {
+        return fileUrl;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetPersistenceAdapter.java
@@ -37,7 +37,7 @@ public class ProblemDatasetPersistenceAdapter implements ProblemDatasetRepositor
                 problem.getProblemType(),
                 dataset.getDatasetId(),
                 connectedProblemId,
-                dataset.getFilePath()
+                dataset.getFileUrl()
         );
     }
 
@@ -54,7 +54,7 @@ public class ProblemDatasetPersistenceAdapter implements ProblemDatasetRepositor
         return ProblemDatasetConnection.connect(
                 problem.getProblemId(),
                 dataset.getDatasetId(),
-                dataset.getFilePath()
+                dataset.getFileUrl()
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/GcsDatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/GcsDatasetFileStorage.java
@@ -8,6 +8,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.wanted.codebombalms.problems.dataset.application.command.UploadProblemDatasetCommand;
 import com.wanted.codebombalms.problems.dataset.application.port.StoreDatasetFilePort;
 import com.wanted.codebombalms.problems.dataset.domain.model.StoredDatasetFile;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
@@ -19,6 +20,7 @@ import java.util.UUID;
 
 @Primary
 @Component
+@Slf4j
 public class GcsDatasetFileStorage implements StoreDatasetFilePort {
 
     private static final String CSV_CONTENT_TYPE = "text/csv";
@@ -64,6 +66,21 @@ public class GcsDatasetFileStorage implements StoreDatasetFilePort {
                 .setCredentials(loadCredentials())
                 .build()
                 .getService();
+    }
+
+    @Override
+    public void delete(String filePath) {
+        if (filePath == null || filePath.isBlank()) {
+            return;
+        }
+
+        try {
+            createStorage().delete(
+                    BlobId.of(properties.getStorage().getBucket(), filePath)
+            );
+        } catch (Exception e) {
+            log.warn("GCS에서 파일 삭제를 실패했습니다. filePath={}", filePath, e);
+        }
     }
 
     private GoogleCredentials loadCredentials() throws IOException {

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/LocalDatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/LocalDatasetFileStorage.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.problems.dataset.infrastructure.storage;
 import com.wanted.codebombalms.problems.dataset.application.command.UploadProblemDatasetCommand;
 import com.wanted.codebombalms.problems.dataset.application.port.StoreDatasetFilePort;
 import com.wanted.codebombalms.problems.dataset.domain.model.StoredDatasetFile;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -11,6 +12,7 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 @Component
+@Slf4j
 public class LocalDatasetFileStorage implements StoreDatasetFilePort {
 
     private static final String UPLOAD_DIR = "uploads/datasets";
@@ -36,5 +38,17 @@ public class LocalDatasetFileStorage implements StoreDatasetFilePort {
                 filePath,
                 command.fileSize()
         );
+    }
+
+    @Override
+    public void delete(String filePath) {
+        if(filePath == null || filePath.isBlank()) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(Path.of(filePath));
+        } catch (IOException e) {
+            log.warn("로컬 데이터 세트 삭제를 실패했습니다. filePath={}", filePath, e);
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemStartCodePersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemStartCodePersistenceAdapter.java
@@ -17,7 +17,7 @@ public class ProblemStartCodePersistenceAdapter implements LoadProblemStartCodeP
     public String loadStartCode(Long problemId) {
         return problemDatasetRepository.findFirstByProblem_ProblemIdAndStatus(problemId, ACTIVE_STATUS)
                 .map(dataset -> "import pandas as pd\n\n"
-                        + "df = pd.read_csv(\"" + dataset.getFilePath() + "\")")
+                        + "df = pd.read_csv(\"" + dataset.getFileUrl() + "\")")
                 .orElse(null);
     }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #266 

---

## 🛠️ 기능 관련 작업 내용

- 코드 실행형 문제에서 사용할 CSV 데이터셋을 Google Cloud Storage에 업로드하는 기능을 구현했습니다.
- 업로드 파일명은 UUID를 붙여 저장하도록 처리했습니다.
- GCS 업로드 후 원본 파일명, 저장 파일명, fileUrl, filePath, 상태값을 DB에 저장하도록 구현했습니다.
- 문제-데이터셋 연결 시 `pd.read_csv("GCS 공개 URL")` 형태의 시작 코드를 반환하도록 수정했습니다.
- 코드 문제 상세 조회 시 연결된 데이터셋의 GCS URL 기반 시작 코드가 내려가도록 반영했습니다.
- DB 저장 실패 시 GCS에 업로드된 파일 삭제를 시도할 수 있도록 파일 삭제 Port를 추가했습니다.
- GCP project id, bucket name, credentials path, dataset prefix를 설정값으로 분리했습니다.

---

## ♻️ 패키지 변경 사항

- `problems/dataset/application/service/ProblemDatasetCommandService` : 데이터셋 업로드 및 문제-데이터셋 연결 시 GCS URL 기반 시작 코드 생성 로직 추가
- `problems/dataset/application/port/StoreDatasetFilePort` : 파일 저장/삭제 Port 정의
- `problems/dataset/infrastructure/storage/GcsDatasetFileStorage` : GCS 업로드, UUID 파일명 생성, 공개 URL 생성, 파일 삭제 구현
- `problems/dataset/infrastructure/storage/GcpStorageProperties` : GCP Storage 설정값 바인딩 추가
- `problems/dataset/infrastructure/persistence/ProblemDatasetPersistenceAdapter` : 업로드된 데이터셋 저장 및 연결 시 fileUrl 제공
- `problems/dataset/infrastructure/persistence/ProblemDatasetJpaEntity` : 업로드 후 문제 연결이 가능하도록 데이터셋 엔티티 관리
- `problems/set/infrastructure/persistence/ProblemStartCodePersistenceAdapter` : 문제 상세 조회 시 GCS URL 기반 시작 코드 반환
- `src/main/resources/application.yml` : GCP Storage 관련 설정 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.