### PR TITLE
[Feat] 문제 풀이에서 채팅방조회

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.wanted.codebombalms.chatbot.application.result.RenameChatRoomResult;
 import java.time.Instant;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,14 +29,27 @@ public class ChatRoomCommandService implements ChatRoomCommandUseCase {
 
     @Override
     public SendFirstMessageResult sendFirst(SendFirstMessageCommand command) {
-        ChatRoom room = createRoom(
-                command.userId(), command.problemSetId(), command.problemId(), command.userMessage());
+        ChatRoom room = getOrCreateRoom(command);
 
         AiChatResult aiResult = chatMessageCommandUseCase.send(
                 new SendMessageCommand(command.userId(), room.getId(), command.userMessage())
         );
 
         return new SendFirstMessageResult(room.getId(), aiResult.answer());
+    }
+
+    private ChatRoom getOrCreateRoom(SendFirstMessageCommand command) {
+        // 문제 채팅방(problemSetId+problemId 둘 다 있음)이면 기존 방 재사용
+        if (command.problemSetId() != null && command.problemId() != null) {
+            Optional<ChatRoom> existing = chatRoomRepository.findByUserIdAndProblem(
+                    command.userId(), command.problemSetId(), command.problemId());
+            if (existing.isPresent()) {
+                return existing.get();
+            }
+        }
+        // 자유대화 방(null) 또는 신규 문제 방은 새로 생성
+        return createRoom(
+                command.userId(), command.problemSetId(), command.problemId(), command.userMessage());
     }
 
     private ChatRoom createRoom(Long userId, Long problemSetId, Long problemId, String userMessage) {

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomQueryService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,12 @@ public class ChatRoomQueryService implements ChatRoomQueryUseCase {
                 .stream()
                 .map(this::toResult)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Long> findProblemRoomId(Long userId, Long problemSetId, Long problemId) {
+        return chatRoomRepository.findByUserIdAndProblem(userId, problemSetId, problemId)
+                .map(ChatRoom::getId);
     }
 
     private ChatRoomResult toResult(ChatRoom chatRoom) {

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/usecase/ChatRoomQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/usecase/ChatRoomQueryUseCase.java
@@ -3,9 +3,13 @@ package com.wanted.codebombalms.chatbot.application.usecase;
 import com.wanted.codebombalms.chatbot.application.result.ChatRoomResult;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomQueryUseCase {
 
     // userId 기준 채팅방 목록 조회 (최신순)
     List<ChatRoomResult> listRooms(Long userId);
+
+    // 문제 채팅방 단건 조회 → roomId (없으면 empty)
+    Optional<Long> findProblemRoomId(Long userId, Long problemSetId, Long problemId);
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/exception/ChatErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/exception/ChatErrorCode.java
@@ -10,7 +10,8 @@ public enum ChatErrorCode implements ErrorCode {
 
     CHAT_ROOM_NOT_FOUND("CHT-001", "채팅방을 찾을 수 없습니다."),
     CHAT_ROOM_FORBIDDEN("CHT-002", "채팅방에 접근 권한이 없습니다."),
-    AI_RESPONSE_FAILED("CHT-003", "AI 응답 생성에 실패했습니다.");
+    AI_RESPONSE_FAILED("CHT-003", "AI 응답 생성에 실패했습니다."),
+    CHAT_ROOM_TITLE_INVALID("CHT-004", "채팅방 제목이 올바르지 않습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/model/ChatRoom.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/model/ChatRoom.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 
 import java.time.Instant;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 
 public class ChatRoom {
 
@@ -46,6 +47,9 @@ public class ChatRoom {
     }
 
     public void rename(String newTitle, Instant now) {
+        if (newTitle == null || newTitle.isBlank()) {
+            throw new ValidationException(ChatErrorCode.CHAT_ROOM_TITLE_INVALID);
+        }
         this.title = newTitle;
         this.updatedAt = now;
     }

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/repository/ChatRoomRepository.java
@@ -21,6 +21,9 @@ public interface ChatRoomRepository {
                 .orElseThrow(() -> new NotFoundException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
     }
 
+    // 문제 채팅방 단건 조회 (userId + problemSetId + problemId)
+    Optional<ChatRoom> findByUserIdAndProblem(Long userId, Long problemSetId, Long problemId);
+
     // userId로 채팅방 목록 조회
     List<ChatRoom> findByUserId(Long userId);
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatRoomJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatRoomJpaEntity.java
@@ -7,7 +7,13 @@ import lombok.NoArgsConstructor;
 import java.time.Instant;
 
 @Entity
-@Table(name = "chat_room")
+@Table(
+        name = "chat_room",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_chat_room_user_problem",
+                columnNames = {"user_id", "problem_set_id", "problem_id"}
+        )
+)
 @Getter
 @NoArgsConstructor
 public class ChatRoomJpaEntity {

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatRoomRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatRoomRepositoryAdapter.java
@@ -39,4 +39,11 @@ public class ChatRoomRepositoryAdapter implements ChatRoomRepository {
     public void deleteById(Long id) {
         springDataRepository.deleteById(id);
     }
+
+    @Override
+    public Optional<ChatRoom> findByUserIdAndProblem(Long userId, Long problemSetId, Long problemId) {
+        return springDataRepository
+                .findByUserIdAndProblemSetIdAndProblemId(userId, problemSetId, problemId)
+                .map(ChatRoomMapper::toDomain);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SpringDataChatMessageRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SpringDataChatMessageRepository.java
@@ -17,4 +17,5 @@ public interface SpringDataChatMessageRepository extends JpaRepository<ChatMessa
 
     // roomId로 메시지 전체 삭제
     void deleteByRoomId(Long roomId);
+
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SpringDataChatRoomRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SpringDataChatRoomRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.chatbot.infrastructure.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +9,7 @@ public interface SpringDataChatRoomRepository extends JpaRepository<ChatRoomJpaE
 
     // userId로 채팅방 목록 조회 (최신순)
     List<ChatRoomJpaEntity> findByUserIdOrderByUpdatedAtDesc(Long userId);
+
+    Optional<ChatRoomJpaEntity> findByUserIdAndProblemSetIdAndProblemId(
+            Long userId, Long problemSetId, Long problemId);
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseMessage.java
@@ -9,5 +9,6 @@ public class ChatResponseMessage {
     public static final String MESSAGES_RETRIEVED = "채팅 내역 조회에 성공했습니다.";
     public static final String MESSAGE_SENT = "메시지 전송에 성공했습니다.";
     public static final String ROOM_RENAMED = "채팅방 제목이 변경되었습니다.";
+    public static final String ROOM_FOUND = "채팅방 조회에 성공했습니다.";
 
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import com.wanted.codebombalms.chatbot.presentation.api.request.RenameChatRoomRequest;
 import com.wanted.codebombalms.chatbot.presentation.api.response.RenameChatRoomResponse;
+import com.wanted.codebombalms.chatbot.presentation.api.response.ChatRoomIdResponse;
 
 @Tag(name = "Chatbot - 채팅방", description = "AI 채팅방 생성/조회/삭제 및 메시지 전송 API")
 @PreAuthorize("isAuthenticated()")  // ← 추가
@@ -320,6 +321,34 @@ public class ChatRoomController {
                 )
         );
     }
+
+    @Operation(
+            summary = "문제 채팅방 단건 조회",
+            description = "문제 풀이 진입 시 해당 문제의 기존 채팅방을 조회합니다. 없으면 204."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200", description = "기존 방 존재 → roomId 반환"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "204", description = "해당 문제의 방 없음")
+    })
+    @GetMapping("/room")
+    public ResponseEntity<ApiResponse<ChatRoomIdResponse>> findProblemRoom(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam Long problemSetId,
+            @RequestParam Long problemId
+    ) {
+        return chatRoomQueryUseCase.findProblemRoomId(userId, problemSetId, problemId)
+                .map(roomId -> ResponseEntity.ok(
+                        ApiResponse.success(
+                                ChatResponseCode.ROOM_RETRIEVED,
+                                ChatResponseMessage.ROOM_FOUND,
+                                new ChatRoomIdResponse(roomId)
+                        )
+                ))
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
 
     @Operation(
             summary = "채팅방 삭제",

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/ChatRoomIdResponse.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/ChatRoomIdResponse.java
@@ -1,0 +1,4 @@
+package com.wanted.codebombalms.chatbot.presentation.api.response;
+
+public record ChatRoomIdResponse
+        (Long roomId) {}


### PR DESCRIPTION
#374 아직 미커밋이지만 PR 본문은 채워줄게. 이 브랜치(`feat/aiBrain`) 이번 세션 작업 = **#372 + #374** 기준 (#373은 아직 안 함).

---

## 🚨 Pull Request 유형

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #372
- Closes #374

---

## 🛠️ 기능 관련 작업 내용

- **채팅방 제목 수정 API(#372)** 를 추가했습니다. `PATCH /api/v1/chat/{roomId}` 로 본인 채팅방 제목을 변경합니다.
- 제목 검증을 도메인 모델에서 수행하도록 했습니다. null/blank 제목은 `ValidationException(CHT-004)` → 400 으로 처리합니다(`@Valid` DTO 검증 + 도메인 가드 2중 방어).
- **문제 채팅방 1방 제약(#374)** 을 적용했습니다. `(user_id, problem_set_id, problem_id)` 유니크 제약 + `sendFirst` get-or-create 로 같은 문제에 채팅방이 중복 생성되지 않도록 했습니다. 자유대화 방(`problemSetId=null`)은 기존대로 매번 새로 생성됩니다.
- **문제 채팅방 단건 조회 API(#374)** 를 추가했습니다. `GET /api/v1/chat/room?problemSetId=&problemId=` 로 문제 PK에 연결된 기존 방의 `roomId` 를 조회하고, 없으면 `204` 를 반환합니다. (프론트가 챗봇 진입 시 이전 대화를 이어받는 용도)
- 미사용 상수 `ROOM_DELETED` 를 제거했습니다.

---

## ♻️ 패키지 변경 사항

**#372 — 제목 수정**
- `chatbot/domain/model/ChatRoom` : `title` final 해제 + `rename()` 도메인 메서드(null/blank 검증) 추가
- `chatbot/domain/exception/ChatErrorCode` : `CHAT_ROOM_TITLE_INVALID`(CHT-004) 추가
- `chatbot/application/usecase/ChatRoomCommandUseCase` : `rename()` 시그니처 추가
- `chatbot/application/service/ChatRoomCommandService` : `rename()` 구현(소유권 검증 + 저장)
- `chatbot/application/result/RenameChatRoomResult` : 신규
- `chatbot/presentation/api/request/RenameChatRoomRequest` : 신규(`@NotBlank @Size(max=50)`)
- `chatbot/presentation/api/response/RenameChatRoomResponse` : 신규
- `chatbot/presentation/api/ChatRoomController` : `PATCH /{roomId}` 엔드포인트 추가
- `chatbot/presentation/api/ChatResponseCode`·`ChatResponseMessage` : `ROOM_RENAMED` 추가, `ROOM_DELETED` 제거

**#374 — 1방 제약 + 단건 조회**
- `chatbot/infrastructure/persistence/ChatRoomJpaEntity` : `(user_id, problem_set_id, problem_id)` 유니크 제약 선언
- `chatbot/domain/repository/ChatRoomRepository` : `findByUserIdAndProblem()` 추가
- `chatbot/infrastructure/persistence/SpringDataChatRoomRepository` : `findByUserIdAndProblemSetIdAndProblemId()` 추가
- `chatbot/infrastructure/persistence/ChatRoomRepositoryAdapter` : 위임 구현
- `chatbot/application/service/ChatRoomCommandService` : `sendFirst` get-or-create 분기 추가
- `chatbot/application/usecase/ChatRoomQueryUseCase`·`ChatRoomQueryService` : `findProblemRoomId()` 추가
- `chatbot/presentation/api/response/ChatRoomIdResponse` : 신규
- `chatbot/presentation/api/ChatRoomController` : `GET /room` 엔드포인트 추가
- `chatbot/presentation/api/ChatResponseMessage` : `ROOM_FOUND` 추가

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다. (로컬 동작 확인 필요)
- [x] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.

---

⚠️ **리뷰어 주의**: `chat_room` 유니크 인덱스는 엔티티 선언만 추가됨. local `ddl-auto: validate` 라 dev DB엔 자동 반영 안 됨 → 필요 시 `ALTER TABLE chat_room ADD CONSTRAINT uq_chat_room_user_problem UNIQUE (user_id, problem_set_id, problem_id);` 수동 적용(중복 데이터 없을 때).

---

참고: 지금 #374가 **미커밋** 상태야. PR 올리려면 먼저 #374 커밋+푸시해야 함. 커밋부터 할까? (`compileJava` 검증 먼저 할지도 알려줘)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 문제 풀이 진입 시 기존 채팅방 자동 재사용 기능 추가
  * 특정 문제의 채팅방 ID 조회 API 엔드포인트 추가

* **Bug Fixes**
  * 채팅방 제목 유효성 검증 강화 (공백/null 값 제외)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->