### PR TITLE
[Feat] 부하테스트 시나리오 + Actuator 메트릭 노출 처리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Gradle 설정 (캐싱 포함)
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Gradle 실행 권한 부여
         run: chmod +x ./gradlew
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle 설정 (캐싱 포함)
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: Gradle 실행 권한 부여
         run: chmod +x ./gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ CLAUDE.md
 .ai/
 /ai/
 .obsidian/
-_배포용*/
 .claude
 CONTEXT.md
 
@@ -80,3 +79,7 @@ __pycache__/
 
 monitoring/k6/results/*.json
 !src/main/resources/application-loadtest.yml
+
+##개인 이그노어
+forme/
+_배포용*/

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -28,6 +28,7 @@ k6 ──부하──▶ Spring Boot 앱 (호스트, :8080)
 ### 사전 준비
 
 - Docker Desktop 실행 중일 것
+- (부하테스트 시) 앱이 사용하는 Redis(6379)는 기존 개발 환경대로 각자 실행 — 이 스택에는 포함되지 않음
 
 ### 스택 실행 / 종료
 
@@ -47,7 +48,14 @@ k6 ──부하──▶ Spring Boot 앱 (호스트, :8080)
 ### 1. 앱을 loadtest 프로파일로 실행 (중요!)
 
 ```bash
+# macOS / Linux
 ./gradlew bootRun --args='--spring.profiles.active=loadtest'
+
+# Windows PowerShell
+.\gradlew.bat bootRun --args='--spring.profiles.active=loadtest'
+
+# Windows CMD (큰따옴표 필수!)
+gradlew.bat bootRun --args="--spring.profiles.active=loadtest"
 ```
 
 > 🚨 **반드시 loadtest 프로파일로!** local 프로파일로 부하를 주면 **AWS RDS로 트래픽이 가서 과금/장애 위험**이 있습니다.
@@ -94,6 +102,7 @@ docker compose run --rm -e RESULT_NAME=login-after-index k6 run -o experimental-
 
 | 증상 | 원인 / 해결 |
 |------|------------|
+| `no configuration file provided: not found` | `monitoring/` 폴더 밖에서 실행함 → `cd monitoring` 후 실행 (또는 루트에서 `docker compose -f monitoring/docker-compose.yml up -d`) |
 | Grafana 포트 3000 충돌 (`address already in use`) | 로컬에 brew 등으로 설치한 grafana가 점유 중 → `brew services stop grafana prometheus` |
 | Prometheus 타겟 `lms-app` DOWN | 앱이 안 떠 있거나 Actuator 미설정 — 앱 실행 + `/actuator/prometheus` 200 확인 |
 | Grafana에 데이터소스 없음 | `grafana/provisioning/datasources/datasources.yml` 내용 확인 후 `docker compose restart grafana` |

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -64,7 +64,7 @@ gradlew.bat bootRun --args="--spring.profiles.active=loadtest"
 ### 2. k6 실행
 
 ```bash
-docker compose run --rm k6 run -o experimental-prometheus-rw /scripts/<스크립트명>.js
+docker compose run --rm k6 run -o experimental-prometheus-rw /scripts/<도메인>/<스크립트명>.js   # 예: /scripts/auth/01-email-check.js
 ```
 
 결과는 3곳에서 확인:
@@ -78,9 +78,9 @@ docker compose run --rm k6 run -o experimental-prometheus-rw /scripts/<스크립
 `RESULT_NAME` 으로 결과 파일명을 바꿔 저장하면 덮어쓰지 않고 비교 가능:
 
 ```bash
-docker compose run --rm -e RESULT_NAME=login-before-index k6 run -o experimental-prometheus-rw /scripts/01-login.js
+docker compose run --rm -e RESULT_NAME=login-before-index k6 run -o experimental-prometheus-rw /scripts/auth/02-login.js
 # (개선 작업 후)
-docker compose run --rm -e RESULT_NAME=login-after-index k6 run -o experimental-prometheus-rw /scripts/01-login.js
+docker compose run --rm -e RESULT_NAME=login-after-index k6 run -o experimental-prometheus-rw /scripts/auth/02-login.js
 ```
 
 ---

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -9,6 +9,7 @@
 # 자세한 내용: ./README.md
 # =============================================================
 
+
 services:
   prometheus:
     image: prom/prometheus:v2.53.0

--- a/monitoring/k6/lib/config.js
+++ b/monitoring/k6/lib/config.js
@@ -1,0 +1,20 @@
+// k6 시나리오 공통 설정 (LMS Auth/User 도메인)
+
+// 테스트 대상 앱 주소. 도커 k6 컨테이너 → 호스트 앱(8080)
+export const BASE_URL = __ENV.BASE_URL || "http://host.docker.internal:8080";
+
+// 사용자가 요청 사이에 쉬는 시간 (실제 사용자 흉내)
+export const MIN_SLEEP = Number(__ENV.MIN_SLEEP || 0.5);
+export const MAX_SLEEP = Number(__ENV.MAX_SLEEP || 2);
+
+export function randomInt(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export function randomSleep() {
+    return Math.random() * (MAX_SLEEP - MIN_SLEEP) + MIN_SLEEP;
+}
+
+// 매번 다른 이메일 생성 (중복확인 테스트용 — 실제 가입 X)
+export function randomEmail() {
+    return `loadtest_${randomInt(1, 1000000)}@example.com`;}

--- a/monitoring/k6/results/01-email-check-summary.md
+++ b/monitoring/k6/results/01-email-check-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - 01-email-check
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2169 |
+| iterations | 2169 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 1242819 |
+| data_sent bytes | 320765 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 11.11 | 2.56 | 10.57 | 16.81 | 19.21 | 24.63 | 87.62 |
+| http_req_waiting | 10.79 | 2.52 | 10.27 | 16.30 | 18.51 | 24.20 | 87.29 |
+| http_req_blocked | 0.06 | 0.00 | 0.01 | 0.01 | 0.02 | 2.50 | 4.98 |
+| http_req_connecting | 0.05 | 0 | 0 | 0 | 0 | 2.38 | 4.85 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2169 pass / 0 fail |
+| has available field | 2169 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/scripts/01-email-check.js
+++ b/monitoring/k6/scripts/01-email-check.js
@@ -1,0 +1,36 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomEmail, randomSleep } from "../lib/config.js";
+import { createSummaryHandler } from "../lib/summary.js";
+
+export const options = {
+    // 부하 단계: 0 → 50명까지 서서히 올렸다 유지 후 종료
+    stages: [
+        { duration: "20s", target: 50 },  // 20초간 50명까지 증가
+        { duration: "40s", target: 50 },  // 40초간 50명 유지
+        { duration: "10s", target: 0 },   // 10초간 0으로 감소
+    ],
+    // 합격 기준
+    thresholds: {
+        http_req_failed: ["rate<0.01"],          // 실패율 1% 미만
+        http_req_duration: ["p(95)<500"],        // p95 응답시간 500ms 미만
+    },
+    // p99까지 결과에 포함
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export default function () {
+    const email = randomEmail();
+    const res = http.get(`${BASE_URL}/api/v1/auth/check/email?email=${email}`, {
+        tags: { api: "GET /auth/check/email" },
+    });
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "has available field": (r) => r.json("data.available") !== undefined,
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("01-email-check");

--- a/monitoring/k6/scripts/auth/01-email-check.js
+++ b/monitoring/k6/scripts/auth/01-email-check.js
@@ -1,7 +1,7 @@
 import http from "k6/http";
 import { check, sleep } from "k6";
-import { BASE_URL, randomEmail, randomSleep } from "../lib/config.js";
-import { createSummaryHandler } from "../lib/summary.js";
+import { BASE_URL, randomEmail, randomSleep } from "../../lib/config.js";
+import { createSummaryHandler } from "../../lib/summary.js";
 
 export const options = {
     // 부하 단계: 0 → 50명까지 서서히 올렸다 유지 후 종료

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Swagger
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
+                        // 모니터링 (Prometheus 스크레이핑)
+                        .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
                         // 인증 불필요
                         .requestMatchers("/api/v1/auth/**").permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,3 +58,16 @@ code-runner:
 
 code-execution:
   default-timeout-ms: ${CODE_EXECUTION_DEFAULT_TIMEOUT_MS:5000}
+
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    tags:
+      application: code-bomba-lms

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,13 @@ code-execution:
   default-timeout-ms: ${CODE_EXECUTION_DEFAULT_TIMEOUT_MS:5000}
 
 
+# ===== 모니터링 (local/loadtest 프로파일에서만 메트릭 노출) =====
+---
+spring:
+  config:
+    activate:
+      on-profile: local, loadtest
+
 management:
   endpoints:
     web:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -82,7 +82,7 @@
     </logger>
 
     <!-- 프로파일별 분기 -->
-    <springProfile name="local,dev">
+    <springProfile name="local,dev,loadtest">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="APP_FILE"/>


### PR DESCRIPTION
## 🚨 Pull Request 유형
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #N

---

## 🛠️ 기능 관련 작업 내용
- Actuator + Micrometer 로 `/actuator/prometheus` 노출, 프로메테우스 5초 스크레이핑 연동
- `loadtest` 프로파일 신설 — `local,loadtest` 조합으로 시크릿 상속 + DB만 도커 MySQL(3307)로 전환 (RDS 과금/운영 영향 차단)
- k6 공통 설정(`config.js`) + 이메일 중복확인 시나리오 추가 (2169req 성공률 100%, p95 19.21ms 검증)
- 부하테스트 DB 전용 계정(`lms_loadtest`) 교체 + 팀 가이드 README 작성

---

## ♻️ 패키지 변경 사항
- `build.gradle`: actuator + micrometer-registry-prometheus 의존성
- `src/main/resources`: application.yml(메트릭 노출), application-loadtest.yml 신규, logback-spring.xml(loadtest 분기)
- `monitoring/k6`: config.js + 01-email-check.js 시나리오 신규
- `monitoring`: README.md 팀 가이드 신규

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 애플리케이션 모니터링 엔드포인트(health, info, prometheus) 공개 및 Prometheus 메트릭 수집 지원 (local, loadtest 프로파일 대상)
  * 메트릭에 애플리케이션 태그(code-bomba-lms) 추가

* **Chores**
  * 모니터링 엔드포인트를 인증 없이 접근 가능하도록 보안 설정 조정 (로컬/로드테스트 대상)
  * 로드테스트 환경에 로깅 설정 적용 범위 확대
  * CI 빌드 단계에 Gradle 설정(캐싱 포함) 스텝 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->