### PR TITLE
[Feat] MASTER role 및 관리자 권한 엔티티 기반 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/admin/permission/domain/model/AdminPermissionType.java
+++ b/src/main/java/com/wanted/codebombalms/admin/permission/domain/model/AdminPermissionType.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.admin.permission.domain.model;
+
+public enum AdminPermissionType {
+    USER_MANAGEMENT,
+    RULE_MANAGEMENT
+}

--- a/src/main/java/com/wanted/codebombalms/admin/permission/infrastructure/persistence/AdminPermissionJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/admin/permission/infrastructure/persistence/AdminPermissionJpaEntity.java
@@ -1,0 +1,80 @@
+package com.wanted.codebombalms.admin.permission.infrastructure.persistence;
+
+import com.wanted.codebombalms.admin.permission.domain.model.AdminPermissionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "admin_permissions",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_admin_permission_user_type",
+                        columnNames = {"admin_user_id", "permission_type"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor
+public class AdminPermissionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "admin_permission_id")
+    private Long adminPermissionId;
+
+    @Column(name = "admin_user_id", nullable = false)
+    private Long adminUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "permission_type", nullable = false, length = 50)
+    private AdminPermissionType permissionType;
+
+    @Column(name = "granted_by", nullable = false)
+    private Long grantedBy;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public AdminPermissionJpaEntity(
+            Long adminPermissionId,
+            Long adminUserId,
+            AdminPermissionType permissionType,
+            Long grantedBy,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.adminPermissionId = adminPermissionId;
+        this.adminUserId = adminUserId;
+        this.permissionType = permissionType;
+        this.grantedBy = grantedBy;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/permission/infrastructure/persistence/AdminPermissionJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/admin/permission/infrastructure/persistence/AdminPermissionJpaEntity.java
@@ -53,19 +53,13 @@ public class AdminPermissionJpaEntity {
     private LocalDateTime updatedAt;
 
     public AdminPermissionJpaEntity(
-            Long adminPermissionId,
             Long adminUserId,
             AdminPermissionType permissionType,
-            Long grantedBy,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt
+            Long grantedBy
     ) {
-        this.adminPermissionId = adminPermissionId;
         this.adminUserId = adminUserId;
         this.permissionType = permissionType;
         this.grantedBy = grantedBy;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
     }
 
     @PrePersist

--- a/src/main/java/com/wanted/codebombalms/user/domain/model/UserRole.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/model/UserRole.java
@@ -1,5 +1,5 @@
 package com.wanted.codebombalms.user.domain.model;
 
 public enum UserRole {
-    STUDENT, OPERATOR, ADMIN
+    STUDENT, OPERATOR, ADMIN, MASTER
 }

--- a/src/main/resources/db/seed/00_users.sql
+++ b/src/main/resources/db/seed/00_users.sql
@@ -15,7 +15,13 @@
         updated_at,
         deleted_at
     ) VALUES
+          ('MASTER', 'master@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '마스터관리자', 'master', '010-1000-0000', 'LOCAL', NULL, TRUE, FALSE, '최고 관리자 계정', 'LMS 최고 관리자', NOW(), NOW(), NULL),
           ('ADMIN', 'admin@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '관리자', 'admin', '010-1000-0001', 'LOCAL', NULL, TRUE, FALSE, '시스템 관리자 계정', 'LMS 관리자', NOW(), NOW(), NULL),
+          ('ADMIN', 'admin01@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '유저관리자', 'admin01', '010-1000-0011', 'LOCAL', NULL, TRUE, FALSE, '유저 관리 담당 관리자 계정', 'LMS 유저 관리', NOW(), NOW(), NULL),
+          ('ADMIN', 'admin02@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '규칙관리자', 'admin02', '010-1000-0012', 'LOCAL', NULL, TRUE, FALSE, '운영 규칙 관리 담당 관리자 계정', 'LMS 규칙 관리', NOW(), NOW(), NULL),
+          ('ADMIN', 'admin03@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '통합관리자', 'admin03', '010-1000-0013', 'LOCAL', NULL, TRUE, FALSE, '유저 및 규칙 관리 담당 관리자 계정', 'LMS 통합 관리', NOW(), NOW(), NULL),
+          ('ADMIN', 'admin04@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '대기관리자', 'admin04', '010-1000-0014', 'LOCAL', NULL, TRUE, FALSE, '권한 부여 대기 관리자 계정', 'LMS 관리자 대기', NOW(), NOW(), NULL),
+          ('ADMIN', 'admin05@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '보조관리자', 'admin05', '010-1000-0015', 'LOCAL', NULL, TRUE, FALSE, '보조 관리자 계정', 'LMS 보조 관리', NOW(), NOW(), NULL),
           ('OPERATOR', 'op@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '운영자', 'operator', '010-1000-0002', 'LOCAL', NULL, TRUE, FALSE, '운영 담당자 계정', 'LMS 운영자', NOW(), NOW(), NULL),
           ('STUDENT', 'u01@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '김학생', 'user01', '010-2000-0001', 'LOCAL', NULL, TRUE, FALSE, '데이터 분석 입문 학습자', '비전공자 입문', NOW(), NOW(), NULL),
           ('STUDENT', 'u02@test.com', '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy', '이학생', 'user02', '010-2000-0002', 'LOCAL', NULL, TRUE, FALSE, 'SQL 학습 중인 학생', 'SQL 입문', NOW(), NOW(), NULL),


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #378 

---

## 🛠️ 기능 관련 작업 내용
- 최고 관리자 구분을 위해 `UserRole`에 `MASTER` role을 추가했습니다.
- admin 계정별 세부 권한 관리를 위한 `AdminPermissionType` enum을 추가했습니다.
- `admin_permissions` 테이블 매핑용 JPA 엔티티를 추가했습니다.
- seed users에 `MASTER` 계정과 테스트용 `ADMIN` 계정 5개를 추가했습니다.

---

## ♻️ 패키지 변경 사항
- `project/user/domain/model`: `MASTER` role 추가
- `project/admin/permission/domain/model`: 관리자 권한 타입 enum 추가
- `project/admin/permission/infrastructure/persistence`: 관리자 권한 JPA 엔티티 추가
- `project/resources/db/seed`: master/admin 테스트 계정 seed 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 권한 유형 추가(사용자 관리, 규칙 관리)
  * 새로운 사용자 역할 추가: MASTER

* **변경사항**
  * 관리자 권한 데이터 모델 및 영속성 매핑 추가
  * 시드 데이터 업데이트: MASTER 계정 추가 및 다수 관리자 계정으로 대체
<!-- end of auto-generated comment: release notes by coderabbit.ai -->