### PR TITLE
[Ref] 추천 비활성 데이터 hard delete cleanup 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/cleanup/RecommendationCleanupConfig.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/cleanup/RecommendationCleanupConfig.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.recommendation.infrastructure.cleanup;
+
+import com.wanted.codebombalms.global.application.cleanup.DefaultHardDeleteTarget;
+import com.wanted.codebombalms.global.application.cleanup.port.HardDeleteTarget;
+import com.wanted.codebombalms.recommendation.infrastructure.persistence.SpringDataProblemRecommendationRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Period;
+
+@Configuration
+// 추천 도메인의 하드 딜리트 대상을 공통 cleanup 실행기에 등록합니다.
+public class RecommendationCleanupConfig {
+
+    // INACTIVE 상태로 3개월이 지난 문제 세트 추천 row를 하드 딜리트하도록 설정합니다.
+    @Bean
+    public HardDeleteTarget problemRecommendationHardDeleteTarget(
+            SpringDataProblemRecommendationRepository repository
+    ) {
+        return new DefaultHardDeleteTarget(
+                "problem-recommendation",
+                Period.ofMonths(3),
+                repository::hardDeleteInactiveByUpdatedAtBefore
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 /** problem_recommendation 조회용 Spring Data JPA repository입니다. */
 public interface SpringDataProblemRecommendationRepository
@@ -81,6 +82,19 @@ public interface SpringDataProblemRecommendationRepository
             @Param("userId") Long userId,
             @Param("updatedAt") LocalDateTime updatedAt
     );
+
+    /** 비활성화된 지 오래된 추천 row를 하드 딜리트합니다. */
+    @Transactional
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+            value = """
+                    DELETE FROM problem_recommendation
+                    WHERE status = 'INACTIVE'
+                        AND updated_at < :threshold
+                    """,
+            nativeQuery = true
+    )
+    int hardDeleteInactiveByUpdatedAtBefore(@Param("threshold") LocalDateTime threshold);
 
     /** native query 결과를 추천 응답 구성에 필요한 필드로 투영합니다. */
     interface ProblemSetRecommendationProjection {

--- a/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapterTest.java
@@ -125,6 +125,62 @@ class ProblemRecommendationCommandAdapterTest {
         assertRecommendationRow(otherUserRows.get(0), otherUserId, 9001L, "ACTIVE", 1);
     }
 
+    /** INACTIVE 상태이고 기준 시각보다 오래된 추천 row만 하드 딜리트됩니다. */
+    @Test
+    @DisplayName("updated_at이 기준 시각 이전인 INACTIVE 추천 row만 hard delete한다.")
+    void hardDeleteInactiveByUpdatedAtBefore_deletesOldInactiveRowsOnly() {
+        Long userId = 10L;
+        LocalDateTime threshold = LocalDateTime.of(2026, 6, 15, 3, 0);
+
+        repository.saveAll(List.of(
+                ProblemRecommendationJpaEntity.active(
+                        userId,
+                        1001L,
+                        BigDecimal.valueOf(0.01),
+                        BigDecimal.valueOf(0.40),
+                        BigDecimal.valueOf(1.10),
+                        1,
+                        RecommendationAlgorithm.APRIORI,
+                        threshold.minusMonths(4)
+                ),
+                ProblemRecommendationJpaEntity.active(
+                        userId,
+                        1002L,
+                        BigDecimal.valueOf(0.02),
+                        BigDecimal.valueOf(0.50),
+                        BigDecimal.valueOf(1.20),
+                        2,
+                        RecommendationAlgorithm.APRIORI,
+                        threshold.minusMonths(2)
+                ),
+                ProblemRecommendationJpaEntity.active(
+                        userId,
+                        1003L,
+                        BigDecimal.valueOf(0.03),
+                        BigDecimal.valueOf(0.60),
+                        BigDecimal.valueOf(1.30),
+                        3,
+                        RecommendationAlgorithm.APRIORI,
+                        threshold.minusMonths(4)
+                )
+        ));
+        repository.flush();
+
+        updateStatusAndUpdatedAt(1001L, "INACTIVE", threshold.minusDays(1));
+        updateStatusAndUpdatedAt(1002L, "INACTIVE", threshold.plusDays(1));
+        updateStatusAndUpdatedAt(1003L, "ACTIVE", threshold.minusDays(1));
+
+        int deletedCount = repository.hardDeleteInactiveByUpdatedAtBefore(threshold);
+        repository.flush();
+
+        List<Map<String, Object>> rows = findRowsByUserId(userId);
+
+        assertEquals(1, deletedCount);
+        assertEquals(2, rows.size());
+        assertEquals("INACTIVE", statusByProblemSetId(rows, 1002L));
+        assertEquals("ACTIVE", statusByProblemSetId(rows, 1003L));
+    }
+
     /** 테스트용 Python 추천 결과 한 건을 생성합니다. */
     private GeneratedProblemSetRecommendation generatedRecommendation(Long problemSetId, int rankNo) {
         return new GeneratedProblemSetRecommendation(
@@ -158,6 +214,21 @@ class ProblemRecommendationCommandAdapterTest {
                         ORDER BY recommendation_id ASC
                         """,
                 userId
+        );
+    }
+
+    /** 테스트 데이터의 상태와 updated_at을 삭제 조건에 맞게 조정합니다. */
+    private void updateStatusAndUpdatedAt(Long problemSetId, String status, LocalDateTime updatedAt) {
+        jdbcTemplate.update(
+                """
+                        UPDATE problem_recommendation
+                        SET status = ?,
+                            updated_at = ?
+                        WHERE problem_set_id = ?
+                        """,
+                status,
+                updatedAt,
+                problemSetId
         );
     }
 


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #410

---

## 🛠️ 기능 관련 작업 내용
- `problem_recommendation`의 `INACTIVE` row를 `updated_at` 기준으로 hard delete하는 repository query를 추가했습니다.
- recommendation cleanup target을 공통 `DefaultHardDeleteTarget`에 등록해 3개월 지난 비활성 추천 데이터를 자동 정리하도록 했습니다.
- 오래된 `INACTIVE` 추천 row만 삭제되고, `ACTIVE` row와 최근 `INACTIVE` row는 유지되는지 테스트를 추가했습니다.

---

## ♻️ 패키지 변경 사항
- `project/recommendation/infrastructure/cleanup`: 추천 도메인 hard delete cleanup 설정 추가
- `project/recommendation/infrastructure/persistence`: 비활성 추천 row hard delete query 추가
- `project/recommendation/infrastructure/persistence/test`: hard delete 삭제 조건 검증 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 비활성화된 문제 추천 데이터의 자동 정리 기능을 추가했습니다. 3개월 이상 업데이트되지 않은 비활성 레코드가 자동으로 삭제됩니다.

* **Tests**
  * 자동 정리 기능의 동작을 검증하는 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->