### PR TITLE
[Update] 문제 세트 진입 응답에 전체 소문제 목록 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
@@ -49,16 +49,24 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
                 entry.title(),
                 entry.description(),
                 entry.currentProblemNumber(),
+                entry.currentProblemId(),
+                entry.totalProblemCount(),
+                entry.solvedProblemCount(),
                 entry.isCompleted(),
-                entry.problem() == null ? null : new ProblemDetailView(
-                        entry.problem().problemId(),
-                        entry.problem().problemNumber(),
-                        entry.problem().title(),
-                        entry.problem().content(),
-                        entry.problem().problemType(),
-                        entry.problem().point(),
-                        entry.problem().startCode()
-                )
+                entry.problems()
+                        .stream()
+                        .map(problem -> new ProblemDetailView(
+                                problem.problemId(),
+                                problem.problemNumber(),
+                                problem.title(),
+                                problem.content(),
+                                problem.problemType(),
+                                problem.point(),
+                                problem.startCode(),
+                                problem.status(),
+                                problem.latestSubmissionId()
+                        ))
+                        .toList()
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/learning/application/usecase/LectureProblemSetQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/usecase/LectureProblemSetQueryUseCase.java
@@ -1,5 +1,7 @@
 package com.wanted.codebombalms.learning.application.usecase;
 
+import java.util.List;
+
 public interface LectureProblemSetQueryUseCase {
 
     LectureProblemSetEntryView enterLectureProblemSet(Long userId, Long lectureProblemSetId);
@@ -12,8 +14,11 @@ public interface LectureProblemSetQueryUseCase {
             String title,
             String description,
             Integer currentProblemNumber,
+            Long currentProblemId,
+            Integer totalProblemCount,
+            Integer solvedProblemCount,
             Boolean completed,
-            ProblemDetailView problem
+            List<ProblemDetailView> problems
     ) {
     }
 
@@ -24,7 +29,9 @@ public interface LectureProblemSetQueryUseCase {
             String content,
             String problemType,
             Integer point,
-            String startCode
+            String startCode,
+            String status,
+            Long latestSubmissionId
     ) {
     }
 

--- a/src/main/java/com/wanted/codebombalms/learning/presentation/api/response/LectureProblemSetEntryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/learning/presentation/api/response/LectureProblemSetEntryResponse.java
@@ -2,14 +2,19 @@ package com.wanted.codebombalms.learning.presentation.api.response;
 
 import com.wanted.codebombalms.learning.application.usecase.LectureProblemSetQueryUseCase.LectureProblemSetEntryView;
 
+import java.util.List;
+
 public record LectureProblemSetEntryResponse(
         Long lectureProblemSetId,
         Long problemSetId,
         String title,
         String description,
         Integer currentProblemNumber,
+        Long currentProblemId,
+        Integer totalProblemCount,
+        Integer solvedProblemCount,
         Boolean completed,
-        ProblemDetailResponse problem
+        List<ProblemDetailResponse> problems
 ) {
 
     public static LectureProblemSetEntryResponse from(LectureProblemSetEntryView entry) {
@@ -19,8 +24,14 @@ public record LectureProblemSetEntryResponse(
                 entry.title(),
                 entry.description(),
                 entry.currentProblemNumber(),
+                entry.currentProblemId(),
+                entry.totalProblemCount(),
+                entry.solvedProblemCount(),
                 entry.completed(),
-                entry.problem() == null ? null : ProblemDetailResponse.from(entry.problem())
+                entry.problems()
+                        .stream()
+                        .map(ProblemDetailResponse::from)
+                        .toList()
         );
     }
 
@@ -31,7 +42,9 @@ public record LectureProblemSetEntryResponse(
             String content,
             String problemType,
             Integer point,
-            String startCode
+            String startCode,
+            String status,
+            Long latestSubmissionId
     ) {
 
         private static ProblemDetailResponse from(
@@ -44,7 +57,9 @@ public record LectureProblemSetEntryResponse(
                     problem.content(),
                     problem.problemType(),
                     problem.point(),
-                    problem.startCode()
+                    problem.startCode(),
+                    problem.status(),
+                    problem.latestSubmissionId()
             );
         }
     }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemForEntryPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemForEntryPort.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.problems.set.application.port;
 
 import com.wanted.codebombalms.problems.set.domain.model.ProblemDetail;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LoadProblemForEntryPort {
@@ -9,4 +10,6 @@ public interface LoadProblemForEntryPort {
     ProblemDetail loadCurrentProblem(Long problemSetId, Integer problemNumber);
 
     Optional<ProblemDetail> loadLastProblem(Long problemSetId);
+
+    List<ProblemDetail> loadProblems(Long problemSetId);
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
@@ -1,5 +1,7 @@
 package com.wanted.codebombalms.problems.set.application.service;
 
+import com.wanted.codebombalms.problems.progress.application.port.LoadProgressProblemPort;
+import com.wanted.codebombalms.problems.progress.domain.model.ProblemProgressItem;
 import com.wanted.codebombalms.problems.set.application.port.FindOrCreateProblemSetProgressPort;
 import com.wanted.codebombalms.problems.set.application.port.LoadProblemForEntryPort;
 import com.wanted.codebombalms.problems.set.application.port.LoadProblemSetEntryPort;
@@ -13,6 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ProblemSetEntryService implements EnterProblemSetUseCase {
@@ -21,50 +27,72 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
     private final FindOrCreateProblemSetProgressPort findOrCreateProblemSetProgressPort;
     private final LoadProblemForEntryPort loadProblemForEntryPort;
     private final LoadProblemStartCodePort loadProblemStartCodePort;
+    private final LoadProgressProblemPort loadProgressProblemPort;
 
     @Override
     @Transactional
     public ProblemSetEntryView handle(EnterProblemSetQuery query) {
         ProblemSetEntry problemSet = loadProblemSetEntryPort.loadProblemSetEntry(query.problemSetId());
+
         ProblemSetProgressState progress =
                 findOrCreateProblemSetProgressPort.findOrCreateProgress(query.userId(), query.problemSetId());
 
-        ProblemDetail currentProblem = Boolean.TRUE.equals(progress.completed())
-                ? loadProblemForEntryPort.loadLastProblem(query.problemSetId()).orElse(null)
-                : loadProblemForEntryPort.loadCurrentProblem(
-                        query.problemSetId(),
-                        progress.currentProblemNumber()
-                );
+        var progressItems = loadProgressProblemPort.loadProgressProblems(
+                query.userId(),
+                query.problemSetId(),
+                progress.currentProblemNumber()
+        );
 
-        if (currentProblem != null) {
-            currentProblem = currentProblem.withStartCode(
-                    loadProblemStartCodePort.loadStartCode(currentProblem.getProblemId())
-            );
-        }
+        Map<Long, ProblemProgressItem> progressItemMap = progressItems.stream()
+                .collect(Collectors.toMap(
+                        ProblemProgressItem::getProblemId,
+                        Function.identity()
+                ));
+
+        var problems = loadProblemForEntryPort.loadProblems(query.problemSetId())
+                .stream()
+                .map(problem -> toDetailItemView(problem, progressItemMap.get(problem.getProblemId())))
+                .toList();
+
+        Long currentProblemId = problems.stream()
+                .filter(problem -> problem.problemNumber().equals(progress.currentProblemNumber()))
+                .map(ProblemDetailItemView::problemId)
+                .findFirst()
+                .orElse(null);
+
+        int solvedProblemCount = (int) problems.stream()
+                .filter(problem -> "CORRECT".equals(problem.status()))
+                .count();
 
         return new ProblemSetEntryView(
                 problemSet.getProblemSetId(),
                 problemSet.getTitle(),
                 problemSet.getDescription(),
                 progress.currentProblemNumber(),
+                currentProblemId,
+                problems.size(),
+                solvedProblemCount,
                 progress.completed(),
-                toView(currentProblem)
+                problems
         );
     }
 
-    private ProblemDetailView toView(ProblemDetail problem) {
-        if (problem == null) {
-            return null;
-        }
+    private ProblemDetailItemView toDetailItemView(
+            ProblemDetail problem,
+            ProblemProgressItem progressItem
+    ) {
+        String startCode = loadProblemStartCodePort.loadStartCode(problem.getProblemId());
 
-        return new ProblemDetailView(
+        return new ProblemDetailItemView(
                 problem.getProblemId(),
                 problem.getProblemNumber(),
                 problem.getTitle(),
                 problem.getContent(),
                 problem.getProblemType(),
                 problem.getPoint(),
-                problem.getStartCode()
+                startCode,
+                progressItem == null ? "UNSOLVED" : progressItem.getStatus().name(),
+                progressItem == null ? null : progressItem.getLatestSubmissionId()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/EnterProblemSetUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/EnterProblemSetUseCase.java
@@ -2,6 +2,8 @@ package com.wanted.codebombalms.problems.set.application.usecase;
 
 import com.wanted.codebombalms.problems.set.application.query.EnterProblemSetQuery;
 
+import java.util.List;
+
 public interface EnterProblemSetUseCase {
 
     ProblemSetEntryView handle(EnterProblemSetQuery query);
@@ -11,19 +13,24 @@ public interface EnterProblemSetUseCase {
             String title,
             String description,
             Integer currentProblemNumber,
+            Long currentProblemId,
+            Integer totalProblemCount,
+            Integer solvedProblemCount,
             Boolean isCompleted,
-            ProblemDetailView problem
+            List<ProblemDetailItemView> problems
     ) {
     }
 
-    record ProblemDetailView(
+    record ProblemDetailItemView(
             Long problemId,
             Integer problemNumber,
             String title,
             String content,
             String problemType,
             Integer point,
-            String startCode
+            String startCode,
+            String status,
+            Long latestSubmissionId
     ) {
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemForEntryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemForEntryPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.problems.set.domain.model.ProblemDetail;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -34,6 +35,15 @@ public class ProblemForEntryPersistenceAdapter implements LoadProblemForEntryPor
         return problemRepository
                 .findTopByProblemSet_ProblemSetIdAndStatusOrderByProblemOrderDesc(problemSetId, "ACTIVE")
                 .map(this::toDetail);
+    }
+
+    @Override
+    public List<ProblemDetail> loadProblems(Long problemSetId) {
+        return problemRepository
+                .findByProblemSet_ProblemSetIdAndStatusOrderByProblemOrderAsc(problemSetId, "ACTIVE")
+                .stream()
+                .map(this::toDetail)
+                .toList();
     }
 
     private ProblemDetail toDetail(ProblemJpaEntity problem) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemDetailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemDetailResponse.java
@@ -1,39 +1,41 @@
 package com.wanted.codebombalms.problems.set.presentation.response;
 
-import com.wanted.codebombalms.problems.set.application.usecase.EnterProblemSetUseCase.ProblemDetailView;
+import com.wanted.codebombalms.problems.set.application.usecase.EnterProblemSetUseCase.ProblemDetailItemView;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ProblemDetailResponse(
         @Schema(description = "문제 ID", example = "3001")
         Long problemId,
 
-        @Schema(description = "문제 세트 내 소문제 번호", example = "1")
+        @Schema(description = "문제 세트 안에서의 소문제 번호", example = "1")
         Integer problemNumber,
 
         @Schema(description = "소문제 제목", example = "데이터 행과 열 개수 확인")
         String title,
 
-        @Schema(description = "소문제 내용", example = "employee_performance.csv 파일을 불러온 뒤 DataFrame의 행과 열 개수를 확인하세요.")
+        @Schema(description = "소문제 내용", example = "DataFrame의 행과 열 개수를 확인하세요.")
         String content,
 
         @Schema(description = "문제 유형", example = "CODE")
         String problemType,
 
-        @Schema(description = "정답 시 지급할 포인트", example = "10")
+        @Schema(description = "정답 시 지급 포인트", example = "10")
         Integer point,
 
-        @Schema(
-                description = "코드 에디터에 표시할 시작 코드. 데이터셋이 연결된 코드 문제는 GCS CSV URL을 읽는 코드가 포함될 수 있습니다.",
-                example = """
-                        import pandas as pd
+        @Schema(description = "코드 에디터에 표시할 시작 코드", nullable = true)
+        String startCode,
 
-                        df = pd.read_csv("https://storage.googleapis.com/codebombalms/problem_dataset/28679fde-6075-4c2e-a3f0-190fa3d80db7_employee_performance.csv")
-                        """,
-                nullable = true
+        @Schema(
+                description = "학생 기준 소문제 상태",
+                example = "LOCKED",
+                allowableValues = {"LOCKED", "UNSOLVED", "CORRECT", "WRONG"}
         )
-        String startCode
+        String status,
+
+        @Schema(description = "가장 최근 제출 ID", example = "3021", nullable = true)
+        Long latestSubmissionId
 ) {
-    public ProblemDetailResponse(ProblemDetailView problem) {
+    public ProblemDetailResponse(ProblemDetailItemView problem) {
         this(
                 problem.problemId(),
                 problem.problemNumber(),
@@ -41,7 +43,9 @@ public record ProblemDetailResponse(
                 problem.content(),
                 problem.problemType(),
                 problem.point(),
-                problem.startCode()
+                problem.startCode(),
+                problem.status(),
+                problem.latestSubmissionId()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetEnterResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetEnterResponse.java
@@ -3,6 +3,8 @@ package com.wanted.codebombalms.problems.set.presentation.response;
 import com.wanted.codebombalms.problems.set.application.usecase.EnterProblemSetUseCase.ProblemSetEntryView;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.util.List;
+
 public record ProblemSetEnterResponse(
         @Schema(description = "문제 세트 ID", example = "3001")
         Long problemSetId,
@@ -10,17 +12,26 @@ public record ProblemSetEnterResponse(
         @Schema(description = "문제 세트 제목", example = "pandas 기초 분석 문제 세트")
         String title,
 
-        @Schema(description = "문제 세트 설명", example = "CSV 데이터를 불러와 기본 정보를 확인하는 문제 세트입니다.")
+        @Schema(description = "문제 세트 설명", example = "CSV 데이터를 활용한 코드 실행형 문제 세트입니다.")
         String description,
 
-        @Schema(description = "현재 풀어야 할 소문제 번호", example = "1")
+        @Schema(description = "현재 풀어야 하는 문제 번호", example = "1")
         Integer currentProblemNumber,
+
+        @Schema(description = "현재 풀어야 하는 문제 ID", example = "3001")
+        Long currentProblemId,
+
+        @Schema(description = "전체 소문제 수", example = "3")
+        Integer totalProblemCount,
+
+        @Schema(description = "정답 처리된 소문제 수", example = "1")
+        Integer solvedProblemCount,
 
         @Schema(description = "문제 세트 완료 여부", example = "false")
         Boolean isCompleted,
 
-        @Schema(description = "현재 풀어야 할 문제 정보. 완료 상태에서는 null일 수 있습니다.", nullable = true)
-        ProblemDetailResponse problem
+        @Schema(description = "문제 세트에 포함된 전체 소문제 목록")
+        List<ProblemDetailResponse> problems
 ) {
     public ProblemSetEnterResponse(ProblemSetEntryView entry) {
         this(
@@ -28,8 +39,13 @@ public record ProblemSetEnterResponse(
                 entry.title(),
                 entry.description(),
                 entry.currentProblemNumber(),
+                entry.currentProblemId(),
+                entry.totalProblemCount(),
+                entry.solvedProblemCount(),
                 entry.isCompleted(),
-                entry.problem() == null ? null : new ProblemDetailResponse(entry.problem())
+                entry.problems().stream()
+                        .map(ProblemDetailResponse::new)
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/submission/application/policy/SubmissionAttemptPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/policy/SubmissionAttemptPolicy.java
@@ -8,10 +8,6 @@ import org.springframework.stereotype.Component;
 public class SubmissionAttemptPolicy {
 
     public void validateAttemptLimit(Integer attemptLimit, Boolean retriable, int previousAttemptCount) {
-        if (attemptLimit != null && previousAttemptCount >= attemptLimit) {
-            throw new ValidationException(SubmissionErrorCode.ATTEMPT_LIMIT_EXCEEDED);
-        }
-
         if (!Boolean.TRUE.equals(retriable) && previousAttemptCount > 0) {
             throw new ValidationException(SubmissionErrorCode.PROBLEM_NOT_RETRIABLE);
         }

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
@@ -57,10 +57,7 @@ public class SubmissionService implements SubmissionCommandUseCase {
 
         boolean isCorrect = gradingResult.correct();
         int attemptNo = previousAttemptCount + 1;
-        Integer remainingAttemptCount = submissionAttemptPolicy.calculateRemainingAttemptCount(
-                problem.attemptLimit(),
-                attemptNo
-        );
+        Integer remainingAttemptCount = null;
         boolean canRetry = submissionAttemptPolicy.canRetry(
                 problem.retriable(),
                 remainingAttemptCount,

--- a/src/test/java/com/wanted/codebombalms/learning/controller/LearningControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/controller/LearningControllerTest.java
@@ -129,15 +129,33 @@ class LearningControllerTest {
                         "Problem Set",
                         "description",
                         1,
+                        3001L,
+                        2,
+                        0,
                         false,
-                        new LectureProblemSetQueryUseCase.ProblemDetailView(
-                                3001L,
-                                1,
-                                "Problem 1",
-                                "content",
-                                "CODE",
-                                10,
-                                "print()"
+                        List.of(
+                                new LectureProblemSetQueryUseCase.ProblemDetailView(
+                                        3001L,
+                                        1,
+                                        "Problem 1",
+                                        "content",
+                                        "CODE",
+                                        10,
+                                        "print()",
+                                        "UNSOLVED",
+                                        null
+                                ),
+                                new LectureProblemSetQueryUseCase.ProblemDetailView(
+                                        3002L,
+                                        2,
+                                        "Problem 2",
+                                        "content 2",
+                                        "CODE",
+                                        10,
+                                        "print()",
+                                        "LOCKED",
+                                        null
+                                )
                         )
                 ));
 
@@ -148,7 +166,13 @@ class LearningControllerTest {
                 .andExpect(jsonPath("$.code").value(LearningResponseCode.RETRIEVED))
                 .andExpect(jsonPath("$.data.lectureProblemSetId").value(6001L))
                 .andExpect(jsonPath("$.data.problemSetId").value(2001L))
-                .andExpect(jsonPath("$.data.problem.problemId").value(3001L));
+                .andExpect(jsonPath("$.data.currentProblemId").value(3001L))
+                .andExpect(jsonPath("$.data.totalProblemCount").value(2))
+                .andExpect(jsonPath("$.data.solvedProblemCount").value(0))
+                .andExpect(jsonPath("$.data.problems[0].problemId").value(3001L))
+                .andExpect(jsonPath("$.data.problems[0].status").value("UNSOLVED"))
+                .andExpect(jsonPath("$.data.problems[1].problemId").value(3002L))
+                .andExpect(jsonPath("$.data.problems[1].status").value("LOCKED"));
     }
 
     @Test


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 문제 세트 진입 API 응답을 현재 소문제 1개 반환 구조에서 전체 소문제 목록 반환 구조로 변경했습니다.
- 프론트에서 문제풀이 화면의 사이드바를 구성할 수 있도록 각 소문제의 상세 정보와 진행 상태를 함께 반환하도록 수정했습니다.
- 잠긴 문제도 `LOCKED` 상태로 내려주되, 프론트 요청에 맞춰 제목, 내용, 시작 코드, 문제 유형, 포인트 정보를 함께 제공하도록 변경했습니다.
- 강의 문제풀이 진입 응답도 변경된 문제 세트 응답 구조에 맞춰 전체 소문제 목록을 반환하도록 수정했습니다.

---

## ♻️ 패키지 변경 사항

- `problems/set` : 문제 세트 진입 시 전체 소문제 상세 정보와 진행 상태를 함께 반환하도록 응답 구조 수정
- `problems/progress` : 기존 문제 진행 상태값을 활용하여 각 소문제의 `LOCKED`, `UNSOLVED`, `CORRECT`, `WRONG` 상태를 응답에 포함
- `learning` : 강의 문제풀이 진입 흐름에서 변경된 문제 세트 응답 구조를 반영하도록 수정

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.

---

## 리뷰어가 확인해야 할 내용

- `GET /api/v1/problem-sets/{problemSetId}` 응답에서 `problems` 배열이 내려오는지 확인 부탁드립니다.
- `LOCKED` 상태의 문제도 프론트 요청에 따라 상세 정보가 함께 내려가도록 처리했습니다.
- 컴파일 검증 완료했습니다.