### PR TITLE
[Feat] 강의 문제세트 soft delete 및 hard delete 처리 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
@@ -11,6 +11,7 @@ import com.wanted.codebombalms.course.application.usecase.CourseCommandUseCase;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -34,6 +35,7 @@ public class CourseCommandService implements CourseCommandUseCase {
     private final CourseCategoryPolicy courseCategoryPolicy;
     private final CoursePublishPolicy coursePublishPolicy;
     private final LectureManagementPort lectureManagementPort;
+    private final CourseProblemSetRepository courseProblemSetRepository;
 
     @LogBusiness
     @LogPerformance
@@ -110,6 +112,7 @@ public class CourseCommandService implements CourseCommandUseCase {
         course.delete();
         courseRepository.save(course);
         lectureManagementPort.deleteLecturesByCourseId(courseId);
+        courseProblemSetRepository.deleteByCourseId(courseId);
 
         log.info("[CourseCommandService] deleted course - courseId: {}", courseId);
     }

--- a/src/main/java/com/wanted/codebombalms/course/domain/model/CourseProblemSet.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/model/CourseProblemSet.java
@@ -3,16 +3,19 @@ package com.wanted.codebombalms.course.domain.model;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
+
 @Getter
 @ToString
 public class CourseProblemSet {
 
-    private final Long courseProblemSetId;
-    private final Long courseId;
-    private final Long lectureId;
-    private final Long problemSetId;
-    private final CourseProblemSetRole role;
-    private final Integer displayOrder;
+    private Long courseProblemSetId;
+    private Long courseId;
+    private Long lectureId;
+    private Long problemSetId;
+    private CourseProblemSetRole role;
+    private Integer displayOrder;
+    private LocalDateTime deletedAt;
 
     private CourseProblemSet(
             Long courseProblemSetId,
@@ -20,7 +23,8 @@ public class CourseProblemSet {
             Long lectureId,
             Long problemSetId,
             CourseProblemSetRole role,
-            Integer displayOrder
+            Integer displayOrder,
+            LocalDateTime deletedAt
     ) {
         this.courseProblemSetId = courseProblemSetId;
         this.courseId = courseId;
@@ -28,6 +32,7 @@ public class CourseProblemSet {
         this.problemSetId = problemSetId;
         this.role = role;
         this.displayOrder = displayOrder;
+        this.deletedAt = deletedAt;
     }
 
     public static CourseProblemSet create(
@@ -37,7 +42,7 @@ public class CourseProblemSet {
             CourseProblemSetRole role,
             Integer displayOrder
     ) {
-        return new CourseProblemSet(null, courseId, lectureId, problemSetId, role, displayOrder);
+        return new CourseProblemSet(null, courseId, lectureId, problemSetId, role, displayOrder, null);
     }
 
     public static CourseProblemSet restore(
@@ -48,6 +53,22 @@ public class CourseProblemSet {
             CourseProblemSetRole role,
             Integer displayOrder
     ) {
-        return new CourseProblemSet(courseProblemSetId, courseId, lectureId, problemSetId, role, displayOrder);
+        return restore(courseProblemSetId, courseId, lectureId, problemSetId, role, displayOrder, null);
+    }
+
+    public static CourseProblemSet restore(
+            Long courseProblemSetId,
+            Long courseId,
+            Long lectureId,
+            Long problemSetId,
+            CourseProblemSetRole role,
+            Integer displayOrder,
+            LocalDateTime deletedAt
+    ) {
+        return new CourseProblemSet(courseProblemSetId, courseId, lectureId, problemSetId, role, displayOrder, deletedAt);
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/domain/repository/CourseProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/repository/CourseProblemSetRepository.java
@@ -18,4 +18,6 @@ public interface CourseProblemSetRepository {
     Optional<CourseProblemSet> findById(Long courseProblemSetId);
 
     void deleteByCourseId(Long courseId);
+
+    void deleteByLectureId(Long lectureId);
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/cleanup/CourseCleanupConfig.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/cleanup/CourseCleanupConfig.java
@@ -1,0 +1,38 @@
+package com.wanted.codebombalms.course.infrastructure.cleanup;
+
+import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseProblemSetRepository;
+import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseRepository;
+import com.wanted.codebombalms.global.application.cleanup.DefaultHardDeleteTarget;
+import com.wanted.codebombalms.global.application.cleanup.port.HardDeleteTarget;
+import java.time.Period;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+public class CourseCleanupConfig {
+
+    @Bean
+    @Order(10)
+    public HardDeleteTarget courseProblemSetHardDeleteTarget(
+            SpringDataCourseProblemSetRepository repository
+    ) {
+        return new DefaultHardDeleteTarget(
+                "course-problem-set",
+                Period.ofMonths(6),
+                repository::hardDeleteByDeletedAtBefore
+        );
+    }
+
+    @Bean
+    @Order(30)
+    public HardDeleteTarget courseHardDeleteTarget(
+            SpringDataCourseRepository repository
+    ) {
+        return new DefaultHardDeleteTarget(
+                "course",
+                Period.ofMonths(6),
+                repository::hardDeleteByDeletedAtBefore
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetJpaEntity.java
@@ -16,6 +16,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -44,6 +46,9 @@ public class CourseProblemSetJpaEntity {
     @Column(name = "display_order", nullable = false)
     private Integer displayOrder;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     private CourseProblemSetJpaEntity(
             CourseJpaEntity course,
             Long lectureId,
@@ -67,6 +72,7 @@ public class CourseProblemSetJpaEntity {
                 courseProblemSet.getDisplayOrder()
         );
         entity.courseProblemSetId = courseProblemSet.getCourseProblemSetId();
+        entity.deletedAt = courseProblemSet.getDeletedAt();
         return entity;
     }
 
@@ -76,6 +82,11 @@ public class CourseProblemSetJpaEntity {
         this.problemSetId = courseProblemSet.getProblemSetId();
         this.role = courseProblemSet.getRole();
         this.displayOrder = courseProblemSet.getDisplayOrder();
+        this.deletedAt = courseProblemSet.getDeletedAt();
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
     }
 
     public CourseProblemSet toDomain() {
@@ -85,7 +96,8 @@ public class CourseProblemSetJpaEntity {
                 lectureId,
                 problemSetId,
                 role,
-                displayOrder
+                displayOrder,
+                deletedAt
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetRepositoryAdapter.java
@@ -34,7 +34,7 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public List<CourseProblemSet> findByCourseId(Long courseId) {
-        return springDataCourseProblemSetRepository.findByCourse_CourseId(courseId)
+        return springDataCourseProblemSetRepository.findByCourse_CourseIdAndDeletedAtIsNull(courseId)
                 .stream()
                 .map(CourseProblemSetJpaEntity::toDomain)
                 .toList();
@@ -42,7 +42,7 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public List<CourseProblemSet> findByCourseIdAndRole(Long courseId, CourseProblemSetRole role) {
-        return springDataCourseProblemSetRepository.findByCourse_CourseIdAndRole(courseId, role)
+        return springDataCourseProblemSetRepository.findByCourse_CourseIdAndRoleAndDeletedAtIsNull(courseId, role)
                 .stream()
                 .map(CourseProblemSetJpaEntity::toDomain)
                 .toList();
@@ -50,7 +50,7 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public List<CourseProblemSet> findByLectureId(Long lectureId) {
-        return springDataCourseProblemSetRepository.findByLectureIdOrderByDisplayOrderAsc(lectureId)
+        return springDataCourseProblemSetRepository.findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(lectureId)
                 .stream()
                 .map(CourseProblemSetJpaEntity::toDomain)
                 .toList();
@@ -58,14 +58,25 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public Optional<CourseProblemSet> findById(Long courseProblemSetId) {
-        return springDataCourseProblemSetRepository.findById(courseProblemSetId)
+        return springDataCourseProblemSetRepository.findByCourseProblemSetIdAndDeletedAtIsNull(courseProblemSetId)
                 .map(CourseProblemSetJpaEntity::toDomain);
     }
 
     @Override
     public void deleteByCourseId(Long courseId) {
-        springDataCourseProblemSetRepository.deleteAll(
-                springDataCourseProblemSetRepository.findByCourse_CourseId(courseId)
-        );
+        List<CourseProblemSetJpaEntity> problemSets =
+                springDataCourseProblemSetRepository.findByCourse_CourseIdAndDeletedAtIsNull(courseId);
+
+        problemSets.forEach(CourseProblemSetJpaEntity::delete);
+        springDataCourseProblemSetRepository.saveAll(problemSets);
+    }
+
+    @Override
+    public void deleteByLectureId(Long lectureId) {
+        List<CourseProblemSetJpaEntity> problemSets =
+                springDataCourseProblemSetRepository.findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(lectureId);
+
+        problemSets.forEach(CourseProblemSetJpaEntity::delete);
+        springDataCourseProblemSetRepository.saveAll(problemSets);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseProblemSetRepository.java
@@ -1,14 +1,60 @@
 package com.wanted.codebombalms.course.infrastructure.persistence;
 
 import com.wanted.codebombalms.course.domain.model.CourseProblemSetRole;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SpringDataCourseProblemSetRepository extends JpaRepository<CourseProblemSetJpaEntity, Long> {
 
-    List<CourseProblemSetJpaEntity> findByCourse_CourseId(Long courseId);
+    List<CourseProblemSetJpaEntity> findByCourse_CourseIdAndDeletedAtIsNull(Long courseId);
 
-    List<CourseProblemSetJpaEntity> findByCourse_CourseIdAndRole(Long courseId, CourseProblemSetRole role);
+    List<CourseProblemSetJpaEntity> findByCourse_CourseIdAndRoleAndDeletedAtIsNull(
+            Long courseId,
+            CourseProblemSetRole role
+    );
 
-    List<CourseProblemSetJpaEntity> findByLectureIdOrderByDisplayOrderAsc(Long lectureId);
+    List<CourseProblemSetJpaEntity> findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(Long lectureId);
+
+    Optional<CourseProblemSetJpaEntity> findByCourseProblemSetIdAndDeletedAtIsNull(Long courseProblemSetId);
+
+    @Transactional
+    default int hardDeleteByDeletedAtBefore(LocalDateTime threshold) {
+        List<Long> lectureProblemSetIds = findHardDeleteTargetIds(threshold);
+        if (lectureProblemSetIds.isEmpty()) {
+            return 0;
+        }
+
+        deleteLectureProblemProgressesByLectureProblemSetIds(lectureProblemSetIds);
+        return deleteLectureProblemSetsByIds(lectureProblemSetIds);
+    }
+
+    @Query("""
+            select cps.courseProblemSetId
+            from CourseProblemSetJpaEntity cps
+            where cps.deletedAt is not null
+              and cps.deletedAt < :threshold
+            """)
+    List<Long> findHardDeleteTargetIds(@Param("threshold") LocalDateTime threshold);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureProblemProgressJpaEntity p
+            where p.lectureProblemSetId in :lectureProblemSetIds
+            """)
+    int deleteLectureProblemProgressesByLectureProblemSetIds(
+            @Param("lectureProblemSetIds") List<Long> lectureProblemSetIds
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from CourseProblemSetJpaEntity cps
+            where cps.courseProblemSetId in :lectureProblemSetIds
+            """)
+    int deleteLectureProblemSetsByIds(@Param("lectureProblemSetIds") List<Long> lectureProblemSetIds);
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -1,10 +1,15 @@
 package com.wanted.codebombalms.course.infrastructure.persistence;
 
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntity, Long> {
 
@@ -22,4 +27,93 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
     Optional<CourseJpaEntity> findByCourseIdAndStatusAndDeletedAtIsNull(Long courseId, CourseStatus status);
 
     List<CourseJpaEntity> findByInstructorIdAndDeletedAtIsNull(Long instructorId);
+
+    @Transactional
+    default int hardDeleteByDeletedAtBefore(LocalDateTime threshold) {
+        List<Long> courseIds = findHardDeleteTargetIds(threshold);
+        if (courseIds.isEmpty()) {
+            return 0;
+        }
+
+        List<Long> lectureIds = findLectureIdsByCourseIds(courseIds);
+        List<Long> lectureProblemSetIds = findLectureProblemSetIdsByCourseIds(courseIds);
+
+        if (!lectureProblemSetIds.isEmpty()) {
+            deleteLectureProblemProgressesByLectureProblemSetIds(lectureProblemSetIds);
+        }
+        if (!lectureIds.isEmpty()) {
+            deleteLectureProgressesByLectureIds(lectureIds);
+        }
+
+        deleteLectureProblemSetsByCourseIds(courseIds);
+        deleteLecturesByCourseIds(courseIds);
+        deleteEnrollmentsByCourseIds(courseIds);
+        return deleteCoursesByIds(courseIds);
+    }
+
+    @Query("""
+            select c.courseId
+            from CourseJpaEntity c
+            where c.deletedAt is not null
+              and c.deletedAt < :threshold
+            """)
+    List<Long> findHardDeleteTargetIds(@Param("threshold") LocalDateTime threshold);
+
+    @Query("""
+            select l.lectureId
+            from LectureJpaEntity l
+            where l.course.courseId in :courseIds
+            """)
+    List<Long> findLectureIdsByCourseIds(@Param("courseIds") List<Long> courseIds);
+
+    @Query("""
+            select cps.courseProblemSetId
+            from CourseProblemSetJpaEntity cps
+            where cps.course.courseId in :courseIds
+            """)
+    List<Long> findLectureProblemSetIdsByCourseIds(@Param("courseIds") List<Long> courseIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureProblemProgressJpaEntity p
+            where p.lectureProblemSetId in :lectureProblemSetIds
+            """)
+    int deleteLectureProblemProgressesByLectureProblemSetIds(
+            @Param("lectureProblemSetIds") List<Long> lectureProblemSetIds
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureProgressJpaEntity p
+            where p.lectureId in :lectureIds
+            """)
+    int deleteLectureProgressesByLectureIds(@Param("lectureIds") List<Long> lectureIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from CourseProblemSetJpaEntity cps
+            where cps.course.courseId in :courseIds
+            """)
+    int deleteLectureProblemSetsByCourseIds(@Param("courseIds") List<Long> courseIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureJpaEntity l
+            where l.course.courseId in :courseIds
+            """)
+    int deleteLecturesByCourseIds(@Param("courseIds") List<Long> courseIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from EnrollmentJpaEntity e
+            where e.course.courseId in :courseIds
+            """)
+    int deleteEnrollmentsByCourseIds(@Param("courseIds") List<Long> courseIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from CourseJpaEntity c
+            where c.courseId in :courseIds
+            """)
+    int deleteCoursesByIds(@Param("courseIds") List<Long> courseIds);
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseProblemAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseProblemAdapter.java
@@ -18,7 +18,10 @@ public class LearningCourseProblemAdapter implements LearningCourseProblemPort {
 
     @Override
     public List<Long> findMainLectureProblemSetIdsByCourse(Long courseId) {
-        return courseProblemSetRepository.findByCourse_CourseIdAndRole(courseId, CourseProblemSetRole.MAIN)
+        return courseProblemSetRepository.findByCourse_CourseIdAndRoleAndDeletedAtIsNull(
+                        courseId,
+                        CourseProblemSetRole.MAIN
+                )
                 .stream()
                 .map(CourseProblemSetJpaEntity::getCourseProblemSetId)
                 .toList();
@@ -26,7 +29,7 @@ public class LearningCourseProblemAdapter implements LearningCourseProblemPort {
 
     @Override
     public List<Long> findLectureProblemSetIdsByLecture(Long lectureId) {
-        return courseProblemSetRepository.findByLectureIdOrderByDisplayOrderAsc(lectureId)
+        return courseProblemSetRepository.findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(lectureId)
                 .stream()
                 .map(CourseProblemSetJpaEntity::getCourseProblemSetId)
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
@@ -29,6 +30,7 @@ public class LectureCommandService implements LectureCommandUseCase {
     private final LectureRepository lectureRepository;
     private final CourseCatalogPort courseCatalogPort;
     private final LectureCreationPolicy lectureCreationPolicy;
+    private final CourseProblemSetRepository courseProblemSetRepository;
 
     @Override
     public Lecture createLecture(CreateLectureCommand command) {
@@ -88,6 +90,7 @@ public class LectureCommandService implements LectureCommandUseCase {
 
         lecture.delete();
         lectureRepository.save(lecture);
+        courseProblemSetRepository.deleteByLectureId(lectureId);
     }
 
     private void validateLectureOrder(Long courseId, Long lectureId, Integer lectureOrder) {

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/cleanup/LectureCleanupConfig.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/cleanup/LectureCleanupConfig.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.lecture.infrastructure.cleanup;
+
+import com.wanted.codebombalms.global.application.cleanup.DefaultHardDeleteTarget;
+import com.wanted.codebombalms.global.application.cleanup.port.HardDeleteTarget;
+import com.wanted.codebombalms.lecture.infrastructure.persistence.SpringDataLectureRepository;
+import java.time.Period;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+public class LectureCleanupConfig {
+
+    @Bean
+    @Order(20)
+    public HardDeleteTarget lectureHardDeleteTarget(
+            SpringDataLectureRepository repository
+    ) {
+        return new DefaultHardDeleteTarget(
+                "lecture",
+                Period.ofMonths(6),
+                repository::hardDeleteByDeletedAtBefore
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -1,9 +1,14 @@
 package com.wanted.codebombalms.lecture.infrastructure.persistence;
 
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEntity, Long> {
 
@@ -18,4 +23,66 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
     boolean existsByCourse_CourseIdAndDeletedAtIsNull(Long courseId);
 
     boolean existsByCourse_CourseIdAndLectureIdAndDeletedAtIsNull(Long courseId, Long lectureId);
+
+    @Transactional
+    default int hardDeleteByDeletedAtBefore(LocalDateTime threshold) {
+        List<Long> lectureIds = findHardDeleteTargetIds(threshold);
+        if (lectureIds.isEmpty()) {
+            return 0;
+        }
+
+        List<Long> lectureProblemSetIds = findLectureProblemSetIdsByLectureIds(lectureIds);
+        if (!lectureProblemSetIds.isEmpty()) {
+            deleteLectureProblemProgressesByLectureProblemSetIds(lectureProblemSetIds);
+        }
+
+        deleteLectureProblemSetsByLectureIds(lectureIds);
+        deleteLectureProgressesByLectureIds(lectureIds);
+        return deleteLecturesByIds(lectureIds);
+    }
+
+    @Query("""
+            select l.lectureId
+            from LectureJpaEntity l
+            where l.deletedAt is not null
+              and l.deletedAt < :threshold
+            """)
+    List<Long> findHardDeleteTargetIds(@Param("threshold") LocalDateTime threshold);
+
+    @Query("""
+            select cps.courseProblemSetId
+            from CourseProblemSetJpaEntity cps
+            where cps.lectureId in :lectureIds
+            """)
+    List<Long> findLectureProblemSetIdsByLectureIds(@Param("lectureIds") List<Long> lectureIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureProblemProgressJpaEntity p
+            where p.lectureProblemSetId in :lectureProblemSetIds
+            """)
+    int deleteLectureProblemProgressesByLectureProblemSetIds(
+            @Param("lectureProblemSetIds") List<Long> lectureProblemSetIds
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from CourseProblemSetJpaEntity cps
+            where cps.lectureId in :lectureIds
+            """)
+    int deleteLectureProblemSetsByLectureIds(@Param("lectureIds") List<Long> lectureIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureProgressJpaEntity p
+            where p.lectureId in :lectureIds
+            """)
+    int deleteLectureProgressesByLectureIds(@Param("lectureIds") List<Long> lectureIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureJpaEntity l
+            where l.lectureId in :lectureIds
+            """)
+    int deleteLecturesByIds(@Param("lectureIds") List<Long> lectureIds);
 }

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -12,6 +12,7 @@ import com.wanted.codebombalms.course.application.service.CourseQueryService;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -49,6 +50,9 @@ class CourseServiceTest {
 
     @Mock
     private LectureManagementPort lectureManagementPort;
+
+    @Mock
+    private CourseProblemSetRepository courseProblemSetRepository;
 
     @InjectMocks
     private CourseCommandService courseCommandService;
@@ -221,6 +225,7 @@ class CourseServiceTest {
         assertNotNull(course.getDeletedAt());
         verify(courseRepository).save(course);
         verify(lectureManagementPort).deleteLecturesByCourseId(courseId);
+        verify(courseProblemSetRepository).deleteByCourseId(courseId);
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
@@ -8,6 +8,10 @@ import com.wanted.codebombalms.course.domain.repository.CourseProblemSetReposito
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.course.infrastructure.persistence.CourseProblemSetRepositoryAdapter;
 import com.wanted.codebombalms.course.infrastructure.persistence.CourseRepositoryAdapter;
+import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
+import com.wanted.codebombalms.learning.infrastructure.persistence.LectureProblemProgressJpaEntity;
+import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLectureProblemProgressRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +20,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest(properties = {
         "spring.jpa.hibernate.ddl-auto=create-drop"
@@ -32,6 +38,12 @@ class CourseProblemRepositoryTest {
 
     @Autowired
     private CourseProblemSetRepository courseProblemSetRepository;
+
+    @Autowired
+    private SpringDataCourseProblemSetRepository springDataCourseProblemSetRepository;
+
+    @Autowired
+    private SpringDataLectureProblemProgressRepository lectureProblemProgressRepository;
 
     @Test
     void saveAndFindProblemSetsByCourse() {
@@ -70,6 +82,76 @@ class CourseProblemRepositoryTest {
         assertEquals(2, problemSets.size());
         assertEquals(1, problemSets.get(0).getDisplayOrder());
         assertEquals(2003L, problemSets.get(0).getProblemSetId());
+    }
+
+    @Test
+    void deleteByCourseId_softDeletesProblemSets() {
+        Course course = courseRepository.save(createCourse());
+        CourseProblemSet problemSet = courseProblemSetRepository.save(
+                CourseProblemSet.create(course.getCourseId(), 101L, 2002L, CourseProblemSetRole.MAIN, 1)
+        );
+
+        courseProblemSetRepository.deleteByCourseId(course.getCourseId());
+
+        assertEquals(0, courseProblemSetRepository.findByCourseId(course.getCourseId()).size());
+        assertEquals(0, courseProblemSetRepository.findByLectureId(101L).size());
+        assertEquals(0, courseProblemSetRepository.findById(problemSet.getCourseProblemSetId()).stream().count());
+    }
+
+    @Test
+    void deleteByLectureId_softDeletesOnlyMatchingLectureProblemSets() {
+        Course course = courseRepository.save(createCourse());
+        CourseProblemSet deletedProblemSet = courseProblemSetRepository.save(
+                CourseProblemSet.create(course.getCourseId(), 101L, 2002L, CourseProblemSetRole.MAIN, 1)
+        );
+        CourseProblemSet remainingProblemSet = courseProblemSetRepository.save(
+                CourseProblemSet.create(course.getCourseId(), 102L, 2003L, CourseProblemSetRole.FINAL, 1)
+        );
+
+        courseProblemSetRepository.deleteByLectureId(101L);
+
+        assertEquals(0, courseProblemSetRepository.findByLectureId(101L).size());
+        assertEquals(0, courseProblemSetRepository.findById(deletedProblemSet.getCourseProblemSetId()).stream().count());
+        assertEquals(1, courseProblemSetRepository.findByLectureId(102L).size());
+        assertEquals(remainingProblemSet.getCourseProblemSetId(), courseProblemSetRepository.findByLectureId(102L).get(0).getCourseProblemSetId());
+    }
+
+    @Test
+    void hardDeleteByDeletedAtBefore_deletesOldSoftDeletedProblemSetsOnly() {
+        Course course = courseRepository.save(createCourse());
+        LocalDateTime threshold = LocalDateTime.of(2026, 5, 1, 0, 0);
+        CourseProblemSet oldDeletedProblemSet = courseProblemSetRepository.save(CourseProblemSet.restore(
+                null,
+                course.getCourseId(),
+                101L,
+                2002L,
+                CourseProblemSetRole.MAIN,
+                1,
+                threshold.minusDays(1)
+        ));
+        CourseProblemSet recentDeletedProblemSet = courseProblemSetRepository.save(CourseProblemSet.restore(
+                null,
+                course.getCourseId(),
+                102L,
+                2003L,
+                CourseProblemSetRole.FINAL,
+                1,
+                threshold.plusDays(1)
+        ));
+        CourseProblemSet activeProblemSet = courseProblemSetRepository.save(
+                CourseProblemSet.create(course.getCourseId(), 103L, 2004L, CourseProblemSetRole.MAIN, 1)
+        );
+        lectureProblemProgressRepository.save(LectureProblemProgressJpaEntity.from(
+                LectureProblemProgress.create(1L, oldDeletedProblemSet.getCourseProblemSetId())
+        ));
+
+        int deletedCount = springDataCourseProblemSetRepository.hardDeleteByDeletedAtBefore(threshold);
+
+        assertEquals(1, deletedCount);
+        assertFalse(springDataCourseProblemSetRepository.findById(oldDeletedProblemSet.getCourseProblemSetId()).isPresent());
+        assertTrue(springDataCourseProblemSetRepository.findById(recentDeletedProblemSet.getCourseProblemSetId()).isPresent());
+        assertTrue(springDataCourseProblemSetRepository.findById(activeProblemSet.getCourseProblemSetId()).isPresent());
+        assertEquals(0, lectureProblemProgressRepository.findAll().size());
     }
 
     private Course createCourse() {

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseRepositoryTest.java
@@ -2,17 +2,33 @@ package com.wanted.codebombalms.course.infrastructure.persistence;
 
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseCategoryStatus;
+import com.wanted.codebombalms.course.domain.model.CourseProblemSet;
+import com.wanted.codebombalms.course.domain.model.CourseProblemSetRole;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseCategoryJpaEntity;
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseRepositoryAdapter;
-import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseCategoryRepository;
+import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
+import com.wanted.codebombalms.enrollment.domain.repository.EnrollmentRepository;
+import com.wanted.codebombalms.enrollment.infrastructure.persistence.EnrollmentRepositoryAdapter;
+import com.wanted.codebombalms.enrollment.infrastructure.persistence.SpringDataEnrollmentRepository;
+import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
+import com.wanted.codebombalms.learning.domain.model.LectureProgress;
+import com.wanted.codebombalms.learning.infrastructure.persistence.LectureProblemProgressJpaEntity;
+import com.wanted.codebombalms.learning.infrastructure.persistence.LectureProgressJpaEntity;
+import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLectureProblemProgressRepository;
+import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLectureProgressRepository;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
+import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import com.wanted.codebombalms.lecture.infrastructure.persistence.LectureRepositoryAdapter;
+import com.wanted.codebombalms.lecture.infrastructure.persistence.SpringDataLectureRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,7 +37,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @DataJpaTest(properties = {
         "spring.jpa.hibernate.ddl-auto=create-drop"
 })
-@Import(CourseRepositoryAdapter.class)
+@Import({
+        CourseRepositoryAdapter.class,
+        LectureRepositoryAdapter.class,
+        CourseProblemSetRepositoryAdapter.class,
+        EnrollmentRepositoryAdapter.class
+})
 @DisplayName("CourseRepository 테스트")
 class CourseRepositoryTest {
 
@@ -30,6 +51,30 @@ class CourseRepositoryTest {
 
     @Autowired
     private SpringDataCourseCategoryRepository springDataCourseCategoryRepository;
+
+    @Autowired
+    private SpringDataCourseRepository springDataCourseRepository;
+
+    @Autowired
+    private LectureRepository lectureRepository;
+
+    @Autowired
+    private SpringDataLectureRepository springDataLectureRepository;
+
+    @Autowired
+    private CourseProblemSetRepository courseProblemSetRepository;
+
+    @Autowired
+    private SpringDataEnrollmentRepository springDataEnrollmentRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private SpringDataLectureProgressRepository lectureProgressRepository;
+
+    @Autowired
+    private SpringDataLectureProblemProgressRepository lectureProblemProgressRepository;
 
     @Test
     @DisplayName("강좌를 저장하고 courseId로 조회할 수 있다.")
@@ -166,6 +211,46 @@ class CourseRepositoryTest {
         assertEquals(1, courses.size());
         assertEquals(category.getCourseCategoryId(), courses.get(0).getCourseCategoryId());
         assertEquals("Python", courses.get(0).getCourseCategoryName());
+    }
+
+    @Test
+    void hardDeleteByDeletedAtBefore_deletesOldSoftDeletedCourseWithDependentsOnly() {
+        LocalDateTime threshold = LocalDateTime.of(2026, 5, 1, 0, 0);
+        Course oldDeletedCourse = createCourse(10L, "Old Deleted", "description", "old.png", CourseStatus.DELETED);
+        oldDeletedCourse.setDeletedAt(threshold.minusDays(1));
+        Course recentDeletedCourse = createCourse(10L, "Recent Deleted", "description", "recent.png", CourseStatus.DELETED);
+        recentDeletedCourse.setDeletedAt(threshold.plusDays(1));
+        Course activeCourse = createCourse(10L, "Active", "description", "active.png", CourseStatus.ACTIVE);
+
+        oldDeletedCourse = courseRepository.save(oldDeletedCourse);
+        recentDeletedCourse = courseRepository.save(recentDeletedCourse);
+        activeCourse = courseRepository.save(activeCourse);
+
+        Lecture oldLecture = lectureRepository.save(
+                Lecture.create(oldDeletedCourse, "Old Lecture", "description", "old.mp4", "old.png", 1, LectureStatus.DELETED)
+        );
+        CourseProblemSet oldProblemSet = courseProblemSetRepository.save(
+                CourseProblemSet.create(oldDeletedCourse.getCourseId(), oldLecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 1)
+        );
+        enrollmentRepository.save(Enrollment.create(1L, oldDeletedCourse.getCourseId()));
+        lectureProgressRepository.save(LectureProgressJpaEntity.from(
+                LectureProgress.create(1L, oldLecture.getLectureId())
+        ));
+        lectureProblemProgressRepository.save(LectureProblemProgressJpaEntity.from(
+                LectureProblemProgress.create(1L, oldProblemSet.getCourseProblemSetId())
+        ));
+
+        int deletedCount = springDataCourseRepository.hardDeleteByDeletedAtBefore(threshold);
+
+        assertEquals(1, deletedCount);
+        assertFalse(springDataCourseRepository.findById(oldDeletedCourse.getCourseId()).isPresent());
+        assertTrue(springDataCourseRepository.findById(recentDeletedCourse.getCourseId()).isPresent());
+        assertTrue(springDataCourseRepository.findById(activeCourse.getCourseId()).isPresent());
+        assertFalse(springDataLectureRepository.findById(oldLecture.getLectureId()).isPresent());
+        assertEquals(0, courseProblemSetRepository.findByCourseId(oldDeletedCourse.getCourseId()).size());
+        assertEquals(0, springDataEnrollmentRepository.findAll().size());
+        assertEquals(0, lectureProgressRepository.findAll().size());
+        assertEquals(0, lectureProblemProgressRepository.findAll().size());
     }
 
     private Course createCourse(

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
@@ -42,6 +43,9 @@ class LectureServiceTest {
 
     @Mock
     private LectureCreationPolicy lectureCreationPolicy;
+
+    @Mock
+    private CourseProblemSetRepository courseProblemSetRepository;
 
     @InjectMocks
     private LectureCommandService lectureCommandService;
@@ -159,6 +163,7 @@ class LectureServiceTest {
         assertEquals(LectureStatus.DELETED, lecture.getStatus());
         assertNotNull(lecture.getDeletedAt());
         verify(lectureRepository).save(lecture);
+        verify(courseProblemSetRepository).deleteByLectureId(lectureId);
     }
 
     private Course createCourse(Long courseId, Long instructorId, String title) {

--- a/src/test/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryTest.java
@@ -1,9 +1,19 @@
 package com.wanted.codebombalms.lecture.infrastructure.persistence;
 
 import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.course.domain.model.CourseProblemSet;
+import com.wanted.codebombalms.course.domain.model.CourseProblemSetRole;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
+import com.wanted.codebombalms.course.infrastructure.persistence.CourseProblemSetRepositoryAdapter;
 import com.wanted.codebombalms.course.infrastructure.persistence.CourseRepositoryAdapter;
+import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
+import com.wanted.codebombalms.learning.domain.model.LectureProgress;
+import com.wanted.codebombalms.learning.infrastructure.persistence.LectureProblemProgressJpaEntity;
+import com.wanted.codebombalms.learning.infrastructure.persistence.LectureProgressJpaEntity;
+import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLectureProblemProgressRepository;
+import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLectureProgressRepository;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
@@ -14,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,7 +33,11 @@ import static org.junit.jupiter.api.Assertions.*;
 @DataJpaTest(properties = {
         "spring.jpa.hibernate.ddl-auto=create-drop"
 })
-@Import({CourseRepositoryAdapter.class, LectureRepositoryAdapter.class})
+@Import({
+        CourseRepositoryAdapter.class,
+        LectureRepositoryAdapter.class,
+        CourseProblemSetRepositoryAdapter.class
+})
 @DisplayName("LectureRepository test")
 class LectureRepositoryTest {
 
@@ -31,6 +46,18 @@ class LectureRepositoryTest {
 
     @Autowired
     private CourseRepository courseRepository;
+
+    @Autowired
+    private CourseProblemSetRepository courseProblemSetRepository;
+
+    @Autowired
+    private SpringDataLectureRepository springDataLectureRepository;
+
+    @Autowired
+    private SpringDataLectureProgressRepository lectureProgressRepository;
+
+    @Autowired
+    private SpringDataLectureProblemProgressRepository lectureProblemProgressRepository;
 
     @Test
     void saveAndFindByLectureId() {
@@ -84,6 +111,60 @@ class LectureRepositoryTest {
         assertTrue(lectures.stream().allMatch(lecture -> lecture.getDeletedAt() == null));
         assertTrue(lectures.stream().anyMatch(lecture -> lecture.getTitle().equals("Java 1")));
         assertFalse(lectures.stream().anyMatch(lecture -> lecture.getTitle().equals("Deleted")));
+    }
+
+    @Test
+    void hardDeleteByDeletedAtBefore_deletesOldSoftDeletedLectureOnly() {
+        Course course = courseRepository.save(createCourse());
+        LocalDateTime threshold = LocalDateTime.of(2026, 5, 1, 0, 0);
+        Lecture oldDeletedLecture = lectureRepository.save(Lecture.restore(
+                null,
+                course,
+                "Old Deleted",
+                "description",
+                "old.mp4",
+                "old.png",
+                LectureStatus.DELETED,
+                null,
+                null,
+                threshold.minusDays(1),
+                1
+        ));
+        Lecture recentDeletedLecture = lectureRepository.save(Lecture.restore(
+                null,
+                course,
+                "Recent Deleted",
+                "description",
+                "recent.mp4",
+                "recent.png",
+                LectureStatus.DELETED,
+                null,
+                null,
+                threshold.plusDays(1),
+                2
+        ));
+        Lecture activeLecture = lectureRepository.save(
+                Lecture.create(course, "Active", "description", "active.mp4", "active.png", 3, LectureStatus.ACTIVE)
+        );
+        CourseProblemSet lectureProblemSet = courseProblemSetRepository.save(
+                CourseProblemSet.create(course.getCourseId(), oldDeletedLecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 1)
+        );
+        lectureProgressRepository.save(LectureProgressJpaEntity.from(
+                LectureProgress.create(1L, oldDeletedLecture.getLectureId())
+        ));
+        lectureProblemProgressRepository.save(LectureProblemProgressJpaEntity.from(
+                LectureProblemProgress.create(1L, lectureProblemSet.getCourseProblemSetId())
+        ));
+
+        int deletedCount = springDataLectureRepository.hardDeleteByDeletedAtBefore(threshold);
+
+        assertEquals(1, deletedCount);
+        assertFalse(springDataLectureRepository.findById(oldDeletedLecture.getLectureId()).isPresent());
+        assertTrue(springDataLectureRepository.findById(recentDeletedLecture.getLectureId()).isPresent());
+        assertTrue(springDataLectureRepository.findById(activeLecture.getLectureId()).isPresent());
+        assertEquals(0, courseProblemSetRepository.findByLectureId(oldDeletedLecture.getLectureId()).size());
+        assertEquals(0, lectureProgressRepository.findAll().size());
+        assertEquals(0, lectureProblemProgressRepository.findAll().size());
     }
 
     private Course createCourse() {


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- Course 삭제 시 연결된 Lecture와 CourseProblemSet 매핑이 함께 soft delete되도록 처리했습니다.
- Lecture 삭제 시 해당 Lecture에 연결된 CourseProblemSet 매핑만 soft delete되도록 처리했습니다.
- Course, Lecture, CourseProblemSet 매핑에 대해 공통 HardDeleteTarget을 등록하고 보관 기간이 지난 데이터를 물리 삭제하도록 구현했습니다.
- hard delete 시 lecture progress, lecture problem progress, enrollment 등 의존 데이터를 먼저 삭제하도록 처리하고 관련 테스트를 추가했습니다.

---

## ♻️ 패키지 변경 사항

- codebombalms/course: Course 삭제 시 CourseProblemSet soft delete 연동 및 Course/CourseProblemSet hard delete 쿼리와 cleanup 설정을 추가했습니다.
- codebombalms/lecture: Lecture 삭제 시 CourseProblemSet soft delete 연동 및 Lecture hard delete 쿼리와 cleanup 설정을 추가했습니다.
- codebombalms/learning: 삭제된 CourseProblemSet 매핑이 학습 조회에 포함되지 않도록 조회 조건을 보완했습니다.
- codebombalms/course test: Course, CourseProblemSet soft delete 및 hard delete 동작 검증 테스트를 추가했습니다.
- codebombalms/lecture test: Lecture 삭제 연동 및 hard delete 동작 검증 테스트를 추가했습니다.

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.
