### PR TITLE
[Fix] 로그인 응답에 nickname 추가

### DIFF
--- a/http/auth.http
+++ b/http/auth.http
@@ -87,12 +87,12 @@ GET http://localhost:8080/api/v1/auth/check/nickname?nickname=길동이
 
 
 
-### 11. 로그인 성공 — 쿠키 2개 발급
+### 11. 로그인 성공 — 쿠키 2개 발급 + body.data.nickname 응답
 POST http://localhost:8080/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "email": "test1@example.com",
+  "email": "u01@test.com",
   "password": "Test1234!"
 }
 

--- a/src/main/java/com/wanted/codebombalms/auth/application/dto/LoginResult.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/dto/LoginResult.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.auth.application.dto;
+
+public record LoginResult(
+        String accessToken,
+        String refreshToken,
+        String nickname
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -1,7 +1,7 @@
 package com.wanted.codebombalms.auth.application.service;
 
 import com.wanted.codebombalms.auth.application.command.LoginCommand;
-import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
 import com.wanted.codebombalms.auth.application.usecase.LoginUseCase;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.model.LoginHistory;
@@ -32,7 +32,7 @@ public class LoginService implements LoginUseCase {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public TokenPair login(LoginCommand command, HttpServletRequest request) {
+    public LoginResult login(LoginCommand command, HttpServletRequest request) {
 
         // 1. 이메일로 회원 조회
         User user = userRepository.findByEmail(command.email())
@@ -73,7 +73,7 @@ public class LoginService implements LoginUseCase {
                 )
         );
 
-        return new TokenPair(accessToken, refreshToken);
+        return new LoginResult(accessToken, refreshToken, user.getNickname());
     }
 
     /** 프록시 환경(X-Forwarded-For) 고려한 클라이언트 IP 추출 */

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
@@ -1,10 +1,10 @@
 package com.wanted.codebombalms.auth.application.usecase;
 
 import com.wanted.codebombalms.auth.application.command.LoginCommand;
-import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface LoginUseCase {
 
-    TokenPair login(LoginCommand command, HttpServletRequest request);
+    LoginResult login(LoginCommand command, HttpServletRequest request);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
@@ -1,8 +1,9 @@
 package com.wanted.codebombalms.auth.presentation.api;
 
-import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
 import com.wanted.codebombalms.auth.application.usecase.LoginUseCase;
 import com.wanted.codebombalms.auth.presentation.api.dto.request.LoginRequest;
+import com.wanted.codebombalms.auth.presentation.api.dto.response.LoginResponse;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,34 +30,35 @@ public class LoginController {
 
     @Operation(
             summary = "로그인",
-            description = "이메일/비밀번호 검증 후 accessToken/refreshToken 쿠키 2개 발급. 단일 세션 강제 + 로그인 이력 저장."
+            description = "이메일/비밀번호 검증 후 accessToken/refreshToken 쿠키 2개 발급. 단일 세션 강제 + 로그인 이력 저장. 응답 body 의 data.nickname 으로 닉네임 노출."
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공 — 쿠키 2개 발급")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공 — 쿠키 2개 발급 + body 에 nickname 포함")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-001 이메일 또는 비밀번호 불일치")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "USR-007 계정 잠금 상태")
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<Void>> login(
+    public ResponseEntity<ApiResponse<LoginResponse>> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletRequest httpRequest,
             HttpServletResponse response
     ) {
-        TokenPair pair = loginUseCase.login(request.toCommand(), httpRequest);
+        LoginResult result = loginUseCase.login(request.toCommand(), httpRequest);
 
-        // 쿠키 2개 설정
+        // 쿠키 2개 설정 (토큰은 body 노출 X — HttpOnly 쿠키로만)
         response.addCookie(createCookie(
                 "accessToken",
-                pair.accessToken(),
+                result.accessToken(),
                 (int) (jwtTokenProvider.getAccessExpiration() / 1000)
         ));
         response.addCookie(createCookie(
                 "refreshToken",
-                pair.refreshToken(),
+                result.refreshToken(),
                 (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
         ));
 
         return ResponseEntity.ok(ApiResponse.success(
                 AuthResponseCode.LOGIN_COMPLETED,
-                AuthResponseMessage.LOGIN_COMPLETED
+                AuthResponseMessage.LOGIN_COMPLETED,
+                LoginResponse.from(result)
         ));
     }
 

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/LoginResponse.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/LoginResponse.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.response;
+
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
+
+public record LoginResponse(String nickname) {
+
+    public static LoginResponse from(LoginResult result) {
+        return new LoginResponse(result.nickname());
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -1,7 +1,7 @@
 package com.wanted.codebombalms.auth.application.service;
 
 import com.wanted.codebombalms.auth.application.command.LoginCommand;
-import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
@@ -55,21 +55,23 @@ class LoginServiceTest {
     }
 
     @Test
-    @DisplayName("정상 로그인 시 TokenPair를 반환하고 새 Refresh Token + LoginHistory를 저장한다.")
+    @DisplayName("정상 로그인 시 LoginResult(토큰 2개 + 닉네임)를 반환하고 새 Refresh Token + LoginHistory를 저장한다.")
     void 로그인_성공() {
         // given
         User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
-        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
         // when
-        TokenPair pair = loginService.login(command, httpRequest);
+        LoginResult result = loginService.login(command, httpRequest);
 
         // then
-        assertEquals("ACCESS_TOKEN", pair.accessToken());
-        assertEquals("REFRESH_TOKEN", pair.refreshToken());
+        assertEquals("ACCESS_TOKEN", result.accessToken());
+        assertEquals("REFRESH_TOKEN", result.refreshToken());
+        assertEquals("길동이", result.nickname());
         verify(refreshTokenRepository).deleteByUserId(1L);
         verify(refreshTokenRepository).save(any(RefreshToken.class));
         verify(loginHistoryRepository).save(any(LoginHistory.class));
@@ -134,7 +136,8 @@ class LoginServiceTest {
         User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
-        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
         // when


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE

---

## 📌 작업한 이슈

- 프론트엔드 요청 대응 (이슈 미등록)

---

## 🛠️ 기능 관련 작업 내용
- 로그인 응답 body 에 `data.nickname` 필드 추가 — 프론트가 HttpOnly 쿠키 토큰을 읽을 수 없는 제약 해소
- 토큰은 쿠키(`accessToken`, `refreshToken`)로만 발급, 닉네임만 응답 body 에 노출하는 보안/표시 정보 분리 구조
- `LoginResult` (Application) / `LoginResponse` (Presentation) 신규로 도입, `TokenPair` 는 `TokenReissueService` 에서 그대로 사용
- `LoginServiceTest` 에 `result.nickname()` 검증 추가 + Swagger `@Operation` description 갱신

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/application/dto`: `LoginResult` 신규 (accessToken, refreshToken, nickname)
- `codebombalms/auth/application/usecase`: `LoginUseCase` 반환 타입 `TokenPair` → `LoginResult`
- `codebombalms/auth/application/service`: `LoginService` 반환 변경 (user.getNickname() 전달)
- `codebombalms/auth/presentation/api/dto/response`: `LoginResponse` 신규 (nickname 단일 필드)
- `codebombalms/auth/presentation/api`: `LoginController` 응답 타입 `ApiResponse<Void>` → `ApiResponse<LoginResponse>` 변경
- `http/`: `auth.http` 11번 주석 갱신 (data.nickname 응답 명시)
- `test/.../auth/application/service`: `LoginServiceTest` 시그니처 + 닉네임 응답 검증 추가
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
