### PR TITLE
[Feat] FINAL 문제세트 강좌 단위 연결 정책 반영

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,148 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ko-KR"
+
+tone_instructions: >
+  간결하고 단호하게 리뷰한다. 운영 장애, 성능 병목, 데이터 정합성,
+  보안 리스크를 우선 지적하고, 지적 시 사유와 권장 대안을 함께 제시한다.
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  poem: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "draft"
+
+  path_filters:
+    - "!build/**"
+    - "!.gradle/**"
+    - "!gradle/**"
+    - "!logs/**"
+    - "!secrets/**"
+    - "!**/generated/**"
+    - "!**/*.lock"
+    - "src/main/**"
+    - "src/test/**"
+    - "src/main/resources/**"
+    - "src/test/resources/**"
+    - "build.gradle"
+    - "settings.gradle"
+    - ".github/**"
+
+  path_instructions:
+    - path: "src/main/java/**/*Controller.java"
+      instructions: |
+        - 인증/인가 누락을 최우선으로 확인한다.
+        - request DTO에 @Valid 누락 여부를 확인한다.
+        - pagination, sort, filter 파라미터의 기본값과 최대값 제한을 확인한다.
+        - 생성/상태 변경 API에서 중복 요청 방어가 필요한지 확인한다.
+        - API 응답 스펙이 ApiResponse 형식을 유지하는지 확인한다.
+        - Controller가 Entity, Repository, JPA 구현체에 직접 의존하지 않는지 확인한다.
+        - Controller에 비즈니스 로직, 쿼리 조립, metric 계산 로직이 들어가지 않았는지 확인한다.
+
+    - path: "src/main/java/**/presentation/**"
+      instructions: |
+        - Web 계층은 요청/응답 변환과 유스케이스 호출에 집중하는지 확인한다.
+        - 민감 정보가 response DTO나 로그로 노출되지 않는지 확인한다.
+        - Validation annotation과 에러 응답 형식이 일관적인지 확인한다.
+
+    - path: "src/main/java/**/application/**"
+      instructions: |
+        - UseCase/Application Service가 도메인 흐름을 조율하는지 확인한다.
+        - 트랜잭션 경계가 UseCase 단위로 적절한지 확인한다.
+        - 읽기 전용 UseCase에는 @Transactional(readOnly = true)가 적용되어 있는지 확인한다.
+        - 외부 구현체, JPA Entity, Web DTO에 과도하게 의존하지 않는지 확인한다.
+
+    - path: "src/main/java/**/domain/**"
+      instructions: |
+        - 도메인이 Spring, JPA, Web, DB 기술에 과도하게 의존하지 않는지 확인한다.
+        - public setter나 무분별한 @Setter 사용을 지적한다.
+        - 상태 변경 로직이 도메인 내부 메서드로 표현되는지 확인한다.
+        - equals/hashCode 구현이 JPA 프록시와 식별자 생성 전략과 충돌하지 않는지 확인한다.
+
+    - path: "src/main/java/**/infrastructure/**"
+      instructions: |
+        - Infrastructure가 Application/Domain의 port 또는 repository interface를 구현하는 방향인지 확인한다.
+        - DB, 외부 API, Metric, Messaging 구현 세부사항이 Application 밖으로 새지 않는지 확인한다.
+        - 외부 호출 실패 시 timeout, retry, fallback, rollback 영향 범위를 확인한다.
+
+    - path: "src/main/java/**/infrastructure/persistence/**"
+      instructions: |
+        - N+1 query 가능성을 최우선으로 확인한다.
+        - Fetch Join, EntityGraph, BatchSize, IN 절 활용 여부를 확인한다.
+        - pagination과 정렬 기준이 안정적인지 확인한다.
+        - native query 사용 시 SQL injection, DB 종속성, index 사용 가능성을 확인한다.
+        - cascade, orphanRemoval 사용이 데이터 삭제 위험을 만들지 않는지 확인한다.
+        - fetch = EAGER 사용을 지적한다.
+
+    - path: "src/main/java/**/repository/**"
+      instructions: |
+        - Repository interface가 도메인 관점의 계약을 유지하는지 확인한다.
+        - findAll()의 무분별한 사용과 대용량 조회 가능성을 지적한다.
+        - 조회 조건과 정렬 기준이 명확한지 확인한다.
+
+    - path: "src/main/java/**/query/**"
+      instructions: |
+        - 조회 전용 Query 모델이 Command/Domain 변경 로직과 섞이지 않았는지 확인한다.
+        - 복잡한 조회에서 projection, DTO query, QueryDSL 사용이 적절한지 확인한다.
+        - where 조건이 index를 탈 수 있는지 확인한다.
+        - group by, join, subquery의 실행 비용과 대용량 데이터 영향을 확인한다.
+
+    - path: "src/main/java/**/*Request.java"
+      instructions: |
+        - @NotNull, @NotBlank, @Email, @Pattern, @Size 등 validation 누락을 확인한다.
+        - 불필요한 가변 필드를 지적한다.
+        - request DTO는 가능하면 record 사용을 권장한다.
+
+    - path: "src/main/java/**/*Response.java"
+      instructions: |
+        - password, token, 내부 ID, PII 등 민감 정보가 노출되지 않는지 확인한다.
+        - Entity를 API 응답으로 직접 반환하지 않는지 확인한다.
+        - response DTO는 가능하면 record 사용을 권장한다.
+
+    - path: "src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/**"
+      instructions: |
+        - requestMatchers 순서와 permitAll/hasRole 사용이 안전한지 확인한다.
+        - 인증/인가 예외 처리 흐름이 기존 GlobalExceptionHandler와 충돌하지 않는지 확인한다.
+
+    - path: "src/main/java/com/wanted/codebombalms/global/infrastructure/jwt/**"
+      instructions: |
+        - 토큰 검증, 만료 처리, refresh flow, claim 추출 안전성을 집중 리뷰한다.
+        - 로그에 credential, token, PII가 남지 않는지 확인한다.
+        - null 처리와 타입 변환 안정성을 확인한다.
+
+    - path: "src/main/java/com/wanted/codebombalms/global/**"
+      instructions: |
+        - 공통 응답, 예외, logging, metric 변경이 기존 클라이언트를 깨지 않는지 확인한다.
+        - ErrorCode 추가 시 HTTP status, code prefix, message 일관성을 확인한다.
+        - 공통 인프라 변경은 모든 도메인에 영향을 미치므로 영향 범위를 확인한다.
+
+    - path: "src/test/java/**"
+      instructions: |
+        - happy path 외 실패 케이스, 경계값, 권한 실패 케이스가 있는지 확인한다.
+        - Repository/Query 테스트에서 N+1, pagination, sort 안정성을 검증하는지 확인한다.
+        - @BeforeEach에서 테스트 격리가 보장되는지 확인한다.
+        - mock이 실제 장애 상황을 충분히 반영하는지 확인한다.
+
+    - path: "**/application*.{yaml,yml,properties}"
+      instructions: |
+        - credentials, API key, secret이 평문으로 노출되지 않는지 확인한다.
+        - 환경 변수 참조 (${VAR}) 누락이나 default 값의 보안 영향을 확인한다.
+        - profile별 설정 분리가 적절한지 확인한다.
+        - 운영 profile에서 show-sql, format_sql이 켜져 있지 않은지 확인한다.
+
+    - path: "**/build.gradle*"
+      instructions: |
+        - 의존성 추가 시 보안 취약점, 라이선스, 버전 충돌 가능성을 확인한다.
+        - JPA, QueryDSL, Micrometer, Actuator 관련 의존성 버전 호환성을 확인한다.
+        - 불필요하게 무거운 라이브러리 추가를 지적한다.
+
+chat:
+  auto_reply: true

--- a/src/main/java/com/wanted/codebombalms/course/application/policy/CourseProblemPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/policy/CourseProblemPolicy.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.course.application.command.ConfigureCourseProblem
 import com.wanted.codebombalms.course.application.port.LectureCatalogPort;
 import com.wanted.codebombalms.course.application.port.ProblemCatalogPort;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
+import com.wanted.codebombalms.course.domain.model.CourseProblemSetRole;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -29,14 +30,22 @@ public class CourseProblemPolicy {
             Long courseId,
             ConfigureCourseProblemSetsCommand.ProblemSetCommand problemSet
     ) {
-        if (problemSet.lectureId() == null
-                || problemSet.problemSetId() == null
+        if (problemSet.problemSetId() == null
                 || problemSet.role() == null
                 || problemSet.displayOrder() == null) {
             throw new ValidationException(CourseErrorCode.COURSE_PROBLEM_SET_REQUIRED);
         }
         if (!problemCatalogPort.existsProblemSet(problemSet.problemSetId())) {
             throw new ValidationException(CourseErrorCode.COURSE_PROBLEM_SET_NOT_FOUND);
+        }
+        if (problemSet.role() == CourseProblemSetRole.FINAL) {
+            if (problemSet.lectureId() != null) {
+                throw new ValidationException(CourseErrorCode.COURSE_FINAL_PROBLEM_LECTURE_NOT_ALLOWED);
+            }
+            return;
+        }
+        if (problemSet.lectureId() == null) {
+            throw new ValidationException(CourseErrorCode.COURSE_PROBLEM_LECTURE_REQUIRED);
         }
         if (!lectureCatalogPort.existsLectureInCourse(courseId, problemSet.lectureId())) {
             throw new ValidationException(CourseErrorCode.COURSE_PROBLEM_LECTURE_NOT_FOUND);

--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseProblemCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseProblemCommandService.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.course.domain.repository.CourseProblemSetReposito
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,7 +34,7 @@ public class CourseProblemCommandService implements CourseProblemCommandUseCase 
 
         for (ConfigureCourseProblemSetsCommand.ProblemSetCommand problemSetCommand : command.problemSets()) {
             Long existingId = existingProblemSets.stream()
-                    .filter(problemSet -> problemSet.getLectureId().equals(problemSetCommand.lectureId()))
+                    .filter(problemSet -> Objects.equals(problemSet.getLectureId(), problemSetCommand.lectureId()))
                     .filter(problemSet -> problemSet.getProblemSetId().equals(problemSetCommand.problemSetId()))
                     .map(CourseProblemSet::getCourseProblemSetId)
                     .findFirst()

--- a/src/main/java/com/wanted/codebombalms/course/domain/exception/CourseErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/exception/CourseErrorCode.java
@@ -20,7 +20,8 @@ public enum CourseErrorCode implements ErrorCode {
     COURSE_PROBLEM_SET_NOT_FOUND("CRS-010", "존재하지 않는 문제세트입니다."),
     COURSE_PROBLEM_NOT_FOUND("CRS-011", "선택한 문제세트에 존재하지 않는 문제입니다."),
     COURSE_PROBLEM_LECTURE_REQUIRED("CRS-012", "MAIN 문제 단계에는 강의가 필요합니다."),
-    COURSE_PROBLEM_LECTURE_NOT_FOUND("CRS-013", "선택한 강좌에 존재하지 않는 강의입니다.");
+    COURSE_PROBLEM_LECTURE_NOT_FOUND("CRS-013", "선택한 강좌에 존재하지 않는 강의입니다."),
+    COURSE_FINAL_PROBLEM_LECTURE_NOT_ALLOWED("CRS-014", "FINAL 문제 단계에는 강의를 지정할 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemSetJpaEntity.java
@@ -31,7 +31,7 @@ public class CourseProblemSetJpaEntity {
     @JoinColumn(name = "course_id", nullable = false)
     private CourseJpaEntity course;
 
-    @Column(name = "lecture_id", nullable = false)
+    @Column(name = "lecture_id")
     private Long lectureId;
 
     @Column(name = "problem_set_id", nullable = false)

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseProblemSetRepository.java
@@ -14,12 +14,12 @@ public interface SpringDataCourseProblemSetRepository extends JpaRepository<Cour
             from CourseProblemSetJpaEntity cps
             where cps.course.courseId = :courseId
               and cps.course.deletedAt is null
-              and exists (
+              and (cps.lectureId is null or exists (
                   select l.lectureId
                   from LectureJpaEntity l
                   where l.lectureId = cps.lectureId
                     and l.deletedAt is null
-              )
+              ))
             """)
     List<CourseProblemSetJpaEntity> findActiveByCourseId(@Param("courseId") Long courseId);
 
@@ -29,12 +29,12 @@ public interface SpringDataCourseProblemSetRepository extends JpaRepository<Cour
             where cps.course.courseId = :courseId
               and cps.role = :role
               and cps.course.deletedAt is null
-              and exists (
+              and (cps.lectureId is null or exists (
                   select l.lectureId
                   from LectureJpaEntity l
                   where l.lectureId = cps.lectureId
                     and l.deletedAt is null
-              )
+              ))
             """)
     List<CourseProblemSetJpaEntity> findActiveByCourseIdAndRole(
             @Param("courseId") Long courseId,
@@ -61,12 +61,12 @@ public interface SpringDataCourseProblemSetRepository extends JpaRepository<Cour
             from CourseProblemSetJpaEntity cps
             where cps.courseProblemSetId = :courseProblemSetId
               and cps.course.deletedAt is null
-              and exists (
+              and (cps.lectureId is null or exists (
                   select l.lectureId
                   from LectureJpaEntity l
                   where l.lectureId = cps.lectureId
                     and l.deletedAt is null
-              )
+              ))
             """)
     Optional<CourseProblemSetJpaEntity> findActiveById(@Param("courseProblemSetId") Long courseProblemSetId);
 }

--- a/src/main/java/com/wanted/codebombalms/course/presentation/api/request/CourseProblemSetConfigureRequest.java
+++ b/src/main/java/com/wanted/codebombalms/course/presentation/api/request/CourseProblemSetConfigureRequest.java
@@ -21,7 +21,7 @@ public record CourseProblemSetConfigureRequest(
     }
 
     public record ProblemSetRequest(
-            @NotNull Long lectureId,
+            Long lectureId,
             @NotNull Long problemSetId,
             @NotNull CourseProblemSetRole role,
             @NotNull Integer displayOrder

--- a/src/test/java/com/wanted/codebombalms/course/controller/CourseProblemControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/controller/CourseProblemControllerTest.java
@@ -45,7 +45,7 @@ class CourseProblemControllerTest {
     void findProblemSetsByCourseReturnsApiResponse() throws Exception {
         given(courseProblemQueryUseCase.findProblemSetsByCourse(101L)).willReturn(List.of(
                 CourseProblemSet.restore(6001L, 101L, 1001L, 2002L, CourseProblemSetRole.MAIN, 1),
-                CourseProblemSet.restore(6002L, 101L, 1003L, 2003L, CourseProblemSetRole.FINAL, 1)
+                CourseProblemSet.restore(6002L, 101L, null, 2003L, CourseProblemSetRole.FINAL, 1)
         ));
 
         mockMvc.perform(get("/api/v1/courses/{courseId}/problem-sets", 101L)
@@ -77,7 +77,7 @@ class CourseProblemControllerTest {
         given(courseProblemCommandUseCase.configureProblemSets(any(ConfigureCourseProblemSetsCommand.class)))
                 .willReturn(List.of(
                         CourseProblemSet.restore(6001L, 101L, 101L, 2002L, CourseProblemSetRole.MAIN, 1),
-                        CourseProblemSet.restore(6002L, 101L, 103L, 2003L, CourseProblemSetRole.FINAL, 1)
+                        CourseProblemSet.restore(6002L, 101L, null, 2003L, CourseProblemSetRole.FINAL, 1)
                 ));
 
         String request = """
@@ -90,7 +90,7 @@ class CourseProblemControllerTest {
                       "displayOrder": 1
                     },
                     {
-                      "lectureId": 103,
+                      "lectureId": null,
                       "problemSetId": 2003,
                       "role": "FINAL",
                       "displayOrder": 1

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
@@ -43,13 +43,12 @@ class CourseProblemRepositoryTest {
     void saveAndFindProblemSetsByCourse() {
         Course course = courseRepository.save(createCourse());
         Lecture mainLecture = lectureRepository.save(createLecture(course, "Java 1", 1, LectureStatus.ACTIVE));
-        Lecture finalLecture = lectureRepository.save(createLecture(course, "Java 2", 2, LectureStatus.ACTIVE));
 
         CourseProblemSet mainProblemSet = courseProblemSetRepository.save(
                 CourseProblemSet.create(course.getCourseId(), mainLecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 1)
         );
-        courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), finalLecture.getLectureId(), 2003L, CourseProblemSetRole.FINAL, 1)
+        CourseProblemSet finalProblemSet = courseProblemSetRepository.save(
+                CourseProblemSet.create(course.getCourseId(), null, 2003L, CourseProblemSetRole.FINAL, 1)
         );
 
         List<CourseProblemSet> allProblemSets = courseProblemSetRepository.findByCourseId(course.getCourseId());
@@ -61,6 +60,12 @@ class CourseProblemRepositoryTest {
         assertEquals(2, allProblemSets.size());
         assertEquals(1, mainProblemSets.size());
         assertEquals(mainProblemSet.getCourseProblemSetId(), mainProblemSets.get(0).getCourseProblemSetId());
+        assertEquals(
+                finalProblemSet.getCourseProblemSetId(),
+                courseProblemSetRepository.findById(finalProblemSet.getCourseProblemSetId())
+                        .orElseThrow()
+                        .getCourseProblemSetId()
+        );
     }
 
     @Test
@@ -71,14 +76,14 @@ class CourseProblemRepositoryTest {
                 CourseProblemSet.create(course.getCourseId(), lecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 2)
         );
         courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), lecture.getLectureId(), 2003L, CourseProblemSetRole.FINAL, 1)
+                CourseProblemSet.create(course.getCourseId(), null, 2003L, CourseProblemSetRole.FINAL, 1)
         );
 
         List<CourseProblemSet> problemSets = courseProblemSetRepository.findByLectureId(lecture.getLectureId());
 
-        assertEquals(2, problemSets.size());
-        assertEquals(1, problemSets.get(0).getDisplayOrder());
-        assertEquals(2003L, problemSets.get(0).getProblemSetId());
+        assertEquals(1, problemSets.size());
+        assertEquals(2, problemSets.get(0).getDisplayOrder());
+        assertEquals(2002L, problemSets.get(0).getProblemSetId());
     }
 
     @Test
@@ -105,7 +110,7 @@ class CourseProblemRepositoryTest {
                 CourseProblemSet.create(course.getCourseId(), deletedLecture.getLectureId(), 2002L, CourseProblemSetRole.MAIN, 1)
         );
         CourseProblemSet remainingProblemSet = courseProblemSetRepository.save(
-                CourseProblemSet.create(course.getCourseId(), remainingLecture.getLectureId(), 2003L, CourseProblemSetRole.FINAL, 1)
+                CourseProblemSet.create(course.getCourseId(), remainingLecture.getLectureId(), 2003L, CourseProblemSetRole.MAIN, 1)
         );
 
         deletedLecture.delete();


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #351

---

## 🛠️ 기능 관련 작업 내용

- FINAL 문제세트는 강좌 전체 최종 평가로 연결되도록 lectureId = null 저장을 허용했습니다.
- MAIN은 lectureId 필수, FINAL은 lectureId 지정 불가로 문제세트 연결 검증 정책을 분리했습니다.
- lectureId = null인 FINAL 문제세트가 강좌별/단건 조회에서 누락되지 않도록 조회 쿼리를 보완했습니다.
- 변경된 정책에 맞춰 CourseProblem 관련 컨트롤러/레포지토리 테스트를 수정했습니다.

---

## ♻️ 패키지 변경 사항

- project/course: 강좌 문제세트 연결 요청, 검증 정책, 저장/조회 로직 수정
- project/course: CourseErrorCode에 FINAL 강의 지정 불가 에러코드 추가
- project/course: FINAL 문제세트 nullable 정책에 맞춘 테스트 보완

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * FINAL 단계 문제세트에 강의 지정 금지 규칙을 명확히 적용
  * 문제세트 검증 흐름을 역할별로 분기해 검증 순서와 오류 반영 개선

* **버그 수정**
  * 강의 ID nullable 처리 강화(비교/조회/매핑 및 쿼리 조건 조정)
  * 관련 오류 코드 추가 및 요청 유효성 검사 조정

* **테스트**
  * 테스트 데이터와 기대값을 강의ID nullable 변경에 맞게 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->