### PR TITLE
[Feat] 포인트 기반 랭킹 조회 API 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/ranking/application/port/RankingQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/application/port/RankingQueryPort.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.ranking.application.port;
+
+import com.wanted.codebombalms.ranking.application.query.RankingItem;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface RankingQueryPort {
+    List<RankingItem> findTotalPointRankings();
+    List<RankingItem> findWeeklyPointRankings(LocalDateTime from);
+    Optional<RankingItem> findMyTotalPointRanking(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/application/query/RankingItem.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/application/query/RankingItem.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.ranking.application.query;
+
+public record RankingItem(
+        Integer rank,
+        Long userId,
+        String nickname,
+        Integer point
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/application/query/RankingItem.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/application/query/RankingItem.java
@@ -3,7 +3,10 @@ package com.wanted.codebombalms.ranking.application.query;
 public record RankingItem(
         Integer rank,
         Long userId,
+        String name,
         String nickname,
-        Integer point
+        String badgeImageUrl,
+        Integer weeklyPoint,
+        Integer totalPoint
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/ranking/application/query/RankingListResult.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/application/query/RankingListResult.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.ranking.application.query;
+
+import java.util.List;
+
+public record RankingListResult(
+        List<RankingItem> rankings
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/application/service/RankingService.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/application/service/RankingService.java
@@ -1,0 +1,43 @@
+package com.wanted.codebombalms.ranking.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.ranking.application.port.RankingQueryPort;
+import com.wanted.codebombalms.ranking.application.query.RankingItem;
+import com.wanted.codebombalms.ranking.application.query.RankingListResult;
+import com.wanted.codebombalms.ranking.application.usecase.RankingQueryUseCase;
+import com.wanted.codebombalms.ranking.exception.RankingErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RankingService implements RankingQueryUseCase {
+    private final RankingQueryPort rankingQueryPort;
+
+    @Override
+    public RankingListResult getTotalPointRankings() {
+        return new RankingListResult(
+                rankingQueryPort.findTotalPointRankings()
+        );
+    }
+
+    @Override
+    public RankingListResult getWeeklyPointRankings() {
+        LocalDateTime from = LocalDateTime.now().minusDays(7);
+
+        return new RankingListResult(
+                rankingQueryPort.findWeeklyPointRankings(from)
+        );
+    }
+
+    @Override
+    public RankingItem getMyPointRanking(Long userId) {
+
+        return rankingQueryPort.findMyTotalPointRanking(userId).
+                orElseThrow(() -> new NotFoundException(RankingErrorCode.RANKING_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/application/usecase/RankingQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/application/usecase/RankingQueryUseCase.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.ranking.application.usecase;
+
+import com.wanted.codebombalms.ranking.application.query.RankingItem;
+import com.wanted.codebombalms.ranking.application.query.RankingListResult;
+
+public interface RankingQueryUseCase {
+
+    RankingListResult getTotalPointRankings();
+
+    RankingListResult getWeeklyPointRankings();
+
+    RankingItem getMyPointRanking(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/exception/RankingErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/exception/RankingErrorCode.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.ranking.exception;
+
+import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RankingErrorCode implements ErrorCode {
+
+    RANKING_NOT_FOUND("RNK-001", "랭킹 정보를 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
@@ -1,0 +1,105 @@
+package com.wanted.codebombalms.ranking.infrastructure.persistence;
+
+import com.wanted.codebombalms.ranking.application.port.RankingQueryPort;
+import com.wanted.codebombalms.ranking.application.query.RankingItem;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class RankingQueryAdapter implements RankingQueryPort {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public List<RankingItem> findTotalPointRankings() {
+        String sql = """
+                select
+                    dense_rank() over (order by up.total_point desc) as ranking,
+                    u.user_id,
+                    u.nickname,
+                    up.total_point
+                from user_point up
+                join users u on u.user_id = up.user_id
+                where u.deleted_at is null
+                  and u.role = 'STUDENT'
+                order by ranking asc, u.user_id asc
+                """;
+
+        return entityManager.createNativeQuery(sql)
+                .getResultList()
+                .stream()
+                .map(row -> toRankingItem((Object[]) row))
+                .toList();
+    }
+
+    @Override
+    public List<RankingItem> findWeeklyPointRankings(LocalDateTime from) {
+        String sql = """
+                select
+                    dense_rank() over (order by sum(ph.point) desc) as ranking,
+                    u.user_id,
+                    u.nickname,
+                    sum(ph.point) as total_point
+                from point_history ph
+                join users u on u.user_id = ph.user_id
+                where ph.created_at >= :from
+                  and u.deleted_at is null
+                  and u.role = 'STUDENT'
+                group by u.user_id, u.nickname
+                order by ranking asc, u.user_id asc
+                """;
+
+        return entityManager.createNativeQuery(sql)
+                .setParameter("from", from)
+                .getResultList()
+                .stream()
+                .map(row -> toRankingItem((Object[]) row))
+                .toList();
+    }
+
+    @Override
+    public Optional<RankingItem> findMyTotalPointRanking(Long userId) {
+        String sql = """
+                select *
+                from (
+                    select
+                        dense_rank() over (order by up.total_point desc) as ranking,
+                        u.user_id,
+                        u.nickname,
+                        up.total_point
+                    from user_point up
+                    join users u on u.user_id = up.user_id
+                    where u.deleted_at is null
+                      and u.role = 'STUDENT'
+                ) ranked
+                where ranked.user_id = :userId
+                """;
+
+        Query query = entityManager.createNativeQuery(sql)
+                .setParameter("userId", userId);
+
+        List<?> result = query.getResultList();
+
+        if (result.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(toRankingItem((Object[]) result.get(0)));
+    }
+
+    private RankingItem toRankingItem(Object[] row) {
+        return new RankingItem(
+                ((Number) row[0]).intValue(),
+                ((Number) row[1]).longValue(),
+                (String) row[2],
+                ((Number) row[3]).intValue()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
@@ -20,17 +20,28 @@ public class RankingQueryAdapter implements RankingQueryPort {
     @Override
     public List<RankingItem> findTotalPointRankings() {
         String sql = """
+            select
+                dense_rank() over (order by up.total_point desc) as ranking,
+                u.user_id,
+                u.name,
+                u.nickname,
+                null as badge_image_url,
+                coalesce(weekly.weekly_point, 0) as weekly_point,
+                up.total_point
+            from user_point up
+            join users u on u.user_id = up.user_id
+            left join (
                 select
-                    dense_rank() over (order by up.total_point desc) as ranking,
-                    u.user_id,
-                    u.nickname,
-                    up.total_point
-                from user_point up
-                join users u on u.user_id = up.user_id
-                where u.deleted_at is null
-                  and u.role = 'STUDENT'
-                order by ranking asc, u.user_id asc
-                """;
+                    ph.user_id,
+                    sum(ph.point) as weekly_point
+                from point_history ph
+                where ph.created_at >= date_sub(now(), interval 7 day)
+                group by ph.user_id
+            ) weekly on weekly.user_id = u.user_id
+            where u.deleted_at is null
+              and u.role = 'STUDENT'
+            order by ranking asc, u.user_id asc
+            """;
 
         return entityManager.createNativeQuery(sql)
                 .getResultList()
@@ -42,19 +53,28 @@ public class RankingQueryAdapter implements RankingQueryPort {
     @Override
     public List<RankingItem> findWeeklyPointRankings(LocalDateTime from) {
         String sql = """
+            select
+                dense_rank() over (order by weekly.weekly_point desc) as ranking,
+                u.user_id,
+                u.name,
+                u.nickname,
+                null as badge_image_url,
+                weekly.weekly_point,
+                coalesce(up.total_point, 0) as total_point
+            from (
                 select
-                    dense_rank() over (order by sum(ph.point) desc) as ranking,
-                    u.user_id,
-                    u.nickname,
-                    sum(ph.point) as total_point
+                    ph.user_id,
+                    sum(ph.point) as weekly_point
                 from point_history ph
-                join users u on u.user_id = ph.user_id
                 where ph.created_at >= :from
-                  and u.deleted_at is null
-                  and u.role = 'STUDENT'
-                group by u.user_id, u.nickname
-                order by ranking asc, u.user_id asc
-                """;
+                group by ph.user_id
+            ) weekly
+            join users u on u.user_id = weekly.user_id
+            left join user_point up on up.user_id = u.user_id
+            where u.deleted_at is null
+              and u.role = 'STUDENT'
+            order by ranking asc, u.user_id asc
+            """;
 
         return entityManager.createNativeQuery(sql)
                 .setParameter("from", from)
@@ -67,20 +87,31 @@ public class RankingQueryAdapter implements RankingQueryPort {
     @Override
     public Optional<RankingItem> findMyTotalPointRanking(Long userId) {
         String sql = """
-                select *
-                from (
+            select *
+            from (
+                select
+                    dense_rank() over (order by up.total_point desc) as ranking,
+                    u.user_id,
+                    u.name,
+                    u.nickname,
+                    null as badge_image_url,
+                    coalesce(weekly.weekly_point, 0) as weekly_point,
+                    up.total_point
+                from user_point up
+                join users u on u.user_id = up.user_id
+                left join (
                     select
-                        dense_rank() over (order by up.total_point desc) as ranking,
-                        u.user_id,
-                        u.nickname,
-                        up.total_point
-                    from user_point up
-                    join users u on u.user_id = up.user_id
-                    where u.deleted_at is null
-                      and u.role = 'STUDENT'
-                ) ranked
-                where ranked.user_id = :userId
-                """;
+                        ph.user_id,
+                        sum(ph.point) as weekly_point
+                    from point_history ph
+                    where ph.created_at >= date_sub(now(), interval 7 day)
+                    group by ph.user_id
+                ) weekly on weekly.user_id = u.user_id
+                where u.deleted_at is null
+                  and u.role = 'STUDENT'
+            ) ranked
+            where ranked.user_id = :userId
+            """;
 
         Query query = entityManager.createNativeQuery(sql)
                 .setParameter("userId", userId);
@@ -99,7 +130,10 @@ public class RankingQueryAdapter implements RankingQueryPort {
                 ((Number) row[0]).intValue(),
                 ((Number) row[1]).longValue(),
                 (String) row[2],
-                ((Number) row[3]).intValue()
+                (String) row[3],
+                (String) row[4],
+                ((Number) row[5]).intValue(),
+                ((Number) row[6]).intValue()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/ranking/presentation/RankingController.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/presentation/RankingController.java
@@ -1,0 +1,101 @@
+package com.wanted.codebombalms.ranking.presentation;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import com.wanted.codebombalms.ranking.application.usecase.RankingQueryUseCase;
+import com.wanted.codebombalms.ranking.presentation.response.MyRankingResponse;
+import com.wanted.codebombalms.ranking.presentation.response.RankingListResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "포인트 랭킹", description = "학생들의 누적 포인트와 주간 포인트 기준 랭킹 조회 API")
+@RestController
+@RequestMapping("/api/v1/rankings/points")
+@RequiredArgsConstructor
+public class RankingController {
+
+    private final RankingQueryUseCase rankingQueryUseCase;
+
+    @Operation(
+            summary = "전체 포인트 랭킹 조회",
+            description = """
+                    학생들의 누적 포인트를 기준으로 전체 랭킹을 조회합니다.
+                    user_point.total_point 값을 기준으로 높은 포인트 순서대로 정렬합니다.
+                    동점자는 같은 순위를 가집니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전체 포인트 랭킹 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<RankingListResponse>> getTotalPointRankings() {
+        var result = rankingQueryUseCase.getTotalPointRankings();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "전체 포인트 랭킹 조회에 성공했습니다.",
+                RankingListResponse.from(result)
+        ));
+    }
+
+    @Operation(
+            summary = "주간 포인트 랭킹 조회",
+            description = """
+                    최근 7일 동안 지급된 포인트를 기준으로 주간 랭킹을 조회합니다.
+                    point_history.created_at 기준으로 최근 7일 데이터를 합산합니다.
+                    동점자는 같은 순위를 가집니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "주간 포인트 랭킹 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/weekly")
+    public ResponseEntity<ApiResponse<RankingListResponse>> getWeeklyPointRankings() {
+        var result = rankingQueryUseCase.getWeeklyPointRankings();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "주간 포인트 랭킹 조회에 성공했습니다.",
+                RankingListResponse.from(result)
+        ));
+    }
+
+    @Operation(
+            summary = "내 포인트 랭킹 조회",
+            description = """
+                    로그인한 사용자의 전체 포인트 랭킹을 조회합니다.
+                    userId는 요청 파라미터로 받지 않고 인증 토큰에서 가져옵니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 포인트 랭킹 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "RNK-001 - 랭킹 정보를 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<MyRankingResponse>> getMyPointRanking(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long userId
+    ) {
+        var result = rankingQueryUseCase.getMyPointRanking(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "내 포인트 랭킹 조회에 성공했습니다.",
+                MyRankingResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/presentation/response/MyRankingResponse.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/presentation/response/MyRankingResponse.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.ranking.presentation.response;
+
+import com.wanted.codebombalms.ranking.application.query.RankingItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 포인트 랭킹 응답")
+public record MyRankingResponse(
+        @Schema(description = "내 랭킹 순위. 동점자는 같은 순위를 가집니다.", example = "5")
+        Integer rank,
+
+        @Schema(description = "내 회원 ID", example = "3")
+        Long userId,
+
+        @Schema(description = "내 닉네임", example = "user01")
+        String nickname,
+
+        @Schema(description = "내 누적 포인트", example = "120")
+        Integer point
+) {
+    public static MyRankingResponse from(RankingItem item) {
+        return new MyRankingResponse(
+                item.rank(),
+                item.userId(),
+                item.nickname(),
+                item.point()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/presentation/response/MyRankingResponse.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/presentation/response/MyRankingResponse.java
@@ -11,18 +11,30 @@ public record MyRankingResponse(
         @Schema(description = "내 회원 ID", example = "3")
         Long userId,
 
+        @Schema(description = "내 이름", example = "김학생")
+        String name,
+
         @Schema(description = "내 닉네임", example = "user01")
         String nickname,
 
+        @Schema(description = "내 뱃지 이미지 URL. 뱃지 기능 구현 전에는 null입니다.", nullable = true)
+        String badgeImageUrl,
+
+        @Schema(description = "내 주간 포인트", example = "30")
+        Integer weeklyPoint,
+
         @Schema(description = "내 누적 포인트", example = "120")
-        Integer point
+        Integer totalPoint
 ) {
     public static MyRankingResponse from(RankingItem item) {
         return new MyRankingResponse(
                 item.rank(),
                 item.userId(),
+                item.name(),
                 item.nickname(),
-                item.point()
+                item.badgeImageUrl(),
+                item.weeklyPoint(),
+                item.totalPoint()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/ranking/presentation/response/RankingListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/presentation/response/RankingListResponse.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.ranking.presentation.response;
+
+import com.wanted.codebombalms.ranking.application.query.RankingListResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "포인트 랭킹 목록 응답")
+public record RankingListResponse(
+        @Schema(description = "랭킹 목록")
+        List<RankingResponse> rankings
+) {
+    public static RankingListResponse from(RankingListResult result) {
+        return new RankingListResponse(
+                result.rankings().stream()
+                        .map(RankingResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/presentation/response/RankingResponse.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/presentation/response/RankingResponse.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.ranking.presentation.response;
+
+import com.wanted.codebombalms.ranking.application.query.RankingItem;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "포인트 랭킹 항목 응답")
+public record RankingResponse(
+        @Schema(description = "랭킹 순위. 동점자는 같은 순위를 가집니다.", example = "1")
+        Integer rank,
+
+        @Schema(description = "회원 ID", example = "3")
+        Long userId,
+
+        @Schema(description = "회원 닉네임", example = "user01")
+        String nickname,
+
+        @Schema(description = "랭킹 기준 포인트", example = "120")
+        Integer point
+) {
+    public static RankingResponse from(RankingItem item) {
+        return new RankingResponse(
+                item.rank(),
+                item.userId(),
+                item.nickname(),
+                item.point()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/ranking/presentation/response/RankingResponse.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/presentation/response/RankingResponse.java
@@ -11,18 +11,30 @@ public record RankingResponse(
         @Schema(description = "회원 ID", example = "3")
         Long userId,
 
+        @Schema(description = "회원 이름", example = "김학생")
+        String name,
+
         @Schema(description = "회원 닉네임", example = "user01")
         String nickname,
 
-        @Schema(description = "랭킹 기준 포인트", example = "120")
-        Integer point
+        @Schema(description = "뱃지 이미지 URL. 뱃지 기능 구현 전에는 null입니다.", example = "/images/badges/problem-beginner.png", nullable = true)
+        String badgeImageUrl,
+
+        @Schema(description = "최근 7일 동안 획득한 주간 포인트", example = "30")
+        Integer weeklyPoint,
+
+        @Schema(description = "누적 포인트", example = "120")
+        Integer totalPoint
 ) {
     public static RankingResponse from(RankingItem item) {
         return new RankingResponse(
                 item.rank(),
                 item.userId(),
+                item.name(),
                 item.nickname(),
-                item.point()
+                item.badgeImageUrl(),
+                item.weeklyPoint(),
+                item.totalPoint()
         );
     }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #153 

---

## 🛠️ 기능 관련 작업 내용

- 학생들의 누적 포인트를 기준으로 전체 포인트 랭킹 조회 API를 구현했습니다.
- 최근 7일간 지급된 포인트를 합산하여 주간 포인트 랭킹 조회 API를 구현했습니다.
- 로그인한 사용자의 포인트 랭킹을 조회하는 내 랭킹 API를 구현했습니다.
- 동점자는 같은 순위를 갖도록 `DENSE_RANK` 기준의 랭킹 조회 로직을 적용했습니다.
- 포인트 랭킹 API와 응답 DTO에 Swagger 설명을 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `ranking/presentation` : 전체 랭킹, 주간 랭킹, 내 랭킹 조회 API 추가 및 Swagger 설명 추가
- `ranking/application/service` : 랭킹 조회 유스케이스 구현 및 주간 랭킹 기준 기간 계산 추가
- `ranking/application/usecase` : 랭킹 조회 UseCase 인터페이스 추가
- `ranking/application/port` : 랭킹 조회 Port 인터페이스 추가
- `ranking/application/query` : 랭킹 조회 결과 객체 추가
- `ranking/infrastructure/persistence` : 포인트 테이블 기반 랭킹 조회 Adapter 구현
- `ranking/presentation/response` : 랭킹 응답 DTO 추가 및 Swagger 필드 설명 추가
- `ranking/exception` : 랭킹 조회 실패 에러코드 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.