### PR TITLE
[Fix] 마이페이지 코드래빗 후속 보강 (재인증 게이트/중복 원자성/공백 차단)

### DIFF
--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -98,20 +97,6 @@ public class GlobalExceptionHandler {
             return ResponseEntity.status(403)
                     .body(ApiErrorResponse.of(403, "AUT-015", "접근 권한이 없습니다.", request.getRequestURI()));
         }
-    }
-
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ApiErrorResponse> handleDataIntegrityViolation(
-            DataIntegrityViolationException e, HttpServletRequest request) {
-        log.warn("[409] 데이터 무결성 위반(unique 충돌 추정) - path: {}, message: {}",
-                request.getRequestURI(), e.getMostSpecificCause().getMessage());
-        return ResponseEntity.status(409)
-                .body(ApiErrorResponse.of(
-                        409,
-                        "COMMON-CONFLICT",
-                        "이미 사용 중인 값입니다.",
-                        request.getRequestURI()
-                ));
     }
 }
 

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authorization.AuthorizationDeniedException;
@@ -97,6 +98,20 @@ public class GlobalExceptionHandler {
             return ResponseEntity.status(403)
                     .body(ApiErrorResponse.of(403, "AUT-015", "접근 권한이 없습니다.", request.getRequestURI()));
         }
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiErrorResponse> handleDataIntegrityViolation(
+            DataIntegrityViolationException e, HttpServletRequest request) {
+        log.warn("[409] 데이터 무결성 위반(unique 충돌 추정) - path: {}, message: {}",
+                request.getRequestURI(), e.getMostSpecificCause().getMessage());
+        return ResponseEntity.status(409)
+                .body(ApiErrorResponse.of(
+                        409,
+                        "COMMON-CONFLICT",
+                        "이미 사용 중인 값입니다.",
+                        request.getRequestURI()
+                ));
     }
 }
 

--- a/src/main/java/com/wanted/codebombalms/user/application/service/ChangePasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/ChangePasswordService.java
@@ -1,11 +1,13 @@
 package com.wanted.codebombalms.user.application.service;
 
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.application.usecase.ChangePasswordUseCase;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.ProfileEditVerificationRepository;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,9 +24,15 @@ public class ChangePasswordService implements ChangePasswordUseCase {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ProfileEditVerificationRepository profileEditVerificationRepository;
 
     @Override
     public void changePassword(Long userId, String newPassword, String confirmPassword) {
+        // 0. 재인증 게이트 — verify-password 통과 도장 없으면 거부 (403 USR-011)
+        if (!profileEditVerificationRepository.isVerified(userId)) {
+            throw new ForbiddenException(UserErrorCode.USER_REVERIFICATION_REQUIRED);
+        }
+
         // 1. 본인 조회 (없으면 USER_NOT_FOUND)
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
@@ -40,6 +48,9 @@ public class ChangePasswordService implements ChangePasswordUseCase {
 
         // 4. Refresh Token 전체 삭제 (강제 재로그인)
         refreshTokenRepository.deleteByUserId(userId);
+
+        // 5. 재인증 도장 제거 (어차피 강제 재로그인 → 세션 종료)
+        profileEditVerificationRepository.clearVerified(userId);
 
         log.info("비밀번호 변경 완료 - userId={}", userId);
     }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
@@ -11,6 +11,7 @@ import com.wanted.codebombalms.user.domain.repository.ProfileEditVerificationRep
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,9 +41,14 @@ public class UpdateMyInfoService implements UpdateMyInfoUseCase {
             throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED);
         }
 
-        // 3. 부분 수정 적용 (전달된 필드만)
+        // 3. 부분 수정 적용 (전달된 필드만) + 즉시 flush
         user.updateProfile(nickname, phone);
-        userRepository.save(user);
+        try {
+            userRepository.saveAndFlush(user); // 즉시 flush — 제약 위반을 이 자리에서 포착
+        } catch (DataIntegrityViolationException e) {
+            // 사전 체크 통과했어도 동시성 레이스로 닉네임 unique 충돌 가능 → 닉네임 중복으로 정밀 매핑
+            throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED);
+        }
 
         log.info("개인정보 수정 완료 - userId={}, nicknameChanged={}", userId, nicknameChanged);
 

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
@@ -1,11 +1,13 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.application.query.UpdateMyInfoResult;
 import com.wanted.codebombalms.user.application.usecase.UpdateMyInfoUseCase;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.ProfileEditVerificationRepository;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,9 +21,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateMyInfoService implements UpdateMyInfoUseCase {
 
     private final UserRepository userRepository;
+    private final ProfileEditVerificationRepository profileEditVerificationRepository;
 
     @Override
     public UpdateMyInfoResult update(Long userId, String nickname, String phone) {
+        // 0. 재인증 게이트 — verify-password 통과 도장 없으면 거부 (403 USR-011)
+        if (!profileEditVerificationRepository.isVerified(userId)) {
+            throw new ForbiddenException(UserErrorCode.USER_REVERIFICATION_REQUIRED);
+        }
+
         // 1. 본인 조회 (없으면 USER_NOT_FOUND)
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/wanted/codebombalms/user/application/service/VerifyPasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/VerifyPasswordService.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ValidationEx
 import com.wanted.codebombalms.user.application.usecase.VerifyPasswordUseCase;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.ProfileEditVerificationRepository;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,6 +20,7 @@ public class VerifyPasswordService implements VerifyPasswordUseCase {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ProfileEditVerificationRepository profileEditVerificationRepository;
 
     @Override
     public void verify(Long userId, String rawPassword) {
@@ -30,5 +32,8 @@ public class VerifyPasswordService implements VerifyPasswordUseCase {
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
             throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_MISMATCH);
         }
+
+        // 3. 재인증 도장 찍기 (TTL 10분 — 이후 정보수정/비번변경 허용)
+        profileEditVerificationRepository.markVerified(userId);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
@@ -25,7 +25,9 @@ public enum UserErrorCode implements ErrorCode {
     USER_SOCIAL_ACCOUNT_NO_PASSWORD("USR-008", "소셜 가입 계정은 비밀번호 재설정을 사용할 수 없습니다."),
     // 이메일 인증
     USER_EMAIL_NOT_VERIFIED("USR-009", "이메일 인증이 완료되지 않았습니다."),
-    STUDENT_NOT_FOUND("USR-010", "학생 회원을 찾을 수 없습니다.");
+    STUDENT_NOT_FOUND("USR-010", "학생 회원을 찾을 수 없습니다."),
+
+    USER_REVERIFICATION_REQUIRED("USR-011", "비밀번호 재인증이 필요합니다. 다시 인증해주세요.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/ProfileEditVerificationRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/ProfileEditVerificationRepository.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.user.domain.repository;
+
+/**
+ * 개인정보 수정 재인증(step-up) 플래그 저장소 (Output Port).
+ * verify-password 성공 시 플래그를 심고, 수정 페이지 내 민감 작업(정보수정/비밀번호변경)에서 확인한다.
+ * Redis 구현체에서 TTL 자동 관리.
+ */
+public interface ProfileEditVerificationRepository {
+
+    /** 재인증 완료 플래그 저장 (TTL 10분 자동) */
+    void markVerified(Long userId);
+
+    /** 재인증 플래그 존재 여부 확인 — 삭제하지 않음(페이지 내 여러 작업 허용) */
+    boolean isVerified(Long userId);
+
+    /** 재인증 플래그 삭제 (비밀번호 변경 후 = 세션 종료 시) */
+    void clearVerified(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
@@ -17,6 +17,7 @@ public interface UserRepository {
     boolean existsByNickname(String nickname);
 
     User save(User user);
+    User saveAndFlush(User user);
 
     List<User> findAllByRole(UserRole role, int page, int size);
 

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/RedisProfileEditVerificationAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/RedisProfileEditVerificationAdapter.java
@@ -1,0 +1,33 @@
+package com.wanted.codebombalms.user.infrastructure.persistence;
+
+import com.wanted.codebombalms.user.domain.repository.ProfileEditVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisProfileEditVerificationAdapter implements ProfileEditVerificationRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_VERIFIED = "profile:verified:"; // + {userId}
+    private static final Duration TTL_VERIFIED = Duration.ofMinutes(10);
+
+    @Override
+    public void markVerified(Long userId) {
+        redisTemplate.opsForValue().set(KEY_VERIFIED + userId, "1", TTL_VERIFIED);
+    }
+
+    @Override
+    public boolean isVerified(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_VERIFIED + userId));
+    }
+
+    @Override
+    public void clearVerified(Long userId) {
+        redisTemplate.delete(KEY_VERIFIED + userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/RedisProfileEditVerificationAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/RedisProfileEditVerificationAdapter.java
@@ -14,7 +14,7 @@ public class RedisProfileEditVerificationAdapter implements ProfileEditVerificat
     private final StringRedisTemplate redisTemplate;
 
     private static final String KEY_VERIFIED = "profile:verified:"; // + {userId}
-    private static final Duration TTL_VERIFIED = Duration.ofMinutes(10);
+    private static final Duration TTL_VERIFIED = Duration.ofMinutes(3);
 
     @Override
     public void markVerified(Long userId) {

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -40,19 +40,24 @@ public class UserRepositoryAdapter implements UserRepository {
 
     @Override
     public User save(User user) {
-        UserJpaEntity entity;
+        return springDataUserRepository.save(toEntity(user)).toDomain();
+    }
 
+    @Override
+    public User saveAndFlush(User user) {
+        return springDataUserRepository.saveAndFlush(toEntity(user)).toDomain();
+    }
+
+    private UserJpaEntity toEntity(User user) {
         if (user.getUserId() == null) {
             // 신규 저장
-            entity = UserJpaEntity.from(user);
-        } else {
-            // 업데이트 — 기존 엔티티 찾아서 상태 반영 (JPA 변경감지 활용)
-            entity = springDataUserRepository.findByUserId(user.getUserId())
-                    .orElseGet(() -> UserJpaEntity.from(user));
-            entity.applyDomain(user);
+            return UserJpaEntity.from(user);
         }
-
-        return springDataUserRepository.save(entity).toDomain();
+        // 업데이트 — 기존 엔티티 찾아서 상태 반영 (JPA 변경감지 활용)
+        UserJpaEntity entity = springDataUserRepository.findByUserId(user.getUserId())
+                .orElseGet(() -> UserJpaEntity.from(user));
+        entity.applyDomain(user);
+        return entity;
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/UpdateMyInfoRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/UpdateMyInfoRequest.java
@@ -1,9 +1,15 @@
 package com.wanted.codebombalms.user.presentation.api.request;
 
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public record UpdateMyInfoRequest(
 
+        @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
+        @Pattern(
+                regexp = "^(?!\\s*$).+",
+                message = "닉네임은 공백일 수 없습니다."
+        )
         String nickname,
 
         @Pattern(


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #113 

---

## 🛠️ 기능 관련 작업 내용
- 비밀번호 변경/개인정보 수정에 `verify-password` 재인증 게이트를 서버측에서 강제 — Redis 플래그(`profile:verified:{userId}`, TTL 3분, peek 방식)가 없으면 403(USR-011)로 차단. 세션 탈취 시 현재 비번 없이 비번 변경하던 우회 제거
- 닉네임 중복 동시성 레이스를 UpdateMyInfoService에서 saveAndFlush + DataIntegrityViolationException catch로 정밀 처리 → USR-003(400) (전역 핸들러 미사용, 다른 도메인 에러 계약 보존)
- 닉네임 공백/빈 문자열 입력 차단(`@Size(max=50)` + `@Pattern`) — 부분수정 유지 위해 `@NotBlank` 대신 패턴 사용
- 비밀번호 변경 완료 시 재인증 플래그 제거 + 강제 재로그인 흐름 유지

---

## ♻️ 패키지 변경 사항
- `codebombalms/user/domain/repository`: `ProfileEditVerificationRepository` 포트 신규
- `codebombalms/user/infrastructure/persistence`: `RedisProfileEditVerificationAdapter` 신규 (TTL 10분)
- `codebombalms/user/application/service`: `VerifyPassword`/`UpdateMyInfo`/`ChangePassword` 재인증 플래그 연동
- `codebombalms/user/presentation/api/request`: `UpdateMyInfoRequest` 닉네임 공백 검증 추가
- `codebombalms/user/domain/exception`: `USER_REVERIFICATION_REQUIRED`(USR-011) 추가
- `codebombalms/user/domain/repository` + `infrastructure/persistence`: `UserRepository.saveAndFlush` 추가 (닉네임 unique 레이스 정밀 처리)
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비밀번호 변경 및 프로필 수정 시 재인증 절차 추가
  * 닉네임 입력 검증 강화: 최대 50자, 공백만 입력 불가

* **개선 사항**
  * 닉네임 중복 오류 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->