### PR TITLE
[Ref] admin - user 강좌 조회버그 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
@@ -50,17 +50,16 @@ public class EnrollmentController {
 
     @GetMapping("/users/{userId}/enrollments")
     @Operation(summary = "학생 수강 목록 조회")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<?>> findMyCourses(
-            @PathVariable Long userId,
-            @AuthenticationPrincipal Long authenticatedUserId
+            @PathVariable Long userId
     ) {
-        log.info("[EnrollmentController] find my courses - userId: {}", authenticatedUserId);
+        log.info("[EnrollmentController] find my courses - userId: {}", userId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 EnrollmentResponseCode.RETRIEVED,
                 EnrollmentResponseMessage.RETRIEVED,
-                enrollmentQueryUseCase.findMyCourses(authenticatedUserId)
+                enrollmentQueryUseCase.findMyCourses(userId)
                         .stream()
                         .map(enrollment -> MyCourseResponse.from(
                                 enrollment,

--- a/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
@@ -75,6 +75,14 @@ class EnrollmentControllerTest {
         );
     }
 
+    private UsernamePasswordAuthenticationToken adminPrincipal(Long userId) {
+        return new UsernamePasswordAuthenticationToken(
+                userId,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+    }
+
     @Test
     void findMyCourses_returnsApiResponse() throws Exception {
         Long studentId = 10L;
@@ -84,7 +92,7 @@ class EnrollmentControllerTest {
         given(courseCatalogPort.getPublicationStatus(1L))
                 .willReturn(new CoursePublicationStatus(1L, 1L, "Java", "description", "java.png", true));
 
-        SecurityContextHolder.getContext().setAuthentication(studentPrincipal(studentId));
+        SecurityContextHolder.getContext().setAuthentication(adminPrincipal(1L));
 
         try {
             mockMvc.perform(get("/api/v1/users/{userId}/enrollments", studentId)


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 관리자 학생 수강 목록 조회 시 인증 사용자 ID가 아닌 경로의 학생 userId로 조회하도록 수정
- 학생 수강 목록 조회 API 권한을 관리자 전용으로 변경
- 관리자 계정으로 특정 학생 수강 목록을 조회하는 컨트롤러 테스트 반영



---

## ♻️ 패키지 변경 사항

- codebombalms/enrollment: 관리자 학생 수강 목록 조회 시 PathVariable userId를 사용하도록 수정
- codebombalms/enrollment: 학생 수강 목록 조회 권한 및 컨트롤러 테스트 보완
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
