### PR TITLE
[Ref] 테스트케이스 검증 및 조회 정책 개선

### DIFF
--- a/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.problems.exception;
 import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -49,6 +50,7 @@ public enum ProblemErrorCode implements ErrorCode {
     PROBLEM_TEST_CASE_INVALID_INPUT("PRB-TC-002", "테스트케이스 입력값이 올바르지 않습니다."),
     PROBLEM_TEST_CASE_ALREADY_EXISTS("PRB-TC-003", "이미 등록된 테스트케이스가 있습니다."),
     PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE("PRB-TC-004", "코드 문제에만 테스트케이스를 등록할 수 있습니다."),
+    PROBLEM_TEST_CASE_DUPLICATE_ORDER( "PRB-TC-006", "이미 같은 순서의 테스트케이스가 존재합니다."),
 
     // 코드 실행 (PRB-EXE)
     PROBLEM_CODE_INVALID_INPUT("PRB-EXE-001", "코드 값이 비어 있습니다."),

--- a/src/main/java/com/wanted/codebombalms/problems/progress/application/service/ProblemProgressQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/progress/application/service/ProblemProgressQueryService.java
@@ -60,7 +60,10 @@ public class ProblemProgressQueryService implements GetProblemProgressUseCase {
         return new ProblemProgressItemView(
                 problem.getProblemId(),
                 problem.getProblemNumber(),
-                problem.getStatus().name()
+                problem.getTitle(),
+                problem.getStatus().name(),
+                problem.getLatestSubmissionId()
         );
     }
 }
+

--- a/src/main/java/com/wanted/codebombalms/problems/progress/application/usecase/GetProblemProgressUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/progress/application/usecase/GetProblemProgressUseCase.java
@@ -21,7 +21,9 @@ public interface GetProblemProgressUseCase {
     record ProblemProgressItemView(
             Long problemId,
             Integer problemNumber,
-            String status
+            String title,
+            String status,
+            Long latestSubmissionId
     ) {
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/progress/domain/model/ProblemProgressItem.java
+++ b/src/main/java/com/wanted/codebombalms/problems/progress/domain/model/ProblemProgressItem.java
@@ -6,28 +6,38 @@ public class ProblemProgressItem {
 
     private final Long problemId;
     private final Integer problemNumber;
+    private final String title;
     private final ProblemProgressStatus status;
+    private final Long latestSubmissionId;
 
     private ProblemProgressItem(
             Long problemId,
             Integer problemNumber,
-            ProblemProgressStatus status
+            String title,
+            ProblemProgressStatus status,
+            Long latestSubmissionId
     ) {
         this.problemId = problemId;
         this.problemNumber = problemNumber;
+        this.title = title;
         this.status = status;
+        this.latestSubmissionId = latestSubmissionId;
     }
 
     public static ProblemProgressItem of(
             Long problemId,
             Integer problemNumber,
+            String title,
             Integer currentProblemNumber,
-            Boolean latestCorrect
+            Boolean latestCorrect,
+            Long latestSubmissionId
     ) {
         return new ProblemProgressItem(
                 problemId,
                 problemNumber,
-                decideStatus(problemNumber, currentProblemNumber, latestCorrect)
+                title,
+                decideStatus(problemNumber, currentProblemNumber, latestCorrect),
+                latestSubmissionId
         );
     }
 
@@ -57,7 +67,15 @@ public class ProblemProgressItem {
         return problemNumber;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
     public ProblemProgressStatus getStatus() {
         return status;
+    }
+
+    public Long getLatestSubmissionId() {
+        return latestSubmissionId;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/progress/infrastructure/persistence/ProblemProgressPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/progress/infrastructure/persistence/ProblemProgressPersistenceAdapter.java
@@ -16,6 +16,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ValidationEx
 import com.wanted.codebombalms.submission.application.port.SubmissionQueryPort;
 import com.wanted.codebombalms.submission.domain.model.LatestSubmission;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -66,16 +67,24 @@ public class ProblemProgressPersistenceAdapter implements
             Integer currentProblemNumber,
             ProblemJpaEntity problem
     ) {
-        Boolean latestCorrect = submissionQueryPort
-                .findLatestResult(userId, problem.getProblemId())
+        var latestSubmission = submissionQueryPort
+                .findLatestResult(userId, problem.getProblemId());
+
+        Boolean latestCorrect = latestSubmission
                 .map(LatestSubmission::correct)
+                .orElse(null);
+
+        Long latestSubmissionId = latestSubmission
+                .map(LatestSubmission::submissionId)
                 .orElse(null);
 
         return ProblemProgressItem.of(
                 problem.getProblemId(),
                 problem.getProblemOrder(),
+                problem.getTitle(),
                 currentProblemNumber,
-                latestCorrect
+                latestCorrect,
+                latestSubmissionId
         );
     }
 
@@ -121,9 +130,19 @@ public class ProblemProgressPersistenceAdapter implements
                 .findByUserIdAndProblemSet_ProblemSetId(userId, problemSetId)
                 .orElseGet(() -> {
                     ProblemSetJpaEntity problemSet = loadProblemSet(problemSetId);
-                    problemSet.increaseStartedUserCount();
-                    return progressRepository.save(new ProgressJpaEntity(userId, problemSet));
+                    return createProgressSafely(userId, problemSet);
                 });
+    }
+
+    private ProgressJpaEntity createProgressSafely(Long userId, ProblemSetJpaEntity problemSet) {
+        try {
+            problemSet.increaseStartedUserCount();
+            return progressRepository.saveAndFlush(new ProgressJpaEntity(userId, problemSet));
+        } catch (DataIntegrityViolationException e) {
+            return progressRepository
+                    .findByUserIdAndProblemSet_ProblemSetId(userId, problemSet.getProblemSetId())
+                    .orElseThrow(() -> e);
+        }
     }
 
     private ProblemSetJpaEntity loadProblemSet(Long problemSetId) {

--- a/src/main/java/com/wanted/codebombalms/problems/progress/presentation/ProgressApiController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/progress/presentation/ProgressApiController.java
@@ -98,6 +98,21 @@ public class ProgressApiController {
             )
     })
     @GetMapping("/api/v1/problem-sets/{problemSetId}/progress")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "AUT-016 - 인증이 필요합니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(value = """
+                        {
+                          "status": 401,
+                          "code": "AUT-016",
+                          "message": "인증이 필요합니다.",
+                          "path": "/api/v1/problem-sets/3001/progress"
+                        }
+                        """)
+            )
+    )
     public ResponseEntity<ApiResponse<ProblemProgressResponse>> findProblemSetProgress(
             @Parameter(description = "진행 상태를 조회할 문제 세트 ID", example = "3001")
             @PathVariable Long problemSetId,

--- a/src/main/java/com/wanted/codebombalms/problems/progress/presentation/response/ProblemProgressItemResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/progress/presentation/response/ProblemProgressItemResponse.java
@@ -7,22 +7,29 @@ public record ProblemProgressItemResponse(
         @Schema(description = "소문제 ID", example = "3001")
         Long problemId,
 
-        @Schema(description = "문제 세트 내 소문제 번호", example = "1")
+        @Schema(description = "문제 세트 안에서의 소문제 번호", example = "1")
         Integer problemNumber,
 
+        @Schema(description = "소문제 제목", example = "데이터 행과 열 개수 확인")
+        String title,
+
         @Schema(
-                description = "학생 기준 소문제 진행 상태. LOCKED는 아직 열리지 않음, OPEN은 현재 풀이 가능, SOLVED는 해결 완료를 의미합니다.",
-                example = "OPEN",
-                allowableValues = {"LOCKED", "OPEN", "SOLVED"}
+                description = "학생 기준 소문제 진행 상태. LOCKED는 아직 열리지 않음, UNSOLVED는 풀이 전, CORRECT는 정답, WRONG은 오답입니다.",
+                example = "CORRECT",
+                allowableValues = {"LOCKED", "UNSOLVED", "CORRECT", "WRONG"}
         )
-        String status
-)
-{
+        String status,
+
+        @Schema(description = "해당 소문제의 최신 제출 ID. 제출 기록이 없으면 null입니다.", example = "3001", nullable = true)
+        Long latestSubmissionId
+) {
     public ProblemProgressItemResponse(ProblemProgressItemView item) {
         this(
                 item.problemId(),
                 item.problemNumber(),
-                item.status()
+                item.title(),
+                item.status(),
+                item.latestSubmissionId()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetEntryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetEntryPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.problems.set.application.port.FindOrCreateProblem
 import com.wanted.codebombalms.problems.set.application.port.LoadProblemSetEntryPort;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -30,17 +31,27 @@ public class ProblemSetEntryPersistenceAdapter implements
     @Override
     public ProblemSetProgressState findOrCreateProgress(Long userId, Long problemSetId) {
         ProblemSetJpaEntity problemSet = loadProblemSet(problemSetId);
+
         ProgressJpaEntity progress = progressRepository
                 .findByUserIdAndProblemSet_ProblemSetId(userId, problemSetId)
-                .orElseGet(() -> {
-                    problemSet.increaseStartedUserCount();
-                    return progressRepository.save(new ProgressJpaEntity(userId, problemSet));
-                });
+                .orElseGet(() -> createProgressSafely(userId, problemSet));
 
         return new ProblemSetProgressState(
                 progress.getCurrentProblemNumber(),
                 progress.getCompleted()
         );
+    }
+
+
+    private ProgressJpaEntity createProgressSafely(Long userId, ProblemSetJpaEntity problemSet) {
+        try {
+            problemSet.increaseStartedUserCount();
+            return progressRepository.save(new ProgressJpaEntity(userId, problemSet));
+        } catch (DataIntegrityViolationException e) {
+            return progressRepository
+                    .findByUserIdAndProblemSet_ProblemSetId(userId, problemSet.getProblemSetId())
+                    .orElseThrow(() -> e);
+        }
     }
 
     private ProblemSetJpaEntity loadProblemSet(Long problemSetId) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
@@ -27,7 +27,9 @@ import com.wanted.codebombalms.problems.set.presentation.response.ProblemSetWith
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -85,6 +87,48 @@ public class ProblemManageController {
             summary = "문제 세트 수정",
             description = "문제 세트 기본 정보와 소문제 목록을 수정합니다."
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "문제 세트 및 데이터셋 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "status": 200,
+                                  "code": "COMMON-SUCCESS",
+                                  "message": "요청이 성공적으로 처리되었습니다.",
+                                  "data": {
+                                    "problemSetId": 3001,
+                                    "title": "pandas 기초 분석 문제 세트",
+                                    "categoryName": "Python 데이터 분석",
+                                    "totalProblemCount": 2
+                                  }
+                                }
+                                """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "PRB-SET-006, PRB-PBL-009, PRB-DAT-004, PRB-DAT-005 - 입력값 오류 또는 CSV 업로드 실패"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "AUT-003, AUT-016 - 인증 토큰 만료 또는 인증 필요"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "AUT-015 - 접근 권한 없음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "PRB-SET-001 - 문제 세트를 찾을 수 없음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "PRB-002 - 문제 도메인 처리 중 서버 오류"
+            )
+    })
     @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
     @PutMapping("/api/v1/problems/{problemSetId}")
     public ResponseEntity<ApiResponse<ProblemSetUpdateResponse>> updateProblemSet(
@@ -219,7 +263,7 @@ public class ProblemManageController {
                 response
         ));
     }
-    
+
     private ProblemSetUpdateRequest parseProblemSetUpdateRequest(String requestJson) {
         try {
             return objectMapper.readValue(requestJson, ProblemSetUpdateRequest.class);

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/policy/ProblemTestCasePolicy.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/policy/ProblemTestCasePolicy.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.problems.testcase.application.port.LoadTestCaseProblemPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import com.wanted.codebombalms.problems.testcase.application.port.CheckDuplicateTestCaseOrderPort;
 
 @Component
 @RequiredArgsConstructor
@@ -14,9 +15,17 @@ public class ProblemTestCasePolicy {
 
     private final LoadTestCaseProblemPort loadTestCaseProblemPort;
 
+    private final CheckDuplicateTestCaseOrderPort checkDuplicateTestCaseOrderPort;
 
-    public void validateCreatable(Long problemId) {
+    public void validateCreatable(Long problemId, Integer testOrder) {
         validateCodeProblem(problemId);
+        validateDuplicateOrder(problemId, testOrder);
+    }
+
+    private void validateDuplicateOrder(Long problemId, Integer testOrder) {
+        if (checkDuplicateTestCaseOrderPort.existsActiveOrder(problemId, testOrder)) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_DUPLICATE_ORDER);
+        }
     }
 
     public void validateReadable(Long problemId) {
@@ -32,6 +41,17 @@ public class ProblemTestCasePolicy {
 
         if (!CODE_PROBLEM_TYPE.equals(problem.problemType())) {
             throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE);
+        }
+    }
+
+    public void validateUpdatable(Long problemId, Long testCaseId, Integer testOrder) {
+        validateCodeProblem(problemId);
+        validateDuplicateOrderExceptSelf(problemId, testCaseId, testOrder);
+    }
+
+    private void validateDuplicateOrderExceptSelf(Long problemId, Long testCaseId, Integer testOrder) {
+        if (checkDuplicateTestCaseOrderPort.existsActiveOrderExceptSelf(problemId, testOrder, testCaseId)) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_TEST_CASE_DUPLICATE_ORDER);
         }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/port/CheckDuplicateTestCaseOrderPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/port/CheckDuplicateTestCaseOrderPort.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.problems.testcase.application.port;
+
+public interface CheckDuplicateTestCaseOrderPort {
+
+    boolean existsActiveOrder(Long problemId, Integer testOrder);
+
+    boolean existsActiveOrderExceptSelf(Long problemId, Integer testOrder, Long testCaseId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/application/service/ProblemTestCaseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/application/service/ProblemTestCaseCommandService.java
@@ -26,7 +26,10 @@ public class ProblemTestCaseCommandService implements ProblemTestCaseCommandUseC
     @Override
     @Transactional
     public TestCaseView handle(CreateProblemTestCaseCommand command) {
-        problemTestCasePolicy.validateCreatable(command.problemId());
+        problemTestCasePolicy.validateCreatable(
+                command.problemId(),
+                command.testOrder()
+        );
 
         ProblemTestCase testCase = ProblemTestCase.create(
                 command.problemId(),
@@ -45,7 +48,11 @@ public class ProblemTestCaseCommandService implements ProblemTestCaseCommandUseC
     public TestCaseView handle(UpdateProblemTestCaseCommand command) {
         ProblemTestCase existingTestCase = problemTestCaseRepository.findActiveById(command.testCaseId());
 
-        problemTestCasePolicy.validateUpdatable(existingTestCase.getProblemId());
+        problemTestCasePolicy.validateUpdatable(
+                existingTestCase.getProblemId(),
+                existingTestCase.getTestCaseId(),
+                command.testOrder()
+        );
 
         ProblemTestCase updatedTestCase = ProblemTestCase.restore(
                 existingTestCase.getTestCaseId(),

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/domain/repository/ProblemTestCaseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/domain/repository/ProblemTestCaseRepository.java
@@ -13,3 +13,4 @@ public interface ProblemTestCaseRepository {
 
     ProblemTestCase deactivate(Long testCaseId);
 }
+

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCaseJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCaseJpaEntity.java
@@ -1,20 +1,20 @@
 package com.wanted.codebombalms.problems.testcase.infrastructure.persistence;
 
 import com.wanted.codebombalms.problems.problem.infrastructure.persistence.ProblemJpaEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "problem_test_case")
+@Table(
+        name = "problem_test_case",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_problem_test_case_problem_order",
+                        columnNames = {"problem_id", "test_order"}
+                )
+        }
+)
 public class ProblemTestCaseJpaEntity {
 
     @Id

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCasePersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/ProblemTestCasePersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundExce
 import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.problems.problem.infrastructure.persistence.ProblemJpaEntity;
 import com.wanted.codebombalms.problems.problem.infrastructure.persistence.SpringDataProblemRepository;
+import com.wanted.codebombalms.problems.testcase.application.port.CheckDuplicateTestCaseOrderPort;
 import com.wanted.codebombalms.problems.testcase.application.port.LoadTestCaseProblemPort;
 import com.wanted.codebombalms.problems.testcase.domain.model.ProblemTestCase;
 import com.wanted.codebombalms.problems.testcase.domain.repository.ProblemTestCaseRepository;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class ProblemTestCasePersistenceAdapter implements ProblemTestCaseRepository, LoadTestCaseProblemPort {
+public class ProblemTestCasePersistenceAdapter implements ProblemTestCaseRepository, CheckDuplicateTestCaseOrderPort,LoadTestCaseProblemPort {
 
     private static final String ACTIVE = "ACTIVE";
 
@@ -63,8 +64,28 @@ public class ProblemTestCasePersistenceAdapter implements ProblemTestCaseReposit
     }
 
     @Override
+    public boolean existsActiveOrderExceptSelf(Long problemId, Integer testOrder, Long testCaseId) {
+        return testCaseRepository
+                .existsByProblem_ProblemIdAndTestOrderAndStatusAndTestCaseIdNot(
+                        problemId,
+                        testOrder,
+                        "ACTIVE",
+                        testCaseId
+                );
+    }
+
+    @Override
     public ProblemTestCase findActiveById(Long testCaseId) {
         return toDomain(loadActiveTestCase(testCaseId));
+    }
+
+    @Override
+    public boolean existsActiveOrder(Long problemId, Integer testOrder) {
+        return testCaseRepository.existsByProblem_ProblemIdAndTestOrderAndStatus(
+                problemId,
+                testOrder,
+                "ACTIVE"
+        );
     }
 
     @Override
@@ -108,3 +129,4 @@ public class ProblemTestCasePersistenceAdapter implements ProblemTestCaseReposit
         );
     }
 }
+

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/SpringDataProblemTestCaseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/infrastructure/persistence/SpringDataProblemTestCaseRepository.java
@@ -15,4 +15,17 @@ public interface SpringDataProblemTestCaseRepository extends JpaRepository<Probl
             Long testCaseId,
             String status
     );
+
+    boolean existsByProblem_ProblemIdAndTestOrderAndStatus(
+            Long problemId,
+            Integer testOrder,
+            String status
+    );
+
+    boolean existsByProblem_ProblemIdAndTestOrderAndStatusAndTestCaseIdNot(
+            Long problemId,
+            Integer testOrder,
+            String status,
+            Long testCaseId
+    );
 }

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/request/CreateProblemTestCaseRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/request/CreateProblemTestCaseRequest.java
@@ -28,6 +28,8 @@ public record CreateProblemTestCaseRequest(
                 example = "1",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
+        @NotNull(message = "테스트 순서는 필수입니다.")
+        @Min(value = 1, message = "테스트 순서는 1 이상이어야 합니다.")
         Integer testOrder,
 
         @NotNull(message = "히든 여부는 필수입니다.")
@@ -45,6 +47,8 @@ public record CreateProblemTestCaseRequest(
                 example = "3000",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
+        @NotNull(message = "실행 제한 시간은 필수입니다.")
+        @Min(value = 1, message = "실행 제한 시간은 1ms 이상이어야 합니다.")
         Integer timeoutMs
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/request/UpdateProblemTestCaseRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/testcase/presentation/request/UpdateProblemTestCaseRequest.java
@@ -28,6 +28,8 @@ public record UpdateProblemTestCaseRequest(
                 example = "1",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
+        @NotNull(message = "테스트 순서는 필수입니다.")
+        @Min(value = 1, message = "테스트 순서는 1 이상이어야 합니다.")
         Integer testOrder,
 
         @NotNull(message = "히든 여부는 필수입니다.")
@@ -44,6 +46,8 @@ public record UpdateProblemTestCaseRequest(
                 example = "3000",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
+        @NotNull(message = "실행 제한 시간은 필수입니다.")
+        @Min(value = 1, message = "실행 제한 시간은 1ms 이상이어야 합니다.")
         Integer timeoutMs
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/ranking/presentation/RankingController.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/presentation/RankingController.java
@@ -7,6 +7,8 @@ import com.wanted.codebombalms.ranking.presentation.response.MyRankingResponse;
 import com.wanted.codebombalms.ranking.presentation.response.RankingListResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -90,7 +92,22 @@ public class RankingController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내 포인트 랭킹 조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "RNK-001 - 랭킹 정보를 찾을 수 없습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "RNK-001 - 랭킹 정보를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                        {
+                          "status": 404,
+                          "code": "RNK-001",
+                          "message": "랭킹 정보를 찾을 수 없습니다.",
+                          "path": "/api/v1/rankings/points/me"
+                        }
+                        """)
+                    )
+            )
     })
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<MyRankingResponse>> getMyPointRanking(

--- a/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionListQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/port/SubmissionListQueryPort.java
@@ -4,5 +4,5 @@ import com.wanted.codebombalms.submission.domain.model.CodeSubmissionPage;
 
 public interface SubmissionListQueryPort {
 
-    CodeSubmissionPage findCodeSubmissions(Long problemId, int page, int size);
+    CodeSubmissionPage findCodeSubmissions(Long userId, Long problemId, int page, int size);
 }

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/CodeSubmissionListQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/CodeSubmissionListQueryService.java
@@ -29,7 +29,7 @@ public class CodeSubmissionListQueryService implements CodeSubmissionListQueryUs
 
     @Override
     @Transactional(readOnly = true)
-    public CodeSubmissionPageView handle(Long problemId, int page, int size) {
+    public CodeSubmissionPageView handle(Long userId, Long problemId, int page, int size) {
         if (problemId == null) {
             throw new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND);
         }
@@ -38,7 +38,8 @@ public class CodeSubmissionListQueryService implements CodeSubmissionListQueryUs
 
         int safePage = page < 1 ? DEFAULT_PAGE : page;
         int safeSize = size < 1 ? DEFAULT_SIZE : size;
-        CodeSubmissionPage result = submissionListQueryPort.findCodeSubmissions(problemId, safePage, safeSize);
+        CodeSubmissionPage result =
+                submissionListQueryPort.findCodeSubmissions(userId, problemId, safePage, safeSize);
 
         return new CodeSubmissionPageView(
                 result.submissions()

--- a/src/main/java/com/wanted/codebombalms/submission/application/usecase/CodeSubmissionListQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/usecase/CodeSubmissionListQueryUseCase.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface CodeSubmissionListQueryUseCase {
 
-    CodeSubmissionPageView handle(Long problemId, int page, int size);
+    CodeSubmissionPageView handle(Long userId, Long problemId, int page, int size);
 
     record CodeSubmissionPageView(
             List<CodeSubmissionListItemView> submissions,

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/LatestSubmission.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/LatestSubmission.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.submission.domain.model;
 import java.time.LocalDateTime;
 
 public record LatestSubmission(
+        Long submissionId,
         Long problemId,
         Integer problemOrder,
         String submittedAnswer,

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionRepository.java
@@ -21,4 +21,10 @@ public interface SpringDataSubmissionRepository extends JpaRepository<Submission
             Long problemId,
             Pageable pageable
     );
+
+    Page<SubmissionJpaEntity> findByUserIdAndProblem_ProblemIdAndSubmittedCodeIsNotNullOrderBySubmittedAtDesc(
+            Long userId,
+            Long problemId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionListQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionListQueryPersistenceAdapter.java
@@ -17,10 +17,14 @@ public class SubmissionListQueryPersistenceAdapter implements SubmissionListQuer
     }
 
     @Override
-    public CodeSubmissionPage findCodeSubmissions(Long problemId, int page, int size) {
+    public CodeSubmissionPage findCodeSubmissions(Long userId, Long problemId, int page, int size){
         PageRequest pageRequest = PageRequest.of(page - 1, size);
         Page<SubmissionJpaEntity> result = submissionRepository
-                .findByProblem_ProblemIdAndSubmittedCodeIsNotNullOrderBySubmittedAtDesc(problemId, pageRequest);
+                .findByUserIdAndProblem_ProblemIdAndSubmittedCodeIsNotNullOrderBySubmittedAtDesc(
+                        userId,
+                        problemId,
+                        pageRequest
+                );
 
         return new CodeSubmissionPage(
                 result.getContent()

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionQueryPersistenceAdapter.java
@@ -24,6 +24,7 @@ public class SubmissionQueryPersistenceAdapter implements SubmissionQueryPort {
 
     private LatestSubmission toResult(SubmissionJpaEntity submission) {
         return new LatestSubmission(
+                submission.getSubmissionId(),
                 submission.getProblem().getProblemId(),
                 submission.getProblem().getProblemOrder(),
                 submission.getSubmittedAnswer(),

--- a/src/main/java/com/wanted/codebombalms/submission/presentation/SubmissionController.java
+++ b/src/main/java/com/wanted/codebombalms/submission/presentation/SubmissionController.java
@@ -351,17 +351,16 @@ public class SubmissionController {
                     )
             )
     })
+    @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/v1/code-problems/{problemId}/submissions")
     public ResponseEntity<ApiResponse<CodeSubmissionListResponse>> getCodeSubmissions(
-            @Parameter(description = "제출 기록을 조회할 코드 문제 ID", example = "3001")
             @PathVariable Long problemId,
-            @Parameter(description = "페이지 번호. 기본값 1", example = "1")
+            @AuthenticationPrincipal Long userId,
             @RequestParam(defaultValue = "1") int page,
-            @Parameter(description = "페이지 크기. 기본값 10", example = "10")
             @RequestParam(defaultValue = "10") int size
     ) {
         var response = new CodeSubmissionListResponse(
-                codeSubmissionListQueryUseCase.handle(problemId, page, size)
+                codeSubmissionListQueryUseCase.handle(userId, problemId, page, size)
         );
 
         return ResponseEntity.ok(ApiResponse.success(


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->

---

## 🛠️ 기능 관련 작업 내용

- 테스트케이스 복수 등록이 가능하도록 기존 단일 등록 제한 정책을 수정했습니다.
- 같은 문제 내 테스트케이스 순서가 중복되지 않도록 중복 순서 검증 로직을 추가했습니다.
- 테스트케이스 수정 요청에서도 `testOrder`, `timeoutMs` 값이 1 이상인지 검증하도록 보강했습니다.
- 테스트케이스 조회/수정/삭제 흐름에서 도메인 레포지토리와 Spring Data 레포지토리의 역할을 분리했습니다.

---

## ♻️ 패키지 변경 사항

- `problems/testcase/presentation` : 테스트케이스 등록/수정 요청 DTO 검증 보강
- `problems/testcase/application` : 테스트케이스 순서 중복 검증 포트 추가
- `problems/testcase/domain` : 테스트케이스 생성/수정 정책에서 중복 순서 검증 처리
- `problems/testcase/infrastructure` : Spring Data 기반 테스트케이스 중복 조회 메서드 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.

---

## 리뷰어가 확인해야 할 내용

- 하나의 코드 문제에 여러 테스트케이스를 등록할 수 있도록 정책을 변경했습니다.
- 단, 같은 문제 안에서 동일한 `testOrder`는 허용하지 않도록 검증했습니다.
- 요청값 검증 실패 시 서비스 로직까지 들어가기 전에 400 응답으로 처리됩니다.