### PR TITLE
[Fix] 수강 및 학습 API 인증 주체 적용

### DIFF
--- a/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseProblemController.java
+++ b/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseProblemController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -62,6 +63,7 @@ public class CourseProblemController {
 
     @PutMapping("/courses/{courseId}/problem-sets")
     @Operation(summary = "강좌 문제세트 연결 저장")
+    @PreAuthorize("hasRole('OPERATOR')")
     public ResponseEntity<ApiResponse<?>> configureProblemSets(
             @PathVariable Long courseId,
             @Valid @RequestBody CourseProblemSetConfigureRequest request

--- a/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
@@ -50,13 +50,17 @@ public class EnrollmentController {
 
     @GetMapping("/users/{userId}/enrollments")
     @Operation(summary = "학생 수강 목록 조회")
-    public ResponseEntity<ApiResponse<?>> findMyCourses(@PathVariable Long userId) {
-        log.info("[EnrollmentController] find my courses - userId: {}", userId);
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<?>> findMyCourses(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal Long authenticatedUserId
+    ) {
+        log.info("[EnrollmentController] find my courses - userId: {}", authenticatedUserId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 EnrollmentResponseCode.RETRIEVED,
                 EnrollmentResponseMessage.RETRIEVED,
-                enrollmentQueryUseCase.findMyCourses(userId)
+                enrollmentQueryUseCase.findMyCourses(authenticatedUserId)
                         .stream()
                         .map(enrollment -> MyCourseResponse.from(
                                 enrollment,

--- a/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningController.java
+++ b/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningController.java
@@ -29,6 +29,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -54,15 +55,15 @@ public class LearningController {
 
     @PatchMapping("/lectures/{lectureId}/progress")
     @Operation(summary = "강의 수강 진행률 저장")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<LectureProgressResponse>> recordLectureProgress(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long lectureId,
             @Valid @RequestBody LectureProgressRequest request
     ) {
-        Long requesterId = userId != null ? userId : request.userId();
         LectureProgressResponse response = LectureProgressResponse.from(
                 lectureProgressCommandUseCase.recordProgress(new RecordLectureProgressCommand(
-                        requesterId,
+                        userId,
                         lectureId,
                         request.completed()
                 ))

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -59,6 +60,7 @@ public class LectureController {
 
     @PostMapping("/courses/{courseId}/lectures")
     @Operation(summary = "강의 생성")
+    @PreAuthorize("hasRole('OPERATOR')")
     public ResponseEntity<ApiResponse<?>> createLecture(
             @PathVariable Long courseId,
             @Valid @RequestBody LectureCreateRequest request
@@ -83,6 +85,7 @@ public class LectureController {
 
     @PutMapping("/lectures/{lectureId}")
     @Operation(summary = "강의 수정")
+    @PreAuthorize("hasRole('OPERATOR')")
     public ResponseEntity<ApiResponse<?>> updateLecture(
             @PathVariable Long lectureId,
             @Valid @RequestBody LectureUpdateRequest request
@@ -106,6 +109,7 @@ public class LectureController {
 
     @DeleteMapping("/lectures/{lectureId}")
     @Operation(summary = "강의 삭제")
+    @PreAuthorize("hasRole('OPERATOR')")
     public ResponseEntity<Void> deleteLecture(@PathVariable Long lectureId) {
         log.info("[LectureController] delete lecture - lectureId: {}", lectureId);
 

--- a/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
@@ -83,14 +84,19 @@ class EnrollmentControllerTest {
         given(courseCatalogPort.getPublicationStatus(1L))
                 .willReturn(new CoursePublicationStatus(1L, 1L, "Java", "description", "java.png", true));
 
-        mockMvc.perform(get("/api/v1/users/{userId}/enrollments", studentId)
-                        .principal(studentPrincipal(studentId))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.code").value(EnrollmentResponseCode.RETRIEVED))
-                .andExpect(jsonPath("$.message").value(EnrollmentResponseMessage.RETRIEVED))
-                .andExpect(jsonPath("$.data[0].courseTitle").value("Java"));
+        SecurityContextHolder.getContext().setAuthentication(studentPrincipal(studentId));
+
+        try {
+            mockMvc.perform(get("/api/v1/users/{userId}/enrollments", studentId)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.code").value(EnrollmentResponseCode.RETRIEVED))
+                    .andExpect(jsonPath("$.message").value(EnrollmentResponseMessage.RETRIEVED))
+                    .andExpect(jsonPath("$.data[0].courseTitle").value("Java"));
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
@@ -84,6 +84,7 @@ class EnrollmentControllerTest {
                 .willReturn(new CoursePublicationStatus(1L, 1L, "Java", "description", "java.png", true));
 
         mockMvc.perform(get("/api/v1/users/{userId}/enrollments", studentId)
+                        .principal(studentPrincipal(studentId))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 수강 목록 조회 시 path userId 대신 JWT 인증 사용자 ID 기준으로 조회하도록 변경
- 강의 수강 진행률 저장 API에 인증 권한을 추가하고 인증 사용자 ID로 진도 저장
- 강좌 문제세트 연결 변경 및 강의 변경 API에 OPERATOR 권한 적용
- 요청 body 또는 path userId를 신뢰하던 흐름을 인증 주체 기반으로 보완

---

## ♻️ 패키지 변경 사항

- codebombalms/enrollment: 수강 목록 조회 API에 인증 권한을 적용하고 JWT 사용자 ID 기준으로 조회하도록 수정
- codebombalms/learning: 강의 수강 진행률 저장 API에 인증 권한을 적용하고 요청 userId fallback 제거
- codebombalms/course: 강좌 문제세트 연결 변경 API에 OPERATOR 권한 적용
- codebombalms/lecture: 강의 생성, 수정, 삭제 API에 OPERATOR 권한 적용

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.
