### PR TITLE
[Feat] 첫 메세지에 채팅방생성 기능 구현

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendFirstMessageCommand.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendFirstMessageCommand.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.chatbot.application.command;
+
+public record SendFirstMessageCommand(
+        Long userId,
+        String userMessage,
+        Long problemSetId,
+        Long problemId
+) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/result/SendFirstMessageResult.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/result/SendFirstMessageResult.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.chatbot.application.result;
+
+public record SendFirstMessageResult(
+        Long roomId,
+        String answer
+) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
@@ -1,8 +1,11 @@
 package com.wanted.codebombalms.chatbot.application.service;
 
-import com.wanted.codebombalms.chatbot.application.command.CreateChatRoomCommand;
+import com.wanted.codebombalms.chatbot.application.command.SendFirstMessageCommand;
+import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
 import com.wanted.codebombalms.chatbot.application.port.ChatContextPort;
-import com.wanted.codebombalms.chatbot.application.result.ChatRoomResult;
+import com.wanted.codebombalms.chatbot.application.result.AiChatResult;
+import com.wanted.codebombalms.chatbot.application.result.SendFirstMessageResult;
+import com.wanted.codebombalms.chatbot.application.usecase.ChatMessageCommandUseCase;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatRoomCommandUseCase;
 import com.wanted.codebombalms.chatbot.domain.model.ChatRoom;
 import com.wanted.codebombalms.chatbot.domain.repository.ChatMessageRepository;
@@ -19,27 +22,26 @@ public class ChatRoomCommandService implements ChatRoomCommandUseCase {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatContextPort chatContextPort;
+    private final ChatMessageCommandUseCase chatMessageCommandUseCase;
 
     @Override
-    public ChatRoomResult create(CreateChatRoomCommand command) {
-        ChatContextPort.ProblemSetInfo problemSetInfo =
-                chatContextPort.findProblemSet(command.problemSetId());
+    public SendFirstMessageResult sendFirst(SendFirstMessageCommand command) {
+        ChatRoom room = createRoom(command.userId(), command.problemSetId(), command.problemId());
 
-        String title = problemSetInfo != null ? problemSetInfo.title() : "";
-        ChatRoom newRoom = ChatRoom.create(command.userId(), command.problemSetId(), command.problemId(), title);
-        ChatRoom saved = chatRoomRepository.save(newRoom);
-        return toResult(saved);
+        AiChatResult aiResult = chatMessageCommandUseCase.send(
+                new SendMessageCommand(command.userId(), room.getId(), command.userMessage())
+        );
+
+        return new SendFirstMessageResult(room.getId(), aiResult.answer());
     }
 
-    private ChatRoomResult toResult(ChatRoom chatRoom) {
-        return new ChatRoomResult(
-                chatRoom.getId(),
-                chatRoom.getProblemSetId(),
-                chatRoom.getProblemId(),
-                chatRoom.getTitle(),
-                chatRoom.getCreatedAt(),
-                chatRoom.getUpdatedAt()
-        );
+    private ChatRoom createRoom(Long userId, Long problemSetId, Long problemId) {
+        ChatContextPort.ProblemSetInfo problemSetInfo =
+                problemSetId != null ? chatContextPort.findProblemSet(problemSetId) : null;
+
+        String title = problemSetInfo != null ? problemSetInfo.title() : "";
+        ChatRoom newRoom = ChatRoom.create(userId, problemSetId, problemId, title);
+        return chatRoomRepository.save(newRoom);
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/usecase/ChatRoomCommandUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/usecase/ChatRoomCommandUseCase.java
@@ -1,13 +1,11 @@
 package com.wanted.codebombalms.chatbot.application.usecase;
 
-import com.wanted.codebombalms.chatbot.application.command.CreateChatRoomCommand;
-import com.wanted.codebombalms.chatbot.application.result.ChatRoomResult;
+import com.wanted.codebombalms.chatbot.application.command.SendFirstMessageCommand;
+import com.wanted.codebombalms.chatbot.application.result.SendFirstMessageResult;
 
 public interface ChatRoomCommandUseCase {
 
-    // 채팅방 생성 또는 기존 방 반환
-    ChatRoomResult create(CreateChatRoomCommand command);
+    SendFirstMessageResult sendFirst(SendFirstMessageCommand command);
 
-    // 채팅방 삭제 (소유권 검증 포함)
     void delete(Long roomId, Long userId);
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseCode.java
@@ -4,7 +4,8 @@ public class ChatResponseCode {
 
     private ChatResponseCode() {}
 
-    public static final String ROOM_CREATED = "CHAT-ROOM-CREATED";
+    // ROOM_CREATED 삭제
+    public static final String FIRST_MESSAGE_SENT = "CHAT-FIRST-MESSAGE-SENT";
     public static final String ROOM_RETRIEVED = "CHAT-ROOM-RETRIEVED";
     public static final String MESSAGES_RETRIEVED = "CHAT-MESSAGES-RETRIEVED";
     public static final String MESSAGE_SENT = "CHAT-MESSAGE-SENT";

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseMessage.java
@@ -4,7 +4,8 @@ public class ChatResponseMessage {
 
     private ChatResponseMessage() {}
 
-    public static final String ROOM_CREATED = "채팅방이 생성되었습니다.";
+    // ROOM_CREATED 삭제
+    public static final String FIRST_MESSAGE_SENT = "채팅방이 생성되고 메시지가 전송되었습니다.";
     public static final String ROOM_RETRIEVED = "채팅방 목록 조회에 성공했습니다.";
     public static final String MESSAGES_RETRIEVED = "채팅 내역 조회에 성공했습니다.";
     public static final String MESSAGE_SENT = "메시지 전송에 성공했습니다.";

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
@@ -1,10 +1,10 @@
 package com.wanted.codebombalms.chatbot.presentation.api;
 
-import com.wanted.codebombalms.chatbot.application.command.CreateChatRoomCommand;
-import com.wanted.codebombalms.chatbot.application.result.ChatRoomResult;
+import com.wanted.codebombalms.chatbot.application.command.SendFirstMessageCommand;
+import com.wanted.codebombalms.chatbot.presentation.api.request.SendFirstMessageRequest;
+import com.wanted.codebombalms.chatbot.presentation.api.response.SendFirstMessageResponse;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatRoomCommandUseCase;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatRoomQueryUseCase;
-import com.wanted.codebombalms.chatbot.presentation.api.request.ChatRoomCreateRequest;
 import com.wanted.codebombalms.chatbot.presentation.api.response.ChatRoomResponse;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,77 +35,77 @@ public class ChatRoomController {
     private final ChatMessageCommandUseCase chatMessageCommandUseCase;
 
     @Operation(
-            summary = "채팅방 생성",
-            description = "항상 새 방 생성. 동일 문제에 대해 기존 방이 있어도 새로 생성됩니다."
+            summary = "첫 메시지 전송 (채팅방 자동 생성)",
+            description = "채팅방을 생성하고 첫 메시지를 전송합니다. 응답의 roomId로 이후 메시지를 전송합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "201",
-                    description = "채팅방 생성 성공",
+                    description = "채팅방 생성 + 메시지 전송 성공",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "생성 성공",
+                                    name = "성공",
                                     value = """
-                                            {
-                                              "timestamp": "2026-05-28T12:00:00",
-                                              "status": 201,
-                                              "code": "CHT-001",
-                                              "message": "채팅방이 생성되었습니다.",
-                                              "data": {
-                                                "roomId": 1,
-                                                "problemSetId": 10,
-                                                "problemId": 100,
-                                                "title": "문제 100 채팅방",
-                                                "createdAt": "2026-05-28T12:00:00Z",
-                                                "updatedAt": "2026-05-28T12:00:00Z"
-                                              }
-                                            }
-                                            """
+                                        {
+                                          "timestamp": "2026-05-29T12:00:00",
+                                          "status": 201,
+                                          "code": "CHAT-FIRST-MESSAGE-SENT",
+                                          "message": "채팅방이 생성되고 메시지가 전송되었습니다.",
+                                          "data": {
+                                            "roomId": 42,
+                                            "answer": "힌트: 배열의 합을 구할 때는 누적합을 활용해보세요."
+                                          }
+                                        }
+                                        """
                             )
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "401",
-                    description = "CHT-002 - 권한 없음",
+                    responseCode = "502",
+                    description = "CHT-003 - AI 응답 실패",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "권한 없음",
+                                    name = "AI 응답 실패",
                                     value = """
-                                            {
-                                              "timestamp": "2026-05-28T12:00:00",
-                                              "status": 401,
-                                              "code": "CHT-002",
-                                              "message": "채팅방에 접근 권한이 없습니다.",
-                                              "path": "/api/v1/chat"
-                                            }
-                                            """
+                                        {
+                                          "timestamp": "2026-05-29T12:00:00",
+                                          "status": 502,
+                                          "code": "CHT-003",
+                                          "message": "AI 응답 생성에 실패했습니다.",
+                                          "path": "/api/v1/chat/messages"
+                                        }
+                                        """
                             )
                     )
             )
     })
-    @PostMapping
-    public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(
+    @PostMapping("/messages")
+    public ResponseEntity<ApiResponse<SendFirstMessageResponse>> sendFirstMessage(
             @AuthenticationPrincipal Long userId,
-            @RequestBody ChatRoomCreateRequest request
+            @RequestBody SendFirstMessageRequest request
     ) {
-        CreateChatRoomCommand command = new CreateChatRoomCommand(
+        SendFirstMessageCommand command = new SendFirstMessageCommand(
                 userId,
+                request.userMessage(),
                 request.problemSetId(),
                 request.problemId()
         );
-        ChatRoomResult result = chatRoomCommandUseCase.create(command);
-        ChatRoomResponse response = ChatRoomResponse.from(result);
+
+        SendFirstMessageResponse response = SendFirstMessageResponse.from(
+                chatRoomCommandUseCase.sendFirst(command)
+        );
 
         return ResponseEntity.status(201).body(
                 ApiResponse.created(
-                        ChatResponseCode.ROOM_CREATED,
-                        ChatResponseMessage.ROOM_CREATED,
+                        ChatResponseCode.FIRST_MESSAGE_SENT,
+                        ChatResponseMessage.FIRST_MESSAGE_SENT,
                         response
                 )
         );
     }
+
 
     @Operation(
             summary = "채팅방 목록 조회",

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/SendFirstMessageRequest.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/SendFirstMessageRequest.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.chatbot.presentation.api.request;
 
-public record ChatRoomCreateRequest(
+public record SendFirstMessageRequest(
+        String userMessage,
         Long problemSetId,
         Long problemId
 ) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/SendFirstMessageResponse.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/SendFirstMessageResponse.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.chatbot.presentation.api.response;
+
+import com.wanted.codebombalms.chatbot.application.result.SendFirstMessageResult;
+
+public record SendFirstMessageResponse(
+        Long roomId,
+        String answer
+) {
+    public static SendFirstMessageResponse from(SendFirstMessageResult result) {
+        return new SendFirstMessageResponse(result.roomId(), result.answer());
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [x] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #185

---

## 🛠️ 기능 관련 작업 내용

- 첫 메시지 전송 시 채팅방 자동 생성 + AI 응답을 한 번에 반환하는 엔드포인트를 구현했습니다. (`POST /api/v1/chat/messages` → `{ roomId, answer }`)
- 기존 채팅방 단독 생성 API(`POST /api/v1/chat`)를 제거하고, `create()` 로직을 내부 private 메서드로 전환했습니다.
- Spring → FastAPI 호출 시 WebClient 타임아웃을 설정했습니다. (연결 5초, 응답 30초)
- FastAPI 호출 실패 시 `ExternalServiceException`(502)으로 감싸서 반환하도록 에러 핸들링을 추가했습니다.
- FastAPI 프롬프트 빌더에서 현재 문제 1개만 전달하던 로직을 전체 문제 목록 전달로 변경했습니다.
- Gemini implicit caching 최적화를 위해 `submitted_answer`를 `system_instruction`에서 `contents`로 분리했습니다.
- Gemini Client를 매 요청 생성에서 싱글톤으로 변경했습니다.
- Spring Swagger에서 FastAPI 직접 호출 테스트를 위해 CORS 미들웨어를 추가했습니다.

---

## ♻️ 패키지 변경 사항

**Spring — 신규**
- `chatbot/application/command/SendFirstMessageCommand` : 첫 메시지 전송용 Command record
- `chatbot/application/result/SendFirstMessageResult` : 첫 메시지 응답 Result record (roomId + answer)
- `chatbot/presentation/api/request/SendFirstMessageRequest` : 첫 메시지 요청 DTO
- `chatbot/presentation/api/response/SendFirstMessageResponse` : 첫 메시지 응답 DTO
- `global/domain/common/error/exception/ExternalServiceException` : 외부 서비스 호출 실패 예외 (HTTP 502)

**Spring — 수정**
- `chatbot/presentation/api/ChatRoomController` : `createChatRoom()` 삭제, `sendFirstMessage()` 추가 (`POST /api/v1/chat/messages`)
- `chatbot/application/usecase/ChatRoomCommandUseCase` : `create()` 제거, `sendFirst()` 추가
- `chatbot/application/service/ChatRoomCommandService` : `create()` → `private createRoom()` 전환, `sendFirst()` 구현
- `chatbot/infrastructure/client/FastApiChatClient` : try-catch 에러 핸들링 추가
- `chatbot/infrastructure/client/WebClientConfig` : 연결 타임아웃 5초, 응답 타임아웃 30초 설정
- `chatbot/presentation/api/ChatResponseCode` : `ROOM_CREATED` 삭제, `FIRST_MESSAGE_SENT` 추가
- `chatbot/presentation/api/ChatResponseMessage` : `ROOM_CREATED` 삭제, `FIRST_MESSAGE_SENT` 추가

**Spring — 삭제**
- `chatbot/presentation/api/request/ChatRoomCreateRequest` : 채팅방 단독 생성 API 제거에 따라 삭제

**FastAPI (Python)**
- `app/service/prompt_builder.py` : 현재 문제 1개 → 전체 문제 목록 + current_problem_number 전달로 변경
- `app/service/gemini_client.py` : Client 싱글톤화, submitted_answer를 contents user_message prefix로 이동
- `app/main.py` : CORS 미들웨어 추가 (localhost:8080 허용)
- `templates/system_problem.j2` : 전체 문제 목록 렌더링, submitted_answer 제거, 피드백 가이드 일반 규칙화
- `templates/ko/system_problem.j2` : 한국어 참조본 동기화

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.