### PR TITLE
[Fix] SecurityConfig 인증/인가 잠금 적용

### DIFF
--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -44,19 +44,19 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // 추가
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Swagger
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // 인증 불필요
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/users/find-email").permitAll()
-                        // course 및 lecture 테스트
+                        // 강의/코스 브라우징
                         .requestMatchers("/api/v1/courses/**").permitAll()
                         .requestMatchers("/api/v1/lectures/**").permitAll()
-                        // 관리자 전용
-                        .requestMatchers("/api/v1/admin/**").permitAll()
+                        // 운영/관리자 전용 (권한 경계 확정 전까지 둘 다 허용)
+                        .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN", "OPERATOR")
                         // 그 외 모두 인증 필요
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtTokenProvider),


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- 이슈 없음 (팀 합의 후 보안 설정 즉시 적용)

---

## 🛠️ 기능 관련 작업 내용
- `/api/v1/admin/**` 접근을 ADMIN·OPERATOR 권한으로 제한
- `anyRequest` 를 permitAll에서 authenticated로 전환하여 미인증 접근 차단
- auth, courses, lectures 공개 엔드포인트는 화이트리스트로 유지

---

## ♻️ 패키지 변경 사항
- `codebombalms/global/infrastructure/config/security/SecurityConfig`: authorizeHttpRequests 권한 규칙 잠금
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
