### PR TITLE
[Fix] 문제 세트 등록 생성자 정보 처리 개선

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -7,8 +7,8 @@ POST http://localhost:8080/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "email": "op@test.com",
-  "password": "Test1234!"
+  "email": "admin@codebomba.com",
+  "password": "password"
 }
 
 ### 1. 내 정보 조회 — 정상 (0번 직후 실행)

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/command/RegisterProblemSetCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/command/RegisterProblemSetCommand.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.problems.set.application.command;
 import java.util.List;
 
 public record RegisterProblemSetCommand(
+        Long createdBy,
         String title,
         String categoryName,
         String difficulty,

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/policy/ProblemSetCommandValidationPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/policy/ProblemSetCommandValidationPolicy.java
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Component;
 public class ProblemSetCommandValidationPolicy {
 
     public void validate(RegisterProblemSetCommand command) {
+        if (command.createdBy() == null) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+
         validateProblemSet(
                 command.title(),
                 command.categoryName(),

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetRegistrationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetRegistrationService.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Service
 public class ProblemSetRegistrationService implements RegisterProblemSetUseCase {
 
-    private static final Long TEMP_OPERATOR_USER_ID = 2L;
+
     private static final String CODE_PROBLEM_TYPE = "CODE";
     private static final int DEFAULT_ATTEMPT_LIMIT = 3;
     private static final boolean DEFAULT_RETRIABLE = true;
@@ -38,7 +38,7 @@ public class ProblemSetRegistrationService implements RegisterProblemSetUseCase 
 
         return toCommandResult(problemSetManagementRepository.createProblemSet(
                 toRegistration(command),
-                TEMP_OPERATOR_USER_ID
+                command.createdBy()
         ));
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
@@ -36,6 +36,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -70,9 +71,10 @@ public class ProblemManageController {
     @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
     @PostMapping("/api/v1/problems")
     public ResponseEntity<ApiResponse<ProblemSetCreateResponse>> createProblem(
+            @AuthenticationPrincipal Long createdBy,
             @RequestBody ProblemSetCreateRequest request
     ) {
-        var result = registerProblemSetUseCase.handle(toCommand(request));
+        var result = registerProblemSetUseCase.handle(toCommand(createdBy, request));
         var response = new ProblemSetCreateResponse(result);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -185,13 +187,14 @@ public class ProblemManageController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     public ResponseEntity<ApiResponse<ProblemSetWithDatasetCreateResponse>> createProblemWithDataset(
+            @AuthenticationPrincipal Long createdBy,
             @Parameter(description = "문제 세트 등록 JSON 파트", required = true)
             @RequestPart("request") ProblemSetCreateRequest request,
             @Parameter(description = "문제 세트에 연결할 CSV 데이터셋 파일", required = true)
             @RequestPart("datasetFile") MultipartFile datasetFile
     ) {
         var result = registerProblemSetWithDatasetUseCase.handle(
-                toCommand(request),
+                toCommand(createdBy, request),
                 toDatasetCommand(datasetFile)
         );
 
@@ -285,15 +288,16 @@ public class ProblemManageController {
         }
     }
 
-    private RegisterProblemSetCommand toCommand(ProblemSetCreateRequest request) {
+    private RegisterProblemSetCommand toCommand(Long createdBy, ProblemSetCreateRequest request) {
         List<ProblemCreateCommand> problems = request.problems() == null
                 ? null
                 : request.problems()
-                        .stream()
-                        .map(this::toCommand)
-                        .toList();
+                .stream()
+                .map(this::toCommand)
+                .toList();
 
         return new RegisterProblemSetCommand(
+                createdBy,
                 request.title(),
                 request.categoryName(),
                 request.difficulty(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
   profiles:
     active: local
   datasource:
-    url: ${DB_URL}
+    url: jdbc:mysql://localhost:3306/wanted_lms?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 문제 세트 등록 시 `createdBy` 값을 하드코딩하지 않고 로그인한 사용자 ID를 사용하도록 수정했습니다.
- 데이터셋 포함 문제 세트 등록에서도 인증 사용자 ID가 `created_by`로 저장되도록 흐름을 통일했습니다.
- `problem_set.created_by` FK 제약 조건으로 인해 문제 세트 등록이 실패하던 문제를 해결했습니다.
- 문제 세트 등록 요청에서 생성자 ID가 비어 있는 경우를 검증하도록 보완했습니다.

---

## ♻️ 패키지 변경 사항

- `problems/set/presentation/ProblemManageController` : 문제 세트 등록 API에서 `@AuthenticationPrincipal` 기반 생성자 ID 전달
- `problems/set/application/command/RegisterProblemSetCommand` : 문제 세트 등록 커맨드에 `createdBy` 필드 추가
- `problems/set/application/service/ProblemSetRegistrationService` : 하드코딩된 운영자 ID 제거 및 커맨드의 생성자 ID 사용
- `problems/set/application/policy/ProblemSetCommandValidationPolicy` : 문제 세트 등록 시 생성자 ID 검증 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.

---

## 리뷰어가 확인해야 할 내용

- 기존에는 문제 세트 등록 시 `created_by`에 임시 운영자 ID가 들어가 FK 오류가 발생할 수 있었습니다.
- 수정 후에는 로그인한 ADMIN/OPERATOR 사용자의 ID가 `created_by`로 저장됩니다.
- 프론트에서는 별도로 `createdBy` 값을 보낼 필요 없이 로그인 토큰만 포함하면 됩니다.