### PR TITLE
[Fix] 공용 DB 스키마 기준 lecture_problem_set 삭제 처리 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
@@ -11,7 +11,6 @@ import com.wanted.codebombalms.course.application.usecase.CourseCommandUseCase;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
-import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -35,7 +34,6 @@ public class CourseCommandService implements CourseCommandUseCase {
     private final CourseCategoryPolicy courseCategoryPolicy;
     private final CoursePublishPolicy coursePublishPolicy;
     private final LectureManagementPort lectureManagementPort;
-    private final CourseProblemSetRepository courseProblemSetRepository;
 
     @LogBusiness
     @LogPerformance
@@ -112,7 +110,6 @@ public class CourseCommandService implements CourseCommandUseCase {
         course.delete();
         courseRepository.save(course);
         lectureManagementPort.deleteLecturesByCourseId(courseId);
-        courseProblemSetRepository.deleteByCourseId(courseId);
 
         log.info("[CourseCommandService] deleted course - courseId: {}", courseId);
     }

--- a/src/main/java/com/wanted/codebombalms/course/domain/model/CourseProblemSet.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/model/CourseProblemSet.java
@@ -3,8 +3,6 @@ package com.wanted.codebombalms.course.domain.model;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.time.LocalDateTime;
-
 @Getter
 @ToString
 public class CourseProblemSet {
@@ -15,7 +13,6 @@ public class CourseProblemSet {
     private Long problemSetId;
     private CourseProblemSetRole role;
     private Integer displayOrder;
-    private LocalDateTime deletedAt;
 
     private CourseProblemSet(
             Long courseProblemSetId,
@@ -23,8 +20,7 @@ public class CourseProblemSet {
             Long lectureId,
             Long problemSetId,
             CourseProblemSetRole role,
-            Integer displayOrder,
-            LocalDateTime deletedAt
+            Integer displayOrder
     ) {
         this.courseProblemSetId = courseProblemSetId;
         this.courseId = courseId;
@@ -32,7 +28,6 @@ public class CourseProblemSet {
         this.problemSetId = problemSetId;
         this.role = role;
         this.displayOrder = displayOrder;
-        this.deletedAt = deletedAt;
     }
 
     public static CourseProblemSet create(
@@ -42,7 +37,7 @@ public class CourseProblemSet {
             CourseProblemSetRole role,
             Integer displayOrder
     ) {
-        return new CourseProblemSet(null, courseId, lectureId, problemSetId, role, displayOrder, null);
+        return new CourseProblemSet(null, courseId, lectureId, problemSetId, role, displayOrder);
     }
 
     public static CourseProblemSet restore(
@@ -53,22 +48,6 @@ public class CourseProblemSet {
             CourseProblemSetRole role,
             Integer displayOrder
     ) {
-        return restore(courseProblemSetId, courseId, lectureId, problemSetId, role, displayOrder, null);
-    }
-
-    public static CourseProblemSet restore(
-            Long courseProblemSetId,
-            Long courseId,
-            Long lectureId,
-            Long problemSetId,
-            CourseProblemSetRole role,
-            Integer displayOrder,
-            LocalDateTime deletedAt
-    ) {
-        return new CourseProblemSet(courseProblemSetId, courseId, lectureId, problemSetId, role, displayOrder, deletedAt);
-    }
-
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
+        return new CourseProblemSet(courseProblemSetId, courseId, lectureId, problemSetId, role, displayOrder);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/domain/repository/CourseProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/repository/CourseProblemSetRepository.java
@@ -16,8 +16,4 @@ public interface CourseProblemSetRepository {
     List<CourseProblemSet> findByLectureId(Long lectureId);
 
     Optional<CourseProblemSet> findById(Long courseProblemSetId);
-
-    void deleteByCourseId(Long courseId);
-
-    void deleteByLectureId(Long lectureId);
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/cleanup/CourseCleanupConfig.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/cleanup/CourseCleanupConfig.java
@@ -1,6 +1,5 @@
 package com.wanted.codebombalms.course.infrastructure.cleanup;
 
-import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseProblemSetRepository;
 import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseRepository;
 import com.wanted.codebombalms.global.application.cleanup.DefaultHardDeleteTarget;
 import com.wanted.codebombalms.global.application.cleanup.port.HardDeleteTarget;
@@ -11,18 +10,6 @@ import org.springframework.core.annotation.Order;
 
 @Configuration
 public class CourseCleanupConfig {
-
-    @Bean
-    @Order(10)
-    public HardDeleteTarget courseProblemSetHardDeleteTarget(
-            SpringDataCourseProblemSetRepository repository
-    ) {
-        return new DefaultHardDeleteTarget(
-                "course-problem-set",
-                Period.ofMonths(6),
-                repository::hardDeleteByDeletedAtBefore
-        );
-    }
 
     @Bean
     @Order(30)

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetJpaEntity.java
@@ -16,8 +16,6 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @NoArgsConstructor
@@ -46,9 +44,6 @@ public class CourseProblemSetJpaEntity {
     @Column(name = "display_order", nullable = false)
     private Integer displayOrder;
 
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
-
     private CourseProblemSetJpaEntity(
             CourseJpaEntity course,
             Long lectureId,
@@ -72,7 +67,6 @@ public class CourseProblemSetJpaEntity {
                 courseProblemSet.getDisplayOrder()
         );
         entity.courseProblemSetId = courseProblemSet.getCourseProblemSetId();
-        entity.deletedAt = courseProblemSet.getDeletedAt();
         return entity;
     }
 
@@ -82,11 +76,6 @@ public class CourseProblemSetJpaEntity {
         this.problemSetId = courseProblemSet.getProblemSetId();
         this.role = courseProblemSet.getRole();
         this.displayOrder = courseProblemSet.getDisplayOrder();
-        this.deletedAt = courseProblemSet.getDeletedAt();
-    }
-
-    public void delete() {
-        this.deletedAt = LocalDateTime.now();
     }
 
     public CourseProblemSet toDomain() {
@@ -96,8 +85,7 @@ public class CourseProblemSetJpaEntity {
                 lectureId,
                 problemSetId,
                 role,
-                displayOrder,
-                deletedAt
+                displayOrder
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetRepositoryAdapter.java
@@ -34,7 +34,7 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public List<CourseProblemSet> findByCourseId(Long courseId) {
-        return springDataCourseProblemSetRepository.findByCourse_CourseIdAndDeletedAtIsNull(courseId)
+        return springDataCourseProblemSetRepository.findActiveByCourseId(courseId)
                 .stream()
                 .map(CourseProblemSetJpaEntity::toDomain)
                 .toList();
@@ -42,7 +42,7 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public List<CourseProblemSet> findByCourseIdAndRole(Long courseId, CourseProblemSetRole role) {
-        return springDataCourseProblemSetRepository.findByCourse_CourseIdAndRoleAndDeletedAtIsNull(courseId, role)
+        return springDataCourseProblemSetRepository.findActiveByCourseIdAndRole(courseId, role)
                 .stream()
                 .map(CourseProblemSetJpaEntity::toDomain)
                 .toList();
@@ -50,7 +50,7 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public List<CourseProblemSet> findByLectureId(Long lectureId) {
-        return springDataCourseProblemSetRepository.findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(lectureId)
+        return springDataCourseProblemSetRepository.findActiveByLectureIdOrderByDisplayOrderAsc(lectureId)
                 .stream()
                 .map(CourseProblemSetJpaEntity::toDomain)
                 .toList();
@@ -58,25 +58,7 @@ public class CourseProblemSetRepositoryAdapter implements CourseProblemSetReposi
 
     @Override
     public Optional<CourseProblemSet> findById(Long courseProblemSetId) {
-        return springDataCourseProblemSetRepository.findByCourseProblemSetIdAndDeletedAtIsNull(courseProblemSetId)
+        return springDataCourseProblemSetRepository.findActiveById(courseProblemSetId)
                 .map(CourseProblemSetJpaEntity::toDomain);
-    }
-
-    @Override
-    public void deleteByCourseId(Long courseId) {
-        List<CourseProblemSetJpaEntity> problemSets =
-                springDataCourseProblemSetRepository.findByCourse_CourseIdAndDeletedAtIsNull(courseId);
-
-        problemSets.forEach(CourseProblemSetJpaEntity::delete);
-        springDataCourseProblemSetRepository.saveAll(problemSets);
-    }
-
-    @Override
-    public void deleteByLectureId(Long lectureId) {
-        List<CourseProblemSetJpaEntity> problemSets =
-                springDataCourseProblemSetRepository.findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(lectureId);
-
-        problemSets.forEach(CourseProblemSetJpaEntity::delete);
-        springDataCourseProblemSetRepository.saveAll(problemSets);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseProblemSetRepository.java
@@ -1,60 +1,72 @@
 package com.wanted.codebombalms.course.infrastructure.persistence;
 
 import com.wanted.codebombalms.course.domain.model.CourseProblemSetRole;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface SpringDataCourseProblemSetRepository extends JpaRepository<CourseProblemSetJpaEntity, Long> {
 
-    List<CourseProblemSetJpaEntity> findByCourse_CourseIdAndDeletedAtIsNull(Long courseId);
-
-    List<CourseProblemSetJpaEntity> findByCourse_CourseIdAndRoleAndDeletedAtIsNull(
-            Long courseId,
-            CourseProblemSetRole role
-    );
-
-    List<CourseProblemSetJpaEntity> findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(Long lectureId);
-
-    Optional<CourseProblemSetJpaEntity> findByCourseProblemSetIdAndDeletedAtIsNull(Long courseProblemSetId);
-
-    @Transactional
-    default int hardDeleteByDeletedAtBefore(LocalDateTime threshold) {
-        List<Long> lectureProblemSetIds = findHardDeleteTargetIds(threshold);
-        if (lectureProblemSetIds.isEmpty()) {
-            return 0;
-        }
-
-        deleteLectureProblemProgressesByLectureProblemSetIds(lectureProblemSetIds);
-        return deleteLectureProblemSetsByIds(lectureProblemSetIds);
-    }
-
     @Query("""
-            select cps.courseProblemSetId
+            select cps
             from CourseProblemSetJpaEntity cps
-            where cps.deletedAt is not null
-              and cps.deletedAt < :threshold
+            where cps.course.courseId = :courseId
+              and cps.course.deletedAt is null
+              and exists (
+                  select l.lectureId
+                  from LectureJpaEntity l
+                  where l.lectureId = cps.lectureId
+                    and l.deletedAt is null
+              )
             """)
-    List<Long> findHardDeleteTargetIds(@Param("threshold") LocalDateTime threshold);
+    List<CourseProblemSetJpaEntity> findActiveByCourseId(@Param("courseId") Long courseId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
-            delete from LectureProblemProgressJpaEntity p
-            where p.lectureProblemSetId in :lectureProblemSetIds
+            select cps
+            from CourseProblemSetJpaEntity cps
+            where cps.course.courseId = :courseId
+              and cps.role = :role
+              and cps.course.deletedAt is null
+              and exists (
+                  select l.lectureId
+                  from LectureJpaEntity l
+                  where l.lectureId = cps.lectureId
+                    and l.deletedAt is null
+              )
             """)
-    int deleteLectureProblemProgressesByLectureProblemSetIds(
-            @Param("lectureProblemSetIds") List<Long> lectureProblemSetIds
+    List<CourseProblemSetJpaEntity> findActiveByCourseIdAndRole(
+            @Param("courseId") Long courseId,
+            @Param("role") CourseProblemSetRole role
     );
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
-            delete from CourseProblemSetJpaEntity cps
-            where cps.courseProblemSetId in :lectureProblemSetIds
+            select cps
+            from CourseProblemSetJpaEntity cps
+            where cps.lectureId = :lectureId
+              and cps.course.deletedAt is null
+              and exists (
+                  select l.lectureId
+                  from LectureJpaEntity l
+                  where l.lectureId = cps.lectureId
+                    and l.deletedAt is null
+              )
+            order by cps.displayOrder asc
             """)
-    int deleteLectureProblemSetsByIds(@Param("lectureProblemSetIds") List<Long> lectureProblemSetIds);
+    List<CourseProblemSetJpaEntity> findActiveByLectureIdOrderByDisplayOrderAsc(@Param("lectureId") Long lectureId);
+
+    @Query("""
+            select cps
+            from CourseProblemSetJpaEntity cps
+            where cps.courseProblemSetId = :courseProblemSetId
+              and cps.course.deletedAt is null
+              and exists (
+                  select l.lectureId
+                  from LectureJpaEntity l
+                  where l.lectureId = cps.lectureId
+                    and l.deletedAt is null
+              )
+            """)
+    Optional<CourseProblemSetJpaEntity> findActiveById(@Param("courseProblemSetId") Long courseProblemSetId);
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseProblemAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseProblemAdapter.java
@@ -18,7 +18,7 @@ public class LearningCourseProblemAdapter implements LearningCourseProblemPort {
 
     @Override
     public List<Long> findMainLectureProblemSetIdsByCourse(Long courseId) {
-        return courseProblemSetRepository.findByCourse_CourseIdAndRoleAndDeletedAtIsNull(
+        return courseProblemSetRepository.findActiveByCourseIdAndRole(
                         courseId,
                         CourseProblemSetRole.MAIN
                 )
@@ -29,7 +29,7 @@ public class LearningCourseProblemAdapter implements LearningCourseProblemPort {
 
     @Override
     public List<Long> findLectureProblemSetIdsByLecture(Long lectureId) {
-        return courseProblemSetRepository.findByLectureIdAndDeletedAtIsNullOrderByDisplayOrderAsc(lectureId)
+        return courseProblemSetRepository.findActiveByLectureIdOrderByDisplayOrderAsc(lectureId)
                 .stream()
                 .map(CourseProblemSetJpaEntity::getCourseProblemSetId)
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
@@ -1,7 +1,6 @@
 package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.course.domain.model.Course;
-import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
@@ -30,7 +29,6 @@ public class LectureCommandService implements LectureCommandUseCase {
     private final LectureRepository lectureRepository;
     private final CourseCatalogPort courseCatalogPort;
     private final LectureCreationPolicy lectureCreationPolicy;
-    private final CourseProblemSetRepository courseProblemSetRepository;
 
     @Override
     public Lecture createLecture(CreateLectureCommand command) {
@@ -90,7 +88,6 @@ public class LectureCommandService implements LectureCommandUseCase {
 
         lecture.delete();
         lectureRepository.save(lecture);
-        courseProblemSetRepository.deleteByLectureId(lectureId);
     }
 
     private void validateLectureOrder(Long courseId, Long lectureId, Integer lectureOrder) {

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -12,7 +12,6 @@ import com.wanted.codebombalms.course.application.service.CourseQueryService;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
-import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -50,9 +49,6 @@ class CourseServiceTest {
 
     @Mock
     private LectureManagementPort lectureManagementPort;
-
-    @Mock
-    private CourseProblemSetRepository courseProblemSetRepository;
 
     @InjectMocks
     private CourseCommandService courseCommandService;
@@ -225,7 +221,6 @@ class CourseServiceTest {
         assertNotNull(course.getDeletedAt());
         verify(courseRepository).save(course);
         verify(lectureManagementPort).deleteLecturesByCourseId(courseId);
-        verify(courseProblemSetRepository).deleteByCourseId(courseId);
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
@@ -6,12 +6,10 @@ import com.wanted.codebombalms.course.domain.model.CourseProblemSetRole;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseProblemSetRepositoryAdapter;
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseRepositoryAdapter;
-import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
-import com.wanted.codebombalms.learning.infrastructure.persistence.LectureProblemProgressJpaEntity;
-import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLectureProblemProgressRepository;
-import java.time.LocalDateTime;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
+import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import com.wanted.codebombalms.lecture.infrastructure.persistence.LectureRepositoryAdapter;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,15 +18,14 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest(properties = {
         "spring.jpa.hibernate.ddl-auto=create-drop"
 })
 @Import({
         CourseRepositoryAdapter.class,
-        CourseProblemSetRepositoryAdapter.class
+        CourseProblemSetRepositoryAdapter.class,
+        LectureRepositoryAdapter.class
 })
 @DisplayName("Course problem repository test")
 class CourseProblemRepositoryTest {
@@ -40,20 +37,19 @@ class CourseProblemRepositoryTest {
     private CourseProblemSetRepository courseProblemSetRepository;
 
     @Autowired
-    private SpringDataCourseProblemSetRepository springDataCourseProblemSetRepository;
-
-    @Autowired
-    private SpringDataLectureProblemProgressRepository lectureProblemProgressRepository;
+    private LectureRepository lectureRepository;
 
     @Test
     void saveAndFindProblemSetsByCourse() {
         Course course = courseRepository.save(createCourse());
+        Lecture mainLecture = lectureRepository.save(createLecture(course, "Java 1", 1, LectureStatus.ACTIVE));
+        Lecture finalLecture = lectureRepository.save(createLecture(course, "Java 2", 2, LectureStatus.ACTIVE));
 
         CourseProblemSet mainProblemSet = courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 101L, 2002L, CourseProblemSetRole.MAIN, 1)
+                CourseProblemSet.create(course.getCourseId(), mainLecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 1)
         );
         courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 103L, 2003L, CourseProblemSetRole.FINAL, 1)
+                CourseProblemSet.create(course.getCourseId(), finalLecture.getLectureId(), 2003L, CourseProblemSetRole.FINAL, 1)
         );
 
         List<CourseProblemSet> allProblemSets = courseProblemSetRepository.findByCourseId(course.getCourseId());
@@ -70,14 +66,15 @@ class CourseProblemRepositoryTest {
     @Test
     void saveAndFindProblemSetsByLecture() {
         Course course = courseRepository.save(createCourse());
+        Lecture lecture = lectureRepository.save(createLecture(course, "Java 1", 1, LectureStatus.ACTIVE));
         courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 101L, 2002L, CourseProblemSetRole.MAIN, 2)
+                CourseProblemSet.create(course.getCourseId(), lecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 2)
         );
         courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 101L, 2003L, CourseProblemSetRole.FINAL, 1)
+                CourseProblemSet.create(course.getCourseId(), lecture.getLectureId(), 2003L, CourseProblemSetRole.FINAL, 1)
         );
 
-        List<CourseProblemSet> problemSets = courseProblemSetRepository.findByLectureId(101L);
+        List<CourseProblemSet> problemSets = courseProblemSetRepository.findByLectureId(lecture.getLectureId());
 
         assertEquals(2, problemSets.size());
         assertEquals(1, problemSets.get(0).getDisplayOrder());
@@ -85,73 +82,39 @@ class CourseProblemRepositoryTest {
     }
 
     @Test
-    void deleteByCourseId_softDeletesProblemSets() {
+    void findByCourseId_excludesWhenCourseIsDeleted() {
         Course course = courseRepository.save(createCourse());
-        CourseProblemSet problemSet = courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 101L, 2002L, CourseProblemSetRole.MAIN, 1)
+        Lecture lecture = lectureRepository.save(createLecture(course, "Java 1", 1, LectureStatus.ACTIVE));
+        courseProblemSetRepository.save(
+                CourseProblemSet.create(course.getCourseId(), lecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 1)
         );
 
-        courseProblemSetRepository.deleteByCourseId(course.getCourseId());
+        course.delete();
+        courseRepository.save(course);
 
         assertEquals(0, courseProblemSetRepository.findByCourseId(course.getCourseId()).size());
-        assertEquals(0, courseProblemSetRepository.findByLectureId(101L).size());
-        assertEquals(0, courseProblemSetRepository.findById(problemSet.getCourseProblemSetId()).stream().count());
+        assertEquals(0, courseProblemSetRepository.findByLectureId(lecture.getLectureId()).size());
     }
 
     @Test
-    void deleteByLectureId_softDeletesOnlyMatchingLectureProblemSets() {
+    void findByLectureId_excludesOnlyDeletedLectureProblemSets() {
         Course course = courseRepository.save(createCourse());
+        Lecture deletedLecture = lectureRepository.save(createLecture(course, "Deleted", 1, LectureStatus.ACTIVE));
+        Lecture remainingLecture = lectureRepository.save(createLecture(course, "Active", 2, LectureStatus.ACTIVE));
         CourseProblemSet deletedProblemSet = courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 101L, 2002L, CourseProblemSetRole.MAIN, 1)
+                CourseProblemSet.create(course.getCourseId(), deletedLecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 1)
         );
         CourseProblemSet remainingProblemSet = courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 102L, 2003L, CourseProblemSetRole.FINAL, 1)
+                CourseProblemSet.create(course.getCourseId(), remainingLecture.getLectureId(), 2003L, CourseProblemSetRole.FINAL, 1)
         );
 
-        courseProblemSetRepository.deleteByLectureId(101L);
+        deletedLecture.delete();
+        lectureRepository.save(deletedLecture);
 
-        assertEquals(0, courseProblemSetRepository.findByLectureId(101L).size());
+        assertEquals(0, courseProblemSetRepository.findByLectureId(deletedLecture.getLectureId()).size());
         assertEquals(0, courseProblemSetRepository.findById(deletedProblemSet.getCourseProblemSetId()).stream().count());
-        assertEquals(1, courseProblemSetRepository.findByLectureId(102L).size());
-        assertEquals(remainingProblemSet.getCourseProblemSetId(), courseProblemSetRepository.findByLectureId(102L).get(0).getCourseProblemSetId());
-    }
-
-    @Test
-    void hardDeleteByDeletedAtBefore_deletesOldSoftDeletedProblemSetsOnly() {
-        Course course = courseRepository.save(createCourse());
-        LocalDateTime threshold = LocalDateTime.of(2026, 5, 1, 0, 0);
-        CourseProblemSet oldDeletedProblemSet = courseProblemSetRepository.save(CourseProblemSet.restore(
-                null,
-                course.getCourseId(),
-                101L,
-                2002L,
-                CourseProblemSetRole.MAIN,
-                1,
-                threshold.minusDays(1)
-        ));
-        CourseProblemSet recentDeletedProblemSet = courseProblemSetRepository.save(CourseProblemSet.restore(
-                null,
-                course.getCourseId(),
-                102L,
-                2003L,
-                CourseProblemSetRole.FINAL,
-                1,
-                threshold.plusDays(1)
-        ));
-        CourseProblemSet activeProblemSet = courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), 103L, 2004L, CourseProblemSetRole.MAIN, 1)
-        );
-        lectureProblemProgressRepository.save(LectureProblemProgressJpaEntity.from(
-                LectureProblemProgress.create(1L, oldDeletedProblemSet.getCourseProblemSetId())
-        ));
-
-        int deletedCount = springDataCourseProblemSetRepository.hardDeleteByDeletedAtBefore(threshold);
-
-        assertEquals(1, deletedCount);
-        assertFalse(springDataCourseProblemSetRepository.findById(oldDeletedProblemSet.getCourseProblemSetId()).isPresent());
-        assertTrue(springDataCourseProblemSetRepository.findById(recentDeletedProblemSet.getCourseProblemSetId()).isPresent());
-        assertTrue(springDataCourseProblemSetRepository.findById(activeProblemSet.getCourseProblemSetId()).isPresent());
-        assertEquals(0, lectureProblemProgressRepository.findAll().size());
+        assertEquals(1, courseProblemSetRepository.findByLectureId(remainingLecture.getLectureId()).size());
+        assertEquals(remainingProblemSet.getCourseProblemSetId(), courseProblemSetRepository.findByLectureId(remainingLecture.getLectureId()).get(0).getCourseProblemSetId());
     }
 
     private Course createCourse() {
@@ -162,5 +125,17 @@ class CourseProblemRepositoryTest {
         course.setThumbnailUrl("java.png");
         course.setStatus(CourseStatus.ACTIVE);
         return course;
+    }
+
+    private Lecture createLecture(Course course, String title, Integer lectureOrder, LectureStatus status) {
+        return Lecture.create(
+                course,
+                title,
+                "description",
+                "video.mp4",
+                "lecture.png",
+                lectureOrder,
+                status
+        );
     }
 }

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
@@ -2,7 +2,6 @@ package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
-import com.wanted.codebombalms.course.domain.repository.CourseProblemSetRepository;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
@@ -43,9 +42,6 @@ class LectureServiceTest {
 
     @Mock
     private LectureCreationPolicy lectureCreationPolicy;
-
-    @Mock
-    private CourseProblemSetRepository courseProblemSetRepository;
 
     @InjectMocks
     private LectureCommandService lectureCommandService;
@@ -163,7 +159,6 @@ class LectureServiceTest {
         assertEquals(LectureStatus.DELETED, lecture.getStatus());
         assertNotNull(lecture.getDeletedAt());
         verify(lectureRepository).save(lecture);
-        verify(courseProblemSetRepository).deleteByLectureId(lectureId);
     }
 
     private Course createCourse(Long courseId, Long instructorId, String title) {


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 공용 DB에 없는 lecture_problem_set.deleted_at 컬럼을 전제로 한 soft delete 처리를 제거했습니다.
- Course/Lecture 삭제 시 lecture_problem_set row를 수정하지 않고, 부모 Course/Lecture의 deleted_at 기준으로 조회에서 제외되도록 변경했습니다.
- hard delete 단계에서는 기존 DB 구조를 유지한 채 의존 데이터와 lecture_problem_set row를 정리하도록 유지했습니다.
- lecture_problem_set 조회 테스트를 부모 Course/Lecture 삭제 상태 기준으로 검증하도록 수정했습니다.

---

## ♻️ 패키지 변경 사항

- codebombalms/course: lecture_problem_set 컬럼 추가 전제를 제거하고 부모 삭제 상태 기준 조회 조건으로 변경했습니다.
- codebombalms/lecture: Lecture 삭제 시 lecture_problem_set soft delete 호출을 제거했습니다.
- codebombalms/learning: lecture_problem_set 조회 시 삭제된 Course/Lecture에 연결된 매핑이 제외되도록 유지했습니다.
- codebombalms/course test: Course/Lecture 삭제 상태에 따른 lecture_problem_set 조회 제외 테스트를 수정했습니다.
- codebombalms/lecture test: Lecture 삭제 시 연결 매핑 soft delete 호출 검증을 제거했습니다.

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.
