### PR TITLE
[Feat] 문제 세트 추천 생성 스케줄러 구현

### DIFF
--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -1,12 +1,27 @@
 package com.wanted.codebombalms.global.infrastructure.config;
 
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
 @EnableScheduling
 // 애플리케이션 전역 스케줄링과 비동기 실행 기능을 활성화한다.
 public class SchedulingConfig {
+
+    /** 추천 생성 배치가 같은 애플리케이션 인스턴스 안에서 동시에 여러 개 실행되지 않도록 단일 스레드로 제한한다. */
+    @Bean(name = "recommendationTaskExecutor")
+    public Executor recommendationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(1);
+        executor.setThreadNamePrefix("recommendation-batch-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -1,10 +1,12 @@
 package com.wanted.codebombalms.global.infrastructure.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
+@EnableAsync
 @EnableScheduling
-// 애플리케이션 전역 스케줄링 기능을 활성화한다.
+// 애플리케이션 전역 스케줄링과 비동기 실행 기능을 활성화한다.
 public class SchedulingConfig {
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/command/GeneratedProblemSetRecommendation.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/command/GeneratedProblemSetRecommendation.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.recommendation.application.command;
+
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import java.math.BigDecimal;
+
+/** Python 추천 서버가 계산한 사용자별 문제 세트 추천 한 건을 표현합니다. */
+public record GeneratedProblemSetRecommendation(
+        Long problemSetId,
+        BigDecimal support,
+        BigDecimal confidence,
+        BigDecimal lift,
+        Integer rankNo,
+        RecommendationAlgorithm algorithm
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/command/GeneratedUserProblemSetRecommendations.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/command/GeneratedUserProblemSetRecommendations.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.recommendation.application.command;
+
+import java.util.List;
+
+/** Python 추천 서버가 반환한 한 사용자 기준의 문제 세트 추천 묶음입니다. */
+public record GeneratedUserProblemSetRecommendations(
+        Long userId,
+        List<GeneratedProblemSetRecommendation> problemSets
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/port/ProblemRecommendationCommandPort.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/port/ProblemRecommendationCommandPort.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.recommendation.application.port;
+
+import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
+
+/** 추천 생성 결과 저장에 필요한 쓰기 저장소 접근을 추상화합니다. */
+public interface ProblemRecommendationCommandPort {
+
+    /** 사용자의 기존 활성 추천을 비활성화하고 새 추천 결과를 활성 상태로 저장합니다. */
+    void replaceActiveRecommendations(GeneratedUserProblemSetRecommendations recommendations);
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/port/ProblemRecommendationGenerationClient.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/port/ProblemRecommendationGenerationClient.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.recommendation.application.port;
+
+import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
+import java.util.List;
+
+/** 외부 추천 생성 서버 호출을 추상화합니다. */
+public interface ProblemRecommendationGenerationClient {
+
+    /** Python 추천 서버에서 사용자별 문제 세트 추천 결과를 생성해 가져옵니다. */
+    List<GeneratedUserProblemSetRecommendations> generateProblemSetRecommendations();
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.recommendation.application.service;
+
+import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationCommandPort;
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationGenerationClient;
+import com.wanted.codebombalms.recommendation.application.usecase.GenerateProblemSetRecommendationsUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Python 추천 서버 호출 결과를 검증하고 problem_recommendation에 반영합니다. */
+@Service
+@RequiredArgsConstructor
+public class ProblemRecommendationGenerationService implements GenerateProblemSetRecommendationsUseCase {
+
+    private static final int EXPECTED_RECOMMENDATION_COUNT = 3;
+
+    private final ProblemRecommendationGenerationClient generationClient;
+    private final ProblemRecommendationCommandPort commandPort;
+
+    /** 사용자별 추천 3개 반환을 전제로 기존 추천 교체 저장을 수행합니다. */
+    @Override
+    @Transactional
+    public int generate() {
+        var generatedRecommendations = generationClient.generateProblemSetRecommendations();
+
+        generatedRecommendations.forEach(this::validateRecommendationCount);
+        generatedRecommendations.forEach(commandPort::replaceActiveRecommendations);
+
+        return generatedRecommendations.size();
+    }
+
+    /** 추천 대상 사용자는 Python 서버에서 항상 3개의 문제 세트를 반환해야 합니다. */
+    private void validateRecommendationCount(GeneratedUserProblemSetRecommendations recommendations) {
+        int actualCount = recommendations.problemSets() == null ? 0 : recommendations.problemSets().size();
+
+        if (actualCount != EXPECTED_RECOMMENDATION_COUNT) {
+            throw new IllegalStateException(
+                    "Python 추천 서버는 추천 대상 사용자별 문제 세트 3개를 반환해야 합니다. userId="
+                            + recommendations.userId()
+                            + ", actualCount="
+                            + actualCount
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/usecase/GenerateProblemSetRecommendationsUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/usecase/GenerateProblemSetRecommendationsUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.recommendation.application.usecase;
+
+/** 스케줄러가 문제 세트 추천 생성 배치를 실행할 때 사용하는 유스케이스입니다. */
+public interface GenerateProblemSetRecommendationsUseCase {
+
+    /** Python 추천 서버를 호출하고 반환된 추천 결과를 저장합니다. */
+    int generate();
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java
@@ -10,8 +10,8 @@ import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
@@ -78,10 +78,15 @@ public class FastApiProblemRecommendationGenerationClient implements ProblemReco
         private GeneratedUserProblemSetRecommendations toCommand() {
             return new GeneratedUserProblemSetRecommendations(
                     userId,
-                    problemSets.stream()
+                    normalizedProblemSets().stream()
                             .map(PythonProblemSetRecommendation::toCommand)
                             .toList()
             );
+        }
+
+        /** 외부 응답의 null 목록은 서비스 계층의 개수 검증으로 넘기기 위해 빈 목록으로 정규화합니다. */
+        private List<PythonProblemSetRecommendation> normalizedProblemSets() {
+            return problemSets == null ? List.of() : problemSets;
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java
@@ -1,0 +1,109 @@
+package com.wanted.codebombalms.recommendation.infrastructure.client;
+
+import com.wanted.codebombalms.recommendation.application.command.GeneratedProblemSetRecommendation;
+import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationGenerationClient;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import io.netty.channel.ChannelOption;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+/** 추천 시스템 전용 Python FastAPI endpoint를 호출하는 client입니다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FastApiProblemRecommendationGenerationClient implements ProblemRecommendationGenerationClient {
+
+    private final RecommendationPythonProperties properties;
+
+    @Value("${fastapi.url}")
+    private String fastApiBaseUrl;
+
+    /** 설정된 Python 추천 생성 endpoint를 호출해 사용자별 추천 결과를 가져옵니다. */
+    @Override
+    public List<GeneratedUserProblemSetRecommendations> generateProblemSetRecommendations() {
+        if (!properties.isEnabled()) {
+            log.info("Python 추천 생성 호출이 비활성화되어 추천 생성 배치를 건너뜁니다.");
+            return List.of();
+        }
+
+        PythonRecommendationResponse response = webClient().post()
+                .uri(properties.getGeneratePath())
+                .bodyValue(new PythonRecommendationRequest(3))
+                .retrieve()
+                .bodyToMono(PythonRecommendationResponse.class)
+                .block();
+
+        if (response == null || response.recommendations() == null) {
+            return List.of();
+        }
+
+        return response.recommendations()
+                .stream()
+                .map(PythonUserRecommendations::toCommand)
+                .toList();
+    }
+
+    /** 추천 기능이 챗봇 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
+    private WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
+
+        return WebClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    /** Python 서버에 요청하는 추천 개수 조건입니다. */
+    private record PythonRecommendationRequest(int recommendationCount) {
+    }
+
+    /** Python 추천 생성 API의 최상위 응답입니다. */
+    private record PythonRecommendationResponse(List<PythonUserRecommendations> recommendations) {
+    }
+
+    /** Python 추천 생성 API의 사용자별 추천 묶음입니다. */
+    private record PythonUserRecommendations(Long userId, List<PythonProblemSetRecommendation> problemSets) {
+
+        private GeneratedUserProblemSetRecommendations toCommand() {
+            return new GeneratedUserProblemSetRecommendations(
+                    userId,
+                    problemSets.stream()
+                            .map(PythonProblemSetRecommendation::toCommand)
+                            .toList()
+            );
+        }
+    }
+
+    /** Python 추천 생성 API의 문제 세트 추천 한 건입니다. */
+    private record PythonProblemSetRecommendation(
+            Long problemSetId,
+            BigDecimal support,
+            BigDecimal confidence,
+            BigDecimal lift,
+            Integer rankNo,
+            RecommendationAlgorithm algorithm
+    ) {
+
+        private GeneratedProblemSetRecommendation toCommand() {
+            return new GeneratedProblemSetRecommendation(
+                    problemSetId,
+                    support,
+                    confidence,
+                    lift,
+                    rankNo,
+                    algorithm == null ? RecommendationAlgorithm.APRIORI : algorithm
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/RecommendationPythonProperties.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/RecommendationPythonProperties.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.recommendation.infrastructure.client;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** 추천 시스템 전용 Python FastAPI 호출 설정입니다. */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "recommendation.python")
+public class RecommendationPythonProperties {
+
+    private boolean enabled = true;
+    private String generatePath = "/internal/recommendations/problem-sets/generate";
+    private int connectTimeoutMs = 3000;
+    private int readTimeoutMs = 300000;
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/RecommendationPythonProperties.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/RecommendationPythonProperties.java
@@ -1,19 +1,29 @@
 package com.wanted.codebombalms.recommendation.infrastructure.client;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 /** 추천 시스템 전용 Python FastAPI 호출 설정입니다. */
 @Getter
 @Setter
+@Validated
 @Component
 @ConfigurationProperties(prefix = "recommendation.python")
 public class RecommendationPythonProperties {
 
     private boolean enabled = true;
+
+    @NotBlank
     private String generatePath = "/internal/recommendations/problem-sets/generate";
+
+    @Positive
     private int connectTimeoutMs = 3000;
+
+    @Positive
     private int readTimeoutMs = 300000;
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 
 import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationCommandPort;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationStatus;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,8 @@ public class ProblemRecommendationCommandAdapter implements ProblemRecommendatio
     public void replaceActiveRecommendations(GeneratedUserProblemSetRecommendations recommendations) {
         LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
 
-        problemRecommendationRepository.deactivateActiveByUserId(recommendations.userId());
+        problemRecommendationRepository.lockByUserIdAndStatus(recommendations.userId(), RecommendationStatus.ACTIVE);
+        problemRecommendationRepository.deactivateActiveByUserId(recommendations.userId(), now);
         problemRecommendationRepository.saveAll(recommendations.problemSets()
                 .stream()
                 .map(problemSet -> ProblemRecommendationJpaEntity.active(

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java
@@ -1,0 +1,39 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationCommandPort;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** 추천 생성 결과 저장 port를 JPA repository로 구현하는 persistence adapter입니다. */
+@Component
+@RequiredArgsConstructor
+public class ProblemRecommendationCommandAdapter implements ProblemRecommendationCommandPort {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final SpringDataProblemRecommendationRepository problemRecommendationRepository;
+
+    /** 기존 ACTIVE 추천을 INACTIVE 처리한 뒤 Python 서버가 반환한 3개 추천을 ACTIVE로 저장합니다. */
+    @Override
+    public void replaceActiveRecommendations(GeneratedUserProblemSetRecommendations recommendations) {
+        LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
+
+        problemRecommendationRepository.deactivateActiveByUserId(recommendations.userId());
+        problemRecommendationRepository.saveAll(recommendations.problemSets()
+                .stream()
+                .map(problemSet -> ProblemRecommendationJpaEntity.active(
+                        recommendations.userId(),
+                        problemSet.problemSetId(),
+                        problemSet.support(),
+                        problemSet.confidence(),
+                        problemSet.lift(),
+                        problemSet.rankNo(),
+                        problemSet.algorithm(),
+                        now
+                ))
+                .toList());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationJpaEntity.java
@@ -58,4 +58,29 @@ public class ProblemRecommendationJpaEntity {
     /** JPA가 엔티티를 생성할 때 사용하는 기본 생성자입니다. */
     protected ProblemRecommendationJpaEntity() {
     }
+
+    /** 추천 생성 결과를 ACTIVE 상태의 신규 저장 엔티티로 만듭니다. */
+    public static ProblemRecommendationJpaEntity active(
+            Long userId,
+            Long problemSetId,
+            BigDecimal support,
+            BigDecimal confidence,
+            BigDecimal lift,
+            Integer rankNo,
+            RecommendationAlgorithm algorithm,
+            LocalDateTime now
+    ) {
+        ProblemRecommendationJpaEntity entity = new ProblemRecommendationJpaEntity();
+        entity.userId = userId;
+        entity.problemSetId = problemSetId;
+        entity.support = support;
+        entity.confidence = confidence;
+        entity.lift = lift;
+        entity.rankNo = rankNo;
+        entity.status = RecommendationStatus.ACTIVE;
+        entity.algorithm = algorithm;
+        entity.createdAt = now;
+        entity.updatedAt = now;
+        return entity;
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -46,6 +47,20 @@ public interface SpringDataProblemRecommendationRepository
             @Param("userId") Long userId,
             @Param("limit") int limit
     );
+
+    /** 지정 사용자에게 기존에 노출 중이던 추천 row를 모두 비활성화합니다. */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            value = """
+                    UPDATE problem_recommendation
+                    SET status = 'INACTIVE',
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE user_id = :userId
+                        AND status = 'ACTIVE'
+                    """,
+            nativeQuery = true
+    )
+    int deactivateActiveByUserId(@Param("userId") Long userId);
 
     /** native query 결과를 추천 응답 구성에 필요한 필드로 투영합니다. */
     interface ProblemSetRecommendationProjection {

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
@@ -1,7 +1,11 @@
 package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationStatus;
+import jakarta.persistence.LockModeType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -48,19 +52,35 @@ public interface SpringDataProblemRecommendationRepository
             @Param("limit") int limit
     );
 
+    /** 사용자별 활성 추천 row를 잠가 같은 트랜잭션 안의 교체 저장 경합을 줄입니다. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT pr
+            FROM ProblemRecommendationJpaEntity pr
+            WHERE pr.userId = :userId
+                AND pr.status = :status
+            """)
+    List<ProblemRecommendationJpaEntity> lockByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") RecommendationStatus status
+    );
+
     /** 지정 사용자에게 기존에 노출 중이던 추천 row를 모두 비활성화합니다. */
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
             value = """
                     UPDATE problem_recommendation
                     SET status = 'INACTIVE',
-                        updated_at = CURRENT_TIMESTAMP
+                        updated_at = :updatedAt
                     WHERE user_id = :userId
                         AND status = 'ACTIVE'
                     """,
             nativeQuery = true
     )
-    int deactivateActiveByUserId(@Param("userId") Long userId);
+    int deactivateActiveByUserId(
+            @Param("userId") Long userId,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
 
     /** native query 결과를 추천 응답 구성에 필요한 필드로 투영합니다. */
     interface ProblemSetRecommendationProjection {

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
@@ -16,7 +16,7 @@ public class ProblemRecommendationScheduler {
     private final GenerateProblemSetRecommendationsUseCase generateUseCase;
 
     /** 매일 새벽 5시(Asia/Seoul)에 비동기로 추천 생성 배치를 실행합니다. */
-    @Async
+    @Async("recommendationTaskExecutor")
     @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
     public void generateDailyProblemSetRecommendations() {
         try {

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.recommendation.infrastructure.scheduler;
+
+import com.wanted.codebombalms.recommendation.application.usecase.GenerateProblemSetRecommendationsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 매일 새벽 Python 추천 서버를 호출해 문제 세트 추천 결과를 갱신합니다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProblemRecommendationScheduler {
+
+    private final GenerateProblemSetRecommendationsUseCase generateUseCase;
+
+    /** 매일 새벽 5시(Asia/Seoul)에 비동기로 추천 생성 배치를 실행합니다. */
+    @Async
+    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
+    public void generateDailyProblemSetRecommendations() {
+        try {
+            int userCount = generateUseCase.generate();
+            log.info("문제 세트 추천 생성 배치를 완료했습니다. userCount={}", userCount);
+        } catch (Exception e) {
+            log.error("문제 세트 추천 생성 배치 중 예외가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
@@ -13,15 +13,24 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProblemRecommendationScheduler {
 
+    private static final String LOCK_NAME = "problemRecommendationGeneration";
+
     private final GenerateProblemSetRecommendationsUseCase generateUseCase;
+    private final RecommendationBatchLockExecutor lockExecutor;
 
     /** 매일 새벽 5시(Asia/Seoul)에 비동기로 추천 생성 배치를 실행합니다. */
     @Async("recommendationTaskExecutor")
     @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
     public void generateDailyProblemSetRecommendations() {
         try {
-            int userCount = generateUseCase.generate();
-            log.info("문제 세트 추천 생성 배치를 완료했습니다. userCount={}", userCount);
+            var generatedUserCount = lockExecutor.executeIfLockAcquired(LOCK_NAME, generateUseCase::generate);
+
+            if (generatedUserCount.isEmpty()) {
+                log.info("다른 서버에서 문제 세트 추천 생성 배치가 실행 중이라 이번 실행을 건너뜁니다.");
+                return;
+            }
+
+            log.info("문제 세트 추천 생성 배치를 완료했습니다. userCount={}", generatedUserCount.getAsInt());
         } catch (Exception e) {
             log.error("문제 세트 추천 생성 배치 중 예외가 발생했습니다.", e);
         }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/RecommendationBatchLockExecutor.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/RecommendationBatchLockExecutor.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class RecommendationBatchLockExecutor {
 
     private static final int LOCK_TIMEOUT_SECONDS = 0;
+    private static final int LOCK_QUERY_TIMEOUT_SECONDS = 5;
 
     private final DataSource dataSource;
 
@@ -25,10 +26,22 @@ public class RecommendationBatchLockExecutor {
                 return OptionalInt.empty();
             }
 
+            Exception taskException = null;
             try {
                 return OptionalInt.of(task.getAsInt());
+            } catch (Exception e) {
+                taskException = e;
+                throw e;
             } finally {
-                releaseLock(connection, lockName);
+                try {
+                    releaseLock(connection, lockName);
+                } catch (Exception releaseException) {
+                    if (taskException != null) {
+                        taskException.addSuppressed(releaseException);
+                    } else {
+                        throw releaseException;
+                    }
+                }
             }
         } catch (Exception e) {
             throw new IllegalStateException("추천 생성 배치 락 처리 중 예외가 발생했습니다.", e);
@@ -38,6 +51,7 @@ public class RecommendationBatchLockExecutor {
     /** MySQL named lock을 같은 커넥션에서 획득합니다. */
     private boolean tryAcquireLock(Connection connection, String lockName) throws Exception {
         try (PreparedStatement statement = connection.prepareStatement("SELECT GET_LOCK(?, ?)")) {
+            statement.setQueryTimeout(LOCK_QUERY_TIMEOUT_SECONDS);
             statement.setString(1, lockName);
             statement.setInt(2, LOCK_TIMEOUT_SECONDS);
 
@@ -50,6 +64,7 @@ public class RecommendationBatchLockExecutor {
     /** MySQL named lock은 커넥션 단위라 획득한 커넥션에서 직접 해제합니다. */
     private void releaseLock(Connection connection, String lockName) throws Exception {
         try (PreparedStatement statement = connection.prepareStatement("SELECT RELEASE_LOCK(?)")) {
+            statement.setQueryTimeout(LOCK_QUERY_TIMEOUT_SECONDS);
             statement.setString(1, lockName);
             statement.executeQuery();
         }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/RecommendationBatchLockExecutor.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/RecommendationBatchLockExecutor.java
@@ -1,0 +1,57 @@
+package com.wanted.codebombalms.recommendation.infrastructure.scheduler;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.OptionalInt;
+import java.util.function.IntSupplier;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** 다중 서버 환경에서 추천 생성 배치가 동시에 실행되지 않도록 DB named lock으로 보호합니다. */
+@Component
+@RequiredArgsConstructor
+public class RecommendationBatchLockExecutor {
+
+    private static final int LOCK_TIMEOUT_SECONDS = 0;
+
+    private final DataSource dataSource;
+
+    /** lock 획득에 성공한 서버에서만 작업을 실행하고, 실패하면 빈 결과를 반환합니다. */
+    public OptionalInt executeIfLockAcquired(String lockName, IntSupplier task) {
+        try (Connection connection = dataSource.getConnection()) {
+            if (!tryAcquireLock(connection, lockName)) {
+                return OptionalInt.empty();
+            }
+
+            try {
+                return OptionalInt.of(task.getAsInt());
+            } finally {
+                releaseLock(connection, lockName);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("추천 생성 배치 락 처리 중 예외가 발생했습니다.", e);
+        }
+    }
+
+    /** MySQL named lock을 같은 커넥션에서 획득합니다. */
+    private boolean tryAcquireLock(Connection connection, String lockName) throws Exception {
+        try (PreparedStatement statement = connection.prepareStatement("SELECT GET_LOCK(?, ?)")) {
+            statement.setString(1, lockName);
+            statement.setInt(2, LOCK_TIMEOUT_SECONDS);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() && resultSet.getInt(1) == 1;
+            }
+        }
+    }
+
+    /** MySQL named lock은 커넥션 단위라 획득한 커넥션에서 직접 해제합니다. */
+    private void releaseLock(Connection connection, String lockName) throws Exception {
+        try (PreparedStatement statement = connection.prepareStatement("SELECT RELEASE_LOCK(?)")) {
+            statement.setString(1, lockName);
+            statement.executeQuery();
+        }
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationServiceTest.java
@@ -1,0 +1,79 @@
+package com.wanted.codebombalms.recommendation.application.service;
+
+import com.wanted.codebombalms.recommendation.application.command.GeneratedProblemSetRecommendation;
+import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationCommandPort;
+import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationGenerationClient;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/** Python 추천 생성 결과 검증과 저장 위임 정책을 검증합니다. */
+@ExtendWith(MockitoExtension.class)
+class ProblemRecommendationGenerationServiceTest {
+
+    @Mock
+    private ProblemRecommendationGenerationClient generationClient;
+
+    @Mock
+    private ProblemRecommendationCommandPort commandPort;
+
+    @InjectMocks
+    private ProblemRecommendationGenerationService service;
+
+    /** 사용자별 추천 3개가 반환되면 저장 port에 교체 저장을 위임합니다. */
+    @Test
+    void generate_whenEachUserHasThreeRecommendations_replacesActiveRecommendations() {
+        var recommendations = userRecommendations(1L, 3);
+        given(generationClient.generateProblemSetRecommendations()).willReturn(List.of(recommendations));
+
+        int generatedUserCount = service.generate();
+
+        assertEquals(1, generatedUserCount);
+        verify(commandPort).replaceActiveRecommendations(recommendations);
+    }
+
+    /** 추천 대상 사용자의 추천 개수가 3개가 아니면 저장하지 않고 예외를 발생시킵니다. */
+    @Test
+    void generate_whenRecommendationCountIsNotThree_throwsExceptionWithoutSaving() {
+        var recommendations = userRecommendations(1L, 2);
+        given(generationClient.generateProblemSetRecommendations()).willReturn(List.of(recommendations));
+
+        assertThrows(IllegalStateException.class, () -> service.generate());
+
+        verify(commandPort, never()).replaceActiveRecommendations(recommendations);
+    }
+
+    /** 테스트용 사용자별 추천 묶음을 생성합니다. */
+    private GeneratedUserProblemSetRecommendations userRecommendations(Long userId, int count) {
+        return new GeneratedUserProblemSetRecommendations(
+                userId,
+                java.util.stream.IntStream.rangeClosed(1, count)
+                        .mapToObj(rankNo -> recommendation(100L + rankNo, rankNo))
+                        .toList()
+        );
+    }
+
+    /** 테스트용 문제 세트 추천 한 건을 생성합니다. */
+    private GeneratedProblemSetRecommendation recommendation(Long problemSetId, int rankNo) {
+        return new GeneratedProblemSetRecommendation(
+                problemSetId,
+                BigDecimal.valueOf(0.03),
+                BigDecimal.valueOf(0.7),
+                BigDecimal.valueOf(1.5),
+                rankNo,
+                RecommendationAlgorithm.APRIORI
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapterTest.java
@@ -1,0 +1,197 @@
+package com.wanted.codebombalms.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.recommendation.application.command.GeneratedProblemSetRecommendation;
+import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
+import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** 추천 생성 결과가 problem_recommendation 테이블에 저장되는 형태를 검증합니다. */
+@DataJpaTest(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
+@Import(ProblemRecommendationCommandAdapter.class)
+class ProblemRecommendationCommandAdapterTest {
+
+    @Autowired
+    private ProblemRecommendationCommandAdapter adapter;
+
+    @Autowired
+    private SpringDataProblemRecommendationRepository repository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /** Python 반환값 3개가 dev DB에서 보이는 컬럼 형태 그대로 ACTIVE row로 저장됩니다. */
+    @Test
+    @DisplayName("추천 생성 결과 3개를 ACTIVE 상태로 insert하고 테이블에서 조회할 수 있다.")
+    void replaceActiveRecommendations_insertsThreeActiveRows() {
+        Long userId = 10L;
+
+        adapter.replaceActiveRecommendations(new GeneratedUserProblemSetRecommendations(
+                userId,
+                List.of(
+                        generatedRecommendation(2001L, 1),
+                        generatedRecommendation(2002L, 2),
+                        generatedRecommendation(2003L, 3)
+                )
+        ));
+        repository.flush();
+
+        List<Map<String, Object>> rows = findRowsByUserId(userId);
+
+        assertEquals(3, rows.size());
+        assertRecommendationRow(rows.get(0), userId, 2001L, "ACTIVE", 1);
+        assertRecommendationRow(rows.get(1), userId, 2002L, "ACTIVE", 2);
+        assertRecommendationRow(rows.get(2), userId, 2003L, "ACTIVE", 3);
+    }
+
+    /** 기존 ACTIVE 추천이 있는 사용자는 신규 추천 저장 전 기존 row가 INACTIVE로 전환됩니다. */
+    @Test
+    @DisplayName("기존 ACTIVE 추천이 있으면 INACTIVE 처리 후 신규 추천 3개를 ACTIVE로 insert한다.")
+    void replaceActiveRecommendations_deactivatesExistingActiveRowsBeforeInsert() {
+        Long userId = 10L;
+        Long otherUserId = 20L;
+        LocalDateTime now = LocalDateTime.of(2026, 6, 15, 5, 0);
+
+        repository.saveAll(List.of(
+                ProblemRecommendationJpaEntity.active(
+                        userId,
+                        1001L,
+                        BigDecimal.valueOf(0.01),
+                        BigDecimal.valueOf(0.40),
+                        BigDecimal.valueOf(1.10),
+                        1,
+                        RecommendationAlgorithm.APRIORI,
+                        now.minusDays(1)
+                ),
+                ProblemRecommendationJpaEntity.active(
+                        userId,
+                        1002L,
+                        BigDecimal.valueOf(0.02),
+                        BigDecimal.valueOf(0.50),
+                        BigDecimal.valueOf(1.20),
+                        2,
+                        RecommendationAlgorithm.APRIORI,
+                        now.minusDays(1)
+                ),
+                ProblemRecommendationJpaEntity.active(
+                        otherUserId,
+                        9001L,
+                        BigDecimal.valueOf(0.09),
+                        BigDecimal.valueOf(0.90),
+                        BigDecimal.valueOf(1.90),
+                        1,
+                        RecommendationAlgorithm.APRIORI,
+                        now.minusDays(1)
+                )
+        ));
+        repository.flush();
+
+        adapter.replaceActiveRecommendations(new GeneratedUserProblemSetRecommendations(
+                userId,
+                List.of(
+                        generatedRecommendation(2001L, 1),
+                        generatedRecommendation(2002L, 2),
+                        generatedRecommendation(2003L, 3)
+                )
+        ));
+        repository.flush();
+
+        List<Map<String, Object>> userRows = findRowsByUserId(userId);
+        List<Map<String, Object>> otherUserRows = findRowsByUserId(otherUserId);
+
+        assertEquals(5, userRows.size());
+        assertEquals("INACTIVE", statusByProblemSetId(userRows, 1001L));
+        assertEquals("INACTIVE", statusByProblemSetId(userRows, 1002L));
+        assertEquals("ACTIVE", statusByProblemSetId(userRows, 2001L));
+        assertEquals("ACTIVE", statusByProblemSetId(userRows, 2002L));
+        assertEquals("ACTIVE", statusByProblemSetId(userRows, 2003L));
+
+        assertEquals(3, countByStatus(userRows, "ACTIVE"));
+        assertEquals(2, countByStatus(userRows, "INACTIVE"));
+        assertEquals(1, otherUserRows.size());
+        assertRecommendationRow(otherUserRows.get(0), otherUserId, 9001L, "ACTIVE", 1);
+    }
+
+    /** 테스트용 Python 추천 결과 한 건을 생성합니다. */
+    private GeneratedProblemSetRecommendation generatedRecommendation(Long problemSetId, int rankNo) {
+        return new GeneratedProblemSetRecommendation(
+                problemSetId,
+                BigDecimal.valueOf(0.03),
+                BigDecimal.valueOf(0.70),
+                BigDecimal.valueOf(1.50),
+                rankNo,
+                RecommendationAlgorithm.APRIORI
+        );
+    }
+
+    /** dev DB 조회 화면과 같은 주요 컬럼 목록으로 추천 row를 조회합니다. */
+    private List<Map<String, Object>> findRowsByUserId(Long userId) {
+        return jdbcTemplate.queryForList(
+                """
+                        SELECT
+                            recommendation_id,
+                            user_id,
+                            problem_set_id,
+                            support,
+                            confidence,
+                            lift,
+                            rank_no,
+                            status,
+                            algorithm,
+                            created_at,
+                            updated_at
+                        FROM problem_recommendation
+                        WHERE user_id = ?
+                        ORDER BY recommendation_id ASC
+                        """,
+                userId
+        );
+    }
+
+    /** 조회된 row의 핵심 저장 컬럼이 기대값과 같은지 검증합니다. */
+    private void assertRecommendationRow(
+            Map<String, Object> row,
+            Long userId,
+            Long problemSetId,
+            String status,
+            int rankNo
+    ) {
+        assertNotNull(row.get("RECOMMENDATION_ID"));
+        assertEquals(userId, ((Number) row.get("USER_ID")).longValue());
+        assertEquals(problemSetId, ((Number) row.get("PROBLEM_SET_ID")).longValue());
+        assertEquals(status, row.get("STATUS"));
+        assertEquals("APRIORI", row.get("ALGORITHM"));
+        assertEquals(rankNo, ((Number) row.get("RANK_NO")).intValue());
+        assertNotNull(row.get("CREATED_AT"));
+        assertNotNull(row.get("UPDATED_AT"));
+    }
+
+    /** 문제 세트 ID 기준으로 조회 row의 상태값을 찾습니다. */
+    private String statusByProblemSetId(List<Map<String, Object>> rows, Long problemSetId) {
+        return rows.stream()
+                .filter(row -> ((Number) row.get("PROBLEM_SET_ID")).longValue() == problemSetId)
+                .map(row -> (String) row.get("STATUS"))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    /** 조회 row 중 특정 상태값의 개수를 셉니다. */
+    private long countByStatus(List<Map<String, Object>> rows, String status) {
+        return rows.stream()
+                .filter(row -> status.equals(row.get("STATUS")))
+                .count();
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationSchedulerTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationSchedulerTest.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.recommendation.infrastructure.scheduler;
 
 import com.wanted.codebombalms.recommendation.application.usecase.GenerateProblemSetRecommendationsUseCase;
 import java.lang.reflect.Method;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -9,6 +10,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,12 +23,16 @@ class ProblemRecommendationSchedulerTest {
     @Test
     void generateDailyProblemSetRecommendations_callsGenerateUseCase() {
         GenerateProblemSetRecommendationsUseCase useCase = mock(GenerateProblemSetRecommendationsUseCase.class);
+        RecommendationBatchLockExecutor lockExecutor = mock(RecommendationBatchLockExecutor.class);
+        when(lockExecutor.executeIfLockAcquired(eq("problemRecommendationGeneration"), any()))
+                .thenAnswer(invocation -> OptionalInt.of(invocation.getArgument(1, java.util.function.IntSupplier.class).getAsInt()));
         when(useCase.generate()).thenReturn(2);
-        ProblemRecommendationScheduler scheduler = new ProblemRecommendationScheduler(useCase);
+        ProblemRecommendationScheduler scheduler = new ProblemRecommendationScheduler(useCase, lockExecutor);
 
         scheduler.generateDailyProblemSetRecommendations();
 
         verify(useCase).generate();
+        verify(lockExecutor).executeIfLockAcquired(eq("problemRecommendationGeneration"), any());
     }
 
     /** 매일 새벽 5시 Asia/Seoul 기준으로 비동기 실행되도록 설정되어 있습니다. */
@@ -48,10 +55,28 @@ class ProblemRecommendationSchedulerTest {
     @Test
     void generateDailyProblemSetRecommendations_whenUseCaseThrows_doesNotPropagateException() {
         GenerateProblemSetRecommendationsUseCase useCase = mock(GenerateProblemSetRecommendationsUseCase.class);
+        RecommendationBatchLockExecutor lockExecutor = mock(RecommendationBatchLockExecutor.class);
+        when(lockExecutor.executeIfLockAcquired(eq("problemRecommendationGeneration"), any()))
+                .thenAnswer(invocation -> OptionalInt.of(invocation.getArgument(1, java.util.function.IntSupplier.class).getAsInt()));
         when(useCase.generate()).thenThrow(new RuntimeException("Python server error"));
-        ProblemRecommendationScheduler scheduler = new ProblemRecommendationScheduler(useCase);
+        ProblemRecommendationScheduler scheduler = new ProblemRecommendationScheduler(useCase, lockExecutor);
 
         assertDoesNotThrow(scheduler::generateDailyProblemSetRecommendations);
         verify(useCase).generate();
+    }
+
+    /** 다른 서버가 이미 락을 잡고 있으면 추천 생성 유스케이스를 실행하지 않습니다. */
+    @Test
+    void generateDailyProblemSetRecommendations_whenLockNotAcquired_skipsGenerateUseCase() {
+        GenerateProblemSetRecommendationsUseCase useCase = mock(GenerateProblemSetRecommendationsUseCase.class);
+        RecommendationBatchLockExecutor lockExecutor = mock(RecommendationBatchLockExecutor.class);
+        when(lockExecutor.executeIfLockAcquired(eq("problemRecommendationGeneration"), any()))
+                .thenReturn(OptionalInt.empty());
+        ProblemRecommendationScheduler scheduler = new ProblemRecommendationScheduler(useCase, lockExecutor);
+
+        scheduler.generateDailyProblemSetRecommendations();
+
+        verify(lockExecutor).executeIfLockAcquired(eq("problemRecommendationGeneration"), any());
+        verify(useCase, org.mockito.Mockito.never()).generate();
     }
 }

--- a/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationSchedulerTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationSchedulerTest.java
@@ -1,0 +1,44 @@
+package com.wanted.codebombalms.recommendation.infrastructure.scheduler;
+
+import com.wanted.codebombalms.recommendation.application.usecase.GenerateProblemSetRecommendationsUseCase;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** 문제 세트 추천 스케줄러의 실행 위임과 스케줄 설정을 검증합니다. */
+class ProblemRecommendationSchedulerTest {
+
+    /** 스케줄러 실행 시 추천 생성 유스케이스를 호출합니다. */
+    @Test
+    void generateDailyProblemSetRecommendations_callsGenerateUseCase() {
+        GenerateProblemSetRecommendationsUseCase useCase = mock(GenerateProblemSetRecommendationsUseCase.class);
+        when(useCase.generate()).thenReturn(2);
+        ProblemRecommendationScheduler scheduler = new ProblemRecommendationScheduler(useCase);
+
+        scheduler.generateDailyProblemSetRecommendations();
+
+        verify(useCase).generate();
+    }
+
+    /** 매일 새벽 5시 Asia/Seoul 기준으로 비동기 실행되도록 설정되어 있습니다. */
+    @Test
+    void generateDailyProblemSetRecommendations_hasScheduledAndAsyncAnnotations() throws NoSuchMethodException {
+        Method method = ProblemRecommendationScheduler.class
+                .getMethod("generateDailyProblemSetRecommendations");
+
+        Scheduled scheduled = method.getAnnotation(Scheduled.class);
+        Async async = method.getAnnotation(Async.class);
+
+        assertNotNull(scheduled);
+        assertNotNull(async);
+        assertEquals("0 0 5 * * *", scheduled.cron());
+        assertEquals("Asia/Seoul", scheduled.zone());
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationSchedulerTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationSchedulerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -38,7 +39,19 @@ class ProblemRecommendationSchedulerTest {
 
         assertNotNull(scheduled);
         assertNotNull(async);
+        assertEquals("recommendationTaskExecutor", async.value());
         assertEquals("0 0 5 * * *", scheduled.cron());
         assertEquals("Asia/Seoul", scheduled.zone());
+    }
+
+    /** 추천 생성 중 예외가 발생해도 스케줄러 메서드는 예외를 외부로 전파하지 않습니다. */
+    @Test
+    void generateDailyProblemSetRecommendations_whenUseCaseThrows_doesNotPropagateException() {
+        GenerateProblemSetRecommendationsUseCase useCase = mock(GenerateProblemSetRecommendationsUseCase.class);
+        when(useCase.generate()).thenThrow(new RuntimeException("Python server error"));
+        ProblemRecommendationScheduler scheduler = new ProblemRecommendationScheduler(useCase);
+
+        assertDoesNotThrow(scheduler::generateDailyProblemSetRecommendations);
+        verify(useCase).generate();
     }
 }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #342 

---

## 🛠️ 기능 관련 작업 내용
- 매일 새벽 5시 `Asia/Seoul` 기준으로 문제 세트 추천 생성 스케줄러가 실행되도록 구현했습니다.
- Python 추천 서버의 추천 생성 API를 호출하고, 사용자별 추천 결과 3개를 검증하는 흐름을 추가했습니다.
- 기존 ACTIVE 추천을 INACTIVE 처리한 뒤 신규 추천 결과를 ACTIVE row로 저장하도록 구현했습니다.
- 스케줄러 실행, 추천 결과 검증, 추천 row 저장/조회/비활성화 정책을 테스트로 검증했습니다.

---

## ♻️ 패키지 변경 사항
- `project/global/infrastructure/config`: 스케줄러 비동기 실행을 위한 `@EnableAsync` 설정 추가
- `project/recommendation/application`: 추천 생성 command, port, usecase, service 추가
- `project/recommendation/infrastructure/client`: Python FastAPI 추천 생성 API 호출 client 및 설정 클래스 추가
- `project/recommendation/infrastructure/persistence`: 추천 저장 adapter, 기존 ACTIVE 추천 비활성화 query, 신규 ACTIVE 엔티티 생성 로직 추가
- `project/recommendation/infrastructure/scheduler`: 매일 새벽 5시 추천 생성 스케줄러 추가
- `project/recommendation/test`: 추천 생성 서비스, 저장 adapter, 스케줄러 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 매일 오전 5시(한국 시간) 문제 세트 추천 생성 배치가 동작합니다.
  * Python(FastAPI) 추천 서버와 연동해 사용자별 추천을 생성합니다.
* **개선 사항**
  * 배치 실행 중 중복 실행을 방지하고, 사용자별 기존 활성 추천을 새 추천으로 교체합니다.
  * 사용자별 추천 개수 기준을 검증해 이상 시 저장을 중단합니다.
* **테스트**
  * 추천 생성/저장 흐름, 스케줄러 락 처리, 예외 및 상태 전환 시나리오를 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->