### PR TITLE
[Feat] 로그인 응답에 role 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/dto/LoginResult.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/dto/LoginResult.java
@@ -1,8 +1,11 @@
 package com.wanted.codebombalms.auth.application.dto;
 
+import com.wanted.codebombalms.user.domain.model.UserRole;
+
 public record LoginResult(
         String accessToken,
         String refreshToken,
-        String nickname
+        String nickname,
+        UserRole role
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -73,7 +73,7 @@ public class LoginService implements LoginUseCase {
                 )
         );
 
-        return new LoginResult(accessToken, refreshToken, user.getNickname());
+        return new LoginResult(accessToken, refreshToken, user.getNickname(), user.getRole());
     }
 
     /** 프록시 환경(X-Forwarded-For) 고려한 클라이언트 IP 추출 */

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/LoginResponse.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/LoginResponse.java
@@ -2,9 +2,9 @@ package com.wanted.codebombalms.auth.presentation.api.dto.response;
 
 import com.wanted.codebombalms.auth.application.dto.LoginResult;
 
-public record LoginResponse(String nickname) {
+public record LoginResponse(String nickname, String role) {
 
     public static LoginResponse from(LoginResult result) {
-        return new LoginResponse(result.nickname());
+        return new LoginResponse(result.nickname(), result.role(). name());
     }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- 이슈 없음 

---

## 🛠️ 기능 관련 작업 내용
- 로그인 응답 `data` 에 `role` 필드 추가 
- 토큰은 기존대로 HttpOnly 쿠키 유지, `role` 만 body 노출
- 값: `STUDENT` / `OPERATOR` / `ADMIN`

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/application/dto/LoginResult`: `UserRole role` 필드 추가
- `codebombalms/auth/application/service/LoginService`: 반환부에 `user.getRole()` 전달
- `codebombalms/auth/presentation/api/dto/response/LoginResponse`: `role` 필드 추가 (enum → `name()` 문자열)
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
