### PR TITLE
[Fix] 메세지 전송 / 채팅방생성 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatContextPort.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatContextPort.java
@@ -13,6 +13,9 @@ public interface ChatContextPort {
     // problemId로 현재 문제 순서 조회
     SessionProgressInfo findSessionProgress(Long problemId);
 
+    // problemId로 문제 제목 조회
+    String findProblemTitle(Long problemId);
+
     // problemSetId로 데이터셋 정보 조회
     DatasetInfo findDataset(Long problemSetId);
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
@@ -5,12 +5,10 @@ import com.wanted.codebombalms.chatbot.application.model.ChatContext;
 import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
 import com.wanted.codebombalms.chatbot.application.result.AiChatResult;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatMessageCommandUseCase;
-import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
 import com.wanted.codebombalms.chatbot.domain.model.ChatMessage;
 import com.wanted.codebombalms.chatbot.domain.model.ChatRoom;
 import com.wanted.codebombalms.chatbot.domain.repository.ChatMessageRepository;
 import com.wanted.codebombalms.chatbot.domain.repository.ChatRoomRepository;
-import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,8 +27,7 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
 
     @Override
     public AiChatResult send(SendMessageCommand command) {
-        ChatRoom chatRoom = chatRoomRepository.findById(command.roomId())
-                .orElseThrow(() -> new NotFoundException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        ChatRoom chatRoom = chatRoomRepository.getById(command.roomId());
 
         chatRoom.verifyOwner(command.userId());
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
@@ -26,7 +26,8 @@ public class ChatRoomCommandService implements ChatRoomCommandUseCase {
 
     @Override
     public SendFirstMessageResult sendFirst(SendFirstMessageCommand command) {
-        ChatRoom room = createRoom(command.userId(), command.problemSetId(), command.problemId());
+        ChatRoom room = createRoom(
+                command.userId(), command.problemSetId(), command.problemId(), command.userMessage());
 
         AiChatResult aiResult = chatMessageCommandUseCase.send(
                 new SendMessageCommand(command.userId(), room.getId(), command.userMessage())
@@ -35,13 +36,35 @@ public class ChatRoomCommandService implements ChatRoomCommandUseCase {
         return new SendFirstMessageResult(room.getId(), aiResult.answer());
     }
 
-    private ChatRoom createRoom(Long userId, Long problemSetId, Long problemId) {
-        ChatContextPort.ProblemSetInfo problemSetInfo =
-                problemSetId != null ? chatContextPort.findProblemSet(problemSetId) : null;
-
-        String title = problemSetInfo != null ? problemSetInfo.title() : "";
+    private ChatRoom createRoom(Long userId, Long problemSetId, Long problemId, String userMessage) {
+        String title = resolveTitle(problemSetId, problemId, userMessage);
         ChatRoom newRoom = ChatRoom.create(userId, problemSetId, problemId, title);
         return chatRoomRepository.save(newRoom);
+    }
+
+    private String resolveTitle(Long problemSetId, Long problemId, String userMessage) {
+        if (problemSetId == null) {
+            return summarize(userMessage);
+        }
+
+        ChatContextPort.ProblemSetInfo setInfo = chatContextPort.findProblemSet(problemSetId);
+        String setTitle = setInfo != null ? setInfo.title() : "";
+
+        if (problemId != null) {
+            String problemTitle = chatContextPort.findProblemTitle(problemId);
+            if (problemTitle != null && !problemTitle.isBlank()) {
+                return setTitle + " - " + problemTitle;
+            }
+        }
+        return setTitle;
+    }
+
+    private String summarize(String message) {
+        if (message == null || message.isBlank()) {
+            return "새 대화";
+        }
+        String trimmed = message.strip();
+        return trimmed.length() <= 20 ? trimmed : trimmed.substring(0, 20) + "…";
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/adapter/ChatContextAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/adapter/ChatContextAdapter.java
@@ -1,10 +1,11 @@
 package com.wanted.codebombalms.chatbot.infrastructure.adapter;
 
 import com.wanted.codebombalms.chatbot.application.port.ChatContextPort;
-import com.wanted.codebombalms.problems.dataset.infrastructure.persistence.SpringDataProblemDatasetRepository;
-import com.wanted.codebombalms.problems.problem.infrastructure.persistence.SpringDataProblemRepository;
-import com.wanted.codebombalms.problems.set.infrastructure.persistence.SpringDataProblemSetRepository;
-import com.wanted.codebombalms.submission.infrastructure.persistence.SpringDataSubmissionRepository;
+import com.wanted.codebombalms.problems.dataset.application.service.ProblemDatasetQueryService;
+import com.wanted.codebombalms.problems.problem.application.service.ProblemQueryService;
+import com.wanted.codebombalms.problems.set.application.service.ProblemSetQueryService;
+import com.wanted.codebombalms.submission.application.service.SubmissionQueryService;
+import com.wanted.codebombalms.submission.domain.model.LatestSubmission;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,38 +15,32 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatContextAdapter implements ChatContextPort {
 
-    private final SpringDataProblemSetRepository problemSetRepository;
-    private final SpringDataProblemRepository problemRepository;
-    private final SpringDataSubmissionRepository submissionRepository;
-    private final SpringDataProblemDatasetRepository datasetRepository;
+    // 교안 패턴: 타 BC SpringData 직접참조 제거 → 타 BC application service 경유
+    private final ProblemSetQueryService problemSetQueryService;
+    private final ProblemQueryService problemQueryService;
+    private final SubmissionQueryService submissionQueryService;
+    private final ProblemDatasetQueryService problemDatasetQueryService;
 
     @Override
     public ProblemSetInfo findProblemSet(Long problemSetId) {
-        return problemSetRepository.findById(problemSetId)
-                .map(e -> new ProblemSetInfo(
-                        e.getProblemSetId(),
-                        e.getTitle(),
-                        e.getDescription()
-                ))
-                .orElse(null);
+        var ps = problemSetQueryService.findProblemSetDetail(problemSetId);
+        return new ProblemSetInfo(ps.problemSetId(), ps.title(), ps.description());
     }
 
     @Override
     public List<ProblemInfo> findProblems(Long problemSetId, Long userId) {
-        return problemRepository
-                .findByProblemSet_ProblemSetIdAndStatusOrderByProblemOrderAsc(problemSetId, "ACTIVE")
-                .stream()
+        return problemQueryService.findProblemsForChat(problemSetId).stream()
                 .map(p -> {
-                    String submittedAnswer = submissionRepository
-                            .findTopByUserIdAndProblem_ProblemIdOrderBySubmittedAtDesc(userId, p.getProblemId())
-                            .map(s -> s.getSubmittedAnswer())
+                    String submittedAnswer = submissionQueryService
+                            .findLatestResult(userId, p.problemId())
+                            .map(LatestSubmission::submittedAnswer)
                             .orElse(null);
                     return new ProblemInfo(
-                            p.getTitle(),
-                            p.getContent(),
-                            p.getProblemType(),
-                            p.getAnswer(),
-                            p.getExplanation(),
+                            p.title(),
+                            p.content(),
+                            p.problemType(),
+                            p.answer(),
+                            p.explanation(),
                             submittedAnswer
                     );
                 })
@@ -54,17 +49,21 @@ public class ChatContextAdapter implements ChatContextPort {
 
     @Override
     public SessionProgressInfo findSessionProgress(Long problemId) {
-        int currentProblemNumber = problemRepository.findById(problemId)
-                .map(e -> e.getProblemOrder())
-                .orElse(1);
+        int currentProblemNumber = problemQueryService
+                .findProblemForSubmission(problemId)
+                .problemOrder();
         return new SessionProgressInfo(currentProblemNumber);
     }
 
     @Override
+    public String findProblemTitle(Long problemId) {
+        return problemQueryService.findProblem(problemId).getTitle();
+    }
+
+    @Override
     public DatasetInfo findDataset(Long problemSetId) {
-        return datasetRepository
-                .findFirstByProblemSet_ProblemSetIdAndStatusOrderByDatasetIdDesc(problemSetId, "ACTIVE")
-                .map(e -> new DatasetInfo(e.getMetadata()))
+        return problemDatasetQueryService.findLatestActiveMetadata(problemSetId)
+                .map(DatasetInfo::new)
                 .orElse(null);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatMessageController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatMessageController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +22,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")  // ← 추가
 public class ChatMessageController {
 
     private final ChatMessageQueryUseCase chatMessageQueryUseCase;

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -86,7 +87,7 @@ public class ChatRoomController {
     @PostMapping("/messages")
     public ResponseEntity<ApiResponse<SendFirstMessageResponse>> sendFirstMessage(
             @AuthenticationPrincipal Long userId,
-            @RequestBody SendFirstMessageRequest request
+            @Valid @RequestBody SendFirstMessageRequest request
     ) {
         SendFirstMessageCommand command = new SendFirstMessageCommand(
                 userId,
@@ -267,7 +268,7 @@ public class ChatRoomController {
             @Parameter(description = "메시지를 전송할 채팅방 ID", example = "1")
             @PathVariable Long roomId,
             @AuthenticationPrincipal Long userId,
-            @RequestBody ChatMessageRequest request
+            @Valid @RequestBody ChatMessageRequest request
     ) {
         SendMessageCommand command = new SendMessageCommand(
                 userId,

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Tag(name = "Chatbot - 채팅방", description = "AI 채팅방 생성/조회/삭제 및 메시지 전송 API")
+@PreAuthorize("isAuthenticated()")  // ← 추가
 @RestController
 @RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
@@ -105,8 +107,6 @@ public class ChatRoomController {
                 )
         );
     }
-
-
     @Operation(
             summary = "채팅방 목록 조회",
             description = "로그인한 사용자의 채팅방 목록을 최신순으로 반환합니다."

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/ChatMessageRequest.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/ChatMessageRequest.java
@@ -1,5 +1,8 @@
 package com.wanted.codebombalms.chatbot.presentation.api.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ChatMessageRequest(
+        @NotBlank(message = "메시지를 입력해주세요.")  // ← 추가
         String userMessage
 ) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/SendFirstMessageRequest.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/SendFirstMessageRequest.java
@@ -1,7 +1,10 @@
 package com.wanted.codebombalms.chatbot.presentation.api.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record SendFirstMessageRequest(
+        @NotBlank(message = "메시지를 입력해주세요.")  // ← 추가
         String userMessage,
-        Long problemSetId,
-        Long problemId
+        Long problemSetId,   // null 허용 (선택값)
+        Long problemId       // null 허용 (선택값)
 ) {}

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/application/port/LoadProblemDatasetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/application/port/LoadProblemDatasetPort.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.dataset.application.port;
+
+import java.util.Optional;
+
+// 챗봇 adapter용 dataset 조회 포트
+public interface LoadProblemDatasetPort {
+
+    Optional<String> findLatestActiveMetadata(Long problemSetId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/application/service/ProblemDatasetQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/application/service/ProblemDatasetQueryService.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.problems.dataset.application.service;
+
+import com.wanted.codebombalms.problems.dataset.application.port.LoadProblemDatasetPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemDatasetQueryService {
+
+    private final LoadProblemDatasetPort loadProblemDatasetPort;
+
+    // === 챗봇 adapter용 메서드 ===
+    // chatbot ChatContextAdapter.findDataset() 가 호출
+    @Transactional(readOnly = true)
+    public Optional<String> findLatestActiveMetadata(Long problemSetId) {
+        return loadProblemDatasetPort.findLatestActiveMetadata(problemSetId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetQueryPersistenceAdapter.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.problems.dataset.infrastructure.persistence;
+
+import com.wanted.codebombalms.problems.dataset.application.port.LoadProblemDatasetPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemDatasetQueryPersistenceAdapter implements LoadProblemDatasetPort {
+
+    private final SpringDataProblemDatasetRepository problemDatasetRepository;
+
+    @Override
+    public Optional<String> findLatestActiveMetadata(Long problemSetId) {
+        return problemDatasetRepository
+                .findFirstByProblemSet_ProblemSetIdAndStatusOrderByDatasetIdDesc(problemSetId, "ACTIVE")
+                .map(ProblemDatasetJpaEntity::getMetadata);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/problem/application/service/ProblemQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/problem/application/service/ProblemQueryService.java
@@ -66,6 +66,32 @@ public class ProblemQueryService {
                 .map(this::toView);
     }
 
+    // === 챗봇 adapter용 메서드 ===
+    // chatbot ChatContextAdapter.findProblems() 가 호출
+    @Transactional(readOnly = true)
+    public List<ProblemForChatView> findProblemsForChat(Long problemSetId) {
+        return problemRepository.findActiveProblemsByProblemSet(problemSetId)
+                .stream()
+                .map(p -> new ProblemForChatView(
+                        p.getProblemId(),
+                        p.getTitle(),
+                        p.getContent(),
+                        p.getProblemType(),
+                        p.getAnswer(),
+                        p.getExplanation()))
+                .toList();
+    }
+
+    // 챗봇 adapter 응답 DTO
+    public record ProblemForChatView(
+            Long problemId,
+            String title,
+            String content,
+            String problemType,
+            String answer,
+            String explanation
+    ) {}
+
     private ProblemView toView(Problem problem) {
         return new ProblemView(
                 problem.getProblemId(),

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemSetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemSetPort.java
@@ -1,13 +1,17 @@
 package com.wanted.codebombalms.problems.set.application.port;
 
+import com.wanted.codebombalms.problems.set.domain.model.ProblemSetBrief;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface LoadProblemSetPort {
 
     List<ProblemSetSummary> loadActiveProblemSetsByCategory(Long categoryId);
 
     List<ProblemSetSummary> loadActiveProblemSets();
+
+    // 챗봇 adapter용 단건 조회
+    Optional<ProblemSetBrief> loadById(Long problemSetId);
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
@@ -40,6 +40,25 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
                 .toList();
     }
 
+    // === 챗봇 adapter용 메서드 ===
+    // chatbot ChatContextAdapter.findProblemSet() 가 호출
+    @Transactional(readOnly = true)
+    public ProblemSetDetailView findProblemSetDetail(Long problemSetId) {
+        return loadProblemSetPort.loadById(problemSetId)
+                .map(ps -> new ProblemSetDetailView(
+                        ps.getProblemSetId(),
+                        ps.getTitle(),
+                        ps.getDescription()))
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
+    }
+
+    // 챗봇 adapter 응답 DTO
+    public record ProblemSetDetailView(
+            Long problemSetId,
+            String title,
+            String description
+    ) {}
+
     private ProblemSetSummaryView toView(ProblemSetSummary problemSet) {
         return new ProblemSetSummaryView(
                 problemSet.getProblemSetId(),

--- a/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetBrief.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetBrief.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.problems.set.domain.model;
+
+// 챗봇 adapter용 최소 조회 모델 (problemSetId, title, description 만)
+public class ProblemSetBrief {
+
+    private final Long problemSetId;
+    private final String title;
+    private final String description;
+
+    private ProblemSetBrief(Long problemSetId, String title, String description) {
+        this.problemSetId = problemSetId;
+        this.title = title;
+        this.description = description;
+    }
+
+    public static ProblemSetBrief of(Long problemSetId, String title, String description) {
+        return new ProblemSetBrief(problemSetId, title, description);
+    }
+
+    public Long getProblemSetId() {
+        return problemSetId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetMapper.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetMapper.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.problems.set.infrastructure.persistence;
 
+import com.wanted.codebombalms.problems.set.domain.model.ProblemSetBrief;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetEntry;
 
@@ -18,6 +19,15 @@ public class ProblemSetMapper {
                 problemSet.getCompletedUserCount(),
                 problemSet.getStartedUserCount(),
                 problemSet.getCreatedAt()
+        );
+    }
+
+    // 챗봇 adapter용 단건 조회 매핑
+    public static ProblemSetBrief toBrief(ProblemSetJpaEntity problemSet) {
+        return ProblemSetBrief.of(
+                problemSet.getProblemSetId(),
+                problemSet.getTitle(),
+                problemSet.getDescription()
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetPersistenceAdapter.java
@@ -1,11 +1,13 @@
 package com.wanted.codebombalms.problems.set.infrastructure.persistence;
 
+import com.wanted.codebombalms.problems.set.domain.model.ProblemSetBrief;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import com.wanted.codebombalms.problems.set.application.port.LoadProblemSetPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 @Component
@@ -31,6 +33,12 @@ public class ProblemSetPersistenceAdapter implements LoadProblemSetPort {
         return IntStream.range(0, problemSets.size())
                 .mapToObj(index -> ProblemSetMapper.toSummary(problemSets.get(index), index + 1))
                 .toList();
+    }
+
+    @Override
+    public Optional<ProblemSetBrief> loadById(Long problemSetId) {
+        return problemSetRepository.findById(problemSetId)
+                .map(ProblemSetMapper::toBrief);
     }
 
 }


### PR DESCRIPTION
---

## 🚨 Pull Request 유형

- [x] ⭐ Fix

---

## 🛠️ 기능 관련 작업 내용

채팅방 첫 메시지 전송 시 **채팅방 제목을 자동 생성**하도록 구현했습니다.

- 기존에는 문제집(ProblemSet)이 없는 일반 대화방의 제목이 빈 문자열(`""`)로 저장되어 사이드바에 표시되지 않는 문제가 있었습니다.
- 제목 생성 규칙을 다음과 같이 분기 처리했습니다.
  - **문제집 + 특정 문제** → `"{문제집 제목} - {문제 제목}"`
  - **문제집만 (특정 문제 없음)** → `"{문제집 제목}"`
  - **일반 대화 (문제집 없음)** → 첫 메시지 앞 20자 (초과 시 `…`, 빈 메시지면 `"새 대화"`)
- 제목 결정 로직을 `resolveTitle()` 메서드로 분리해 `createRoom()`의 책임을 명확히 했습니다.
- 제목은 채팅방 생성 시점(첫 메시지 송신, AI 응답 이전)에 확정되어 추가 호출/대기 비용이 없습니다.

---

## ♻️ 패키지 변경 사항

- `chatbot/application/port/ChatContextPort` : 문제 제목 조회 메서드 `findProblemTitle(Long)` 추가
- `chatbot/infrastructure/adapter/ChatContextAdapter` : `findProblemTitle` 구현 (`ProblemQueryService.findProblem().getTitle()` 경유)
- `chatbot/application/service/ChatRoomCommandService` : `resolveTitle()` / `summarize()` 추가, `createRoom()`이 첫 메시지를 받아 제목 분기 처리

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.

---

비고:
- "정상 동작" 체크 안 함 — `compileJava`는 통과했지만 런타임 E2E(사이드바 제목 표시)는 아직 미확인. 확인 후 체크해.
- 프롬프트 개선(동문서답/인사)은 **Python 레포(tsarbombaChatBot)** 변경이라 이 PR과 별개. 따로 PR 필요하면 그것도 써줄게.