### PR TITLE
[Update] 관리자 코드 구조 개선

### DIFF
--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/adapter/OperationAlertTargetDetailAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/adapter/OperationAlertTargetDetailAdapter.java
@@ -8,8 +8,13 @@ import com.wanted.codebombalms.admin.operation.alert.application.query.Operation
 import com.wanted.codebombalms.admin.operation.alert.application.query.OperationAlertTargetInfo;
 import com.wanted.codebombalms.admin.operation.alert.domain.exception.OperationAlertErrorCode;
 import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+import com.wanted.codebombalms.course.application.usecase.CourseQueryUseCase;
+import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
-import jakarta.persistence.EntityManager;
+import com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort.ProblemTargetDetailView;
+import com.wanted.codebombalms.problems.problem.application.usecase.ProblemTargetDetailQueryUseCase;
+import com.wanted.codebombalms.user.application.query.StudentDetail;
+import com.wanted.codebombalms.user.application.usecase.GetStudentDetailUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +27,9 @@ import java.math.BigDecimal;
 // COURSE, PROBLEM, USER 알림 대상의 상세 정보와 담당자 정보를 조회한다.
 public class OperationAlertTargetDetailAdapter implements OperationAlertTargetDetailPort {
 
-    private final EntityManager entityManager;
+    private final CourseQueryUseCase courseQueryUseCase;
+    private final ProblemTargetDetailQueryUseCase problemTargetDetailQueryUseCase;
+    private final GetStudentDetailUseCase getStudentDetailUseCase;
 
     @Override
     // 대상 타입에 따라 강좌, 문제 또는 사용자 상세 조회로 분기한다.
@@ -47,43 +54,24 @@ public class OperationAlertTargetDetailAdapter implements OperationAlertTargetDe
             BigDecimal thresholdValue,
             OperationAlertRuleInfo rule
     ) {
-        Object[] row = entityManager.createQuery("""
-                        select c.courseId,
-                               c.title,
-                               c.status,
-                               u.userId,
-                               u.name,
-                               u.nickname,
-                               u.email,
-                               u.role
-                        from CourseJpaEntity c
-                        left join UserJpaEntity u
-                            on u.userId = c.instructorId
-                           and u.deletedAt is null
-                        where c.courseId = :courseId
-                          and c.deletedAt is null
-                        """, Object[].class)
-                .setParameter("courseId", courseId)
-                .getResultStream()
-                .findFirst()
-                .orElseThrow(() -> new NotFoundException(OperationAlertErrorCode.OPERATION_ALERT_TARGET_NOT_FOUND));
+        Course course = courseQueryUseCase.findCourseByIdForOperator(courseId);
 
         OperationAlertTargetInfo target = new OperationAlertTargetInfo(
                 OperationTargetType.COURSE,
-                (Long) row[0],
-                (String) row[1],
-                toStringOrNull(row[2]),
+                course.getCourseId(),
+                course.getTitle(),
+                toStringOrNull(course.getStatus()),
                 null,
                 null,
-                (Long) row[0],
-                (String) row[1],
+                course.getCourseId(),
+                course.getTitle(),
                 null,
                 null
         );
 
         return new OperationAlertTargetDetail(
                 target,
-                toAssignee(row, 3),
+                loadAssignee(course.getInstructorId()),
                 toMetric(rule, detectedValue, thresholdValue)
         );
     }
@@ -95,45 +83,24 @@ public class OperationAlertTargetDetailAdapter implements OperationAlertTargetDe
             BigDecimal thresholdValue,
             OperationAlertRuleInfo rule
     ) {
-        Object[] row = entityManager.createQuery("""
-                        select p.problemId,
-                               p.title,
-                               p.status,
-                               ps.problemSetId,
-                               ps.title,
-                               u.userId,
-                               u.name,
-                               u.nickname,
-                               u.email,
-                               u.role
-                        from ProblemJpaEntity p
-                        join p.problemSet ps
-                        left join UserJpaEntity u
-                            on u.userId = ps.createdBy
-                           and u.deletedAt is null
-                        where p.problemId = :problemId
-                        """, Object[].class)
-                .setParameter("problemId", problemId)
-                .getResultStream()
-                .findFirst()
-                .orElseThrow(() -> new NotFoundException(OperationAlertErrorCode.OPERATION_ALERT_TARGET_NOT_FOUND));
+        ProblemTargetDetailView problem = problemTargetDetailQueryUseCase.findProblemTargetDetail(problemId);
 
         OperationAlertTargetInfo target = new OperationAlertTargetInfo(
                 OperationTargetType.PROBLEM,
-                (Long) row[0],
-                (String) row[1],
-                (String) row[2],
+                problem.problemId(),
+                problem.title(),
+                problem.status(),
                 null,
                 null,
                 null,
                 null,
-                (Long) row[3],
-                (String) row[4]
+                problem.problemSetId(),
+                problem.problemSetTitle()
         );
 
         return new OperationAlertTargetDetail(
                 target,
-                toAssignee(row, 5),
+                loadAssignee(problem.createdBy()),
                 toMetric(rule, detectedValue, thresholdValue)
         );
     }
@@ -145,29 +112,15 @@ public class OperationAlertTargetDetailAdapter implements OperationAlertTargetDe
             BigDecimal thresholdValue,
             OperationAlertRuleInfo rule
     ) {
-        Object[] row = entityManager.createQuery("""
-                        select u.userId,
-                               u.name,
-                               u.nickname,
-                               u.email,
-                               u.role,
-                               u.isLocked
-                        from UserJpaEntity u
-                        where u.userId = :userId
-                          and u.deletedAt is null
-                        """, Object[].class)
-                .setParameter("userId", userId)
-                .getResultStream()
-                .findFirst()
-                .orElseThrow(() -> new NotFoundException(OperationAlertErrorCode.OPERATION_ALERT_TARGET_NOT_FOUND));
+        StudentDetail user = loadUser(userId);
 
         OperationAlertTargetInfo target = new OperationAlertTargetInfo(
                 OperationTargetType.USER,
-                (Long) row[0],
-                (String) row[1],
-                toUserStatus(row[4], row[5]),
-                (String) row[2],
-                (String) row[3],
+                user.userId(),
+                user.name(),
+                toUserStatus(user.role(), user.isLocked()),
+                user.nickname(),
+                user.email(),
                 null,
                 null,
                 null,
@@ -181,20 +134,27 @@ public class OperationAlertTargetDetailAdapter implements OperationAlertTargetDe
         );
     }
 
-    // 조회 결과의 사용자 컬럼을 담당자 정보로 변환한다.
-    private OperationAlertAssigneeInfo toAssignee(Object[] row, int startIndex) {
-        Long userId = (Long) row[startIndex];
+    private OperationAlertAssigneeInfo loadAssignee(Long userId) {
         if (userId == null) {
             return null;
         }
 
+        StudentDetail user = loadUser(userId);
         return new OperationAlertAssigneeInfo(
-                userId,
-                (String) row[startIndex + 1],
-                (String) row[startIndex + 2],
-                (String) row[startIndex + 3],
-                toStringOrNull(row[startIndex + 4])
+                user.userId(),
+                user.name(),
+                user.nickname(),
+                user.email(),
+                toStringOrNull(user.role())
         );
+    }
+
+    private StudentDetail loadUser(Long userId) {
+        try {
+            return getStudentDetailUseCase.getStudentDetail(userId);
+        } catch (NotFoundException exception) {
+            throw new NotFoundException(OperationAlertErrorCode.OPERATION_ALERT_TARGET_NOT_FOUND);
+        }
     }
 
     // 규칙 메타데이터와 알림 값을 화면 표시용 지표 정보로 변환한다.

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/CourseOperationMetricAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/CourseOperationMetricAdapter.java
@@ -3,15 +3,18 @@ package com.wanted.codebombalms.admin.operation.automation.infrastructure.adapte
 import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
 import com.wanted.codebombalms.admin.operation.automation.application.port.CourseOperationMetricPort;
 import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+import com.wanted.codebombalms.course.application.usecase.CourseQueryUseCase;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
 import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -19,29 +22,29 @@ import java.util.List;
 // 강좌와 수강신청 데이터를 조회해 수강생 부족 강좌 지표를 만든다.
 public class CourseOperationMetricAdapter implements CourseOperationMetricPort {
 
-    private final EntityManager entityManager;
+    private final CourseQueryUseCase courseQueryUseCase;
+    private final EnrollmentQueryUseCase enrollmentQueryUseCase;
 
     @Override
     public List<OperationRuleDetectionResult> findLowEnrollmentCourses(BigDecimal threshold) {
         long maxEnrollmentCount = threshold.longValue();
-
-        return entityManager.createQuery("""
-                        select c.courseId, count(e.enrollmentId)
-                        from CourseJpaEntity c
-                        left join EnrollmentJpaEntity e
-                            on e.course = c
-                            and e.status = :activeEnrollmentStatus
-                        where c.deletedAt is null
-                          and c.status = :activeCourseStatus
-                        group by c.courseId
-                        having count(e.enrollmentId) <= :maxEnrollmentCount
-                        """, Object[].class)
-                .setParameter("activeEnrollmentStatus", EnrollmentStatus.ACTIVE)
-                .setParameter("activeCourseStatus", CourseStatus.ACTIVE)
-                .setParameter("maxEnrollmentCount", maxEnrollmentCount)
-                .getResultList()
+        Map<Long, Long> enrollmentCountsByCourseId = enrollmentQueryUseCase.findAllActiveEnrollments()
                 .stream()
-                .map(row -> toResult((Long) row[0], (Long) row[1], threshold))
+                .filter(enrollment -> enrollment.getStatus() == EnrollmentStatus.ACTIVE)
+                .collect(Collectors.groupingBy(
+                        enrollment -> enrollment.getCourseId(),
+                        Collectors.counting()
+                ));
+
+        return courseQueryUseCase.findAllCourses(null)
+                .stream()
+                .filter(course -> course.getStatus() == CourseStatus.ACTIVE)
+                .map(course -> new CourseEnrollmentMetric(
+                        course.getCourseId(),
+                        enrollmentCountsByCourseId.getOrDefault(course.getCourseId(), 0L)
+                ))
+                .filter(metric -> metric.enrollmentCount() <= maxEnrollmentCount)
+                .map(metric -> toResult(metric.courseId(), metric.enrollmentCount(), threshold))
                 .toList();
     }
 
@@ -57,5 +60,8 @@ public class CourseOperationMetricAdapter implements CourseOperationMetricPort {
                 "수강생 수가 기준 이하입니다. 현재 수강생 수: " + enrollmentCount + "명",
                 "강좌 노출, 홍보 상태, 커리큘럼 구성을 점검하세요. 기준값: " + threshold + "명"
         );
+    }
+
+    private record CourseEnrollmentMetric(Long courseId, Long enrollmentCount) {
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/ProblemOperationMetricAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/ProblemOperationMetricAdapter.java
@@ -3,13 +3,12 @@ package com.wanted.codebombalms.admin.operation.automation.infrastructure.adapte
 import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
 import com.wanted.codebombalms.admin.operation.automation.application.port.ProblemOperationMetricPort;
 import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
-import jakarta.persistence.EntityManager;
+import com.wanted.codebombalms.submission.application.usecase.ProblemSubmissionMetricQueryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
 
 @Component
@@ -18,45 +17,22 @@ import java.util.List;
 // 문제와 제출 데이터를 조회해 오답률 높은 문제 지표를 만든다.
 public class ProblemOperationMetricAdapter implements ProblemOperationMetricPort {
 
-    private final EntityManager entityManager;
+    private final ProblemSubmissionMetricQueryUseCase problemSubmissionMetricQueryUseCase;
 
     @Override
     public List<OperationRuleDetectionResult> findHighWrongRateProblems(
             BigDecimal wrongRateThreshold,
             Integer minSampleCount
     ) {
-        return entityManager.createQuery("""
-                        select p.problemId,
-                               count(s.submissionId),
-                               sum(case when s.isCorrect = false then 1 else 0 end)
-                        from ProblemJpaEntity p
-                        join SubmissionJpaEntity s on s.problem = p
-                        where p.status = 'ACTIVE'
-                        group by p.problemId
-                        having count(s.submissionId) >= :minSampleCount
-                        """, Object[].class)
-                .setParameter("minSampleCount", minSampleCount.longValue())
-                .getResultList()
+        return problemSubmissionMetricQueryUseCase
+                .findHighWrongRateProblems(wrongRateThreshold, minSampleCount)
                 .stream()
-                .map(this::toMetric)
-                .filter(metric -> metric.wrongRate().compareTo(wrongRateThreshold) >= 0)
                 .map(metric -> toResult(metric, wrongRateThreshold, minSampleCount))
                 .toList();
     }
 
-    private ProblemWrongRateMetric toMetric(Object[] row) {
-        Long problemId = (Long) row[0];
-        Long submissionCount = (Long) row[1];
-        Long wrongCount = (Long) row[2];
-        BigDecimal wrongRate = BigDecimal.valueOf(wrongCount)
-                .multiply(BigDecimal.valueOf(100))
-                .divide(BigDecimal.valueOf(submissionCount), 2, RoundingMode.HALF_UP);
-
-        return new ProblemWrongRateMetric(problemId, submissionCount, wrongCount, wrongRate);
-    }
-
     private OperationRuleDetectionResult toResult(
-            ProblemWrongRateMetric metric,
+            ProblemSubmissionMetricQueryUseCase.ProblemWrongRateView metric,
             BigDecimal wrongRateThreshold,
             Integer minSampleCount
     ) {
@@ -67,13 +43,5 @@ public class ProblemOperationMetricAdapter implements ProblemOperationMetricPort
                 "오답률이 기준 이상입니다. 현재 오답률: " + metric.wrongRate() + "%, 제출 수: " + metric.submissionCount() + "회",
                 "문제 설명, 정답, 테스트 케이스를 점검하세요. 기준값: " + wrongRateThreshold + "%, 최소 제출 수: " + minSampleCount + "회"
         );
-    }
-
-    private record ProblemWrongRateMetric(
-            Long problemId,
-            Long submissionCount,
-            Long wrongCount,
-            BigDecimal wrongRate
-    ) {
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/UserOperationMetricAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/UserOperationMetricAdapter.java
@@ -3,8 +3,8 @@ package com.wanted.codebombalms.admin.operation.automation.infrastructure.adapte
 import com.wanted.codebombalms.admin.operation.automation.application.model.OperationRuleDetectionResult;
 import com.wanted.codebombalms.admin.operation.automation.application.port.UserOperationMetricPort;
 import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
-import com.wanted.codebombalms.user.domain.model.UserRole;
-import jakarta.persistence.EntityManager;
+import com.wanted.codebombalms.auth.application.usecase.LoginActivityQueryUseCase;
+import com.wanted.codebombalms.user.application.usecase.UserOperationQueryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +21,8 @@ import java.util.List;
 // 사용자와 로그인 이력을 조회해 장기 미접속 학생 지표를 만든다.
 public class UserOperationMetricAdapter implements UserOperationMetricPort {
 
-    private final EntityManager entityManager;
+    private final UserOperationQueryUseCase userOperationQueryUseCase;
+    private final LoginActivityQueryUseCase loginActivityQueryUseCase;
     private final Clock clock;
 
     @Override
@@ -30,35 +31,25 @@ public class UserOperationMetricAdapter implements UserOperationMetricPort {
         LocalDateTime now = LocalDateTime.now(clock);
         LocalDateTime cutoff = now.minusDays(inactiveDays);
 
-        return entityManager.createQuery("""
-                        select u.userId,
-                               u.name,
-                               u.email,
-                               coalesce(max(lh.createdAt), u.createdAt)
-                        from UserJpaEntity u
-                        left join LoginHistoryJpaEntity lh
-                            on lh.userId = u.userId
-                        where u.deletedAt is null
-                          and u.role = :studentRole
-                        group by u.userId, u.name, u.email, u.createdAt
-                        """, Object[].class)
-                .setParameter("studentRole", UserRole.STUDENT)
-                .getResultList()
-                .stream()
-                .map(row -> toMetric(row, now))
+        return userOperationQueryUseCase.findStudents().stream()
+                .map(student -> toMetric(student, now))
                 .filter(metric -> !metric.lastActivityAt().isAfter(cutoff))
                 .map(metric -> toResult(metric, inactiveDaysThreshold))
                 .toList();
     }
 
-    private UserInactiveMetric toMetric(Object[] row, LocalDateTime now) {
-        LocalDateTime lastActivityAt = (LocalDateTime) row[3];
+    private UserInactiveMetric toMetric(
+            UserOperationQueryUseCase.UserOperationView student,
+            LocalDateTime now
+    ) {
+        LocalDateTime lastActivityAt = loginActivityQueryUseCase.findLatestLoginAt(student.userId())
+                .orElse(student.createdAt());
         long inactiveDays = ChronoUnit.DAYS.between(lastActivityAt, now);
 
         return new UserInactiveMetric(
-                (Long) row[0],
-                (String) row[1],
-                (String) row[2],
+                student.userId(),
+                student.name(),
+                student.email(),
                 lastActivityAt,
                 inactiveDays
         );

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginActivityQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginActivityQueryService.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.usecase.LoginActivityQueryUseCase;
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoginActivityQueryService implements LoginActivityQueryUseCase {
+
+    private final LoginHistoryRepository loginHistoryRepository;
+
+    @Override
+    public Optional<LocalDateTime> findLatestLoginAt(Long userId) {
+        return loginHistoryRepository.findLatestByUserId(userId)
+                .map(LoginHistory::getCreatedAt);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginActivityQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginActivityQueryUseCase.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface LoginActivityQueryUseCase {
+
+    Optional<LocalDateTime> findLatestLoginAt(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/problem/application/port/ProblemTargetDetailPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/problem/application/port/ProblemTargetDetailPort.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.problems.problem.application.port;
+
+import java.util.Optional;
+
+public interface ProblemTargetDetailPort {
+
+    Optional<ProblemTargetDetailView> findProblemTargetDetail(Long problemId);
+
+    record ProblemTargetDetailView(
+            Long problemId,
+            String title,
+            String status,
+            Long problemSetId,
+            String problemSetTitle,
+            Long createdBy
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/problem/application/service/ProblemTargetDetailQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/problem/application/service/ProblemTargetDetailQueryService.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.problems.problem.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort;
+import com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort.ProblemTargetDetailView;
+import com.wanted.codebombalms.problems.problem.application.usecase.ProblemTargetDetailQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemTargetDetailQueryService implements ProblemTargetDetailQueryUseCase {
+
+    private final ProblemTargetDetailPort problemTargetDetailPort;
+
+    @Override
+    public ProblemTargetDetailView findProblemTargetDetail(Long problemId) {
+        return problemTargetDetailPort.findProblemTargetDetail(problemId)
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/problem/application/usecase/ProblemTargetDetailQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/problem/application/usecase/ProblemTargetDetailQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.problems.problem.application.usecase;
+
+import com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort.ProblemTargetDetailView;
+
+public interface ProblemTargetDetailQueryUseCase {
+
+    ProblemTargetDetailView findProblemTargetDetail(Long problemId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/problem/infrastructure/persistence/ProblemTargetDetailPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/problem/infrastructure/persistence/ProblemTargetDetailPersistenceAdapter.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.problems.problem.infrastructure.persistence;
+
+import com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort;
+import com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort.ProblemTargetDetailView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemTargetDetailPersistenceAdapter implements ProblemTargetDetailPort {
+
+    private final SpringDataProblemRepository problemRepository;
+
+    @Override
+    public Optional<ProblemTargetDetailView> findProblemTargetDetail(Long problemId) {
+        return problemRepository.findProblemTargetDetail(problemId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/problem/infrastructure/persistence/SpringDataProblemRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/problem/infrastructure/persistence/SpringDataProblemRepository.java
@@ -1,8 +1,11 @@
 package com.wanted.codebombalms.problems.problem.infrastructure.persistence;
 
+import com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort.ProblemTargetDetailView;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SpringDataProblemRepository extends JpaRepository<ProblemJpaEntity, Long> {
 
@@ -31,4 +34,19 @@ public interface SpringDataProblemRepository extends JpaRepository<ProblemJpaEnt
             Long problemId,
             Long problemSetId
     );
+
+    @Query("""
+            select new com.wanted.codebombalms.problems.problem.application.port.ProblemTargetDetailPort$ProblemTargetDetailView(
+                p.problemId,
+                p.title,
+                p.status,
+                ps.problemSetId,
+                ps.title,
+                ps.createdBy
+            )
+            from ProblemJpaEntity p
+            join p.problemSet ps
+            where p.problemId = :problemId
+            """)
+    Optional<ProblemTargetDetailView> findProblemTargetDetail(@Param("problemId") Long problemId);
 }

--- a/src/main/java/com/wanted/codebombalms/submission/application/port/ProblemSubmissionMetricPort.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/port/ProblemSubmissionMetricPort.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.submission.application.port;
+
+import java.util.List;
+
+public interface ProblemSubmissionMetricPort {
+
+    List<ProblemWrongRateMetric> findProblemWrongRateMetrics(Integer minSampleCount);
+
+    record ProblemWrongRateMetric(
+            Long problemId,
+            Long submissionCount,
+            Long wrongCount
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/ProblemSubmissionMetricQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/ProblemSubmissionMetricQueryService.java
@@ -1,0 +1,43 @@
+package com.wanted.codebombalms.submission.application.service;
+
+import com.wanted.codebombalms.submission.application.port.ProblemSubmissionMetricPort;
+import com.wanted.codebombalms.submission.application.usecase.ProblemSubmissionMetricQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemSubmissionMetricQueryService implements ProblemSubmissionMetricQueryUseCase {
+
+    private final ProblemSubmissionMetricPort problemSubmissionMetricPort;
+
+    @Override
+    public List<ProblemWrongRateView> findHighWrongRateProblems(
+            BigDecimal wrongRateThreshold,
+            Integer minSampleCount
+    ) {
+        return problemSubmissionMetricPort.findProblemWrongRateMetrics(minSampleCount).stream()
+                .map(this::toView)
+                .filter(metric -> metric.wrongRate().compareTo(wrongRateThreshold) >= 0)
+                .toList();
+    }
+
+    private ProblemWrongRateView toView(ProblemSubmissionMetricPort.ProblemWrongRateMetric metric) {
+        BigDecimal wrongRate = BigDecimal.valueOf(metric.wrongCount())
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(metric.submissionCount()), 2, RoundingMode.HALF_UP);
+
+        return new ProblemWrongRateView(
+                metric.problemId(),
+                metric.submissionCount(),
+                metric.wrongCount(),
+                wrongRate
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/usecase/ProblemSubmissionMetricQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/usecase/ProblemSubmissionMetricQueryUseCase.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.submission.application.usecase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public interface ProblemSubmissionMetricQueryUseCase {
+
+    List<ProblemWrongRateView> findHighWrongRateProblems(
+            BigDecimal wrongRateThreshold,
+            Integer minSampleCount
+    );
+
+    record ProblemWrongRateView(
+            Long problemId,
+            Long submissionCount,
+            Long wrongCount,
+            BigDecimal wrongRate
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/ProblemSubmissionMetricPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/ProblemSubmissionMetricPersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.submission.infrastructure.persistence;
+
+import com.wanted.codebombalms.submission.application.port.ProblemSubmissionMetricPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemSubmissionMetricPersistenceAdapter implements ProblemSubmissionMetricPort {
+
+    private final SpringDataSubmissionRepository submissionRepository;
+
+    @Override
+    public List<ProblemWrongRateMetric> findProblemWrongRateMetrics(Integer minSampleCount) {
+        return submissionRepository.findProblemWrongRateMetrics(minSampleCount.longValue());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionRepository.java
@@ -3,7 +3,12 @@ package com.wanted.codebombalms.submission.infrastructure.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.wanted.codebombalms.submission.application.port.ProblemSubmissionMetricPort.ProblemWrongRateMetric;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface SpringDataSubmissionRepository extends JpaRepository<SubmissionJpaEntity, Long> {
@@ -27,4 +32,17 @@ public interface SpringDataSubmissionRepository extends JpaRepository<Submission
             Long problemId,
             Pageable pageable
     );
+
+    @Query("""
+            select new com.wanted.codebombalms.submission.application.port.ProblemSubmissionMetricPort$ProblemWrongRateMetric(
+                s.problem.problemId,
+                count(s.submissionId),
+                sum(case when s.isCorrect = false then 1 else 0 end)
+            )
+            from SubmissionJpaEntity s
+            where s.problem.status = 'ACTIVE'
+            group by s.problem.problemId
+            having count(s.submissionId) >= :minSampleCount
+            """)
+    List<ProblemWrongRateMetric> findProblemWrongRateMetrics(@Param("minSampleCount") Long minSampleCount);
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UserOperationQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UserOperationQueryService.java
@@ -1,0 +1,38 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.user.application.usecase.UserOperationQueryUseCase;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserOperationQueryService implements UserOperationQueryUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public List<UserOperationView> findStudents() {
+        return userRepository.findAllByRole(UserRole.STUDENT).stream()
+                .map(this::toView)
+                .toList();
+    }
+
+    private UserOperationView toView(User user) {
+        return new UserOperationView(
+                user.getUserId(),
+                user.getName(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getRole(),
+                user.isLocked(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/UserOperationQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/UserOperationQueryUseCase.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import com.wanted.codebombalms.user.domain.model.UserRole;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserOperationQueryUseCase {
+
+    List<UserOperationView> findStudents();
+
+    record UserOperationView(
+            Long userId,
+            String name,
+            String nickname,
+            String email,
+            UserRole role,
+            boolean locked,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
@@ -20,5 +20,7 @@ public interface UserRepository {
 
     List<User> findAllByRole(UserRole role, int page, int size);
 
+    List<User> findAllByRole(UserRole role);
+
     long countByRole(UserRole role);
 }

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -19,5 +19,7 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
 
     List<UserJpaEntity> findAllByRoleOrderByCreatedAtDesc(UserRole role, Pageable pageable);
 
+    List<UserJpaEntity> findAllByRoleOrderByCreatedAtDesc(UserRole role);
+
     long countByRole(UserRole role);
 }

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -64,6 +64,13 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
+    public List<User> findAllByRole(UserRole role) {
+        return springDataUserRepository.findAllByRoleOrderByCreatedAtDesc(role).stream()
+                .map(UserJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public long countByRole(UserRole role) {
         return springDataUserRepository.countByRole(role);
     }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- ADMIN 운영 자동화 지표 조회 시 타 모듈 JPA Entity 및 EntityManager 직접 접근 제거
- 사용자, 로그인 이력, 제출 통계, 문제 상세 조회를 각 도메인의 application usecase 경유 방식으로 변경
- 운영 알림 대상 상세 조회 로직을 타 도메인 공개 조회 서비스 기반으로 리팩터링
- ADMIN 내부 포트 구조는 유지하면서 타 도메인 영속 계층 결합도 완화


---

## ♻️ 패키지 변경 사항

- codebombalms/admin: 운영 자동화 지표 및 알림 상세 - adapter가 타 도메인 usecase를 호출하도록 변경
- codebombalms/auth: 사용자 최신 로그인 시각 조회용 usecase/service 추가
- codebombalms/user: 운영 지표용 학생 조회 - usecase/service 추가 및 사용자 repository 조회 메서드 보완
- codebombalms/submission: 문제별 오답률 통계 조회 usecase/port/adapter 추가
- codebombalms/problems: 문제 알림 대상 상세 조회 usecase/port/adapter 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
