### PR TITLE
[Feat] 뱃지 관리 및 사용자 뱃지 조회 기능 구조 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/badge/application/command/CreateBadgeCommand.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/command/CreateBadgeCommand.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.badge.application.command;
+
+public record CreateBadgeCommand(
+        String badgeName,
+        String description,
+        Integer requiredPoint,
+        String originalFileName,
+        String contentType,
+        long fileSize,
+        byte[] imageBytes
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/command/UpdateBadgeCommand.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/command/UpdateBadgeCommand.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.badge.application.command;
+
+public record UpdateBadgeCommand(
+        String badgeName,
+        String description,
+        Integer requiredPoint,
+        String status,
+        String originalFileName,
+        String contentType,
+        long fileSize,
+        byte[] imageBytes
+) {
+    public boolean hasNewImage() {
+        return imageBytes != null && imageBytes.length > 0;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/port/BadgeImageStoragePort.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/port/BadgeImageStoragePort.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.application.port;
+
+public class BadgeImageStoragePort {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/port/BadgeQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/port/BadgeQueryPort.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.application.port;
+
+public class BadgeQueryPort {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/query/BadgeResult.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/query/BadgeResult.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.badge.application.query;
+
+import java.time.LocalDateTime;
+
+public record BadgeResult(
+        Long badgeId,
+        String badgeName,
+        String description,
+        Integer requiredPoint,
+        String imageUrl,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/query/BadgeSyncResult.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/query/BadgeSyncResult.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.badge.application.query;
+
+import java.util.List;
+
+public record BadgeSyncResult(
+        Long userId,
+        Integer totalPoint,
+        Integer newlyEarnedBadgeCount,
+        List<MyBadgeResult> newlyEarnedBadges
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/query/MyBadgeResult.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/query/MyBadgeResult.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.badge.application.query;
+
+import java.time.LocalDateTime;
+
+public record MyBadgeResult(
+        Long badgeId,
+        String badgeName,
+        String description,
+        Integer requiredPoint,
+        String imageUrl,
+        String status,
+        LocalDateTime earnedAt,
+        Boolean isEquipped
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/service/AdminBadgeService.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/service/AdminBadgeService.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.application.service;
+
+public class AdminBadgeService {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/service/AdminBadgeService.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/service/AdminBadgeService.java
@@ -1,4 +1,37 @@
 package com.wanted.codebombalms.badge.application.service;
 
-public class AdminBadgeService {
+import com.wanted.codebombalms.badge.application.command.CreateBadgeCommand;
+import com.wanted.codebombalms.badge.application.command.UpdateBadgeCommand;
+import com.wanted.codebombalms.badge.application.query.BadgeResult;
+import com.wanted.codebombalms.badge.application.usecase.AdminBadgeUseCase;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AdminBadgeService implements AdminBadgeUseCase {
+
+    @Override
+    public List<BadgeResult> getBadges() {
+        return List.of();
+    }
+
+    @Override
+    public BadgeResult getBadge(Long badgeId) {
+        return null;
+    }
+
+    @Override
+    public BadgeResult createBadge(CreateBadgeCommand command) {
+        return null;
+    }
+
+    @Override
+    public BadgeResult updateBadge(Long badgeId, UpdateBadgeCommand command) {
+        return null;
+    }
+
+    @Override
+    public void deleteBadge(Long badgeId) {
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/badge/application/service/MyBadgeService.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/service/MyBadgeService.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.application.service;
+
+public class MyBadgeService {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/service/MyBadgeService.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/service/MyBadgeService.java
@@ -1,4 +1,32 @@
 package com.wanted.codebombalms.badge.application.service;
 
-public class MyBadgeService {
+import com.wanted.codebombalms.badge.application.query.BadgeSyncResult;
+import com.wanted.codebombalms.badge.application.query.MyBadgeResult;
+import com.wanted.codebombalms.badge.application.usecase.MyBadgeUseCase;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MyBadgeService implements MyBadgeUseCase {
+
+    @Override
+    public List<MyBadgeResult> getMyBadges(Long userId) {
+        return List.of();
+    }
+
+    @Override
+    public MyBadgeResult equipBadge(Long userId, Long badgeId) {
+        return null;
+    }
+
+    @Override
+    public BadgeSyncResult syncBadges(Long userId) {
+        return new BadgeSyncResult(
+                userId,
+                0,
+                0,
+                List.of()
+        );
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/badge/application/usecase/AdminBadgeUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/usecase/AdminBadgeUseCase.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.badge.application.usecase;
+
+import com.wanted.codebombalms.badge.application.command.CreateBadgeCommand;
+import com.wanted.codebombalms.badge.application.command.UpdateBadgeCommand;
+import com.wanted.codebombalms.badge.application.query.BadgeResult;
+
+import java.util.List;
+
+public interface AdminBadgeUseCase {
+
+    List<BadgeResult> getBadges();
+
+    BadgeResult getBadge(Long badgeId);
+
+    BadgeResult createBadge(CreateBadgeCommand command);
+
+    BadgeResult updateBadge(Long badgeId, UpdateBadgeCommand command);
+
+    void deleteBadge(Long badgeId);
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/usecase/MyBadgeUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/usecase/MyBadgeUseCase.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.application.usecase;
+
+public class MyBadgeUseCase {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/application/usecase/MyBadgeUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/usecase/MyBadgeUseCase.java
@@ -1,4 +1,15 @@
 package com.wanted.codebombalms.badge.application.usecase;
 
-public class MyBadgeUseCase {
+import com.wanted.codebombalms.badge.application.query.BadgeSyncResult;
+import com.wanted.codebombalms.badge.application.query.MyBadgeResult;
+
+import java.util.List;
+
+public interface MyBadgeUseCase {
+
+    List<MyBadgeResult> getMyBadges(Long userId);
+
+    MyBadgeResult equipBadge(Long userId, Long badgeId);
+
+    BadgeSyncResult syncBadges(Long userId);
 }

--- a/src/main/java/com/wanted/codebombalms/badge/exception/BadgeErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/badge/exception/BadgeErrorCode.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.exception;
+
+public class BadgeErrorCode {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/BadgeJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/BadgeJpaEntity.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.infrastructure.persistence;
+
+public class BadgeJpaEntity {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/SpringDataBadgeRepository.java
+++ b/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/SpringDataBadgeRepository.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.infrastructure.persistence;
+
+public class SpringDataBadgeRepository {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/SpringDataUserBadgeRepository.java
+++ b/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/SpringDataUserBadgeRepository.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.infrastructure.persistence;
+
+public class SpringDataUserBadgeRepository {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/UserBadgeJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/UserBadgeJpaEntity.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.infrastructure.persistence;
+
+public class UserBadgeJpaEntity {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/persistence.java
+++ b/src/main/java/com/wanted/codebombalms/badge/infrastructure/persistence/persistence.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.infrastructure.persistence;
+
+public class persistence {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/infrastructure/storage/GcsBadgeImageStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/badge/infrastructure/storage/GcsBadgeImageStorageAdapter.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.infrastructure.storage;
+
+public class GcsBadgeImageStorageAdapter {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/AdminBadgeController.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/AdminBadgeController.java
@@ -15,6 +15,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -55,7 +56,7 @@ public class AdminBadgeController {
     public ResponseEntity<ApiResponse<BadgeResponse>> createBadge(
             @RequestPart("request") CreateBadgeRequest request,
             @RequestPart("badgeImage") MultipartFile badgeImage
-    ) {
+    ) throws IOException {
         var command = new CreateBadgeCommand(
                 request.badgeName(),
                 request.description(),
@@ -84,7 +85,7 @@ public class AdminBadgeController {
             @PathVariable Long badgeId,
             @RequestPart("request") UpdateBadgeRequest request,
             @RequestPart(value = "badgeImage", required = false) MultipartFile badgeImage
-    ) {
+    ) throws IOException {
         var command = new UpdateBadgeCommand(
                 request.badgeName(),
                 request.description(),

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/AdminBadgeController.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/AdminBadgeController.java
@@ -1,0 +1,120 @@
+package com.wanted.codebombalms.badge.presentation;
+
+import com.wanted.codebombalms.badge.application.command.CreateBadgeCommand;
+import com.wanted.codebombalms.badge.application.command.UpdateBadgeCommand;
+import com.wanted.codebombalms.badge.application.usecase.AdminBadgeUseCase;
+import com.wanted.codebombalms.badge.presentation.request.CreateBadgeRequest;
+import com.wanted.codebombalms.badge.presentation.request.UpdateBadgeRequest;
+import com.wanted.codebombalms.badge.presentation.response.BadgeResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/badges")
+@RequiredArgsConstructor
+@PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
+public class AdminBadgeController {
+
+    private final AdminBadgeUseCase adminBadgeUseCase;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<BadgeResponse>>> getBadges() {
+        var badges = adminBadgeUseCase.getBadges().stream()
+                .map(BadgeResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "뱃지 목록 조회에 성공했습니다.",
+                badges
+        ));
+    }
+
+    @GetMapping("/{badgeId}")
+    public ResponseEntity<ApiResponse<BadgeResponse>> getBadge(
+            @PathVariable Long badgeId
+    ) {
+        var badge = adminBadgeUseCase.getBadge(badgeId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "뱃지 상세 조회에 성공했습니다.",
+                BadgeResponse.from(badge)
+        ));
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<BadgeResponse>> createBadge(
+            @RequestPart("request") CreateBadgeRequest request,
+            @RequestPart("badgeImage") MultipartFile badgeImage
+    ) {
+        var command = new CreateBadgeCommand(
+                request.badgeName(),
+                request.description(),
+                request.requiredPoint(),
+                badgeImage.getOriginalFilename(),
+                badgeImage.getContentType(),
+                badgeImage.getSize(),
+                badgeImage.getBytes()
+        );
+
+
+        var badge = adminBadgeUseCase.createBadge(command);
+
+        return ResponseEntity.ok(ApiResponse.created(
+                ApiResponseCode.CREATED,
+                "뱃지 등록에 성공했습니다.",
+                BadgeResponse.from(badge)
+        ));
+    }
+
+    @PatchMapping(
+            value = "/{badgeId}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<ApiResponse<BadgeResponse>> updateBadge(
+            @PathVariable Long badgeId,
+            @RequestPart("request") UpdateBadgeRequest request,
+            @RequestPart(value = "badgeImage", required = false) MultipartFile badgeImage
+    ) {
+        var command = new UpdateBadgeCommand(
+                request.badgeName(),
+                request.description(),
+                request.requiredPoint(),
+                request.status(),
+                badgeImage != null ? badgeImage.getOriginalFilename() : null,
+                badgeImage != null ? badgeImage.getContentType() : null,
+                badgeImage != null ? badgeImage.getSize() : 0,
+                badgeImage != null ? badgeImage.getBytes() : null
+        );
+
+        var badge = adminBadgeUseCase.updateBadge(badgeId, command);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "뱃지 수정에 성공했습니다.",
+                BadgeResponse.from(badge)
+        ));
+    }
+
+    @DeleteMapping("/{badgeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteBadge(
+            @PathVariable Long badgeId
+    ) {
+        adminBadgeUseCase.deleteBadge(badgeId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "뱃지 삭제에 성공했습니다.",
+                null
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/MyBadgeController.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/MyBadgeController.java
@@ -1,0 +1,63 @@
+package com.wanted.codebombalms.badge.presentation;
+
+import com.wanted.codebombalms.badge.application.usecase.MyBadgeUseCase;
+import com.wanted.codebombalms.badge.presentation.response.BadgeSyncResponse;
+import com.wanted.codebombalms.badge.presentation.response.MyBadgeResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/badges/me")
+@RequiredArgsConstructor
+public class MyBadgeController {
+
+    private final MyBadgeUseCase myBadgeUseCase;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<MyBadgeResponse>>> getMyBadges(
+            @AuthenticationPrincipal Long userId
+    ) {
+        var badges = myBadgeUseCase.getMyBadges(userId).stream()
+                .map(MyBadgeResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "내 뱃지 목록 조회에 성공했습니다.",
+                badges
+        ));
+    }
+
+    @PatchMapping("/{badgeId}/equip")
+    public ResponseEntity<ApiResponse<MyBadgeResponse>> equipBadge(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long badgeId
+    ) {
+        var badge = myBadgeUseCase.equipBadge(userId, badgeId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "대표 뱃지 설정에 성공했습니다.",
+                MyBadgeResponse.from(badge)
+        ));
+    }
+
+    @PostMapping("/sync")
+    public ResponseEntity<ApiResponse<BadgeSyncResponse>> syncMyBadges(
+            @AuthenticationPrincipal Long userId
+    ) {
+        var result = myBadgeUseCase.syncBadges(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                "획득 가능한 뱃지 동기화에 성공했습니다.",
+                BadgeSyncResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/request/CreateBadgeRequest.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/request/CreateBadgeRequest.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.badge.presentation.request;
+
+public record CreateBadgeRequest(
+        String badgeName,
+        String description,
+        Integer requiredPoint
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/request/UpdateBadgeRequest.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/request/UpdateBadgeRequest.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.badge.presentation.request;
+
+public record UpdateBadgeRequest(
+        String badgeName,
+        String description,
+        Integer requiredPoint,
+        String status
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/response/BadgeResponse.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/response/BadgeResponse.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.badge.presentation.response;
+
+import com.wanted.codebombalms.badge.application.query.BadgeResult;
+
+import java.time.LocalDateTime;
+
+public record BadgeResponse(
+        Long badgeId,
+        String badgeName,
+        String description,
+        Integer requiredPoint,
+        String imageUrl,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static BadgeResponse from(BadgeResult result) {
+        return new BadgeResponse(
+                result.badgeId(),
+                result.badgeName(),
+                result.description(),
+                result.requiredPoint(),
+                result.imageUrl(),
+                result.status(),
+                result.createdAt(),
+                result.updatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/response/BadgeSyncResponse.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/response/BadgeSyncResponse.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.presentation.response;
+
+public class BadgeSyncResponse {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/response/BadgeSyncResponse.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/response/BadgeSyncResponse.java
@@ -1,4 +1,23 @@
 package com.wanted.codebombalms.badge.presentation.response;
 
-public class BadgeSyncResponse {
+import com.wanted.codebombalms.badge.application.query.BadgeSyncResult;
+
+import java.util.List;
+
+public record BadgeSyncResponse(
+        Long userId,
+        Integer totalPoint,
+        Integer newlyEarnedBadgeCount,
+        List<MyBadgeResponse> newlyEarnedBadges
+) {
+    public static BadgeSyncResponse from(BadgeSyncResult result) {
+        return new BadgeSyncResponse(
+                result.userId(),
+                result.totalPoint(),
+                result.newlyEarnedBadgeCount(),
+                result.newlyEarnedBadges().stream()
+                        .map(MyBadgeResponse::from)
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/response/MyBadgeResponse.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/response/MyBadgeResponse.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.badge.presentation.response;
+
+public class MyBadgeResponse {
+}

--- a/src/main/java/com/wanted/codebombalms/badge/presentation/response/MyBadgeResponse.java
+++ b/src/main/java/com/wanted/codebombalms/badge/presentation/response/MyBadgeResponse.java
@@ -1,4 +1,29 @@
 package com.wanted.codebombalms.badge.presentation.response;
 
-public class MyBadgeResponse {
+import com.wanted.codebombalms.badge.application.query.MyBadgeResult;
+
+import java.time.LocalDateTime;
+
+public record MyBadgeResponse(
+        Long badgeId,
+        String badgeName,
+        String description,
+        Integer requiredPoint,
+        String imageUrl,
+        String status,
+        LocalDateTime earnedAt,
+        Boolean isEquipped
+) {
+    public static MyBadgeResponse from(MyBadgeResult result) {
+        return new MyBadgeResponse(
+                result.badgeId(),
+                result.badgeName(),
+                result.description(),
+                result.requiredPoint(),
+                result.imageUrl(),
+                result.status(),
+                result.earnedAt(),
+                result.isEquipped()
+        );
+    }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 관리자 뱃지 관리 API 구조를 추가했습니다.
- 뱃지 등록, 조회, 수정, 삭제 요청을 처리하기 위한 컨트롤러와 요청/응답 DTO 구조를 추가했습니다.
- 사용자 본인 뱃지 조회, 대표 뱃지 설정, 획득 가능 뱃지 동기화 API 구조를 추가했습니다.
- 사용자 뱃지 응답 변환 객체와 뱃지 동기화 응답 객체를 추가하여 컴파일 오류를 수정했습니다.

---

## ♻️ 패키지 변경 사항

- `badge/presentation/AdminBadgeController` : 관리자 뱃지 목록 조회, 상세 조회, 등록, 수정, 삭제 API 엔드포인트 추가
- `badge/presentation/MyBadgeController` : 사용자 본인 뱃지 조회, 대표 뱃지 설정, 뱃지 동기화 API 엔드포인트 추가
- `badge/presentation/request` : 뱃지 등록 및 수정 요청 DTO 추가
- `badge/presentation/response` : 관리자 뱃지 응답, 사용자 뱃지 응답, 뱃지 동기화 응답 DTO 추가
- `badge/application/usecase` : 관리자/사용자 뱃지 유스케이스 메서드 정의
- `badge/application/command` : 뱃지 등록 및 수정 커맨드 객체 추가
- `badge/application/query` : 뱃지 조회 결과, 사용자 뱃지 결과, 뱃지 동기화 결과 객체 추가
- `badge/application/port` : 뱃지 이미지 저장 및 조회 포트 구조 추가
- `badge/application/service` : 관리자/사용자 뱃지 서비스 구현 위치 추가
- `badge/infrastructure/persistence` : 뱃지 및 사용자 뱃지 영속성 구조 추가
- `badge/infrastructure/storage` : GCS 뱃지 이미지 저장 어댑터 구조 추가
- `badge/exception` : 뱃지 도메인 에러 코드 구조 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.