### PR TITLE
[Feat] 내 정보 조회 API 구현

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -1,0 +1,21 @@
+### ===== User 도메인 API 테스트 =====
+### 사전 조건: auth.http 11번(로그인) 또는 아래 0번 먼저 실행해서 쿠키 발급되어 있어야 해용
+### 0번 → 1번 → 2번 → 3번 순서대로 실행하세용
+
+### 0. (사전) 로그인 — 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
+### 1. 내 정보 조회 — 정상 (0번 직후 실행)
+GET http://localhost:8080/api/v1/users/me
+
+### 2. 로그아웃 (다음 401 케이스 준비)
+POST http://localhost:8080/api/v1/auth/logout
+
+### 3. 내 정보 조회 — 401 (로그아웃 후 / 쿠키 만료)
+GET http://localhost:8080/api/v1/users/me

--- a/src/main/java/com/wanted/codebombalms/user/application/query/MyProfileResult.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/query/MyProfileResult.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.user.application.query;
+
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+
+public record MyProfileResult(
+        String email,
+        String name,
+        String nickname,
+        String phone,
+        UserRole role,
+        AuthProvider provider,
+        boolean emailVerified
+) {
+
+    public static MyProfileResult from(User user) {
+        return new MyProfileResult(
+                user.getEmail(),
+                user.getName(),
+                user.getNickname(),
+                user.getPhone(),
+                user.getRole(),
+                user.getProvider(),
+                user.isEmailVerified()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetMyProfileService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetMyProfileService.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.user.application.query.MyProfileResult;
+import com.wanted.codebombalms.user.application.usecase.GetMyProfileUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetMyProfileService implements GetMyProfileUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public MyProfileResult getMyProfile(Long userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        return MyProfileResult.from(user);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/GetMyProfileUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/GetMyProfileUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import com.wanted.codebombalms.user.application.query.MyProfileResult;
+
+public interface GetMyProfileUseCase {
+
+    MyProfileResult getMyProfile(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/MyProfileController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/MyProfileController.java
@@ -1,0 +1,35 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.query.MyProfileResult;
+import com.wanted.codebombalms.user.application.usecase.GetMyProfileUseCase;
+import com.wanted.codebombalms.user.presentation.api.dto.response.MyProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class MyProfileController {
+
+    private final GetMyProfileUseCase getMyProfileUseCase;
+
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal Long userId
+    ) {
+        MyProfileResult result = getMyProfileUseCase.getMyProfile(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.MY_PROFILE_RETRIEVED,
+                UserResponseMessage.MY_PROFILE_RETRIEVED,
+                MyProfileResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+public class UserResponseCode {
+
+    private UserResponseCode() {}
+
+    public static final String MY_PROFILE_RETRIEVED = "USER-ME-RETRIEVED";
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+public class UserResponseMessage {
+
+    private UserResponseMessage() {}
+
+    public static final String MY_PROFILE_RETRIEVED = "내 정보 조회 성공";
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/MyProfileResponse.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.user.presentation.api.dto.response;
+
+import com.wanted.codebombalms.user.application.query.MyProfileResult;
+
+public record MyProfileResponse(
+        String email,
+        String name,
+        String nickname,
+        String phone,
+        String role,
+        String provider,
+        boolean emailVerified
+) {
+
+    public static MyProfileResponse from(MyProfileResult result) {
+        return new MyProfileResponse(
+                result.email(),
+                result.name(),
+                result.nickname(),
+                result.phone(),
+                result.role().name(),
+                result.provider().name(),
+                result.emailVerified()
+        );
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE

---

## 📌 작업한 이슈
- Closes #197

---

## 🛠️ 기능 관련 작업 내용

GET /api/v1/users/me` — 로그인 사용자의 프로필 조회 API

- **계층 분리** — `MyProfileResult`(Application) / `MyProfileResponse`(Presentation)로 분리, enum → String 변환은 Presentation에서 처리
- **인증** — `@PreAuthorize("isAuthenticated()")` + `@AuthenticationPrincipal`로 userId 추출, 비로그인 시 401 `AUT-016`
- **응답** — `USER-ME-RETRIEVED` / `"내 정보 조회 성공"` (도메인별 응답 상수 컨벤션 적용)
---

## ♻️ 패키지 변경 사항
**Application**
- `user/application/query/MyProfileResult` : 신규
- `user/application/usecase/GetMyProfileUseCase` : 신규
- `user/application/service/GetMyProfileService` : 신규

**Presentation**
- `user/presentation/api/MyProfileController` : 신규
- `user/presentation/api/UserResponseCode` / `UserResponseMessage` : 신규
- `user/presentation/api/dto/response/MyProfileResponse` : 신규

**Test**
- `http/user.http` : 신규 (테스트 시나리오 4개) 

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
