### PR TITLE
[Feat] 문제 세트 추천 조회 및 숨김 API 구현

### DIFF
--- a/http/recommendation.http
+++ b/http/recommendation.http
@@ -1,0 +1,11 @@
+### 내 문제 세트 추천 목록 조회
+GET http://localhost:8080/api/v1/recommendations/problem-sets/me?limit=3
+Authorization: Bearer {{accessToken}}
+
+### 내 문제 세트 추천 목록 조회 - limit은 최대 3개로 제한
+GET http://localhost:8080/api/v1/recommendations/problem-sets/me?limit=10
+Authorization: Bearer {{accessToken}}
+
+### 내 문제 세트 추천 오늘 하루 숨김
+POST http://localhost:8080/api/v1/recommendations/problem-sets/hide-today
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/command/RecommendationHideResult.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/command/RecommendationHideResult.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.recommendation.application.command;
+
+import java.time.LocalDateTime;
+
+/** 추천 숨김 처리 유스케이스의 결과를 표현합니다. */
+public record RecommendationHideResult(
+        boolean hidden,
+        LocalDateTime hiddenUntil
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/port/ProblemRecommendationQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/port/ProblemRecommendationQueryPort.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.recommendation.application.port;
+
+import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
+import java.util.List;
+
+/** 추천 목록 조회에 필요한 저장소 접근을 추상화합니다. */
+public interface ProblemRecommendationQueryPort {
+
+    /** 사용자의 활성 문제 세트 추천 목록을 제한 개수만큼 조회합니다. */
+    List<ProblemSetRecommendation> findActiveProblemSetRecommendations(Long userId, int limit);
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/port/RecommendationHidePort.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/port/RecommendationHidePort.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.recommendation.application.port;
+
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/** 추천 숨김 설정 저장과 조회를 추상화합니다. */
+public interface RecommendationHidePort {
+
+    /** 사용자와 숨김 유형에 해당하는 전체 숨김 설정을 조회합니다. */
+    Optional<RecommendationHide> findHide(Long userId, RecommendationHideType hideType);
+
+    /** 사용자와 숨김 유형에 해당하는 전체 숨김 설정을 저장하거나 갱신합니다. */
+    RecommendationHide saveOrUpdate(Long userId, RecommendationHideType hideType, LocalDateTime hiddenUntil);
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/query/ProblemSetRecommendationResult.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/query/ProblemSetRecommendationResult.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.recommendation.application.query;
+
+import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 추천 목록 조회 유스케이스의 결과를 표현합니다. */
+public record ProblemSetRecommendationResult(
+        boolean hidden,
+        LocalDateTime hiddenUntil,
+        List<ProblemSetRecommendation> problemSets
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java
@@ -1,0 +1,50 @@
+package com.wanted.codebombalms.recommendation.application.service;
+
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationQueryPort;
+import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
+import com.wanted.codebombalms.recommendation.application.query.ProblemSetRecommendationResult;
+import com.wanted.codebombalms.recommendation.application.usecase.GetMyProblemSetRecommendationsUseCase;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 문제 세트 추천 목록 조회와 숨김 상태 판정을 처리합니다. */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemRecommendationQueryService implements GetMyProblemSetRecommendationsUseCase {
+
+    private static final int DEFAULT_LIMIT = 3;
+    private static final int MAX_LIMIT = 3;
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final ProblemRecommendationQueryPort problemRecommendationQueryPort;
+    private final RecommendationHidePort recommendationHidePort;
+
+    /** 숨김 상태를 먼저 확인한 뒤 활성 추천 목록을 최대 3개까지 조회합니다. */
+    @Override
+    public ProblemSetRecommendationResult getRecommendations(Long userId, Integer limit) {
+        LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
+
+        return recommendationHidePort.findHide(userId, RecommendationHideType.PROBLEM_SET_RECOMMENDATION)
+                .filter(hide -> hide.isHiddenAt(now))
+                .map(hide -> new ProblemSetRecommendationResult(true, hide.hiddenUntil(), List.of()))
+                .orElseGet(() -> new ProblemSetRecommendationResult(
+                        false,
+                        null,
+                        problemRecommendationQueryPort.findActiveProblemSetRecommendations(userId, clampLimit(limit))
+                ));
+    }
+
+    /** 요청 limit을 기본값 3, 최대값 3 범위로 보정합니다. */
+    private int clampLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.max(1, Math.min(limit, MAX_LIMIT));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java
@@ -1,0 +1,38 @@
+package com.wanted.codebombalms.recommendation.application.service;
+
+import com.wanted.codebombalms.recommendation.application.command.RecommendationHideResult;
+import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
+import com.wanted.codebombalms.recommendation.application.usecase.HideProblemSetRecommendationsTodayUseCase;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 문제 세트 추천을 오늘 하루 숨김 처리합니다. */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RecommendationHideService implements HideProblemSetRecommendationsTodayUseCase {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final RecommendationHidePort recommendationHidePort;
+
+    /** Asia/Seoul 기준 오늘 23:59:59까지 숨김 만료 시간을 저장합니다. */
+    @Override
+    public RecommendationHideResult hideToday(Long userId) {
+        LocalDateTime hiddenUntil = LocalDate.now(SEOUL_ZONE).atTime(LocalTime.of(23, 59, 59));
+        RecommendationHide hide = recommendationHidePort.saveOrUpdate(
+                userId,
+                RecommendationHideType.PROBLEM_SET_RECOMMENDATION,
+                hiddenUntil
+        );
+
+        return new RecommendationHideResult(true, hide.hiddenUntil());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/usecase/GetMyProblemSetRecommendationsUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/usecase/GetMyProblemSetRecommendationsUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.recommendation.application.usecase;
+
+import com.wanted.codebombalms.recommendation.application.query.ProblemSetRecommendationResult;
+
+/** 로그인 사용자의 문제 세트 추천 목록 조회 기능을 정의합니다. */
+public interface GetMyProblemSetRecommendationsUseCase {
+
+    /** 사용자 ID와 요청 limit 기준으로 추천 목록 조회 결과를 반환합니다. */
+    ProblemSetRecommendationResult getRecommendations(Long userId, Integer limit);
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/usecase/HideProblemSetRecommendationsTodayUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/usecase/HideProblemSetRecommendationsTodayUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.recommendation.application.usecase;
+
+import com.wanted.codebombalms.recommendation.application.command.RecommendationHideResult;
+
+/** 로그인 사용자의 문제 세트 추천 오늘 하루 숨김 기능을 정의합니다. */
+public interface HideProblemSetRecommendationsTodayUseCase {
+
+    /** 사용자 ID 기준으로 추천 영역을 오늘 종료 시각까지 숨김 처리합니다. */
+    RecommendationHideResult hideToday(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/domain/model/ProblemSetRecommendation.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/domain/model/ProblemSetRecommendation.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.recommendation.domain.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/** 학생에게 노출할 문제 세트 추천 한 건을 표현합니다. */
+public record ProblemSetRecommendation(
+        Long recommendationId,
+        Long problemSetId,
+        Long categoryId,
+        Long creatorId,
+        BigDecimal support,
+        BigDecimal confidence,
+        BigDecimal lift,
+        Integer rankNo,
+        RecommendationAlgorithm algorithm,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationAlgorithm.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationAlgorithm.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.recommendation.domain.model;
+
+/** 추천 생성에 사용한 알고리즘 타입을 표현합니다. */
+public enum RecommendationAlgorithm {
+    APRIORI
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationHide.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationHide.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.recommendation.domain.model;
+
+import java.time.LocalDateTime;
+
+/** 사용자별 추천 숨김 설정과 만료 시간을 표현합니다. */
+public record RecommendationHide(
+        Long hideId,
+        Long userId,
+        RecommendationHideType hideType,
+        Long targetId,
+        LocalDateTime hiddenUntil,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    /** 전달된 시각 기준으로 숨김이 아직 유효한지 확인합니다. */
+    public boolean isHiddenAt(LocalDateTime now) {
+        return hiddenUntil != null && hiddenUntil.isAfter(now);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationHideType.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationHideType.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.recommendation.domain.model;
+
+/** 추천 숨김이 적용되는 대상 유형을 표현합니다. */
+public enum RecommendationHideType {
+    PROBLEM_SET_RECOMMENDATION
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationStatus.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/domain/model/RecommendationStatus.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.recommendation.domain.model;
+
+/** 추천 row의 노출 가능 상태를 표현합니다. */
+public enum RecommendationStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationJpaEntity.java
@@ -1,0 +1,61 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/** problem_recommendation 테이블과 매핑되는 추천 저장 엔티티입니다. */
+@Entity
+@Table(name = "problem_recommendation")
+public class ProblemRecommendationJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recommendation_id")
+    private Long recommendationId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "problem_set_id", nullable = false)
+    private Long problemSetId;
+
+    @Column(name = "support", nullable = false, precision = 10, scale = 6)
+    private BigDecimal support;
+
+    @Column(name = "confidence", nullable = false, precision = 10, scale = 6)
+    private BigDecimal confidence;
+
+    @Column(name = "lift", nullable = false, precision = 10, scale = 6)
+    private BigDecimal lift;
+
+    @Column(name = "rank_no", nullable = false)
+    private Integer rankNo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private RecommendationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "algorithm", nullable = false, length = 30)
+    private RecommendationAlgorithm algorithm;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** JPA가 엔티티를 생성할 때 사용하는 기본 생성자입니다. */
+    protected ProblemRecommendationJpaEntity() {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationQueryAdapter.java
@@ -1,0 +1,36 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationQueryPort;
+import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** 추천 조회 port를 DB 조회로 구현하는 persistence adapter입니다. */
+@Component
+@RequiredArgsConstructor
+public class ProblemRecommendationQueryAdapter implements ProblemRecommendationQueryPort {
+
+    private final SpringDataProblemRecommendationRepository problemRecommendationRepository;
+
+    /** repository projection을 추천 도메인 모델 목록으로 변환합니다. */
+    @Override
+    public List<ProblemSetRecommendation> findActiveProblemSetRecommendations(Long userId, int limit) {
+        return problemRecommendationRepository.findActiveProblemSetRecommendations(userId, limit)
+                .stream()
+                .map(row -> new ProblemSetRecommendation(
+                        row.getRecommendationId(),
+                        row.getProblemSetId(),
+                        row.getCategoryId(),
+                        row.getCreatorId(),
+                        row.getSupport(),
+                        row.getConfidence(),
+                        row.getLift(),
+                        row.getRankNo(),
+                        RecommendationAlgorithm.valueOf(row.getAlgorithm()),
+                        row.getCreatedAt()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/RecommendationHideJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/RecommendationHideJpaEntity.java
@@ -1,0 +1,77 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/** recommendation_hide 테이블과 매핑되는 추천 숨김 엔티티입니다. */
+@Entity
+@Table(name = "recommendation_hide")
+public class RecommendationHideJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hide_id")
+    private Long hideId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "hide_type", nullable = false, length = 50)
+    private RecommendationHideType hideType;
+
+    @Column(name = "target_id")
+    private Long targetId;
+
+    @Column(name = "hidden_until")
+    private LocalDateTime hiddenUntil;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /** JPA가 엔티티를 생성할 때 사용하는 기본 생성자입니다. */
+    protected RecommendationHideJpaEntity() {
+    }
+
+    /** 전체 문제 세트 추천 숨김 row를 새로 생성합니다. */
+    public RecommendationHideJpaEntity(Long userId, RecommendationHideType hideType, LocalDateTime hiddenUntil) {
+        LocalDateTime now = LocalDateTime.now();
+        this.userId = userId;
+        this.hideType = hideType;
+        this.targetId = null;
+        this.hiddenUntil = hiddenUntil;
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    /** 숨김 만료 시각과 수정 시각을 갱신합니다. */
+    public void updateHiddenUntil(LocalDateTime hiddenUntil) {
+        this.hiddenUntil = hiddenUntil;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /** persistence 엔티티를 application/domain에서 쓰는 모델로 변환합니다. */
+    public RecommendationHide toDomain() {
+        return new RecommendationHide(
+                hideId,
+                userId,
+                hideType,
+                targetId,
+                hiddenUntil,
+                createdAt,
+                updatedAt
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/RecommendationHidePersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/RecommendationHidePersistenceAdapter.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** 추천 숨김 port를 recommendation_hide 테이블 저장/조회로 구현합니다. */
+@Component
+@RequiredArgsConstructor
+public class RecommendationHidePersistenceAdapter implements RecommendationHidePort {
+
+    private final SpringDataRecommendationHideRepository recommendationHideRepository;
+
+    /** 사용자와 숨김 유형 기준의 전체 숨김 설정을 조회합니다. */
+    @Override
+    public Optional<RecommendationHide> findHide(Long userId, RecommendationHideType hideType) {
+        return recommendationHideRepository.findByUserIdAndHideTypeAndTargetIdIsNull(userId, hideType)
+                .map(RecommendationHideJpaEntity::toDomain);
+    }
+
+    /** 기존 숨김 row가 있으면 갱신하고 없으면 새로 생성합니다. */
+    @Override
+    public RecommendationHide saveOrUpdate(
+            Long userId,
+            RecommendationHideType hideType,
+            LocalDateTime hiddenUntil
+    ) {
+        RecommendationHideJpaEntity entity = recommendationHideRepository
+                .findByUserIdAndHideTypeAndTargetIdIsNull(userId, hideType)
+                .orElseGet(() -> new RecommendationHideJpaEntity(userId, hideType, hiddenUntil));
+
+        entity.updateHiddenUntil(hiddenUntil);
+
+        return recommendationHideRepository.save(entity).toDomain();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
@@ -1,0 +1,71 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** problem_recommendation 조회용 Spring Data JPA repository입니다. */
+public interface SpringDataProblemRecommendationRepository
+        extends JpaRepository<ProblemRecommendationJpaEntity, Long> {
+
+    /** 활성 추천과 활성 문제 세트를 조인해 완료된 문제 세트를 제외하고 조회합니다. */
+    @Query(
+            value = """
+                    SELECT
+                        pr.recommendation_id AS recommendationId,
+                        pr.problem_set_id AS problemSetId,
+                        ps.category_id AS categoryId,
+                        ps.created_by AS creatorId,
+                        pr.support AS support,
+                        pr.confidence AS confidence,
+                        pr.lift AS lift,
+                        pr.rank_no AS rankNo,
+                        pr.algorithm AS algorithm,
+                        pr.created_at AS createdAt
+                    FROM problem_recommendation pr
+                    JOIN problem_set ps ON ps.problem_set_id = pr.problem_set_id
+                    LEFT JOIN problem_progress pp
+                        ON pp.user_id = pr.user_id
+                        AND pp.problem_set_id = pr.problem_set_id
+                        AND pp.is_completed = true
+                    WHERE pr.user_id = :userId
+                        AND pr.status = 'ACTIVE'
+                        AND ps.status = 'ACTIVE'
+                        AND pp.progress_id IS NULL
+                    ORDER BY pr.rank_no ASC
+                    LIMIT :limit
+                    """,
+            nativeQuery = true
+    )
+    List<ProblemSetRecommendationProjection> findActiveProblemSetRecommendations(
+            @Param("userId") Long userId,
+            @Param("limit") int limit
+    );
+
+    /** native query 결과를 추천 응답 구성에 필요한 필드로 투영합니다. */
+    interface ProblemSetRecommendationProjection {
+
+        Long getRecommendationId();
+
+        Long getProblemSetId();
+
+        Long getCategoryId();
+
+        Long getCreatorId();
+
+        BigDecimal getSupport();
+
+        BigDecimal getConfidence();
+
+        BigDecimal getLift();
+
+        Integer getRankNo();
+
+        String getAlgorithm();
+
+        LocalDateTime getCreatedAt();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataRecommendationHideRepository.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataRecommendationHideRepository.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** recommendation_hide 저장과 조회를 담당하는 Spring Data JPA repository입니다. */
+public interface SpringDataRecommendationHideRepository
+        extends JpaRepository<RecommendationHideJpaEntity, Long> {
+
+    /** target_id가 NULL인 사용자별 전체 숨김 설정을 조회합니다. */
+    Optional<RecommendationHideJpaEntity> findByUserIdAndHideTypeAndTargetIdIsNull(
+            Long userId,
+            RecommendationHideType hideType
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/presentation/ProblemRecommendationController.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/presentation/ProblemRecommendationController.java
@@ -1,0 +1,84 @@
+package com.wanted.codebombalms.recommendation.presentation;
+
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.recommendation.application.usecase.GetMyProblemSetRecommendationsUseCase;
+import com.wanted.codebombalms.recommendation.application.usecase.HideProblemSetRecommendationsTodayUseCase;
+import com.wanted.codebombalms.recommendation.presentation.response.ProblemSetRecommendationListResponse;
+import com.wanted.codebombalms.recommendation.presentation.response.RecommendationHideTodayResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 문제 세트 추천 목록 조회와 오늘 하루 숨김 API를 제공합니다. */
+@Tag(name = "Recommendation - 문제 세트 추천", description = "로그인 학생의 문제 세트 추천 목록 조회/숨김 API")
+@RestController
+@RequiredArgsConstructor
+public class ProblemRecommendationController {
+
+    private final GetMyProblemSetRecommendationsUseCase getMyProblemSetRecommendationsUseCase;
+    private final HideProblemSetRecommendationsTodayUseCase hideProblemSetRecommendationsTodayUseCase;
+
+    /** 로그인 사용자의 추천 문제 세트 목록을 조회합니다. */
+    @Operation(
+            summary = "내 문제 세트 추천 목록 조회",
+            description = "로그인 학생의 ACTIVE 문제 세트 추천 목록을 rankNo 오름차순으로 조회합니다. "
+                    + "오늘 하루 숨김 상태이면 추천 DB를 조회하지 않고 빈 목록을 반환합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "추천 목록 조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다")
+    @GetMapping("/api/v1/recommendations/problem-sets/me")
+    public ResponseEntity<ApiResponse<ProblemSetRecommendationListResponse>> findMyProblemSetRecommendations(
+            @AuthenticationPrincipal Long userId,
+
+            @Parameter(description = "조회할 추천 개수. 최대 3개로 제한됩니다.", example = "3")
+            @RequestParam(defaultValue = "3") Integer limit
+    ) {
+        validateAuthenticated(userId);
+
+        var result = getMyProblemSetRecommendationsUseCase.getRecommendations(userId, limit);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                RecommendationResponseCode.PROBLEM_SET_RECOMMENDATIONS_RETRIEVED,
+                RecommendationResponseMessage.PROBLEM_SET_RECOMMENDATIONS_RETRIEVED,
+                ProblemSetRecommendationListResponse.from(result)
+        ));
+    }
+
+    /** 로그인 사용자의 추천 문제 세트를 오늘 하루 숨김 처리합니다. */
+    @Operation(
+            summary = "내 문제 세트 추천 오늘 하루 숨김",
+            description = "로그인 학생의 문제 세트 추천 영역을 오늘 23:59:59까지 숨김 처리합니다. 추천 row는 유지합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "추천 숨김 처리 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다")
+    @PostMapping("/api/v1/recommendations/problem-sets/hide-today")
+    public ResponseEntity<ApiResponse<RecommendationHideTodayResponse>> hideMyProblemSetRecommendationsToday(
+            @AuthenticationPrincipal Long userId
+    ) {
+        validateAuthenticated(userId);
+
+        var result = hideProblemSetRecommendationsTodayUseCase.hideToday(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                RecommendationResponseCode.PROBLEM_SET_RECOMMENDATIONS_HIDDEN,
+                RecommendationResponseMessage.PROBLEM_SET_RECOMMENDATIONS_HIDDEN,
+                RecommendationHideTodayResponse.from(result)
+        ));
+    }
+
+    /** 인증 principal이 없으면 공통 인증 예외를 발생시킵니다. */
+    private void validateAuthenticated(Long userId) {
+        if (userId == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/presentation/RecommendationResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/presentation/RecommendationResponseCode.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.recommendation.presentation;
+
+/** recommendation API 성공 응답 코드를 모아둡니다. */
+public class RecommendationResponseCode {
+
+    /** 유틸리티 클래스 인스턴스 생성을 막습니다. */
+    private RecommendationResponseCode() {
+    }
+
+    public static final String PROBLEM_SET_RECOMMENDATIONS_RETRIEVED =
+            "REC-PROBLEM-SET-RETRIEVED";
+    public static final String PROBLEM_SET_RECOMMENDATIONS_HIDDEN =
+            "REC-PROBLEM-SET-HIDDEN";
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/presentation/RecommendationResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/presentation/RecommendationResponseMessage.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.recommendation.presentation;
+
+/** recommendation API 성공 응답 메시지를 모아둡니다. */
+public class RecommendationResponseMessage {
+
+    /** 유틸리티 클래스 인스턴스 생성을 막습니다. */
+    private RecommendationResponseMessage() {
+    }
+
+    public static final String PROBLEM_SET_RECOMMENDATIONS_RETRIEVED =
+            "문제 세트 추천 목록 조회 성공";
+    public static final String PROBLEM_SET_RECOMMENDATIONS_HIDDEN =
+            "문제 세트 추천 오늘 하루 숨김 처리 성공";
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/ProblemSetRecommendationListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/ProblemSetRecommendationListResponse.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.recommendation.presentation.response;
+
+import com.wanted.codebombalms.recommendation.application.query.ProblemSetRecommendationResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** 추천 목록 조회 API 응답을 표현합니다. */
+public record ProblemSetRecommendationListResponse(
+        @Schema(description = "현재 추천 목록 숨김 여부", example = "false")
+        boolean hidden,
+
+        @Schema(description = "숨김 만료 시각", example = "2026-06-14T23:59:59", nullable = true)
+        LocalDateTime hiddenUntil,
+
+        @Schema(description = "추천 문제 세트 목록")
+        List<ProblemSetRecommendationResponse> problemSets
+) {
+
+    /** 추천 목록 조회 결과를 API 응답 DTO로 변환합니다. */
+    public static ProblemSetRecommendationListResponse from(ProblemSetRecommendationResult result) {
+        return new ProblemSetRecommendationListResponse(
+                result.hidden(),
+                result.hiddenUntil(),
+                result.problemSets().stream()
+                        .map(ProblemSetRecommendationResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/ProblemSetRecommendationResponse.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/ProblemSetRecommendationResponse.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.recommendation.presentation.response;
+
+import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/** 추천 문제 세트 한 건의 API 응답을 표현합니다. */
+public record ProblemSetRecommendationResponse(
+        @Schema(description = "추천 ID", example = "101")
+        Long recommendationId,
+
+        @Schema(description = "추천 문제 세트 ID", example = "3001")
+        Long problemSetId,
+
+        @Schema(description = "문제 카테고리 ID", example = "10")
+        Long categoryId,
+
+        @Schema(description = "문제 세트 생성자 ID", example = "7")
+        Long creatorId,
+
+        @Schema(description = "Apriori support", example = "0.034000")
+        BigDecimal support,
+
+        @Schema(description = "Apriori confidence", example = "0.720000")
+        BigDecimal confidence,
+
+        @Schema(description = "Apriori lift", example = "1.850000")
+        BigDecimal lift,
+
+        @Schema(description = "추천 순위", example = "1")
+        Integer rankNo,
+
+        @Schema(description = "추천 알고리즘", example = "APRIORI")
+        String algorithm,
+
+        @Schema(description = "추천 생성일", example = "2026-06-14T02:00:25")
+        LocalDateTime createdAt
+) {
+
+    /** 추천 도메인 모델을 API 응답 DTO로 변환합니다. */
+    public static ProblemSetRecommendationResponse from(ProblemSetRecommendation recommendation) {
+        return new ProblemSetRecommendationResponse(
+                recommendation.recommendationId(),
+                recommendation.problemSetId(),
+                recommendation.categoryId(),
+                recommendation.creatorId(),
+                recommendation.support(),
+                recommendation.confidence(),
+                recommendation.lift(),
+                recommendation.rankNo(),
+                recommendation.algorithm().name(),
+                recommendation.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/RecommendationHideTodayResponse.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/RecommendationHideTodayResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.recommendation.presentation.response;
+
+import com.wanted.codebombalms.recommendation.application.command.RecommendationHideResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+/** 오늘 하루 숨김 처리 API 응답을 표현합니다. */
+public record RecommendationHideTodayResponse(
+        @Schema(description = "숨김 처리 여부", example = "true")
+        boolean hidden,
+
+        @Schema(description = "숨김 만료 시각", example = "2026-06-14T23:59:59")
+        LocalDateTime hiddenUntil
+) {
+
+    /** 숨김 처리 결과를 API 응답 DTO로 변환합니다. */
+    public static RecommendationHideTodayResponse from(RecommendationHideResult result) {
+        return new RecommendationHideTodayResponse(
+                result.hidden(),
+                result.hiddenUntil()
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryServiceTest.java
@@ -1,0 +1,122 @@
+package com.wanted.codebombalms.recommendation.application.service;
+
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationQueryPort;
+import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
+import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/** 문제 세트 추천 조회 서비스의 숨김/limit 정책을 검증합니다. */
+@ExtendWith(MockitoExtension.class)
+class ProblemRecommendationQueryServiceTest {
+
+    @Mock
+    private ProblemRecommendationQueryPort problemRecommendationQueryPort;
+
+    @Mock
+    private RecommendationHidePort recommendationHidePort;
+
+    @InjectMocks
+    private ProblemRecommendationQueryService service;
+
+    /** 숨김이 없으면 limit을 최대 3으로 보정해 활성 추천 목록을 조회합니다. */
+    @Test
+    void getRecommendations_whenNotHidden_returnsActiveRecommendationsWithMaxLimitThree() {
+        Long userId = 1L;
+        var recommendations = List.of(recommendation(101L, 3001L, 1));
+
+        given(recommendationHidePort.findHide(userId, RecommendationHideType.PROBLEM_SET_RECOMMENDATION))
+                .willReturn(Optional.empty());
+        given(problemRecommendationQueryPort.findActiveProblemSetRecommendations(userId, 3))
+                .willReturn(recommendations);
+
+        var result = service.getRecommendations(userId, 10);
+
+        assertFalse(result.hidden());
+        assertEquals(null, result.hiddenUntil());
+        assertEquals(recommendations, result.problemSets());
+        verify(problemRecommendationQueryPort).findActiveProblemSetRecommendations(userId, 3);
+    }
+
+    /** 숨김이 유효하면 추천 목록 저장소를 조회하지 않고 빈 목록을 반환합니다. */
+    @Test
+    void getRecommendations_whenHiddenUntilFuture_returnsEmptyListWithoutRecommendationQuery() {
+        Long userId = 1L;
+        var hiddenUntil = LocalDateTime.now().plusDays(1);
+
+        given(recommendationHidePort.findHide(userId, RecommendationHideType.PROBLEM_SET_RECOMMENDATION))
+                .willReturn(Optional.of(hide(userId, hiddenUntil)));
+
+        var result = service.getRecommendations(userId, 3);
+
+        assertTrue(result.hidden());
+        assertEquals(hiddenUntil, result.hiddenUntil());
+        assertTrue(result.problemSets().isEmpty());
+        verify(problemRecommendationQueryPort, never()).findActiveProblemSetRecommendations(userId, 3);
+    }
+
+    /** 숨김이 만료되었으면 일반 추천 목록 조회 흐름을 수행합니다. */
+    @Test
+    void getRecommendations_whenHideExpired_queriesRecommendations() {
+        Long userId = 1L;
+        var hiddenUntil = LocalDateTime.now().minusDays(1);
+
+        given(recommendationHidePort.findHide(userId, RecommendationHideType.PROBLEM_SET_RECOMMENDATION))
+                .willReturn(Optional.of(hide(userId, hiddenUntil)));
+        given(problemRecommendationQueryPort.findActiveProblemSetRecommendations(userId, 2))
+                .willReturn(List.of());
+
+        var result = service.getRecommendations(userId, 2);
+
+        assertFalse(result.hidden());
+        assertEquals(null, result.hiddenUntil());
+        assertTrue(result.problemSets().isEmpty());
+        verify(problemRecommendationQueryPort).findActiveProblemSetRecommendations(userId, 2);
+    }
+
+    /** 테스트용 추천 숨김 도메인 모델을 생성합니다. */
+    private RecommendationHide hide(Long userId, LocalDateTime hiddenUntil) {
+        return new RecommendationHide(
+                1L,
+                userId,
+                RecommendationHideType.PROBLEM_SET_RECOMMENDATION,
+                null,
+                hiddenUntil,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+
+    /** 테스트용 문제 세트 추천 도메인 모델을 생성합니다. */
+    private ProblemSetRecommendation recommendation(Long recommendationId, Long problemSetId, int rankNo) {
+        return new ProblemSetRecommendation(
+                recommendationId,
+                problemSetId,
+                10L,
+                7L,
+                BigDecimal.valueOf(0.034),
+                BigDecimal.valueOf(0.72),
+                BigDecimal.valueOf(1.85),
+                rankNo,
+                RecommendationAlgorithm.APRIORI,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideServiceTest.java
@@ -1,0 +1,61 @@
+package com.wanted.codebombalms.recommendation.application.service;
+
+import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+/** 추천 오늘 하루 숨김 서비스의 만료 시각 계산을 검증합니다. */
+@ExtendWith(MockitoExtension.class)
+class RecommendationHideServiceTest {
+
+    @Mock
+    private RecommendationHidePort recommendationHidePort;
+
+    @InjectMocks
+    private RecommendationHideService service;
+
+    /** Asia/Seoul 기준 오늘 23:59:59를 숨김 만료 시각으로 저장합니다. */
+    @Test
+    void hideToday_savesUntilTodayEndInSeoul() {
+        Long userId = 1L;
+        LocalDateTime expectedHiddenUntil = LocalDate.now(java.time.ZoneId.of("Asia/Seoul"))
+                .atTime(LocalTime.of(23, 59, 59));
+
+        given(recommendationHidePort.saveOrUpdate(
+                eq(userId),
+                eq(RecommendationHideType.PROBLEM_SET_RECOMMENDATION),
+                eq(expectedHiddenUntil)
+        )).willReturn(hide(userId, expectedHiddenUntil));
+
+        var result = service.hideToday(userId);
+
+        assertTrue(result.hidden());
+        assertEquals(expectedHiddenUntil, result.hiddenUntil());
+    }
+
+    /** 테스트용 추천 숨김 도메인 모델을 생성합니다. */
+    private RecommendationHide hide(Long userId, LocalDateTime hiddenUntil) {
+        return new RecommendationHide(
+                1L,
+                userId,
+                RecommendationHideType.PROBLEM_SET_RECOMMENDATION,
+                null,
+                hiddenUntil,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #344 
- Closes #343 

---

## 🛠️ 기능 관련 작업 내용
- 로그인 사용자 기준 문제 세트 추천 목록 조회 API 구현
- 추천 영역 오늘 하루 숨김 처리 API 구현
- `problem_recommendation`, `recommendation_hide` 테이블 매핑 엔티티 및 persistence adapter 추가
- 추천 조회/숨김 서비스 단위 테스트 및 HTTP 테스트 요청 파일 추가

---

## ♻️ 패키지 변경 사항
- `project/recommendation`: 추천 도메인, 유스케이스, 서비스, port, persistence adapter, controller, response DTO 추가
- `project/http`: 추천 API 호출 테스트용 `recommendation.http` 추가/수정
- `project/.ai`: Recommendation API 명세 및 작업 로그 반영
- `project/test`: 추천 조회/숨김 서비스 단위 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

## 새로운 기능
- **문제 세트 추천 조회**: 사용자가 맞춤형 문제 세트 추천 목록을 조회할 수 있습니다.
- **추천 숨김**: 사용자가 하루 동안 추천을 숨길 수 있으며, 자정에 자동으로 해제됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->