### PR TITLE
[Feat] Admin 학생 관리 API 3종 구현

### DIFF
--- a/http/admin.http
+++ b/http/admin.http
@@ -1,0 +1,81 @@
+### ===== Admin API 테스트 시나리오 =====
+### 사전 조건: DB 에 role = 'ADMIN' 계정 존재 (admin@test.com)
+### 사전 조건: 학생 계정 몇 개 가입 완료된 상태
+
+### 0. Admin 로그인 — 쿠키 발급 (먼저 실행!)
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "admin@test.com",
+  "password": "Test1234!"
+}
+
+### 1. 학생 전체 조회 — 정상 (기본 page=0, size=20)
+GET http://localhost:8080/api/v1/users
+
+### 2. 학생 전체 조회 — 페이지네이션 (page=0, size=5)
+GET http://localhost:8080/api/v1/users?page=0&size=5
+
+### 3. 학생 상세 조회 — 정상 (1번/2번에서 userId 확인 후 입력)
+GET http://localhost:8080/api/v1/admin/users/5
+
+### 4. 학생 상세 조회 — 404 (존재하지 않는 userId)
+GET http://localhost:8080/api/v1/admin/users/99999
+
+### 5. 계정 정지 — locked=true
+PATCH http://localhost:8080/api/v1/users/5/lock
+Content-Type: application/json
+
+{
+  "locked": true
+}
+
+### 6. 정지 처리 후 재조회 — isLocked: true 확인
+GET http://localhost:8080/api/v1/admin/users/5
+
+### 7. 계정 해제 — locked=false
+PATCH http://localhost:8080/api/v1/users/5/lock
+Content-Type: application/json
+
+{
+  "locked": false
+}
+
+### 8. 해제 처리 후 재조회 — isLocked: false 확인
+GET http://localhost:8080/api/v1/admin/users/5
+
+
+### ===== 권한 검증 시나리오 =====
+
+### 9. (사전) 로그아웃 → STUDENT 로그인 준비
+POST http://localhost:8080/api/v1/auth/logout
+
+### 10. STUDENT 로그인
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
+### 11. STUDENT 가 학생 전체 조회 시도 — 403 AUT-015
+GET http://localhost:8080/api/v1/users
+
+### 12. STUDENT 가 계정 정지 시도 — 403 AUT-015
+PATCH http://localhost:8080/api/v1/users/5/lock
+Content-Type: application/json
+
+{
+  "locked": true
+}
+
+### 13. (사전) 로그아웃 → 비로그인 상태
+POST http://localhost:8080/api/v1/auth/logout
+
+### 14. 비로그인 학생 전체 조회 — 401 AUT-016
+GET http://localhost:8080/api/v1/users
+
+### 15. 비로그인 학생 상세 조회 — 401 AUT-016
+GET http://localhost:8080/api/v1/admin/users/5

--- a/src/main/java/com/wanted/codebombalms/user/application/query/StudentDetail.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/query/StudentDetail.java
@@ -1,0 +1,34 @@
+package com.wanted.codebombalms.user.application.query;
+
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+
+import java.time.LocalDateTime;
+
+public record StudentDetail(
+        Long userId,
+        String email,
+        String name,
+        String nickname,
+        String phone,
+        UserRole role,
+        AuthProvider provider,
+        boolean isLocked,
+        LocalDateTime createdAt
+) {
+
+    public static StudentDetail from(User user) {
+        return new StudentDetail(
+                user.getUserId(),
+                user.getEmail(),
+                user.getName(),
+                user.getNickname(),
+                user.getPhone(),
+                user.getRole(),
+                user.getProvider(),
+                user.isLocked(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/query/StudentPageResult.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/query/StudentPageResult.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.application.query;
+
+import java.util.List;
+
+public record StudentPageResult(
+        List<StudentSummary> content,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/query/StudentSummary.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/query/StudentSummary.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.user.application.query;
+
+import com.wanted.codebombalms.user.domain.model.User;
+import java.time.LocalDateTime;
+
+public record StudentSummary(
+        Long userId,
+        String email,
+        String nickname,
+        boolean isLocked,
+        LocalDateTime createdAt
+) {
+
+    public static StudentSummary from(User user) {
+        return new StudentSummary(
+                user.getUserId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.isLocked(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
@@ -1,0 +1,35 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.user.application.usecase.ChangeStudentLockUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChangeStudentLockService implements ChangeStudentLockUseCase {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void changeLock(Long userId, boolean locked) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        if (locked) {
+            user.lock();
+            refreshTokenRepository.deleteByUserId(userId);
+        } else {
+            user.unlock();
+        }
+
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentDetailService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentDetailService.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.user.application.query.StudentDetail;
+import com.wanted.codebombalms.user.application.usecase.GetStudentDetailUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetStudentDetailService implements GetStudentDetailUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public StudentDetail getStudentDetail(Long userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        return StudentDetail.from(user);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.user.application.query.StudentPageResult;
+import com.wanted.codebombalms.user.application.query.StudentSummary;
+import com.wanted.codebombalms.user.application.usecase.GetStudentsUseCase;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetStudentsService implements GetStudentsUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public StudentPageResult getStudents(int page, int size) {
+        // 1. 학생 목록 조회 (가입 최신순)
+        List<User> users = userRepository.findAllByRole(UserRole.STUDENT, page, size);
+
+        // 2. 전체 학생 수
+        long totalElements = userRepository.countByRole(UserRole.STUDENT);
+
+        // 3. 전체 페이지 수 (size = 0 방어)
+        int totalPages = size <= 0 ? 0 : (int) Math.ceil((double) totalElements / size);
+
+        // 4. 변환
+        List<StudentSummary> content = users.stream()
+                .map(StudentSummary::from)
+                .toList();
+
+        return new StudentPageResult(content, totalElements, totalPages);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/ChangeStudentLockUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/ChangeStudentLockUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+public interface ChangeStudentLockUseCase {
+
+    void changeLock(Long userId, boolean locked);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/GetStudentDetailUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/GetStudentDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import com.wanted.codebombalms.user.application.query.StudentDetail;
+
+public interface GetStudentDetailUseCase {
+
+    StudentDetail getStudentDetail(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/GetStudentsUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/GetStudentsUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import com.wanted.codebombalms.user.application.query.StudentPageResult;
+
+public interface GetStudentsUseCase {
+
+    StudentPageResult getStudents(int page, int size);
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
@@ -1,7 +1,9 @@
 package com.wanted.codebombalms.user.domain.repository;
 
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -15,4 +17,8 @@ public interface UserRepository {
     boolean existsByNickname(String nickname);
 
     User save(User user);
+
+    List<User> findAllByRole(UserRole role, int page, int size);
+
+    long countByRole(UserRole role);
 }

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -1,7 +1,10 @@
 package com.wanted.codebombalms.user.infrastructure.persistence;
 
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, Long> {
@@ -13,4 +16,8 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    List<UserJpaEntity> findAllByRoleOrderByCreatedAtDesc(UserRole role, Pageable pageable);
+
+    long countByRole(UserRole role);
 }

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -1,10 +1,13 @@
 package com.wanted.codebombalms.user.infrastructure.persistence;
 
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -50,5 +53,18 @@ public class UserRepositoryAdapter implements UserRepository {
         }
 
         return springDataUserRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public List<User> findAllByRole(UserRole role, int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size);
+        return springDataUserRepository.findAllByRoleOrderByCreatedAtDesc(role, pageable).stream()
+                .map(UserJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public long countByRole(UserRole role) {
+        return springDataUserRepository.countByRole(role);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/ChangeStudentLockController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/ChangeStudentLockController.java
@@ -1,0 +1,47 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.usecase.ChangeStudentLockUseCase;
+import com.wanted.codebombalms.user.presentation.api.dto.request.ChangeStudentLockRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - Admin", description = "관리자 전용 학생 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class ChangeStudentLockController {
+
+    private final ChangeStudentLockUseCase changeStudentLockUseCase;
+
+    @Operation(
+            summary = "계정 정지/해제 (Admin)",
+            description = "userId 대상 계정 잠금 상태 변경. locked=true 정지 + Refresh Token 전체 삭제(강제 로그아웃) / locked=false 해제."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "처리 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "AUT-015 권한 없음")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USR-001 존재하지 않는 회원")
+    @PatchMapping("/{userId}/lock")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> changeLock(
+            @PathVariable Long userId,
+            @Valid @RequestBody ChangeStudentLockRequest request
+    ) {
+        changeStudentLockUseCase.changeLock(userId, request.locked());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.STUDENT_LOCK_CHANGED,
+                UserResponseMessage.STUDENT_LOCK_CHANGED
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentDetailController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentDetailController.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.query.StudentDetail;
+import com.wanted.codebombalms.user.application.usecase.GetStudentDetailUseCase;
+import com.wanted.codebombalms.user.presentation.api.dto.response.StudentDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - Admin", description = "관리자 전용 학생 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@RequiredArgsConstructor
+public class GetStudentDetailController {
+
+    private final GetStudentDetailUseCase getStudentDetailUseCase;
+
+    @Operation(
+            summary = "학생 상세 조회 (Admin)",
+            description = "userId 로 특정 회원 상세 정보 조회 (모든 필드). 관리자 권한 필요."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "AUT-015 권한 없음")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USR-001 존재하지 않는 회원")
+    @GetMapping("/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<StudentDetailResponse>> getStudentDetail(
+            @PathVariable Long userId
+    ) {
+        StudentDetail detail = getStudentDetailUseCase.getStudentDetail(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.STUDENT_DETAIL_RETRIEVED,
+                UserResponseMessage.STUDENT_DETAIL_RETRIEVED,
+                StudentDetailResponse.from(detail)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentsController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentsController.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.query.StudentPageResult;
+import com.wanted.codebombalms.user.application.usecase.GetStudentsUseCase;
+import com.wanted.codebombalms.user.presentation.api.dto.response.StudentPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - Admin", description = "관리자 전용 학생 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class GetStudentsController {
+
+    private final GetStudentsUseCase getStudentsUseCase;
+
+    @Operation(
+            summary = "학생 전체 조회 (Admin)",
+            description = "역할 STUDENT 인 회원 목록 페이지 조회 (가입 최신순). 관리자 권한 필요."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "AUT-015 권한 없음")
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponse<StudentPageResponse>> getStudents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        StudentPageResult result = getStudentsUseCase.getStudents(page, size);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.STUDENTS_RETRIEVED,
+                UserResponseMessage.STUDENTS_RETRIEVED,
+                StudentPageResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
@@ -7,4 +7,5 @@ public class UserResponseCode {
     public static final String MY_PROFILE_RETRIEVED = "USER-ME-RETRIEVED";
     public static final String STUDENTS_RETRIEVED = "USER-STUDENTS-RETRIEVED";
     public static final String STUDENT_DETAIL_RETRIEVED = "USER-STUDENT-DETAIL-RETRIEVED";
+    public static final String STUDENT_LOCK_CHANGED = "USER-STUDENT-LOCK-CHANGED";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
@@ -5,4 +5,6 @@ public class UserResponseCode {
     private UserResponseCode() {}
 
     public static final String MY_PROFILE_RETRIEVED = "USER-ME-RETRIEVED";
+    public static final String STUDENTS_RETRIEVED = "USER-STUDENTS-RETRIEVED";
+    public static final String STUDENT_DETAIL_RETRIEVED = "USER-STUDENT-DETAIL-RETRIEVED";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
@@ -5,4 +5,6 @@ public class UserResponseMessage {
     private UserResponseMessage() {}
 
     public static final String MY_PROFILE_RETRIEVED = "내 정보 조회 성공";
+    public static final String STUDENTS_RETRIEVED = "학생 전체 조회 성공";
+    public static final String STUDENT_DETAIL_RETRIEVED = "학생 상세 조회 성공";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
@@ -7,4 +7,5 @@ public class UserResponseMessage {
     public static final String MY_PROFILE_RETRIEVED = "내 정보 조회 성공";
     public static final String STUDENTS_RETRIEVED = "학생 전체 조회 성공";
     public static final String STUDENT_DETAIL_RETRIEVED = "학생 상세 조회 성공";
+    public static final String STUDENT_LOCK_CHANGED = "계정 정지/해제 처리 성공";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/request/ChangeStudentLockRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/request/ChangeStudentLockRequest.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.presentation.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ChangeStudentLockRequest(
+
+        @NotNull(message = "locked 값은 필수입니다.")
+        Boolean locked
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/StudentDetailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/StudentDetailResponse.java
@@ -1,0 +1,32 @@
+package com.wanted.codebombalms.user.presentation.api.dto.response;
+
+import com.wanted.codebombalms.user.application.query.StudentDetail;
+
+import java.time.LocalDateTime;
+
+public record StudentDetailResponse(
+        Long userId,
+        String email,
+        String name,
+        String nickname,
+        String phone,
+        String role,
+        String provider,
+        boolean isLocked,
+        LocalDateTime createdAt
+) {
+
+    public static StudentDetailResponse from(StudentDetail detail) {
+        return new StudentDetailResponse(
+                detail.userId(),
+                detail.email(),
+                detail.name(),
+                detail.nickname(),
+                detail.phone(),
+                detail.role().name(),
+                detail.provider().name(),
+                detail.isLocked(),
+                detail.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/StudentPageResponse.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/StudentPageResponse.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.user.presentation.api.dto.response;
+
+import com.wanted.codebombalms.user.application.query.StudentPageResult;
+
+import java.util.List;
+
+public record StudentPageResponse(
+        List<StudentSummaryResponse> content,
+        long totalElements,
+        int totalPages
+) {
+
+    public static StudentPageResponse from(StudentPageResult result) {
+        List<StudentSummaryResponse> content = result.content().stream()
+                .map(StudentSummaryResponse::from)
+                .toList();
+        return new StudentPageResponse(content, result.totalElements(), result.totalPages());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/StudentSummaryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/dto/response/StudentSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.user.presentation.api.dto.response;
+
+import com.wanted.codebombalms.user.application.query.StudentSummary;
+
+import java.time.LocalDateTime;
+
+public record StudentSummaryResponse(
+        Long userId,
+        String email,
+        String nickname,
+        boolean isLocked,
+        LocalDateTime createdAt
+) {
+
+    public static StudentSummaryResponse from(StudentSummary summary) {
+        return new StudentSummaryResponse(
+                summary.userId(),
+                summary.email(),
+                summary.nickname(),
+                summary.isLocked(),
+                summary.createdAt()
+        );
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #117 + Closes #118 + Closes #119

---

## 🛠️ 기능 관련 작업 내용
- `GET /api/v1/users` — 학생 전체 조회 (페이지네이션 `page`/`size`, `role=STUDENT` 필터, 가입 최신순 정렬)
- `GET /api/v1/admin/users/{userId}` — 학생 상세 조회 (9필드, 404 USR-001 분기)
- `PATCH /api/v1/users/{userId}/lock` — `User.lock()`/`unlock()` 도메인 행위 + 정지 시 Refresh Token 전체 삭제(강제 로그아웃)
- 공통 — `@PreAuthorize("hasRole('ADMIN')")` 권한 분리, UseCase 단위 Controller 분리 컨벤션 적용, Swagger 어노테이션 동시 작성

---

## ♻️ 패키지 변경 사항
- `codebombalms/user/application/query`: `StudentSummary` / `StudentPageResult` / `StudentDetail` 신규 (Application 결과 record 3종)
- `codebombalms/user/application/usecase`: `GetStudentsUseCase` / `GetStudentDetailUseCase` / `ChangeStudentLockUseCase` 신규
- `codebombalms/user/application/service`: 위 3개 UseCase 구현체 신규 (`@Transactional(readOnly=true)` 또는 `@Transactional`)
- `codebombalms/user/domain/repository`: `UserRepository` 에 `findAllByRole`, `countByRole` 메서드 추가 (도메인 Port 가 Spring Data 의존 X)
- `codebombalms/user/infrastructure/persistence`: `SpringDataUserRepository` JPA 메서드명 매직 + `UserRepositoryAdapter` 페이지네이션 변환 구현
- `codebombalms/user/presentation/api`: `GetStudentsController` / `GetStudentDetailController` / `ChangeStudentLockController` 신규 + `UserResponseCode` / `UserResponseMessage` 상수 3개 추가
- `codebombalms/user/presentation/api/dto/request`: `ChangeStudentLockRequest` 신규 (`@NotNull Boolean locked`)
- `codebombalms/user/presentation/api/dto/response`: `StudentSummaryResponse` / `StudentPageResponse` / `StudentDetailResponse` 신규 (enum → String 변환)
- `http/`: `admin.http` 신규 (테스트 시나리오 15개 — Admin/STUDENT/비로그인 권한 검증 포함)
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
