### PR TITLE
[Update] 추천 문제셋 모달 표시용 응답 정보 확장

### DIFF
--- a/http/recommendation.http
+++ b/http/recommendation.http
@@ -1,11 +1,20 @@
+### 11. 로그인 성공 — 쿠키 2개 발급 + body.data.nickname 응답
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
 ### 내 문제 세트 추천 목록 조회
 GET http://localhost:8080/api/v1/recommendations/problem-sets/me?limit=3
-Authorization: Bearer {{accessToken}}
+
 
 ### 내 문제 세트 추천 목록 조회 - limit은 최대 3개로 제한
 GET http://localhost:8080/api/v1/recommendations/problem-sets/me?limit=10
-Authorization: Bearer {{accessToken}}
+
 
 ### 내 문제 세트 추천 오늘 하루 숨김
 POST http://localhost:8080/api/v1/recommendations/problem-sets/hide-today
-Authorization: Bearer {{accessToken}}
+

--- a/src/main/java/com/wanted/codebombalms/recommendation/domain/model/ProblemSetRecommendation.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/domain/model/ProblemSetRecommendation.java
@@ -1,19 +1,15 @@
 package com.wanted.codebombalms.recommendation.domain.model;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
 /** 학생에게 노출할 문제 세트 추천 한 건을 표현합니다. */
 public record ProblemSetRecommendation(
         Long recommendationId,
         Long problemSetId,
-        Long categoryId,
-        Long creatorId,
-        BigDecimal support,
-        BigDecimal confidence,
-        BigDecimal lift,
         Integer rankNo,
-        RecommendationAlgorithm algorithm,
-        LocalDateTime createdAt
+        String title,
+        String description,
+        String difficulty,
+        Double accuracyRate,
+        Long categoryId,
+        String categoryName
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationQueryAdapter.java
@@ -2,7 +2,6 @@ package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationQueryPort;
 import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
-import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -22,14 +21,13 @@ public class ProblemRecommendationQueryAdapter implements ProblemRecommendationQ
                 .map(row -> new ProblemSetRecommendation(
                         row.getRecommendationId(),
                         row.getProblemSetId(),
-                        row.getCategoryId(),
-                        row.getCreatorId(),
-                        row.getSupport(),
-                        row.getConfidence(),
-                        row.getLift(),
                         row.getRankNo(),
-                        RecommendationAlgorithm.valueOf(row.getAlgorithm()),
-                        row.getCreatedAt()
+                        row.getTitle(),
+                        row.getDescription(),
+                        row.getDifficulty(),
+                        row.getAccuracyRate(),
+                        row.getCategoryId(),
+                        row.getCategoryName()
                 ))
                 .toList();
     }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
@@ -1,7 +1,5 @@
 package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,16 +15,19 @@ public interface SpringDataProblemRecommendationRepository
                     SELECT
                         pr.recommendation_id AS recommendationId,
                         pr.problem_set_id AS problemSetId,
-                        ps.category_id AS categoryId,
-                        ps.created_by AS creatorId,
-                        pr.support AS support,
-                        pr.confidence AS confidence,
-                        pr.lift AS lift,
-                        pr.rank_no AS rankNo,
-                        pr.algorithm AS algorithm,
-                        pr.created_at AS createdAt
+                        ps.title AS title,
+                        ps.description AS description,
+                        ps.difficulty AS difficulty,
+                        CASE
+                            WHEN ps.started_user_count = 0 THEN 0.0
+                            ELSE ROUND(ps.completed_user_count * 100.0 / ps.started_user_count, 1)
+                        END AS accuracyRate,
+                        pc.category_id AS categoryId,
+                        pc.category_name AS categoryName,
+                        pr.rank_no AS rankNo
                     FROM problem_recommendation pr
                     JOIN problem_set ps ON ps.problem_set_id = pr.problem_set_id
+                    JOIN problem_category pc ON pc.category_id = ps.category_id
                     LEFT JOIN problem_progress pp
                         ON pp.user_id = pr.user_id
                         AND pp.problem_set_id = pr.problem_set_id
@@ -34,8 +35,9 @@ public interface SpringDataProblemRecommendationRepository
                     WHERE pr.user_id = :userId
                         AND pr.status = 'ACTIVE'
                         AND ps.status = 'ACTIVE'
+                        AND pc.status = 'ACTIVE'
                         AND pp.progress_id IS NULL
-                    ORDER BY pr.rank_no ASC
+                    ORDER BY pr.rank_no ASC, pr.recommendation_id ASC
                     LIMIT :limit
                     """,
             nativeQuery = true
@@ -52,20 +54,18 @@ public interface SpringDataProblemRecommendationRepository
 
         Long getProblemSetId();
 
+        String getTitle();
+
+        String getDescription();
+
+        String getDifficulty();
+
+        Double getAccuracyRate();
+
         Long getCategoryId();
 
-        Long getCreatorId();
-
-        BigDecimal getSupport();
-
-        BigDecimal getConfidence();
-
-        BigDecimal getLift();
+        String getCategoryName();
 
         Integer getRankNo();
-
-        String getAlgorithm();
-
-        LocalDateTime getCreatedAt();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/ProblemSetRecommendationResponse.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/presentation/response/ProblemSetRecommendationResponse.java
@@ -2,9 +2,6 @@ package com.wanted.codebombalms.recommendation.presentation.response;
 
 import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
 /** 추천 문제 세트 한 건의 API 응답을 표현합니다. */
 public record ProblemSetRecommendationResponse(
         @Schema(description = "추천 ID", example = "101")
@@ -13,29 +10,26 @@ public record ProblemSetRecommendationResponse(
         @Schema(description = "추천 문제 세트 ID", example = "3001")
         Long problemSetId,
 
-        @Schema(description = "문제 카테고리 ID", example = "10")
-        Long categoryId,
-
-        @Schema(description = "문제 세트 생성자 ID", example = "7")
-        Long creatorId,
-
-        @Schema(description = "Apriori support", example = "0.034000")
-        BigDecimal support,
-
-        @Schema(description = "Apriori confidence", example = "0.720000")
-        BigDecimal confidence,
-
-        @Schema(description = "Apriori lift", example = "1.850000")
-        BigDecimal lift,
-
         @Schema(description = "추천 순위", example = "1")
         Integer rankNo,
 
-        @Schema(description = "추천 알고리즘", example = "APRIORI")
-        String algorithm,
+        @Schema(description = "문제 세트 제목", example = "pandas 기초 분석 문제 세트")
+        String title,
 
-        @Schema(description = "추천 생성일", example = "2026-06-14T02:00:25")
-        LocalDateTime createdAt
+        @Schema(description = "문제 세트 설명", example = "CSV 데이터를 불러와 기본 정보를 확인하는 문제 세트입니다.")
+        String description,
+
+        @Schema(description = "문제 세트 난이도", example = "EASY")
+        String difficulty,
+
+        @Schema(description = "문제 세트 정답률", example = "75.5")
+        Double accuracyRate,
+
+        @Schema(description = "문제 카테고리 ID", example = "10")
+        Long categoryId,
+
+        @Schema(description = "문제 카테고리명", example = "데이터 분석")
+        String categoryName
 ) {
 
     /** 추천 도메인 모델을 API 응답 DTO로 변환합니다. */
@@ -43,14 +37,13 @@ public record ProblemSetRecommendationResponse(
         return new ProblemSetRecommendationResponse(
                 recommendation.recommendationId(),
                 recommendation.problemSetId(),
-                recommendation.categoryId(),
-                recommendation.creatorId(),
-                recommendation.support(),
-                recommendation.confidence(),
-                recommendation.lift(),
                 recommendation.rankNo(),
-                recommendation.algorithm().name(),
-                recommendation.createdAt()
+                recommendation.title(),
+                recommendation.description(),
+                recommendation.difficulty(),
+                recommendation.accuracyRate(),
+                recommendation.categoryId(),
+                recommendation.categoryName()
         );
     }
 }

--- a/src/test/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryServiceTest.java
@@ -3,10 +3,8 @@ package com.wanted.codebombalms.recommendation.application.service;
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationQueryPort;
 import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
 import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
-import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -109,14 +107,13 @@ class ProblemRecommendationQueryServiceTest {
         return new ProblemSetRecommendation(
                 recommendationId,
                 problemSetId,
-                10L,
-                7L,
-                BigDecimal.valueOf(0.034),
-                BigDecimal.valueOf(0.72),
-                BigDecimal.valueOf(1.85),
                 rankNo,
-                RecommendationAlgorithm.APRIORI,
-                LocalDateTime.now()
+                "pandas 기초 분석 문제 세트",
+                "CSV 데이터를 불러와 기본 정보를 확인하는 문제 세트입니다.",
+                "EASY",
+                75.5,
+                10L,
+                "데이터 분석"
         );
     }
 }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #404 

---

## 🛠️ 기능 관련 작업 내용
- 추천 문제셋 응답에서 알고리즘 내부값 대신 모달 표시용 문제셋 정보를 반환하도록 변경
- 추천 조회 쿼리에 문제셋/카테고리 조인을 추가해 제목, 설명, 난이도, 정답률, 카테고리명을 조회
- 추천 정렬 기준에 `recommendation_id ASC`를 추가해 동일 순위 결과의 정렬 안정성 보강
- 추천 조회 서비스 테스트의 추천 모델 생성 값을 변경된 응답 구조에 맞게 수정

---

## ♻️ 패키지 변경 사항
- `project/recommendation/domain/model`: 추천 문제셋 조회 모델을 모달 표시용 필드 중심으로 변경
- `project/recommendation/infrastructure/persistence`: 추천 조회 native query와 projection 매핑 수정
- `project/recommendation/presentation/response`: 추천 문제셋 API 응답 DTO 필드 확장
- `project/recommendation/application/service`: 변경된 추천 모델 구조에 맞춰 서비스 테스트 보정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 문제 추천 시스템의 데이터 구조를 재구성했습니다. 기존의 알고리즘 지표 및 생성자 정보 대신 문제 집합의 제목, 설명, 난이도, 정답률, 카테고리명이 우선적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->