### PR TITLE
[Fix] 비밀번호 재설정 코드 원자적 처리 및 보안 보강

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -106,3 +106,116 @@ GET http://localhost:8080/api/v1/users/me
         client.assert(response.status === 401, "기대 401, 실제 " + response.status);
     });
 %}
+
+
+### ===== 개인정보 수정 비밀번호 인증 (#113) =====
+### D0 → D1 → D2 순서대로 실행
+
+### D0. (사전) 로그인 — 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
+### D1. 비밀번호 인증 — 비번 틀림 (400 기대)
+POST http://localhost:8080/api/v1/users/me/verify-password
+Content-Type: application/json
+
+{
+  "password": "wrongpassword!"
+}
+
+> {%
+    client.test("비번 불일치 400", function () {
+        client.assert(response.status === 400, "기대 400, 실제 " + response.status);
+    });
+%}
+
+### D2. 비밀번호 인증 — 정상 (비번 일치, 200 기대)
+POST http://localhost:8080/api/v1/users/me/verify-password
+Content-Type: application/json
+
+{
+  "password": "Test1234!"
+}
+
+### ===== 개인정보 수정 (#114) =====
+### E0 → E1 → E2 → E3 → E4 순서대로 실행
+
+### E0. (사전) 로그인 — 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
+### E1. 전화번호만 수정 — 200 (토큰 재발급 X)
+PUT http://localhost:8080/api/v1/users/me
+Content-Type: application/json
+
+{
+  "phone": "010-9999-8888"
+}
+
+> {%
+    client.test("전화 수정 성공 200", function () {
+        client.assert(response.status === 200, "기대 200, 실제 " + response.status);
+    });
+    const setCookies = response.headers.valuesOf("Set-Cookie");
+    client.test("토큰 재발급 안 됨(accessToken Set-Cookie 없음)", function () {
+        const reissued = setCookies.some(c => c.startsWith("accessToken="));
+        client.assert(!reissued, "전화만 바꿨는데 토큰 재발급됨");
+    });
+%}
+
+### E2. 닉네임 수정 — 200 + accessToken 재발급
+PUT http://localhost:8080/api/v1/users/me
+Content-Type: application/json
+
+{
+  "nickname": "유저01변경"
+}
+
+> {%
+    client.test("닉네임 수정 성공 200", function () {
+        client.assert(response.status === 200, "기대 200, 실제 " + response.status);
+    });
+    const setCookies = response.headers.valuesOf("Set-Cookie");
+    client.test("accessToken 재발급됨", function () {
+        const reissued = setCookies.some(c => c.startsWith("accessToken="));
+        client.assert(reissued, "닉네임 바꿨는데 토큰 재발급 안 됨");
+    });
+%}
+
+### E3. 닉네임 중복 — 400 (다른 유저가 쓰는 닉네임)
+PUT http://localhost:8080/api/v1/users/me
+Content-Type: application/json
+
+{
+  "nickname": "김관리"
+}
+
+> {%
+    client.test("닉네임 중복 400", function () {
+        client.assert(response.status === 400, "기대 400, 실제 " + response.status);
+    });
+%}
+
+### E4. 전화번호 형식 오류 — 400
+PUT http://localhost:8080/api/v1/users/me
+Content-Type: application/json
+
+{
+  "phone": "01099998888"
+}
+
+> {%
+    client.test("전화 형식 오류 400", function () {
+        client.assert(response.status === 400, "기대 400, 실제 " + response.status);
+    });
+%}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/ResetPasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/ResetPasswordService.java
@@ -29,8 +29,8 @@ public class ResetPasswordService implements ResetPasswordUseCase {
     @Override
     public void resetPassword(String code, String newPassword) {
 
-        // 1. 코드로 저장된 이메일 역조회 (없으면 만료)
-        String email = passwordResetRepository.findEmailByCode(code)
+        // 1. 코드로 이메일 역조회 + 즉시 삭제 (원자적 소비 — 동시 요청 중복 사용 차단)
+        String email = passwordResetRepository.findAndDeleteByCode(code)
                 .orElseThrow(() -> new ValidationException(AuthErrorCode.AUTH_PASSWORD_RESET_CODE_EXPIRED));
 
         // 2. 이메일로 사용자 조회 (없으면 404 — 코드 발급 후 탈퇴 등 엣지 케이스)
@@ -41,10 +41,7 @@ public class ResetPasswordService implements ResetPasswordUseCase {
         user.changePassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);
 
-        // 4. 재설정 코드 삭제 (단일 사용 보장)
-        passwordResetRepository.deleteByCode(code);
-
-        // 5. Refresh Token 전체 삭제 (강제 재로그인)
+        // 4. Refresh Token 전체 삭제 (강제 재로그인)
         refreshTokenRepository.deleteByUserId(user.getUserId());
 
         log.info("비밀번호 재설정 완료 - userId={}", user.getUserId());

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/ResetPasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/ResetPasswordService.java
@@ -1,0 +1,52 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.usecase.ResetPasswordUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.repository.PasswordResetRepository;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ResetPasswordService implements ResetPasswordUseCase {
+
+    private final UserRepository userRepository;
+    private final PasswordResetRepository passwordResetRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void resetPassword(String code, String newPassword) {
+
+        // 1. 코드로 저장된 이메일 역조회 (없으면 만료)
+        String email = passwordResetRepository.findEmailByCode(code)
+                .orElseThrow(() -> new ValidationException(AuthErrorCode.AUTH_PASSWORD_RESET_CODE_EXPIRED));
+
+        // 2. 이메일로 사용자 조회 (없으면 404 — 코드 발급 후 탈퇴 등 엣지 케이스)
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        // 3. 새 비밀번호 인코딩 후 교체
+        user.changePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        // 4. 재설정 코드 삭제 (단일 사용 보장)
+        passwordResetRepository.deleteByCode(code);
+
+        // 5. Refresh Token 전체 삭제 (강제 재로그인)
+        refreshTokenRepository.deleteByUserId(user.getUserId());
+
+        log.info("비밀번호 재설정 완료 - userId={}", user.getUserId());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SendPasswordResetCodeService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SendPasswordResetCodeService.java
@@ -1,0 +1,71 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.usecase.SendPasswordResetCodeUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.repository.PasswordResetRepository;
+import com.wanted.codebombalms.auth.domain.service.EmailSender;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.TooManyRequestsException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+
+@Service
+@RequiredArgsConstructor
+public class SendPasswordResetCodeService implements SendPasswordResetCodeUseCase {
+
+    private final UserRepository userRepository;
+    private final PasswordResetRepository passwordResetRepository;
+    private final EmailSender emailSender;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int MAX_SEND_COUNT_PER_10MIN = 5;
+
+    @Override
+    public void sendResetCode(String email) {
+
+        // 1. 가입된 회원인지 확인 (없으면 404)
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 소셜 가입 계정은 비밀번호 재설정 불가 (400)
+        if (user.getProvider() != AuthProvider.LOCAL) {
+            throw new ValidationException(UserErrorCode.USER_SOCIAL_ACCOUNT_NO_PASSWORD);
+        }
+
+        // 3. 재발송 쿨다운 (1분 이내 재요청 차단)
+        if (passwordResetRepository.isRecentlySent(email)) {
+            throw new TooManyRequestsException(AuthErrorCode.AUTH_EMAIL_SEND_TOO_MANY);
+        }
+
+        // 4. 발송 횟수 제한 (10분 내 최대 5회)
+        long count = passwordResetRepository.incrementSendCount(email);
+        if (count > MAX_SEND_COUNT_PER_10MIN) {
+            throw new TooManyRequestsException(AuthErrorCode.AUTH_EMAIL_SEND_TOO_MANY);
+        }
+
+        // 5. 6자리 재설정 코드 생성
+        String code = generateSixDigitCode();
+
+        // 6. Redis 저장 (code → email, TTL 10분)
+        passwordResetRepository.saveCode(email, code);
+
+        // 7. 재발송 쿨다운 마킹 (TTL 1분)
+        passwordResetRepository.markRecentlySent(email);
+
+        // 8. 재설정 코드 이메일 발송
+        emailSender.sendPasswordResetCode(email, code);
+    }
+
+    /** 000000 ~ 999999 (6자리, 0 패딩 포함) */
+    private String generateSixDigitCode() {
+        int number = RANDOM.nextInt(1_000_000);
+        return String.format("%06d", number);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SendPasswordResetCodeService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SendPasswordResetCodeService.java
@@ -26,6 +26,7 @@ public class SendPasswordResetCodeService implements SendPasswordResetCodeUseCas
 
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final int MAX_SEND_COUNT_PER_10MIN = 5;
+    private static final int MAX_CODE_GEN_ATTEMPTS = 5;
 
     @Override
     public void sendResetCode(String email) {
@@ -50,17 +51,26 @@ public class SendPasswordResetCodeService implements SendPasswordResetCodeUseCas
             throw new TooManyRequestsException(AuthErrorCode.AUTH_EMAIL_SEND_TOO_MANY);
         }
 
-        // 5. 6자리 재설정 코드 생성
-        String code = generateSixDigitCode();
+        // 5. 충돌 없는 6자리 재설정 코드 생성 + Redis 저장 (SET NX, TTL 10분)
+        String code = generateAndSaveUniqueCode(email);
 
-        // 6. Redis 저장 (code → email, TTL 10분)
-        passwordResetRepository.saveCode(email, code);
-
-        // 7. 재발송 쿨다운 마킹 (TTL 1분)
-        passwordResetRepository.markRecentlySent(email);
-
-        // 8. 재설정 코드 이메일 발송
+        // 6. 재설정 코드 이메일 발송
         emailSender.sendPasswordResetCode(email, code);
+
+        // 7. 발송 성공 후 재발송 쿨다운 마킹 (TTL 1분)
+        passwordResetRepository.markRecentlySent(email);
+    }
+
+    /** 충돌 없는 코드를 생성해 Redis 에 저장 후 반환. 충돌 시 최대 N회 재생성. */
+    private String generateAndSaveUniqueCode(String email) {
+        for (int attempt = 0; attempt < MAX_CODE_GEN_ATTEMPTS; attempt++) {
+            String code = generateSixDigitCode();
+            if (passwordResetRepository.saveCodeIfAbsent(email, code)) {
+                return code;
+            }
+        }
+        // 극히 드문 연속 충돌 — 잠시 후 재시도하도록 안내
+        throw new TooManyRequestsException(AuthErrorCode.AUTH_EMAIL_SEND_TOO_MANY);
     }
 
     /** 000000 ~ 999999 (6자리, 0 패딩 포함) */

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/VerifyPasswordResetCodeService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/VerifyPasswordResetCodeService.java
@@ -1,0 +1,36 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.usecase.VerifyPasswordResetCodeUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.repository.PasswordResetRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class VerifyPasswordResetCodeService implements VerifyPasswordResetCodeUseCase {
+
+    private final PasswordResetRepository passwordResetRepository;
+
+    @Override
+    public void verifyResetCode(String email, String code) {
+
+        // 1. 코드로 저장된 이메일 역조회
+        Optional<String> storedEmail = passwordResetRepository.findEmailByCode(code);
+
+        // 2. 코드가 없으면 만료된 것 (Redis TTL 경과로 자동 삭제됨)
+        if (storedEmail.isEmpty()) {
+            throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_RESET_CODE_EXPIRED);
+        }
+
+        // 3. 코드는 살아있지만 요청 이메일과 불일치 → 유효하지 않은 코드
+        if (!storedEmail.get().equals(email)) {
+            throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_RESET_CODE_INVALID);
+        }
+
+        // 4. 검증 성공 — 코드는 삭제하지 않음 (reset 단계에서 재사용)
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/ResetPasswordUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/ResetPasswordUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+public interface ResetPasswordUseCase {
+
+    void resetPassword(String code, String newPassword);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/SendPasswordResetCodeUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/SendPasswordResetCodeUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+public interface SendPasswordResetCodeUseCase {
+
+    void sendResetCode(String email);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/VerifyPasswordResetCodeUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/VerifyPasswordResetCodeUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+public interface VerifyPasswordResetCodeUseCase {
+
+    void verifyResetCode(String email, String code);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/PasswordResetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/PasswordResetRepository.java
@@ -9,11 +9,17 @@ import java.util.Optional;
  */
 public interface PasswordResetRepository {
 
-    void saveCode(String email, String code);        // password:reset:{code} = email (TTL 10분)
+    /**
+     * 재설정 코드 저장 (SET NX). 이미 동일 코드가 존재하면 저장하지 않고 false 반환.
+     * 6자리 코드 충돌 시 기존 code → email 매핑 덮어쓰기를 방지한다. (TTL 10분)
+     */
+    boolean saveCodeIfAbsent(String email, String code);
 
-    Optional<String> findEmailByCode(String code);   // 코드로 이메일 역조회
+    /** 코드로 이메일 비파괴 조회 (verify-code 단계 — 코드 유지) */
+    Optional<String> findEmailByCode(String code);
 
-    void deleteByCode(String code);                   // 재설정 완료 후 단일 사용 보장
+    /** 코드로 이메일 조회 + 즉시 삭제 (reset 단계 — 원자적 단일 사용 보장) */
+    Optional<String> findAndDeleteByCode(String code);
 
     void markRecentlySent(String email);              // 재발송 쿨다운 (TTL 1분)
 

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/PasswordResetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/PasswordResetRepository.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.auth.domain.repository;
+
+import java.util.Optional;
+
+/**
+ * 비밀번호 재설정 코드 저장소 (Output Port).
+ * reset 단계에서 email 없이 code 만으로 사용자를 찾기 위해
+ * code 를 키로 email 을 역방향 저장한다. Redis TTL 자동 관리.
+ */
+public interface PasswordResetRepository {
+
+    void saveCode(String email, String code);        // password:reset:{code} = email (TTL 10분)
+
+    Optional<String> findEmailByCode(String code);   // 코드로 이메일 역조회
+
+    void deleteByCode(String code);                   // 재설정 완료 후 단일 사용 보장
+
+    void markRecentlySent(String email);              // 재발송 쿨다운 (TTL 1분)
+
+    boolean isRecentlySent(String email);
+
+    long incrementSendCount(String email);            // 발송 횟수 1 증가 (TTL 10분)
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/service/EmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/service/EmailSender.java
@@ -3,4 +3,6 @@ package com.wanted.codebombalms.auth.domain.service;
 public interface EmailSender {
 
     void sendVerificationCode(String to, String code);
+    
+    void sendPasswordResetCode(String to, String code);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
@@ -30,6 +30,18 @@ public class JavaMailEmailSender implements EmailSender {
         log.info("[EmailSender] 인증 코드 발송 완료 - to: {}", to);
     }
 
+    @Override
+    public void sendPasswordResetCode(String to, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(to);
+        message.setSubject("[Code-Bomba LMS] 비밀번호 재설정 코드");
+        message.setText(buildResetBody(code));
+
+        mailSender.send(message);
+        log.info("[EmailSender] 비밀번호 재설정 코드 발송 완료 - to: {}", to);
+    }
+
     private String buildBody(String code) {
         return """
                 Code-Bomba LMS 이메일 인증 코드입니다.
@@ -38,6 +50,17 @@ public class JavaMailEmailSender implements EmailSender {
 
                 코드 유효 시간: 3분
                 본 메일을 요청하지 않으셨다면 무시해주세요.
+                """.formatted(code);
+    }
+
+    private String buildResetBody(String code) {
+        return """
+                Code-Bomba LMS 비밀번호 재설정 코드입니다.
+
+                재설정 코드: %s
+
+                코드 유효 시간: 10분
+                본인이 요청하지 않으셨다면 즉시 비밀번호를 변경해주세요.
                 """.formatted(code);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
@@ -27,7 +27,7 @@ public class JavaMailEmailSender implements EmailSender {
         message.setText(buildBody(code));
 
         mailSender.send(message);
-        log.info("[EmailSender] 인증 코드 발송 완료 - to: {}", to);
+        log.info("[EmailSender] 인증 코드 발송 완료 - to: {}", maskEmail(to));
     }
 
     @Override
@@ -39,7 +39,19 @@ public class JavaMailEmailSender implements EmailSender {
         message.setText(buildResetBody(code));
 
         mailSender.send(message);
-        log.info("[EmailSender] 비밀번호 재설정 코드 발송 완료 - to: {}", to);
+        log.info("[EmailSender] 비밀번호 재설정 코드 발송 완료 - to: {}", maskEmail(to));
+    }
+
+    /** 로그에 이메일 평문(PII) 노출 방지 — 앞 1글자 + *** + 도메인만 남긴다. (예: j***@gmail.com) */
+    private String maskEmail(String email) {
+        if (email == null) {
+            return "null";
+        }
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return "***";
+        }
+        return email.charAt(0) + "***" + email.substring(at);
     }
 
     private String buildBody(String code) {

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisPasswordResetAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisPasswordResetAdapter.java
@@ -23,8 +23,9 @@ public class RedisPasswordResetAdapter implements PasswordResetRepository {
     private static final Duration TTL_SEND_COUNT  = Duration.ofMinutes(10);
 
     @Override
-    public void saveCode(String email, String code) {
-        redisTemplate.opsForValue().set(KEY_CODE + code, email, TTL_CODE);
+    public boolean saveCodeIfAbsent(String email, String code) {
+        Boolean saved = redisTemplate.opsForValue().setIfAbsent(KEY_CODE + code, email, TTL_CODE);
+        return Boolean.TRUE.equals(saved);
     }
 
     @Override
@@ -33,8 +34,9 @@ public class RedisPasswordResetAdapter implements PasswordResetRepository {
     }
 
     @Override
-    public void deleteByCode(String code) {
-        redisTemplate.delete(KEY_CODE + code);
+    public Optional<String> findAndDeleteByCode(String code) {
+        // GETDEL — 조회와 삭제를 단일 원자 연산으로 수행 (TOCTOU 제거, 단일 사용 보장)
+        return Optional.ofNullable(redisTemplate.opsForValue().getAndDelete(KEY_CODE + code));
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisPasswordResetAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisPasswordResetAdapter.java
@@ -1,0 +1,59 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.repository.PasswordResetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RedisPasswordResetAdapter implements PasswordResetRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_CODE        = "password:reset:";   // + {code} = email
+    private static final String KEY_RECENT_SENT = "password:sent:";    // + {email}
+    private static final String KEY_SEND_COUNT  = "password:count:";   // + {email}
+
+    private static final Duration TTL_CODE        = Duration.ofMinutes(10);
+    private static final Duration TTL_RECENT_SENT = Duration.ofMinutes(1);
+    private static final Duration TTL_SEND_COUNT  = Duration.ofMinutes(10);
+
+    @Override
+    public void saveCode(String email, String code) {
+        redisTemplate.opsForValue().set(KEY_CODE + code, email, TTL_CODE);
+    }
+
+    @Override
+    public Optional<String> findEmailByCode(String code) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(KEY_CODE + code));
+    }
+
+    @Override
+    public void deleteByCode(String code) {
+        redisTemplate.delete(KEY_CODE + code);
+    }
+
+    @Override
+    public void markRecentlySent(String email) {
+        redisTemplate.opsForValue().set(KEY_RECENT_SENT + email, "1", TTL_RECENT_SENT);
+    }
+
+    @Override
+    public boolean isRecentlySent(String email) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_RECENT_SENT + email));
+    }
+
+    @Override
+    public long incrementSendCount(String email) {
+        String key = KEY_SEND_COUNT + email;
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count != null && count == 1L) {
+            redisTemplate.expire(key, TTL_SEND_COUNT);
+        }
+        return count == null ? 0L : count;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
@@ -13,4 +13,7 @@ public class AuthResponseCode {
     public static final String TOKEN_REISSUED = "AUTH-TOKEN-REISSUED";
     public static final String EMAIL_VERIFICATION_SENT = "AUTH-EMAIL-VERIFICATION-SENT";
     public static final String EMAIL_VERIFIED = "AUTH-EMAIL-VERIFIED";
+    public static final String PASSWORD_RESET_CODE_SENT = "AUTH-PASSWORD-RESET-CODE-SENT";
+    public static final String PASSWORD_RESET_CODE_VERIFIED = "AUTH-PASSWORD-RESET-CODE-VERIFIED";
+    public static final String PASSWORD_RESET_COMPLETED = "AUTH-PASSWORD-RESET-COMPLETED";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
@@ -13,4 +13,7 @@ public class AuthResponseMessage {
     public static final String TOKEN_REISSUED = "토큰이 재발급되었습니다.";
     public static final String EMAIL_VERIFICATION_SENT = "인증 이메일이 발송되었습니다.";
     public static final String EMAIL_VERIFIED = "이메일 인증이 완료되었습니다.";
+    public static final String PASSWORD_RESET_CODE_SENT = "비밀번호 재설정 이메일 발송 성공";
+    public static final String PASSWORD_RESET_CODE_VERIFIED = "코드 검증 성공";
+    public static final String PASSWORD_RESET_COMPLETED = "비밀번호 재설정 성공";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/PasswordForgotController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/PasswordForgotController.java
@@ -1,0 +1,42 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.usecase.SendPasswordResetCodeUseCase;
+import com.wanted.codebombalms.auth.presentation.api.dto.request.PasswordForgotRequest;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth - 비밀번호 재설정", description = "비밀번호 재설정 코드 발송/검증/재설정 (Redis OTP) (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth/password")
+@RequiredArgsConstructor
+public class PasswordForgotController {
+
+    private final SendPasswordResetCodeUseCase sendPasswordResetCodeUseCase;
+
+    @Operation(
+            summary = "비밀번호 재설정 코드 요청",
+            description = "가입 이메일로 6자리 재설정 코드 발송. code → email 역방향으로 Redis 10분 TTL 저장."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "발송 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USR-001 존재하지 않는 이메일")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "USR-008 소셜 가입 계정")
+    @PostMapping("/forgot")
+    public ResponseEntity<ApiResponse<Void>> forgot(
+            @Valid @RequestBody PasswordForgotRequest request
+    ) {
+        sendPasswordResetCodeUseCase.sendResetCode(request.email());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.PASSWORD_RESET_CODE_SENT,
+                AuthResponseMessage.PASSWORD_RESET_CODE_SENT
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/PasswordResetController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/PasswordResetController.java
@@ -1,0 +1,41 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.usecase.ResetPasswordUseCase;
+import com.wanted.codebombalms.auth.presentation.api.dto.request.PasswordResetRequest;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth - 비밀번호 재설정", description = "비밀번호 재설정 코드 발송/검증/재설정 (Redis OTP) (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth/password")
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+    private final ResetPasswordUseCase resetPasswordUseCase;
+
+    @Operation(
+            summary = "비밀번호 재설정",
+            description = "6자리 코드로 사용자 식별 후 새 비밀번호로 교체. 처리 후 코드 삭제 + RT 전체 삭제(강제 재로그인)."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재설정 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "AUT-011 유효하지 않은 코드 / AUT-012 만료된 코드 / USR-004 비밀번호 형식 오류")
+    @PutMapping("/reset")
+    public ResponseEntity<ApiResponse<Void>> reset(
+            @Valid @RequestBody PasswordResetRequest request
+    ) {
+        resetPasswordUseCase.resetPassword(request.code(), request.newPassword());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.PASSWORD_RESET_COMPLETED,
+                AuthResponseMessage.PASSWORD_RESET_COMPLETED
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/PasswordVerifyCodeController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/PasswordVerifyCodeController.java
@@ -1,0 +1,41 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.usecase.VerifyPasswordResetCodeUseCase;
+import com.wanted.codebombalms.auth.presentation.api.dto.request.PasswordVerifyCodeRequest;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth - 비밀번호 재설정", description = "비밀번호 재설정 코드 발송/검증/재설정 (Redis OTP) (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth/password")
+@RequiredArgsConstructor
+public class PasswordVerifyCodeController {
+
+    private final VerifyPasswordResetCodeUseCase verifyPasswordResetCodeUseCase;
+
+    @Operation(
+            summary = "비밀번호 재설정 코드 검증",
+            description = "6자리 재설정 코드 + 이메일 쌍의 유효성 검증. 코드는 소비하지 않고 reset 단계로 넘긴다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "검증 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "AUT-011 유효하지 않은 코드 / AUT-012 만료된 코드")
+    @PostMapping("/verify-code")
+    public ResponseEntity<ApiResponse<Void>> verifyCode(
+            @Valid @RequestBody PasswordVerifyCodeRequest request
+    ) {
+        verifyPasswordResetCodeUseCase.verifyResetCode(request.email(), request.code());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.PASSWORD_RESET_CODE_VERIFIED,
+                AuthResponseMessage.PASSWORD_RESET_CODE_VERIFIED
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/PasswordForgotRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/PasswordForgotRequest.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordForgotRequest(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/PasswordResetRequest.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordResetRequest(
+
+        @NotBlank(message = "재설정 코드는 필수입니다.")
+        @Pattern(regexp = "^\\d{6}$", message = "재설정 코드는 6자리 숫자입니다.")
+        String code,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+={}\\[\\]:;\"'<>,.?/~`\\\\|-]).{8,}$",
+                message = "비밀번호는 8자 이상, 영문/숫자/특수문자를 모두 포함해야 합니다."
+        )
+        String newPassword
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/PasswordVerifyCodeRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/PasswordVerifyCodeRequest.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordVerifyCodeRequest(
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "재설정 코드는 필수입니다.")
+        @Pattern(regexp = "^\\d{6}$", message = "재설정 코드는 6자리 숫자입니다.")
+        String code
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/query/UpdateMyInfoResult.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/query/UpdateMyInfoResult.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.application.query;
+
+import com.wanted.codebombalms.user.domain.model.UserRole;
+
+public record UpdateMyInfoResult(
+        boolean nicknameChanged,
+        String nickname,
+        UserRole role
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/ChangePasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/ChangePasswordService.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.user.application.usecase.ChangePasswordUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChangePasswordService implements ChangePasswordUseCase {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void changePassword(Long userId, String newPassword, String confirmPassword) {
+        // 1. 본인 조회 (없으면 USER_NOT_FOUND)
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 새 비밀번호 == 확인값 (불일치 시 400 USR-006)
+        if (!newPassword.equals(confirmPassword)) {
+            throw new ValidationException(UserErrorCode.USER_PASSWORD_CONFIRM_MISMATCH);
+        }
+
+        // 3. 인코딩 후 교체
+        user.changePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        // 4. Refresh Token 전체 삭제 (강제 재로그인)
+        refreshTokenRepository.deleteByUserId(userId);
+
+        log.info("비밀번호 변경 완료 - userId={}", userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
@@ -1,0 +1,44 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.user.application.query.UpdateMyInfoResult;
+import com.wanted.codebombalms.user.application.usecase.UpdateMyInfoUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateMyInfoService implements UpdateMyInfoUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UpdateMyInfoResult update(Long userId, String nickname, String phone) {
+        // 1. 본인 조회 (없으면 USER_NOT_FOUND)
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 닉네임 변경 감지 + 중복 검사 (기존 닉네임과 다를 때만)
+        boolean nicknameChanged = nickname != null && !nickname.equals(user.getNickname());
+        if (nicknameChanged && userRepository.existsByNickname(nickname)) {
+            throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED);
+        }
+
+        // 3. 부분 수정 적용 (전달된 필드만)
+        user.updateProfile(nickname, phone);
+        userRepository.save(user);
+
+        log.info("개인정보 수정 완료 - userId={}, nicknameChanged={}", userId, nicknameChanged);
+
+        // 4. 토큰 재발급 판단용 정보 반환
+        return new UpdateMyInfoResult(nicknameChanged, user.getNickname(), user.getRole());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/VerifyPasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/VerifyPasswordService.java
@@ -1,0 +1,34 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.user.application.usecase.VerifyPasswordUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VerifyPasswordService implements VerifyPasswordUseCase {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void verify(Long userId, String rawPassword) {
+        // 1. 본인 조회 (없으면 USER_NOT_FOUND)
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 비밀번호 재확인 (불일치 시 400 AUT-013)
+        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+            throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_MISMATCH);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/ChangePasswordUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/ChangePasswordUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+public interface ChangePasswordUseCase {
+
+    void changePassword(Long userId, String newPassword, String confirmPassword);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/UpdateMyInfoUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/UpdateMyInfoUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import com.wanted.codebombalms.user.application.query.UpdateMyInfoResult;
+
+public interface UpdateMyInfoUseCase {
+
+    UpdateMyInfoResult update(Long userId, String nickname, String phone);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/VerifyPasswordUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/VerifyPasswordUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+public interface VerifyPasswordUseCase {
+
+    void verify(Long userId, String rawPassword);
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/model/User.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/model/User.java
@@ -91,6 +91,15 @@ public class User {
         return user;
     }
 
+    public void updateProfile(String nickname, String phone) {
+        if (nickname != null) this.nickname = nickname;
+        if (phone != null)    this.phone = phone;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     public void softDelete() { this.deletedAt = LocalDateTime.now(); }
     public void lock()       { this.isLocked = true; }
     public void unlock()     { this.isLocked = false; }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/ChangePasswordController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/ChangePasswordController.java
@@ -1,0 +1,55 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.usecase.ChangePasswordUseCase;
+import com.wanted.codebombalms.user.presentation.api.request.ChangePasswordRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - 마이페이지", description = "로그인 사용자의 프로필 조회/수정 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class ChangePasswordController {
+
+    private final ChangePasswordUseCase changePasswordUseCase;
+    private final AuthCookieFactory authCookieFactory;
+
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "새 비밀번호로 변경 후 Refresh Token 전체 삭제 + accessToken/refreshToken 쿠키 만료(강제 재로그인)."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공 (강제 재로그인)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "USR-004 형식 오류 / USR-006 확인 불일치")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @PutMapping("/me/password")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ChangePasswordRequest request,
+            HttpServletResponse response
+    ) {
+        // 1. 비밀번호 변경 + RT 전체 삭제
+        changePasswordUseCase.changePassword(userId, request.newPassword(), request.confirmPassword());
+
+        // 2. 쿠키 만료 (강제 재로그인)
+        response.addCookie(authCookieFactory.expired("accessToken"));
+        response.addCookie(authCookieFactory.expired("refreshToken"));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.PASSWORD_CHANGED,
+                UserResponseMessage.PASSWORD_CHANGED
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UpdateMyInfoController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UpdateMyInfoController.java
@@ -1,0 +1,66 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.query.UpdateMyInfoResult;
+import com.wanted.codebombalms.user.application.usecase.UpdateMyInfoUseCase;
+import com.wanted.codebombalms.user.presentation.api.request.UpdateMyInfoRequest;
+import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - 마이페이지", description = "로그인 사용자의 프로필 조회/수정 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UpdateMyInfoController {
+
+    private final UpdateMyInfoUseCase updateMyInfoUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthCookieFactory authCookieFactory;
+
+    @Operation(
+            summary = "개인정보 수정",
+            description = "닉네임/전화번호를 수정한다. 닉네임이 변경되면 JWT 일관성을 위해 accessToken 쿠키를 재발급한다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공 (닉네임 변경 시 accessToken 쿠키 재발급)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "USR-003 닉네임 중복 / USR-005 전화번호 형식 오류")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @PutMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Void>> updateMyInfo(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody UpdateMyInfoRequest request,
+            HttpServletResponse response
+    ) {
+        // 1. 개인정보 수정 (닉네임 변경 여부 반환)
+        UpdateMyInfoResult result = updateMyInfoUseCase.update(userId, request.nickname(), request.phone());
+
+        // 2. 닉네임 변경 시에만 accessToken 재발급 (JWT nickname claim 최신화)
+        if (result.nicknameChanged()) {
+            String newAccessToken = jwtTokenProvider.generateAccessToken(
+                    userId, result.nickname(), result.role()
+            );
+            response.addCookie(authCookieFactory.create(
+                    "accessToken",
+                    newAccessToken,
+                    (int) (jwtTokenProvider.getAccessExpiration() / 1000)
+            ));
+        }
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.PROFILE_UPDATED,
+                UserResponseMessage.PROFILE_UPDATED
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
@@ -9,4 +9,7 @@ public class UserResponseCode {
     public static final String STUDENT_DETAIL_RETRIEVED = "USER-STUDENT-DETAIL-RETRIEVED";
     public static final String STUDENT_LOCK_CHANGED = "USER-STUDENT-LOCK-CHANGED";
     public static final String WITHDRAWN = "USER-ME-WITHDRAWN";
+    public static final String PASSWORD_VERIFIED = "USER-ME-PASSWORD-VERIFIED";
+    public static final String PROFILE_UPDATED = "USER-ME-PROFILE-UPDATED";
+    public static final String PASSWORD_CHANGED = "USER-ME-PASSWORD-CHANGED";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
@@ -9,4 +9,7 @@ public class UserResponseMessage {
     public static final String STUDENT_DETAIL_RETRIEVED = "학생 상세 조회 성공";
     public static final String STUDENT_LOCK_CHANGED = "계정 정지/해제 처리 성공";
     public static final String WITHDRAWN = "회원 탈퇴 성공";
+    public static final String PASSWORD_VERIFIED = "비밀번호 인증 성공";
+    public static final String PROFILE_UPDATED = "개인정보 수정 성공";
+    public static final String PASSWORD_CHANGED = "비밀번호 변경 성공";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/VerifyPasswordController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/VerifyPasswordController.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.usecase.VerifyPasswordUseCase;
+import com.wanted.codebombalms.user.presentation.api.request.VerifyPasswordRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - 마이페이지", description = "로그인 사용자의 프로필 조회/수정 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class VerifyPasswordController {
+
+    private final VerifyPasswordUseCase verifyPasswordUseCase;
+
+    @Operation(
+            summary = "개인정보 수정 비밀번호 인증",
+            description = "개인정보 수정 진입 전 현재 비밀번호를 재확인한다. (세션 탈취/자리 비움 중 무단 수정 방지)"
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "AUT-013 비밀번호 불일치")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @PostMapping("/me/verify-password")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Void>> verifyPassword(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody VerifyPasswordRequest request
+    ) {
+        verifyPasswordUseCase.verify(userId, request.password());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.PASSWORD_VERIFIED,
+                UserResponseMessage.PASSWORD_VERIFIED
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/ChangePasswordRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/ChangePasswordRequest.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.user.presentation.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ChangePasswordRequest(
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+={}\\[\\]:;\"'<>,.?/~`\\\\|-]).{8,}$",
+                message = "비밀번호는 8자 이상, 영문/숫자/특수문자를 모두 포함해야 합니다."
+        )
+        String newPassword,
+
+        @NotBlank(message = "비밀번호 확인은 필수입니다.")
+        String confirmPassword
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/UpdateMyInfoRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/UpdateMyInfoRequest.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.user.presentation.api.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateMyInfoRequest(
+
+        String nickname,
+
+        @Pattern(
+                regexp = "^01[0-9]-\\d{3,4}-\\d{4}$",
+                message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
+        )
+        String phone
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/VerifyPasswordRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/VerifyPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.presentation.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record VerifyPasswordRequest(
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #106

---

## 🛠️ 기능 관련 작업 내용
- 비밀번호 재설정 코드 소비를 Redis `GETDEL` 원자 연산(`findAndDeleteByCode`)으로 변경 — 동시 reset 요청 시 코드 중복 사용(TOCTOU) 차단
- 코드 저장을 `SET NX`(`saveCodeIfAbsent`)로 변경하고 충돌 시 재생성 — 6자리 코드 충돌 시 기존 `code → email` 매핑 덮어쓰기(타 계정 재설정) 방지
- 재발송 쿨다운 마킹을 메일 발송 성공 이후로 이동 — 발송 실패 시 사용자만 재시도 차단되던 문제 해소
- 이메일 발송 로그의 이메일 주소(PII)를 마스킹 처리 (`j***@gmail.com`)

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/domain/repository`: `PasswordResetRepository` 포트 변경 (`saveCodeIfAbsent`, `findAndDeleteByCode`)
- `codebombalms/auth/infrastructure/persistence`: `RedisPasswordResetAdapter` — `setIfAbsent`/`getAndDelete` 구현
- `codebombalms/auth/application/service`: `SendPasswordResetCodeService`(쿨다운 순서·충돌 재생성), `ResetPasswordService`(원자적 소비)
- `codebombalms/auth/infrastructure/mail`: `JavaMailEmailSender` — 로그 PII 마스킹
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새 기능

* **비밀번호 재설정**: 비밀번호 찾기(코드 요청) → 코드 검증 → 새 비밀번호 설정까지 지원합니다.  
* **비밀번호 검증**: 인증된 사용자가 현재 비밀번호를 확인할 수 있습니다.  
* **개인정보 관리**: 로그인 사용자가 닉네임과 전화번호를 수정할 수 있습니다.  
* **비밀번호 변경**: 비밀번호를 변경하면 토큰이 만료되어 재로그인이 필요합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->