### PR TITLE
[Feat] 회원 탈퇴 API

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -55,3 +55,45 @@ Cookie: accessToken={{rt}}
     });
 %}
 
+
+
+
+### ===== 회원 탈퇴 (#198) =====
+### C0 → C1 → C2 순서대로 실행
+
+### C0. (사전) 로그인 — 탈퇴할 계정으로 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
+### C1. 회원 탈퇴 — 정상 (C0 직후 실행, 200 기대)
+DELETE http://localhost:8080/api/v1/users/me
+
+> {%
+    client.test("탈퇴 성공 200", function () {
+        client.assert(response.status === 200, "기대 200, 실제 " + response.status);
+    });
+%}
+
+### C2. 탈퇴 후 내 정보 조회 — 401 기대 (쿠키 만료됨)
+GET http://localhost:8080/api/v1/users/me
+
+> {%
+    client.test("탈퇴 후 401", function () {
+        client.assert(response.status === 401, "기대 401, 실제 " + response.status);
+    });
+%}
+
+### C3. (확인용) 미인증 상태 탈퇴 시도 — 401 기대
+# @no-cookie-jar
+DELETE http://localhost:8080/api/v1/users/me
+
+> {%
+    client.test("미인증 탈퇴 401", function () {
+        client.assert(response.status === 401, "기대 401, 실제 " + response.status);
+    });
+%}

--- a/http/user.http
+++ b/http/user.http
@@ -70,8 +70,27 @@ Content-Type: application/json
   "password": "Test1234!"
 }
 
-### C1. 회원 탈퇴 — 정상 (C0 직후 실행, 200 기대)
+### C1. 회원 탈퇴 — 비번 틀림 (400 기대)
 DELETE http://localhost:8080/api/v1/users/me
+Content-Type: application/json
+
+{
+  "password": "wrongpassword!"
+}
+
+> {%
+    client.test("비번 불일치 400", function () {
+        client.assert(response.status === 400, "기대 400, 실제 " + response.status);
+    });
+%}
+
+### C2. 회원 탈퇴 — 정상 (비번 일치, 200 기대)
+DELETE http://localhost:8080/api/v1/users/me
+Content-Type: application/json
+
+{
+  "password": "Test1234!"
+}
 
 > {%
     client.test("탈퇴 성공 200", function () {
@@ -79,21 +98,11 @@ DELETE http://localhost:8080/api/v1/users/me
     });
 %}
 
-### C2. 탈퇴 후 내 정보 조회 — 401 기대 (쿠키 만료됨)
+### C3. 탈퇴 후 내 정보 조회 — 401 기대 (쿠키 만료)
 GET http://localhost:8080/api/v1/users/me
 
 > {%
     client.test("탈퇴 후 401", function () {
-        client.assert(response.status === 401, "기대 401, 실제 " + response.status);
-    });
-%}
-
-### C3. (확인용) 미인증 상태 탈퇴 시도 — 401 기대
-# @no-cookie-jar
-DELETE http://localhost:8080/api/v1/users/me
-
-> {%
-    client.test("미인증 탈퇴 401", function () {
         client.assert(response.status === 401, "기대 401, 실제 " + response.status);
     });
 %}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
@@ -1,15 +1,20 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.application.usecase.WithdrawUserUseCase;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -17,18 +22,27 @@ public class WithdrawUserService implements WithdrawUserUseCase {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
-    public void withdraw(Long userId) {
+    public void withdraw(Long userId, String rawPassword) {
         // 1. 본인 조회 (없으면 USER_NOT_FOUND)
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
 
-        // 2. Soft Delete (deleted_at 기록)
+        // 2. 비밀번호 재확인 (불일치 시 400 AUT-013)
+        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+            throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_MISMATCH);
+        }
+
+        // 3. Soft Delete (deleted_at 기록)
         user.softDelete();
         userRepository.save(user);
 
-        // 3. Refresh Token 전체 삭제 (강제 로그아웃)
+        // 4. Refresh Token 전체 삭제 (강제 로그아웃)
         refreshTokenRepository.deleteByUserId(userId);
+
+        // 5. 감사 추적 로깅
+        log.info("회원 탈퇴 처리 완료 - userId={}, deletedAt={}", userId, user.getDeletedAt());
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
@@ -1,0 +1,34 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.user.application.usecase.WithdrawUserUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class WithdrawUserService implements WithdrawUserUseCase {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void withdraw(Long userId) {
+        // 1. 본인 조회 (없으면 USER_NOT_FOUND)
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. Soft Delete (deleted_at 기록)
+        user.softDelete();
+        userRepository.save(user);
+
+        // 3. Refresh Token 전체 삭제 (강제 로그아웃)
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/WithdrawUserUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/WithdrawUserUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+public interface WithdrawUserUseCase {
+
+    void withdraw(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/WithdrawUserUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/WithdrawUserUseCase.java
@@ -2,5 +2,5 @@ package com.wanted.codebombalms.user.application.usecase;
 
 public interface WithdrawUserUseCase {
 
-    void withdraw(Long userId);
+    void withdraw(Long userId, String rawPassword);
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
@@ -8,4 +8,5 @@ public class UserResponseCode {
     public static final String STUDENTS_RETRIEVED = "USER-STUDENTS-RETRIEVED";
     public static final String STUDENT_DETAIL_RETRIEVED = "USER-STUDENT-DETAIL-RETRIEVED";
     public static final String STUDENT_LOCK_CHANGED = "USER-STUDENT-LOCK-CHANGED";
+    public static final String WITHDRAWN = "USER-ME-WITHDRAWN";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
@@ -8,4 +8,5 @@ public class UserResponseMessage {
     public static final String STUDENTS_RETRIEVED = "학생 전체 조회 성공";
     public static final String STUDENT_DETAIL_RETRIEVED = "학생 상세 조회 성공";
     public static final String STUDENT_LOCK_CHANGED = "계정 정지/해제 처리 성공";
+    public static final String WITHDRAWN = "회원 탈퇴 성공";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/WithdrawUserController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/WithdrawUserController.java
@@ -1,0 +1,50 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.usecase.WithdrawUserUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - 마이페이지", description = "로그인 사용자의 프로필 조회/수정 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class WithdrawUserController {
+
+    private final WithdrawUserUseCase withdrawUserUseCase;
+    private final AuthCookieFactory authCookieFactory;
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "본인 계정 Soft Delete + Refresh Token 전체 삭제 + accessToken/refreshToken 쿠키 만료(Max-Age=0)."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @DeleteMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Void>> withdraw(
+            @AuthenticationPrincipal Long userId,
+            HttpServletResponse response
+    ) {
+        // 1. Soft Delete + RT 전체 삭제
+        withdrawUserUseCase.withdraw(userId);
+
+        // 2. 쿠키 만료
+        response.addCookie(authCookieFactory.expired("accessToken"));
+        response.addCookie(authCookieFactory.expired("refreshToken"));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.WITHDRAWN,
+                UserResponseMessage.WITHDRAWN
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/WithdrawUserController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/WithdrawUserController.java
@@ -3,14 +3,17 @@ package com.wanted.codebombalms.user.presentation.api;
 import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import com.wanted.codebombalms.user.application.usecase.WithdrawUserUseCase;
+import com.wanted.codebombalms.user.presentation.api.request.WithdrawUserRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,18 +28,20 @@ public class WithdrawUserController {
 
     @Operation(
             summary = "회원 탈퇴",
-            description = "본인 계정 Soft Delete + Refresh Token 전체 삭제 + accessToken/refreshToken 쿠키 만료(Max-Age=0)."
+            description = "비밀번호 재확인 후 본인 계정 Soft Delete + Refresh Token 전체 삭제 + accessToken/refreshToken 쿠키 만료(Max-Age=0)."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "AUT-013 비밀번호 불일치")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
     @DeleteMapping("/me")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Void>> withdraw(
             @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody WithdrawUserRequest request,
             HttpServletResponse response
     ) {
-        // 1. Soft Delete + RT 전체 삭제
-        withdrawUserUseCase.withdraw(userId);
+        // 1. 비번 재확인 + Soft Delete + RT 전체 삭제
+        withdrawUserUseCase.withdraw(userId, request.password());
 
         // 2. 쿠키 만료
         response.addCookie(authCookieFactory.expired("accessToken"));

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/WithdrawUserRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/WithdrawUserRequest.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.presentation.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawUserRequest(
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/test/java/com/wanted/codebombalms/BCryptHashGeneratorTest.java
+++ b/src/test/java/com/wanted/codebombalms/BCryptHashGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
@@ -9,6 +10,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
  *
  * 실행: ./gradlew test --tests "com.wanted.codebombalms.BCryptHashGeneratorTest"
  */
+@Disabled("수동 해시 생성 유틸 - CI 자동 실행 제외 (필요 시 직접 실행)")
 class BCryptHashGeneratorTest {
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/BCryptHashGeneratorTest.java
+++ b/src/test/java/com/wanted/codebombalms/BCryptHashGeneratorTest.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * 시연용 더미 계정 비밀번호 BCrypt 해시 생성 유틸.
+ * 한 번 돌려서 콘솔에 출력된 해시를 demo/user_dummy_data.sql 에 붙여넣는다.
+ *
+ * 실행: ./gradlew test --tests "com.wanted.codebombalms.BCryptHashGeneratorTest"
+ */
+class BCryptHashGeneratorTest {
+
+    @Test
+    void printHashes() {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        String[] passwords = {"password", "Password1!", "Demo1234!"};
+
+        System.out.println("=== BCrypt Hash (Spring Security 표준) ===");
+        for (String pw : passwords) {
+            String hash = encoder.encode(pw);
+            boolean matches = encoder.matches(pw, hash);
+            System.out.println("평문='" + pw + "'  →  " + hash + "  (검증=" + matches + ")");
+        }
+        System.out.println("==========================================");
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
@@ -1,7 +1,9 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
@@ -14,11 +16,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -29,6 +34,7 @@ class WithdrawUserServiceTest {
 
     @Mock private UserRepository userRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private WithdrawUserService withdrawUserService;
@@ -44,26 +50,44 @@ class WithdrawUserServiceTest {
     }
 
     @Test
-    @DisplayName("탈퇴 시 softDelete 처리 후 저장하고, Refresh Token을 전부 삭제한다.")
+    @DisplayName("비밀번호가 일치하면 softDelete 후 저장하고 Refresh Token을 전부 삭제한다.")
     void 탈퇴_성공() {
         // given
         User user = activeUser();
         given(userRepository.findByUserId(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
 
         // when
-        withdrawUserService.withdraw(1L);
+        withdrawUserService.withdraw(1L, "Test1234!");
 
         // then — softDelete 반영된 User가 저장되는지 캡처해서 검증
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(captor.capture());
         assertTrue(captor.getValue().isDeleted(), "deleted_at 이 채워져야 한다");
-
-        // RT 전체 삭제 호출 검증
         verify(refreshTokenRepository).deleteByUserId(1L);
     }
 
     @Test
-    @DisplayName("존재하지 않는 회원이면 NotFoundException(USER_NOT_FOUND)을 던지고, 저장/RT삭제는 일어나지 않는다.")
+    @DisplayName("비밀번호가 불일치하면 ValidationException(AUTH_PASSWORD_MISMATCH)을 던지고, 저장/RT삭제는 일어나지 않는다.")
+    void 비밀번호_불일치_예외() {
+        // given
+        User user = activeUser();
+        given(userRepository.findByUserId(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrong", "ENCODED_PW")).willReturn(false);
+
+        // when & then
+        ValidationException ex = assertThrows(
+                ValidationException.class,
+                () -> withdrawUserService.withdraw(1L, "wrong")
+        );
+        assertEquals(AuthErrorCode.AUTH_PASSWORD_MISMATCH, ex.getErrorCode());
+
+        verify(userRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이면 NotFoundException(USER_NOT_FOUND)을 던진다.")
     void 회원_없음_예외() {
         // given
         given(userRepository.findByUserId(99L)).willReturn(Optional.empty());
@@ -71,11 +95,11 @@ class WithdrawUserServiceTest {
         // when & then
         NotFoundException ex = assertThrows(
                 NotFoundException.class,
-                () -> withdrawUserService.withdraw(99L)
+                () -> withdrawUserService.withdraw(99L, "Test1234!")
         );
         assertEquals(UserErrorCode.USER_NOT_FOUND, ex.getErrorCode());
 
-        verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
-        verify(refreshTokenRepository, never()).deleteByUserId(org.mockito.ArgumentMatchers.anyLong());
+        verify(userRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
     }
 }

--- a/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
@@ -1,0 +1,81 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WithdrawUserService 단위 테스트")
+class WithdrawUserServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private WithdrawUserService withdrawUserService;
+
+    private User activeUser() {
+        return User.restore(
+                1L, UserRole.STUDENT, "u01@test.com", "ENCODED_PW",
+                "김학생", "학생01", "010-1234-5678",
+                AuthProvider.LOCAL, null,
+                true, false, null, null,
+                LocalDateTime.now(), LocalDateTime.now(), null
+        );
+    }
+
+    @Test
+    @DisplayName("탈퇴 시 softDelete 처리 후 저장하고, Refresh Token을 전부 삭제한다.")
+    void 탈퇴_성공() {
+        // given
+        User user = activeUser();
+        given(userRepository.findByUserId(1L)).willReturn(Optional.of(user));
+
+        // when
+        withdrawUserService.withdraw(1L);
+
+        // then — softDelete 반영된 User가 저장되는지 캡처해서 검증
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertTrue(captor.getValue().isDeleted(), "deleted_at 이 채워져야 한다");
+
+        // RT 전체 삭제 호출 검증
+        verify(refreshTokenRepository).deleteByUserId(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이면 NotFoundException(USER_NOT_FOUND)을 던지고, 저장/RT삭제는 일어나지 않는다.")
+    void 회원_없음_예외() {
+        // given
+        given(userRepository.findByUserId(99L)).willReturn(Optional.empty());
+
+        // when & then
+        NotFoundException ex = assertThrows(
+                NotFoundException.class,
+                () -> withdrawUserService.withdraw(99L)
+        );
+        assertEquals(UserErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+
+        verify(userRepository, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(refreshTokenRepository, never()).deleteByUserId(org.mockito.ArgumentMatchers.anyLong());
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #198 

---

## 🛠️ 기능 관련 작업 내용
- `DELETE /api/v1/users/me` 회원 탈퇴 API 구현 (Soft Delete + Refresh Token 전체 삭제 + accessToken/refreshToken 쿠키 Max-Age=0 만료)
- 탈퇴 처리를 단일 트랜잭션으로 묶어 원자성 보장 (softDelete → save → RT 삭제)
- `WithdrawUserService` 단위 테스트 추가 (탈퇴 성공 / 회원 없음 예외 시 save·RT삭제 미발생)
- `http/user.http` 회원 탈퇴 테스트 케이스(C0~C3) 추가

---

## ♻️ 패키지 변경 사항
- `codebombalms/user/application/usecase`: `WithdrawUserUseCase` 신규
- `codebombalms/user/application/service`: `WithdrawUserService` 신규 (auth `RefreshTokenRepository` 재활용)
- `codebombalms/user/presentation/api`: `WithdrawUserController` 신규, `UserResponseCode`/`UserResponseMessage`에 `WITHDRAWN` 추가
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 회원 탈퇴(DELETE /api/v1/users/me) 기능 추가 — 비밀번호 재확인 필요, 성공 시 즉시 로그아웃(인증 쿠키 만료) 처리 및 탈퇴 응답 제공.
  * 탈퇴 시 사용자 상태 표기 및 관련 응답 메시지/코드 추가.

* **Bug Fixes**
  * 탈퇴 직후 인증 확인 흐름 강화: 탈퇴 후 인증 요청이 거부되는지 검증됩니다.

* **Tests**
  * 탈퇴 성공, 비밀번호 불일치(400), 사용자 미존재 및 탈퇴 후 인증(401) 시나리오 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->