### PR TITLE
[Ref] lecture/enrollment CourseJpaEntity 직접 의존 제거

### DIFF
--- a/src/main/java/com/wanted/codebombalms/course/domain/repository/CourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/repository/CourseRepository.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.course.domain.model.CourseStatus;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface CourseRepository {
 
@@ -19,6 +20,8 @@ public interface CourseRepository {
     List<Course> findByCourseCategoryIdAndDeletedAtIsNull(Long courseCategoryId);
 
     Optional<Course> findByCourseIdAndDeletedAtIsNull(Long courseId);
+
+    List<Course> findByCourseIdInAndDeletedAtIsNull(Set<Long> courseIds);
 
     Optional<Course> findByCourseIdAndStatusAndDeletedAtIsNull(Long courseId, CourseStatus status);
 

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseRepositoryAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 @RequiredArgsConstructor
@@ -73,6 +74,14 @@ public class CourseRepositoryAdapter implements CourseRepository {
     public Optional<Course> findByCourseIdAndDeletedAtIsNull(Long courseId) {
         return springDataCourseRepository.findByCourseIdAndDeletedAtIsNull(courseId)
                 .map(CourseJpaEntity::toDomain);
+    }
+
+    @Override
+    public List<Course> findByCourseIdInAndDeletedAtIsNull(Set<Long> courseIds) {
+        return springDataCourseRepository.findByCourseIdInAndDeletedAtIsNull(courseIds)
+                .stream()
+                .map(CourseJpaEntity::toDomain)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -64,7 +64,7 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
     @Query("""
             select l.lectureId
             from LectureJpaEntity l
-            where l.course.courseId in :courseIds
+            where l.courseId in :courseIds
             """)
     List<Long> findLectureIdsByCourseIds(@Param("courseIds") List<Long> courseIds);
 
@@ -101,14 +101,14 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             delete from LectureJpaEntity l
-            where l.course.courseId in :courseIds
+            where l.courseId in :courseIds
             """)
     int deleteLecturesByCourseIds(@Param("courseIds") List<Long> courseIds);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             delete from EnrollmentJpaEntity e
-            where e.course.courseId in :courseIds
+            where e.courseId in :courseIds
             """)
     int deleteEnrollmentsByCourseIds(@Param("courseIds") List<Long> courseIds);
 

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,6 +26,8 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
     List<CourseJpaEntity> findByCourseCategory_CourseCategoryIdAndDeletedAtIsNull(Long courseCategoryId);
 
     Optional<CourseJpaEntity> findByCourseIdAndDeletedAtIsNull(Long courseId);
+
+    List<CourseJpaEntity> findByCourseIdInAndDeletedAtIsNull(Set<Long> courseIds);
 
     Optional<CourseJpaEntity> findByCourseIdAndStatusAndDeletedAtIsNull(Long courseId, CourseStatus status);
 

--- a/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentJpaEntity.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 @ToString
 @Table(
         name = "enrollment",
+        indexes = @Index(name = "idx_enrollment_course_id", columnList = "course_id"),
         uniqueConstraints = @UniqueConstraint(
                 name = "uk_enrollment_user_course",
                 columnNames = {"user_id", "course_id"}

--- a/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentJpaEntity.java
@@ -1,6 +1,5 @@
 package com.wanted.codebombalms.enrollment.infrastructure.persistence;
 
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseJpaEntity;
 import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
 import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
 import jakarta.persistence.*;
@@ -31,10 +30,8 @@ public class EnrollmentJpaEntity {
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id", nullable = false)
-    @ToString.Exclude
-    private CourseJpaEntity course;
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
@@ -48,18 +45,18 @@ public class EnrollmentJpaEntity {
 
     public EnrollmentJpaEntity(
             Long userId,
-            CourseJpaEntity course,
+            Long courseId,
             EnrollmentStatus status
     ) {
         this.userId = userId;
-        this.course = course;
+        this.courseId = courseId;
         this.status = status;
     }
 
-    public static EnrollmentJpaEntity from(Enrollment enrollment, CourseJpaEntity course) {
+    public static EnrollmentJpaEntity from(Enrollment enrollment) {
         EnrollmentJpaEntity entity = new EnrollmentJpaEntity(
                 enrollment.getUserId(),
-                course,
+                enrollment.getCourseId(),
                 enrollment.getStatus()
         );
         entity.enrollmentId = enrollment.getEnrollmentId();
@@ -68,9 +65,9 @@ public class EnrollmentJpaEntity {
         return entity;
     }
 
-    public void apply(Enrollment enrollment, CourseJpaEntity course) {
+    public void apply(Enrollment enrollment) {
         this.userId = enrollment.getUserId();
-        this.course = course;
+        this.courseId = enrollment.getCourseId();
         this.status = enrollment.getStatus();
         this.enrolledAt = enrollment.getEnrolledAt();
         this.canceledAt = enrollment.getCanceledAt();
@@ -80,7 +77,7 @@ public class EnrollmentJpaEntity {
         return Enrollment.restore(
                 enrollmentId,
                 userId,
-                course.getCourseId(),
+                courseId,
                 status,
                 enrolledAt,
                 canceledAt

--- a/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/EnrollmentRepositoryAdapter.java
@@ -1,7 +1,5 @@
 package com.wanted.codebombalms.enrollment.infrastructure.persistence;
 
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseJpaEntity;
-import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseRepository;
 import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
 import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
 import com.wanted.codebombalms.enrollment.domain.repository.EnrollmentRepository;
@@ -16,33 +14,29 @@ import java.util.Optional;
 public class EnrollmentRepositoryAdapter implements EnrollmentRepository {
 
     private final SpringDataEnrollmentRepository springDataEnrollmentRepository;
-    private final SpringDataCourseRepository springDataCourseRepository;
 
     @Override
     public Enrollment save(Enrollment enrollment) {
-        CourseJpaEntity courseEntity = springDataCourseRepository.findById(enrollment.getCourseId())
-                .orElseThrow();
-
         EnrollmentJpaEntity entity = enrollment.getEnrollmentId() == null
-                ? EnrollmentJpaEntity.from(enrollment, courseEntity)
+                ? EnrollmentJpaEntity.from(enrollment)
                 : springDataEnrollmentRepository.findById(enrollment.getEnrollmentId())
                 .map(found -> {
-                    found.apply(enrollment, courseEntity);
+                    found.apply(enrollment);
                     return found;
                 })
-                .orElseGet(() -> EnrollmentJpaEntity.from(enrollment, courseEntity));
+                .orElseGet(() -> EnrollmentJpaEntity.from(enrollment));
 
         return springDataEnrollmentRepository.save(entity).toDomain();
     }
 
     @Override
     public boolean existsByCourseIdAndUserIdAndStatus(Long courseId, Long userId, EnrollmentStatus status) {
-        return springDataEnrollmentRepository.existsByCourse_CourseIdAndUserIdAndStatus(courseId, userId, status);
+        return springDataEnrollmentRepository.existsByCourseIdAndUserIdAndStatus(courseId, userId, status);
     }
 
     @Override
     public boolean existsByCourseIdAndUserId(Long courseId, Long userId) {
-        return springDataEnrollmentRepository.existsByCourse_CourseIdAndUserId(courseId, userId);
+        return springDataEnrollmentRepository.existsByCourseIdAndUserId(courseId, userId);
     }
 
     @Override
@@ -55,7 +49,7 @@ public class EnrollmentRepositoryAdapter implements EnrollmentRepository {
 
     @Override
     public List<Enrollment> findByCourseIdAndStatus(Long courseId, EnrollmentStatus status) {
-        return springDataEnrollmentRepository.findByCourse_CourseIdAndStatus(courseId, status)
+        return springDataEnrollmentRepository.findByCourseIdAndStatus(courseId, status)
                 .stream()
                 .map(EnrollmentJpaEntity::toDomain)
                 .toList();
@@ -73,7 +67,7 @@ public class EnrollmentRepositoryAdapter implements EnrollmentRepository {
             Long userId,
             EnrollmentStatus status
     ) {
-        return springDataEnrollmentRepository.findByCourse_CourseIdAndUserIdAndStatus(courseId, userId, status)
+        return springDataEnrollmentRepository.findByCourseIdAndUserIdAndStatus(courseId, userId, status)
                 .map(EnrollmentJpaEntity::toDomain);
     }
 

--- a/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/SpringDataEnrollmentRepository.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/persistence/SpringDataEnrollmentRepository.java
@@ -8,23 +8,23 @@ import java.util.Optional;
 
 public interface SpringDataEnrollmentRepository extends JpaRepository<EnrollmentJpaEntity, Long> {
 
-    boolean existsByCourse_CourseIdAndUserIdAndStatus(
+    boolean existsByCourseIdAndUserIdAndStatus(
             Long courseId,
             Long userId,
             EnrollmentStatus status
     );
 
-    boolean existsByCourse_CourseIdAndUserId(Long courseId, Long userId);
+    boolean existsByCourseIdAndUserId(Long courseId, Long userId);
 
     List<EnrollmentJpaEntity> findByUserIdAndStatus(Long userId, EnrollmentStatus status);
 
-    List<EnrollmentJpaEntity> findByCourse_CourseIdAndStatus(Long courseId, EnrollmentStatus status);
+    List<EnrollmentJpaEntity> findByCourseIdAndStatus(Long courseId, EnrollmentStatus status);
 
     List<EnrollmentJpaEntity> findByStatus(EnrollmentStatus status);
 
     Optional<EnrollmentJpaEntity> findByEnrollmentIdAndStatus(Long enrollmentId, EnrollmentStatus status);
 
-    Optional<EnrollmentJpaEntity> findByCourse_CourseIdAndUserIdAndStatus(
+    Optional<EnrollmentJpaEntity> findByCourseIdAndUserIdAndStatus(
             Long courseId,
             Long userId,
             EnrollmentStatus status

--- a/src/main/java/com/wanted/codebombalms/lecture/application/port/CourseCatalogPort.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/port/CourseCatalogPort.java
@@ -2,7 +2,12 @@ package com.wanted.codebombalms.lecture.application.port;
 
 import com.wanted.codebombalms.course.domain.model.Course;
 
+import java.util.Map;
+import java.util.Set;
+
 public interface CourseCatalogPort {
 
     Course findCourse(Long courseId);
+
+    Map<Long, Course> findCourses(Set<Long> courseIds);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/course/CourseCatalogAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/course/CourseCatalogAdapter.java
@@ -9,6 +9,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,5 +25,18 @@ public class CourseCatalogAdapter implements CourseCatalogPort {
     public Course findCourse(Long courseId) {
         return courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)
                 .orElseThrow(() -> new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
+    }
+
+    @Override
+    public Map<Long, Course> findCourses(Set<Long> courseIds) {
+        Map<Long, Course> courses = courseRepository.findByCourseIdInAndDeletedAtIsNull(courseIds)
+                .stream()
+                .collect(Collectors.toMap(Course::getCourseId, Function.identity()));
+
+        if (courses.size() != courseIds.size()) {
+            throw new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND);
+        }
+
+        return courses;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureJpaEntity.java
@@ -14,7 +14,10 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 @ToString
-@Table(name = "lecture")
+@Table(
+        name = "lecture",
+        indexes = @Index(name = "idx_lecture_course_id", columnList = "course_id")
+)
 public class LectureJpaEntity {
 
     @Id

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureJpaEntity.java
@@ -1,6 +1,6 @@
 package com.wanted.codebombalms.lecture.infrastructure.persistence;
 
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseJpaEntity;
+import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import jakarta.persistence.*;
@@ -22,10 +22,8 @@ public class LectureJpaEntity {
     @Column(name = "lecture_id")
     private Long lectureId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "course_id", nullable = false)
-    @ToString.Exclude
-    private CourseJpaEntity course;
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
 
     @Column(name = "title", nullable = false, length = 100)
     private String title;
@@ -56,7 +54,7 @@ public class LectureJpaEntity {
     private LocalDateTime deletedAt;
 
     public LectureJpaEntity(
-            CourseJpaEntity course,
+            Long courseId,
             String title,
             String description,
             String videoUrl,
@@ -64,7 +62,7 @@ public class LectureJpaEntity {
             LectureStatus status,
             Integer lectureOrder
     ) {
-        this.course = course;
+        this.courseId = courseId;
         this.title = title;
         this.description = description;
         this.videoUrl = videoUrl;
@@ -73,9 +71,9 @@ public class LectureJpaEntity {
         this.lectureOrder = lectureOrder;
     }
 
-    public static LectureJpaEntity from(Lecture lecture, CourseJpaEntity course) {
+    public static LectureJpaEntity from(Lecture lecture) {
         LectureJpaEntity entity = new LectureJpaEntity(
-                course,
+                lecture.getCourse().getCourseId(),
                 lecture.getTitle(),
                 lecture.getDescription(),
                 lecture.getVideoUrl(),
@@ -90,8 +88,8 @@ public class LectureJpaEntity {
         return entity;
     }
 
-    public void apply(Lecture lecture, CourseJpaEntity course) {
-        this.course = course;
+    public void apply(Lecture lecture) {
+        this.courseId = lecture.getCourse().getCourseId();
         this.title = lecture.getTitle();
         this.description = lecture.getDescription();
         this.videoUrl = lecture.getVideoUrl();
@@ -101,10 +99,10 @@ public class LectureJpaEntity {
         this.deletedAt = lecture.getDeletedAt();
     }
 
-    public Lecture toDomain() {
+    public Lecture toDomain(Course course) {
         return Lecture.restore(
                 lectureId,
-                course.toDomain(),
+                course,
                 title,
                 description,
                 videoUrl,

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -7,10 +7,11 @@ import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -35,13 +36,19 @@ public class LectureRepositoryAdapter implements LectureRepository {
 
     @Override
     public List<Lecture> findByDeletedAtIsNull() {
-        Map<Long, Course> courses = new HashMap<>();
-        return springDataLectureRepository.findByDeletedAtIsNull()
+        List<LectureJpaEntity> entities = springDataLectureRepository.findByDeletedAtIsNull();
+        if (entities.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> courseIds = entities.stream()
+                .map(LectureJpaEntity::getCourseId)
+                .collect(Collectors.toSet());
+        Map<Long, Course> courses = courseCatalogPort.findCourses(courseIds);
+
+        return entities
                 .stream()
-                .map(entity -> entity.toDomain(courses.computeIfAbsent(
-                        entity.getCourseId(),
-                        courseCatalogPort::findCourse
-                )))
+                .map(entity -> entity.toDomain(courses.get(entity.getCourseId())))
                 .toList();
     }
 

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -1,13 +1,15 @@
 package com.wanted.codebombalms.lecture.infrastructure.persistence;
 
-import com.wanted.codebombalms.course.infrastructure.persistence.CourseJpaEntity;
-import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseRepository;
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
@@ -15,53 +17,60 @@ import java.util.Optional;
 public class LectureRepositoryAdapter implements LectureRepository {
 
     private final SpringDataLectureRepository springDataLectureRepository;
-    private final SpringDataCourseRepository springDataCourseRepository;
+    private final CourseCatalogPort courseCatalogPort;
 
     @Override
     public Lecture save(Lecture lecture) {
-        CourseJpaEntity courseEntity = springDataCourseRepository.findById(lecture.getCourse().getCourseId())
-                .orElseThrow();
         LectureJpaEntity entity = lecture.getLectureId() == null
-                ? LectureJpaEntity.from(lecture, courseEntity)
+                ? LectureJpaEntity.from(lecture)
                 : springDataLectureRepository.findById(lecture.getLectureId())
                 .map(found -> {
-                    found.apply(lecture, courseEntity);
+                    found.apply(lecture);
                     return found;
                 })
-                .orElseGet(() -> LectureJpaEntity.from(lecture, courseEntity));
+                .orElseGet(() -> LectureJpaEntity.from(lecture));
 
-        return springDataLectureRepository.save(entity).toDomain();
+        return springDataLectureRepository.save(entity).toDomain(lecture.getCourse());
     }
 
     @Override
     public List<Lecture> findByDeletedAtIsNull() {
+        Map<Long, Course> courses = new HashMap<>();
         return springDataLectureRepository.findByDeletedAtIsNull()
                 .stream()
-                .map(LectureJpaEntity::toDomain)
+                .map(entity -> entity.toDomain(courses.computeIfAbsent(
+                        entity.getCourseId(),
+                        courseCatalogPort::findCourse
+                )))
                 .toList();
     }
 
     @Override
     public Optional<Lecture> findByLectureIdAndDeletedAtIsNull(Long lectureId) {
         return springDataLectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
-                .map(LectureJpaEntity::toDomain);
+                .map(this::toDomain);
     }
 
     @Override
     public List<Lecture> findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(Long courseId) {
-        return springDataLectureRepository.findByCourse_CourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId)
+        Course course = courseCatalogPort.findCourse(courseId);
+        return springDataLectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId)
                 .stream()
-                .map(LectureJpaEntity::toDomain)
+                .map(entity -> entity.toDomain(course))
                 .toList();
     }
 
     @Override
     public boolean existsByCourseIdAndDeletedAtIsNull(Long courseId) {
-        return springDataLectureRepository.existsByCourse_CourseIdAndDeletedAtIsNull(courseId);
+        return springDataLectureRepository.existsByCourseIdAndDeletedAtIsNull(courseId);
     }
 
     @Override
     public boolean existsByCourseIdAndLectureIdAndDeletedAtIsNull(Long courseId, Long lectureId) {
-        return springDataLectureRepository.existsByCourse_CourseIdAndLectureIdAndDeletedAtIsNull(courseId, lectureId);
+        return springDataLectureRepository.existsByCourseIdAndLectureIdAndDeletedAtIsNull(courseId, lectureId);
+    }
+
+    private Lecture toDomain(LectureJpaEntity entity) {
+        return entity.toDomain(courseCatalogPort.findCourse(entity.getCourseId()));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -16,13 +16,13 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
 
     Optional<LectureJpaEntity> findByLectureIdAndDeletedAtIsNull(Long lectureId);
 
-    List<LectureJpaEntity> findByCourse_CourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(Long courseId);
+    List<LectureJpaEntity> findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(Long courseId);
 
-    List<LectureJpaEntity> findByCourse_CourseIdAndDeletedAtIsNull(Long courseId);
+    List<LectureJpaEntity> findByCourseIdAndDeletedAtIsNull(Long courseId);
 
-    boolean existsByCourse_CourseIdAndDeletedAtIsNull(Long courseId);
+    boolean existsByCourseIdAndDeletedAtIsNull(Long courseId);
 
-    boolean existsByCourse_CourseIdAndLectureIdAndDeletedAtIsNull(Long courseId, Long lectureId);
+    boolean existsByCourseIdAndLectureIdAndDeletedAtIsNull(Long courseId, Long lectureId);
 
     @Transactional
     default int hardDeleteByDeletedAtBefore(LocalDateTime threshold) {

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseProblemRepositoryTest.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import com.wanted.codebombalms.lecture.infrastructure.course.CourseCatalogAdapter;
 import com.wanted.codebombalms.lecture.infrastructure.persistence.LectureRepositoryAdapter;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Import({
         CourseRepositoryAdapter.class,
         CourseProblemSetRepositoryAdapter.class,
+        CourseCatalogAdapter.class,
         LectureRepositoryAdapter.class
 })
 @DisplayName("Course problem repository test")

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseRepositoryTest.java
@@ -20,6 +20,7 @@ import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLec
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import com.wanted.codebombalms.lecture.infrastructure.course.CourseCatalogAdapter;
 import com.wanted.codebombalms.lecture.infrastructure.persistence.LectureRepositoryAdapter;
 import com.wanted.codebombalms.lecture.infrastructure.persistence.SpringDataLectureRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.*;
 })
 @Import({
         CourseRepositoryAdapter.class,
+        CourseCatalogAdapter.class,
         LectureRepositoryAdapter.class,
         CourseProblemSetRepositoryAdapter.class,
         EnrollmentRepositoryAdapter.class

--- a/src/test/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryTest.java
@@ -17,6 +17,7 @@ import com.wanted.codebombalms.learning.infrastructure.persistence.SpringDataLec
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import com.wanted.codebombalms.lecture.infrastructure.course.CourseCatalogAdapter;
 import com.wanted.codebombalms.lecture.infrastructure.persistence.LectureRepositoryAdapter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.*;
 })
 @Import({
         CourseRepositoryAdapter.class,
+        CourseCatalogAdapter.class,
         LectureRepositoryAdapter.class,
         CourseProblemSetRepositoryAdapter.class
 })


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #349 

---

## 🛠️ 기능 관련 작업 내용

- 강의와 수강 JPA Entity의 `CourseJpaEntity` 연관관계를 `courseId` 값 매핑으로 변경
- Repository Adapter의 `SpringDataCourseRepository` 직접 의존 제거
- 강의 도메인 복원 시 `CourseCatalogPort`를 통해 강좌 정보를 조회하도록 변경
- 변경된 필드 구조에 맞춰 파생 쿼리와 하드 딜리트 JPQL 경로 수정


---

## ♻️ 패키지 변경 사항

- `project/lecture`: 강의 Entity와 Repository Adapter의 course persistence 직접 의존 제거
- `project/enrollment`: 수강 Entity와 Repository Adapter를 `courseId` 기반으로 변경
- `project/course`: 강의·수강의 scalar `courseId` 매핑에 맞게 하드 딜리트 쿼리 경로 수정

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 여러 강좌 ID로 한 번에 강좌 정보를 조회하는 일괄 조회 기능 추가

* **Refactor**
  * 강의·수강 데이터의 참조 방식을 변경하여 저장/조회 흐름을 단순화하고 일관성 향상
  * 저장소 호출 시 식별자 기반 조회로 쿼리 기준 정리

* **Tests**
  * 테스트 컨텍스트 설정을 확장하여 관련 어댑터를 로드하도록 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->