### PR TITLE
[UPDATE] 강좌 썸네일 업로드 API 추가

### DIFF
--- a/http/course.http
+++ b/http/course.http
@@ -16,7 +16,19 @@ GET {{host}}/api/v1/courses
 ### 3. 카테고리별 강좌 목록 조회
 GET {{host}}/api/v1/course-categories/{{courseCategoryId}}/courses
 
-### 4. 강좌 등록
+### 4. 강좌 썸네일 업로드
+### 응답 data.thumbnailUrl 값을 강좌 등록/수정 요청의 thumbnailUrl에 넣어서 사용합니다.
+POST {{host}}/api/v1/courses/thumbnails
+Content-Type: multipart/form-data; boundary=courseThumbnailBoundary
+
+--courseThumbnailBoundary
+Content-Disposition: form-data; name="thumbnail"; filename="thumbnail.png"
+Content-Type: image/png
+
+< ./thumbnail.png
+--courseThumbnailBoundary--
+
+### 5. 강좌 등록
 POST {{host}}/api/v1/courses
 Content-Type: application/json
 
@@ -27,10 +39,10 @@ Content-Type: application/json
   "thumbnailUrl": "java.png"
 }
 
-### 5. 강좌 상세 조회
+### 6. 강좌 상세 조회
 GET {{host}}/api/v1/courses/{{courseId}}
 
-### 6. 강좌 수정
+### 7. 강좌 수정
 PUT {{host}}/api/v1/courses/{{courseId}}
 Content-Type: application/json
 
@@ -42,17 +54,17 @@ Content-Type: application/json
   "status": "DRAFT"
 }
 
-### 7. 강좌 공개
+### 8. 강좌 공개
 ### 주의: 공개하려면 해당 강좌에 강의가 1개 이상 등록되어 있어야 합니다.
 PATCH {{host}}/api/v1/courses/{{courseId}}/publish
 
-### 8. 강좌에 연결된 문제 세트 목록 조회
+### 9. 강좌에 연결된 문제 세트 목록 조회
 GET {{host}}/api/v1/courses/{{courseId}}/problem-sets
 
-### 9. 강의에 연결된 문제 세트 목록 조회
+### 10. 강의에 연결된 문제 세트 목록 조회
 GET {{host}}/api/v1/lectures/{{lectureId}}/problem-sets
 
-### 10. 강좌/강의 문제 세트 연결 저장
+### 11. 강좌/강의 문제 세트 연결 저장
 PUT {{host}}/api/v1/courses/{{courseId}}/problem-sets
 Content-Type: application/json
 
@@ -73,11 +85,11 @@ Content-Type: application/json
   ]
 }
 
-### 11. 강사별 강좌 목록 조회
+### 12. 강사별 강좌 목록 조회
 GET {{host}}/api/v1/users/{{userId}}/courses
 
-### 12. 강좌 삭제 - 다른 모든 http 실행 전에는 실행하지 말 것
+### 13. 강좌 삭제 - 다른 모든 http 실행 전에는 실행하지 말 것
 # DELETE {{host}}/api/v1/courses/{{courseId}}
 
-### 13. 삭제된 강좌 상세 조회 확인 - 강좌 삭제 후 별도 실행
+### 14. 삭제된 강좌 상세 조회 확인 - 강좌 삭제 후 별도 실행
 # GET {{host}}/api/v1/courses/{{courseId}}

--- a/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseController.java
+++ b/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseController.java
@@ -10,19 +10,27 @@ import com.wanted.codebombalms.course.presentation.api.request.CourseCreateReque
 import com.wanted.codebombalms.course.presentation.api.request.CourseUpdateRequest;
 import com.wanted.codebombalms.course.presentation.api.response.CourseDetailResponse;
 import com.wanted.codebombalms.course.presentation.api.response.CourseResponse;
+import com.wanted.codebombalms.course.presentation.api.response.CourseThumbnailUploadResponse;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -31,7 +39,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -40,6 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CourseController {
 
     private static final Logger log = LoggerFactory.getLogger(CourseController.class);
+    private static final String THUMBNAIL_UPLOAD_DIR = "uploads/course-thumbnails";
 
     private final CourseCommandUseCase courseCommandUseCase;
     private final CourseQueryUseCase courseQueryUseCase;
@@ -115,6 +127,48 @@ public class CourseController {
                                 request.thumbnailUrl()
                         )))
                 ));
+    }
+
+    @Operation(summary = "강좌 썸네일 업로드")
+    @PostMapping(value = "/courses/thumbnails", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('OPERATOR')")
+    public ResponseEntity<ApiResponse<?>> uploadCourseThumbnail(
+            @RequestParam("thumbnail") MultipartFile thumbnail
+    ) {
+        if (thumbnail == null || thumbnail.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Thumbnail file is required.");
+        }
+
+        String contentType = thumbnail.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only image files can be uploaded.");
+        }
+
+        try {
+            String originalFilename = StringUtils.cleanPath(
+                    thumbnail.getOriginalFilename() == null ? "thumbnail" : thumbnail.getOriginalFilename()
+            );
+            String storedFilename = UUID.randomUUID() + "_" + originalFilename.replaceAll("[^a-zA-Z0-9._-]", "_");
+            Path uploadPath = Path.of(THUMBNAIL_UPLOAD_DIR).toAbsolutePath().normalize();
+            Files.createDirectories(uploadPath);
+
+            Path targetPath = uploadPath.resolve(storedFilename).normalize();
+            if (!targetPath.startsWith(uploadPath)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid thumbnail filename.");
+            }
+
+            Files.copy(thumbnail.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+
+            String thumbnailUrl = "/" + THUMBNAIL_UPLOAD_DIR + "/" + storedFilename;
+            return ResponseEntity.status(HttpStatus.CREATED)
+                    .body(ApiResponse.created(
+                            CourseResponseCode.THUMBNAIL_UPLOADED,
+                            "Course thumbnail has been uploaded.",
+                            new CourseThumbnailUploadResponse(thumbnailUrl)
+                    ));
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to upload thumbnail.", e);
+        }
     }
 
     @Operation(summary = "강좌 수정")

--- a/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseResponseCode.java
@@ -9,4 +9,5 @@ public class CourseResponseCode {
     public static final String UPDATED = "COURSE-UPDATED";
     public static final String PUBLISHED = "COURSE-PUBLISHED";
     public static final String DELETED = "COURSE-DELETED";
+    public static final String THUMBNAIL_UPLOADED = "COURSE-THUMBNAIL-UPLOADED";
 }

--- a/src/main/java/com/wanted/codebombalms/course/presentation/api/response/CourseThumbnailUploadResponse.java
+++ b/src/main/java/com/wanted/codebombalms/course/presentation/api/response/CourseThumbnailUploadResponse.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.course.presentation.api.response;
+
+public record CourseThumbnailUploadResponse(
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Swagger
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/uploads/**").permitAll()
                         // 인증 불필요
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/users/find-email").permitAll()

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/web/StaticResourceConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/web/StaticResourceConfig.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.global.infrastructure.config.web;
+
+import java.nio.file.Path;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String uploadPath = Path.of("uploads").toAbsolutePath().normalize().toUri().toString();
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(uploadPath);
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 강좌 썸네일 이미지 파일을 업로드할 수 있는 multipart API를 추가했습니다.
- 업로드된 썸네일 파일을 서버 로컬 uploads/course-thumbnails 경로에 저장하고 접근 가능한 thumbnailUrl을 응답하도록 구현했습니다.
- /uploads/** 정적 리소스 접근 설정 및 보안 허용 설정을 추가했습니다.
- course.http에 강좌 썸네일 업로드 API 호출 예시를 추가했습니다.

---

## ♻️ 패키지 변경 사항

- codebombalms/course: 강좌 썸네일 업로드 API 및 응답 DTO 추가
- codebombalms/global: 업로드 파일 정적 리소스 제공 설정 및 /uploads/** 접근 허용 추가
- http: 강좌 썸네일 업로드 multipart 요청 예시 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.
