### PR TITLE
[Feat] 문제별 추천 코스 연결 API 구현

### DIFF
--- a/monitoring/docs/domains/problems/bottleneck-hypothesis.md
+++ b/monitoring/docs/domains/problems/bottleneck-hypothesis.md
@@ -1,0 +1,69 @@
+# Problems 도메인 병목 가설 (Phase 1 파일럿 / 7단계 중 1단계)
+
+> 프로세스: [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션: [`../../CONVENTION.md`](../../CONVENTION.md)
+>
+> 이 문서는 부하테스트 전에 "무엇이 느릴 것인가"를 먼저 가설로 세우는 산출물이다.  
+> 목적은 무작정 부하를 주는 것이 아니라, API 유형별로 병목 후보를 정하고 측정 결과로 검증하는 것이다.
+
+---
+
+## 도메인 유형 분류
+
+Problems 도메인은 하나의 유형으로만 보기 어렵다. 문제 목록 조회, 문제풀이 진입, 코드 실행, 제출/채점, 운영자 관리 API가 섞여 있다.
+
+| 유형 | 해당 흐름 | 병목 성격 | 테스트 방향 |
+|---|---|---|---|
+| 조회/집계형 | 문제세트 목록, 문제세트 진입, 진행 상태, 결과 조회, 추천 코스 조회 | 인덱스, 조인, N+1, 응답 payload 크기 | 조회 API p95와 DB 쿼리 수 확인 |
+| 외부연동형 | 코드 실행, 코드 제출/채점, 데이터셋 다운로드 URL 발급 | Cloud Run Python Runner, GCS Signed URL, 외부 HTTP 지연 | 외부 지연 시간과 타임아웃 비율 확인 |
+| 쓰기/트랜잭션형 | 코드 제출, 문제세트 등록/수정, 추천 코스 연결 저장 | 테스트케이스 실행 결과 저장, 진행 상태 갱신, 포인트 이벤트 발행 | Hikari active, transaction duration, 실패율 확인 |
+| 단순 CRUD형 | 카테고리 조회, 힌트 조회, 테스트케이스 단건 관리 | 병목 가능성 낮음 | baseline만 확인하고 억지 최적화 금지 |
+
+---
+
+## 병목 가설표
+
+| # | 대상 API | 유형 | 병목 가설 | 근거 코드 위치 | 관찰 지표 | 성공 기준 |
+|---|---|---|---|---|---|---|
+| 1 | `POST /api/v1/problems/{problemId}/submissions` | 외부연동 + 쓰기/트랜잭션 | 가장 강한 병목 후보. 제출 1회마다 테스트케이스를 불러오고, 사용자 코드를 Python Runner로 실행한 뒤 결과 저장, 진행 상태 갱신, 포인트 이벤트 발행까지 이어진다. Runner 응답 지연 또는 테스트케이스 수 증가가 p95를 크게 올릴 가능성이 높다. | `submission/application/service/SubmissionService`, `submission/application/service/CodeGradingService`, `problems/execution/infrastructure/runner/CloudRunCodeRunnerAdapter` | `http_server_requests_seconds{uri="/api/v1/problems/{problemId}/submissions"}` p95, Runner 호출 duration, Hikari active, `event=request_completed durationMs`, 4xx/5xx 비율 | VU 20~50에서 p95가 5초 이내, 실패율 1% 미만. Runner 타임아웃은 별도 집계 |
+| 2 | `POST /api/v1/code-problems/{problemId}/executions` | 외부연동형 | 단순 코드 실행이지만 Runner와 GCS 데이터셋 다운로드가 포함되면 외부 지연이 대부분을 차지한다. 서버 내부 최적화보다 Runner 연결/응답 시간, timeout 설정 검증이 핵심이다. | `problems/execution/application/service/CodeExecutionService`, `problems/execution/infrastructure/runner/CloudRunCodeRunnerAdapter` | 코드 실행 API p95, Runner HTTP duration, timeout count, Loki errorMessage | p95가 기본 실행 제한 시간 근처에서 안정적이고, timeout/connection error가 1% 미만 |
+| 3 | `GET /api/v1/problem-sets/{problemSetId}` | 조회/집계형 | 문제세트 진입 시 문제 목록, 진행 상태, 최신 제출, startCode를 함께 구성한다. 문제 수가 많거나 사용자별 진행/제출 상태 조회가 늘어나면 조회 비용이 증가할 수 있다. | `problems/set/application/service/ProblemSetEntryService`, `problems/set/infrastructure/persistence/ProblemSetEntryPersistenceAdapter`, `problems/set/application/service/ProblemStartCodeService` | API p95, DB query count, Hikari active, 응답 payload size | 문제 20개 이상 시에도 p95 500ms~1s 이내. N+1이 보이면 batch/projection 검토 |
+| 4 | `GET /api/v1/problems/{problemSetId}` | 조회/집계형 | 운영자 수정 화면은 문제세트 기본 정보, 문제 목록, 힌트, 데이터셋, 테스트케이스를 한 번에 내려준다. 현재 힌트/테스트케이스는 일괄 조회 구조로 개선됐지만, 문제 수와 테스트케이스 수가 많으면 payload와 조합 비용이 커질 수 있다. | `problems/set/application/service/ProblemSetForUpdateQueryService` | API p95, 응답 크기, DB query count, memory allocation 추세 | 문제 20개, 테스트케이스 40개 수준에서 p95 1초 이내 |
+| 5 | `GET /api/v1/problem-sets` | 조회형 | 전체 문제세트 목록 조회는 단순 조회에 가깝다. 다만 카테고리 필터, 문제세트 수 증가, 정렬 조건에 따라 인덱스 영향이 생길 수 있다. 병목 후보는 낮다. | `problems/set/application/service/ProblemSetQueryService`, `problems/set/infrastructure/persistence/ProblemSetPersistenceAdapter` | API p95, DB rows scanned, Hikari active | VU 50에서 p95 500ms 이내. 병목 없으면 baseline 충족으로 종료 |
+| 6 | `PUT /api/v1/problems/{problemSetId}` / `PUT /api/v1/problems/{problemSetId}/with-dataset` | 쓰기/트랜잭션 + 외부연동 | 운영자 수정은 빈번한 사용자 트래픽 API는 아니지만, 문제/힌트/테스트케이스 동기화와 데이터셋 업로드가 함께 발생한다. CSV 업로드가 포함되면 GCS 지연과 트랜잭션 보상 로직이 병목 후보가 된다. | `problems/set/application/service/ProblemSetUpdateService`, `ProblemSetWithDatasetUpdateService`, `problems/dataset/application/service/ProblemDatasetCommandService` | 요청 duration, GCS upload duration, transaction duration, 실패 로그 | 운영자 API이므로 고부하 최적화 대상은 낮음. 기능 안정성 위주로 5xx 0% 확인 |
+| 7 | `PUT /api/v1/problems/{problemId}/recommended-courses` | 쓰기/트랜잭션형 | 추천 코스 연결 저장은 기존 연결 삭제 후 요청 목록 기준 재저장한다. 코스 수가 많지 않다는 정책이면 병목 가능성은 낮다. 단, 같은 문제에 동시 저장이 몰리면 마지막 요청 기준으로 덮어쓰기 되는 정책 확인이 필요하다. | `problems/recommendation/application/service/ProblemRecommendedCourseCommandService`, `problems/recommendation/infrastructure/persistence/ProblemRecommendedCoursePersistenceAdapter` | API p95, duplicate/validation error, DB lock wait | 단순 운영자 API로 baseline만 확인. 병목 없음 결론 가능 |
+| 8 | `GET /api/v1/problems/{problemId}/recommended-courses` | 조회형 | 학생 문제풀이 화면에서 호출되는 추천 코스 조회다. 현재 연결된 추천 courseId와 ACTIVE 코스 목록을 매칭한다. 코스 전체 목록이 커지면 불필요한 전체 조회가 병목이 될 수 있다. | `problems/recommendation/application/service/ProblemRecommendedCourseQueryService`, `problems/recommendation/infrastructure/course/RecommendationCourseAdapter` | API p95, course rows scanned, DB query count | 코스 수 증가 시에도 p95 500ms 이내. 필요 시 연결된 courseId 기준 IN 조회로 개선 |
+
+---
+
+## 1차 집중 대상
+
+이번 Problems 도메인의 메인 부하테스트 대상은 아래 2개로 잡는다.
+
+| 우선순위 | API | 이유 |
+|---|---|---|
+| 1 | `POST /api/v1/problems/{problemId}/submissions` | 사용자 코드 실행, 테스트케이스 채점, DB 저장, 진행 상태 갱신, 포인트 이벤트가 연결된 핵심 트랜잭션이다. 외부 Runner 지연과 DB 쓰기 병목을 동시에 볼 수 있다. |
+| 2 | `GET /api/v1/problem-sets/{problemSetId}` | 문제풀이 화면 진입 API로 사용자 체감에 직접 영향을 준다. 문제 수가 늘어날 때 N+1 또는 payload 병목이 생기는지 확인하기 좋다. |
+
+운영자 관리 API와 추천 코스 저장 API는 중요하지만 일반 사용자 트래픽이 낮고, 단순 CRUD 또는 관리자 트랜잭션 성격이 강하므로 1차 부하테스트에서는 보조 관찰 대상으로 둔다.
+
+---
+
+## 측정 전 확인할 데이터 조건
+
+| 항목 | 권장 조건 |
+|---|---|
+| 문제세트 | 최소 1개 이상, 가능하면 문제 6~20개 포함 |
+| 테스트케이스 | 문제당 1~3개 이상 |
+| 제출 사용자 | 학생 계정 1개 이상 |
+| 데이터셋 | CSV 데이터셋이 연결된 문제세트 1개 이상 |
+| 추천 코스 | 문제 1개에 추천 코스 1~3개 연결 |
+
+데이터가 너무 적으면 병목이 보이지 않는다. 특히 N+1이나 payload 문제는 문제 수와 테스트케이스 수가 늘어났을 때 드러난다.
+
+---
+
+## 다음 단계
+
+- 2단계: Problems 도메인 전용 커스텀 metric/log 후보를 정리한다. (`metrics.md`)
+- 4단계: `monitoring/k6/scripts/problems/` 아래에 문제세트 진입과 코드 제출 시나리오를 작성한다.
+- 5단계: loadtest DB에 문제세트, 문제, 테스트케이스, 학생 계정, 데이터셋 더미를 넣고 baseline을 측정한다.

--- a/monitoring/docs/domains/problems/metrics.md
+++ b/monitoring/docs/domains/problems/metrics.md
@@ -1,0 +1,317 @@
+# Problems 도메인 메트릭 / 로그 / 부하 테스트 설계
+
+> 프로세스: `monitoring/docs/PROCESS.md` 2~5단계 산출물  
+> 병목 가설: `monitoring/docs/domains/problems/bottleneck-hypothesis.md`
+
+이 문서는 Problems 관련 병목 후보 1, 2순위를 실제로 측정하기 위한 메트릭, 로그, 성공 기준, k6 시나리오, 시드 및 baseline 실행 방법을 정리한다.
+
+---
+
+## 1단계 요약 - 측정 대상 API
+
+| 우선순위 | API | 유형 | 병목 가설 |
+| --- | --- | --- | --- |
+| 1 | `POST /api/v1/problems/{problemId}/submissions` | 쓰기 + 외부 연동 | 사용자 코드 실행, 테스트케이스 채점, 제출 결과 저장, 포인트 이벤트 발행이 한 흐름에 이어져 p95가 커질 수 있다. |
+| 2 | `GET /api/v1/problem-sets/{problemSetId}` | 조회 / 집계 | 문제세트 진입 시 문제 목록, 진행 상태, 최신 제출, 시작 코드를 함께 구성하므로 조회 조합 비용이 커질 수 있다. |
+
+---
+
+## 2단계 - Custom Metrics
+
+| metric name | type | 대상 API | 의미 | 코드 위치 |
+| --- | --- | --- | --- | --- |
+| `submission_grading_duration_seconds` | Timer | 제출/채점 | 제출 요청에서 채점과 결과 저장까지 걸린 시간 | `submission.infrastructure.metrics.SubmissionMetrics.recordGrading()` |
+| `code_execution_runner_duration_seconds` | Timer | 코드 실행 / 제출 | Python Runner 호출과 응답 수신에 걸린 시간 | `problems.execution.infrastructure.metrics.CodeExecutionMetrics.recordRunnerExecution()` |
+| `problem_set_entry_duration_seconds` | Timer | 문제세트 진입 | 문제세트 진입 화면 데이터 구성에 걸린 시간 | `problems.set.infrastructure.metrics.ProblemSetMetrics.recordEntry()` |
+| `submission_failed_total` | Counter | 제출/채점 | 제출 또는 채점 실패 횟수 | `submission.infrastructure.metrics.SubmissionMetrics.incrementFailure()` |
+
+> Micrometer Timer는 Prometheus에서 `_seconds_count`, `_seconds_sum`, `_seconds_max` 형태로 노출된다.
+
+---
+
+## 2단계 - Structured Logs
+
+| event | 대상 API | 남길 값 | 목적 |
+| --- | --- | --- | --- |
+| `event=submission_completed` | 제출/채점 | `userId`, `problemId`, `submissionId`, `isCorrect`, `passedTestCount`, `totalTestCount`, `durationMs` | 정상 제출의 전체 처리 시간 확인 |
+| `event=submission_failed` | 제출/채점 | `userId`, `problemId`, `exceptionType`, `durationMs` | 제출/채점 실패 원인 분류 |
+| `event=code_execution_runner_completed` | Runner 호출 | `success`, `executionTimeMs`, `durationMs` | 외부 Runner 지연 여부 확인 |
+| `event=code_execution_runner_failed` | Runner 호출 | `endpoint`, `exceptionType`, `durationMs` | Runner 호출 실패 원인 확인 |
+| `event=problem_set_entered` | 문제세트 진입 | `userId`, `problemSetId`, `problemCount`, `solvedProblemCount`, `durationMs` | 문제세트 화면 구성 시간 확인 |
+| `event=problem_set_entry_failed` | 문제세트 진입 | `userId`, `problemSetId`, `exceptionType`, `durationMs` | 문제세트 진입 실패 원인 확인 |
+
+로그는 `event=<domain>_<verb> ... durationMs=<n>` 형식을 따른다.
+
+---
+
+## 3단계 - 성공 기준
+
+반드시 트래픽 조건과 측정 기간을 함께 적는다. `평균 500ms 이하`처럼 평균만 보는 기준은 사용하지 않는다.
+
+### 3-1. 문제세트 진입 API
+
+```http
+GET /api/v1/problem-sets/{problemSetId}
+```
+
+| 항목 | 기준 |
+| --- | --- |
+| 트래픽 조건 | VU 50, ramping 0 -> 50, 약 70초 |
+| API 유형 | 조회 / 집계 |
+| 성공 기준 | `http_req_duration{type:entry}` p95 < 800ms |
+| tail latency 기준 | `http_req_duration{type:entry}` p99 < 2s |
+| 실패율 | `http_req_failed < 1%` |
+| check 성공률 | 99% 이상 |
+| 함께 볼 메트릭 | `problem_set_entry_duration_seconds` |
+
+실패 해석:
+
+| 실패 상황 | 의심 지점 |
+| --- | --- |
+| p95가 800ms 초과 | 문제세트 조회 조합, 진행 상태 조회, startCode 구성 |
+| p99가 2초 초과 | 일부 요청의 DB 조회 지연 또는 커넥션 대기 |
+| HTTP duration과 `problem_set_entry_duration_seconds`가 함께 증가 | application 내부 조회 조합 병목 |
+| HTTP만 높고 custom metric은 낮음 | 인증, 필터, 네트워크, 공통 계층 의심 |
+
+### 3-2. 코드 제출/채점 API
+
+```http
+POST /api/v1/problems/{problemId}/submissions
+```
+
+| 항목 | 기준 |
+| --- | --- |
+| 트래픽 조건 | VU 50, ramping 0 -> 50, 약 70초 |
+| API 유형 | 쓰기 + 외부 연동 |
+| 성공 기준 | `http_req_duration{type:submit}` p95 < 2s |
+| tail latency 기준 | `http_req_duration{type:submit}` p99 < 5s |
+| 실패율 | `http_req_failed < 1%` |
+| check 성공률 | 99% 이상 |
+| 함께 볼 메트릭 | `submission_grading_duration_seconds`, `code_execution_runner_duration_seconds`, `submission_failed_total` |
+
+실패 해석:
+
+| 실패 상황 | 의심 지점 |
+| --- | --- |
+| p95가 2초 초과 | Runner, 테스트케이스 채점, DB 저장 중 병목 가능 |
+| p99가 5초 초과 | timeout 근처 요청 또는 외부 Runner 지연 |
+| Runner duration만 높음 | Python Runner / Cloud Run / 네트워크 병목 |
+| Runner는 낮고 submission grading만 높음 | 테스트케이스 조회, 제출 저장, 진행 상태 갱신 병목 |
+| `submission_failed_total` 증가 | 제출/채점 예외 증가 |
+
+---
+
+## 4단계 - k6 시나리오
+
+Problems 도메인은 병목 유형이 다르므로 k6 시나리오를 2개로 분리한다.
+
+| 파일 | 대상 | 설명 |
+| --- | --- | --- |
+| `monitoring/k6/scripts/problems/01-problem-set-entry-baseline.js` | 문제세트 진입 | 조회/집계형 API baseline |
+| `monitoring/k6/scripts/problems/02-submission-baseline.js` | 코드 제출/채점 | 쓰기 + 외부 Runner 연동 API baseline |
+
+### 4-1. 문제세트 진입 시나리오
+
+주요 조건:
+
+| 항목 | 값 |
+| --- | --- |
+| 기본 문제세트 ID | `4001` |
+| 환경변수 | `PROBLEM_SET_ID`로 변경 가능 |
+| k6 tag | `type=entry` |
+| threshold | p95 < 800ms, p99 < 2s, failed < 1% |
+
+실행 대상 파일:
+
+```text
+monitoring/k6/scripts/problems/01-problem-set-entry-baseline.js
+```
+
+### 4-2. 코드 제출/채점 시나리오
+
+주요 조건:
+
+| 항목 | 값 |
+| --- | --- |
+| 기본 문제 ID | `5001` |
+| 기본 제출 코드 | `result = None` |
+| 환경변수 | `PROBLEM_ID`, `SUBMISSION_CODE`로 변경 가능 |
+| k6 tag | `type=submit` |
+| threshold | p95 < 2s, p99 < 5s, failed < 1% |
+
+기본 코드를 오답 코드로 둔 이유:
+
+| 이유 | 설명 |
+| --- | --- |
+| 반복 제출 안정성 | 정답 코드를 반복 제출하면 이미 푼 문제 정책에 막힐 수 있다. |
+| 병목 측정 가능 | 오답이어도 Runner 실행, 테스트케이스 채점, 제출 저장 흐름은 실행된다. |
+| 포인트 중복 방지 | 정답 이벤트와 포인트 지급을 반복 발생시키지 않는다. |
+
+실행 대상 파일:
+
+```text
+monitoring/k6/scripts/problems/02-submission-baseline.js
+```
+
+---
+
+## 5단계 - 시드 + baseline
+
+### 5-1. 시드가 필요한 이유
+
+loadtest DB는 테스트 환경에서 비어 있거나 데이터가 적을 수 있다. 데이터가 너무 적으면 조회 조합, 테스트케이스 채점, Runner 호출 병목이 드러나지 않는다.
+
+| 데이터 | 권장 개수 | 이유 |
+| --- | ---: | --- |
+| 학생 계정 | 1개 이상 | k6 로그인에 필요 |
+| 문제세트 | 1개 이상 | 문제세트 진입 API 대상 |
+| 문제 | 20개 이상 | 문제 목록 조회 비용 확인 |
+| 테스트케이스 | 문제당 1~3개 | 제출/채점 비용 확인 |
+| 데이터셋 | 1개 이상 | Runner에서 CSV 기반 실행 확인 |
+| 문제 진행 상태 | 학생 1명 기준 | 이어풀기 상태 확인 |
+
+시더를 만든다면 다음 조건을 따른다.
+
+| 조건 | 설명 |
+| --- | --- |
+| 프로필 | `@Profile("loadtest")` |
+| 실행 시점 | 애플리케이션 부팅 직후 |
+| 방식 | `JdbcTemplate batch` 권장 |
+| 중복 방지 | 이미 시드 데이터가 있으면 skip |
+| DB | 운영 DB가 아니라 loadtest DB만 사용 |
+
+현재 시더 클래스:
+
+```text
+src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemsLoadTestSeeder.java
+```
+
+시더 기본값:
+
+| 항목 | 값 |
+| --- | --- |
+| 로그인 계정 | `u01@test.com` / `Test1234!` |
+| 문제세트 ID | `4001` |
+| 첫 번째 문제 ID | `5001` |
+| 문제 수 | 20개 |
+| 테스트케이스 | 문제당 1개 |
+| 데이터셋 | `employee_performance.csv` |
+
+### 5-2. 시드 확인 SQL
+
+```bash
+docker compose exec mysql mysql -ulms_loadtest -ploadtest lms_loadtest \
+  -e "select count(*) from problem_set;"
+```
+
+```bash
+docker compose exec mysql mysql -ulms_loadtest -ploadtest lms_loadtest \
+  -e "select count(*) from problem;"
+```
+
+```bash
+docker compose exec mysql mysql -ulms_loadtest -ploadtest lms_loadtest \
+  -e "select count(*) from problem_test_case;"
+```
+
+기대값:
+
+| 테이블 | 기대값 |
+| --- | ---: |
+| `problem_set` | 1 이상 |
+| `problem` | 20 이상 |
+| `problem_test_case` | 20 이상 |
+| `problem_dataset` | 1 이상 |
+| `users` | 테스트 학생 1명 이상 |
+
+### 5-3. baseline 실행
+
+문제세트 진입 baseline:
+
+```bash
+MSYS_NO_PATHCONV=1 docker compose run --rm \
+  -e PROBLEM_SET_ID=4001 \
+  -e RESULT_NAME=problem-set-entry-before \
+  k6 run -o experimental-prometheus-rw /scripts/problems/01-problem-set-entry-baseline.js
+```
+
+코드 제출/채점 baseline:
+
+```bash
+MSYS_NO_PATHCONV=1 docker compose run --rm \
+  -e PROBLEM_ID=5001 \
+  -e RESULT_NAME=submission-before \
+  k6 run -o experimental-prometheus-rw /scripts/problems/02-submission-baseline.js
+```
+
+### 5-4. 결과 저장 위치
+
+k6 결과는 `handleSummary`에 의해 아래 위치에 저장된다.
+
+```text
+monitoring/k6/results/problem-set-entry-before-summary.md
+monitoring/k6/results/problem-set-entry-before-summary.json
+monitoring/k6/results/submission-before-summary.md
+monitoring/k6/results/submission-before-summary.json
+```
+
+---
+
+## 6단계 준비 - PromQL / LogQL 후보
+
+### 제출/채점 평균 처리 시간
+
+```promql
+rate(submission_grading_duration_seconds_sum[1m])
+/
+rate(submission_grading_duration_seconds_count[1m])
+```
+
+### Runner 평균 실행 시간
+
+```promql
+rate(code_execution_runner_duration_seconds_sum[1m])
+/
+rate(code_execution_runner_duration_seconds_count[1m])
+```
+
+### 문제세트 진입 평균 처리 시간
+
+```promql
+rate(problem_set_entry_duration_seconds_sum[1m])
+/
+rate(problem_set_entry_duration_seconds_count[1m])
+```
+
+### 제출 실패 증가량
+
+```promql
+rate(submission_failed_total[1m])
+```
+
+### 제출/채점 완료 로그
+
+```logql
+{job="lms"} |= "event=submission_completed"
+```
+
+### Runner 호출 완료 로그
+
+```logql
+{job="lms"} |= "event=code_execution_runner_completed"
+```
+
+### 문제세트 진입 로그
+
+```logql
+{job="lms"} |= "event=problem_set_entered"
+```
+
+### 1초 이상 걸린 Problems 요청
+
+```logql
+{job="lms"}
+  |= "event=request_completed"
+  |= "/api/v1/problem"
+  | regexp "durationMs=([1-9][0-9]{3,})"
+```

--- a/monitoring/k6/results/problem-set-entry-before-summary.json
+++ b/monitoring/k6/results/problem-set-entry-before-summary.json
@@ -1,0 +1,265 @@
+{
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 72923.207321
+  },
+  "metrics": {
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.08651860000000001,
+        "p(95)": 0.12022139999999994,
+        "p(99)": 0.1820531799999998,
+        "max": 0.67982,
+        "avg": 0.05613148714384989,
+        "min": 0.010133,
+        "med": 0.051898
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.570986,
+        "p(90)": 1.0734068,
+        "p(95)": 1.3243581,
+        "p(99)": 2.13216109999999,
+        "max": 6.310288,
+        "avg": 0.6442371591382917,
+        "min": 0.052812
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1439
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "data_sent": {
+      "contains": "data",
+      "values": {
+        "count": 484814,
+        "rate": 6648.281360773144
+      },
+      "type": "counter"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 4314,
+        "fails": 0
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 663.135859,
+        "med": 1954.486293,
+        "p(90)": 2678.5007186000003,
+        "p(95)": 2858.8447369999994,
+        "p(99)": 3116.26201132,
+        "max": 3717.674725,
+        "avg": 1948.5318386900622
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1438,
+        "rate": 19.719374021360316
+      }
+    },
+    "http_req_duration{type:entry}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 1647.105580879999,
+        "max": 1897.875032,
+        "avg": 721.3083426335195,
+        "min": 70.2381,
+        "med": 769.5216785,
+        "p(90)": 1112.2393771999998,
+        "p(95)": 1245.3244540999997
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": false
+        },
+        "p(99)<2000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.008597,
+        "p(90)": 0.012032000000000001,
+        "p(95)": 0.033343999999999846,
+        "p(99)": 3.999903679999992,
+        "max": 7.153613,
+        "avg": 0.1411111487143844,
+        "min": 0.003591
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 1647.0276681199991,
+        "max": 1897.875032,
+        "avg": 721.6125656275198,
+        "min": 70.2381,
+        "med": 769.639951,
+        "p(90)": 1112.498868,
+        "p(95)": 1245.2412683999999
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 1245.2412683999999,
+        "p(99)": 1647.0276681199991,
+        "max": 1897.875032,
+        "avg": 721.6125656275198,
+        "min": 70.2381,
+        "med": 769.639951,
+        "p(90)": 1112.498868
+      }
+    },
+    "http_req_waiting": {
+      "contains": "time",
+      "values": {
+        "min": 70.020023,
+        "med": 768.841537,
+        "p(90)": 1111.6863678,
+        "p(95)": 1244.7858933999998,
+        "p(99)": 1646.5682847599992,
+        "max": 1897.447161,
+        "avg": 720.9121969812375
+      },
+      "type": "trend"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 0,
+        "max": 50
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      }
+    },
+    "http_reqs": {
+      "contains": "default",
+      "values": {
+        "count": 1439,
+        "rate": 19.733087077007994
+      },
+      "type": "counter"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 3.8180480199999893,
+        "max": 6.966387,
+        "avg": 0.12519457123002084
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 10116954,
+        "rate": 138734.35318699398
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE3NzIyMjksImV4cCI6MTc4MTc3NTgyOX0.LMax1NxmtHs-tCa-m8n6_EJzEEB_e_MPRguMmKuPk6E"
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 1438,
+          "fails": 0,
+          "name": "status is 200"
+        },
+        {
+          "name": "has problemSetId",
+          "path": "::has problemSetId",
+          "id": "5678b9b28638de3e1b8680fff0fe5794",
+          "passes": 1438,
+          "fails": 0
+        },
+        {
+          "name": "has problems array",
+          "path": "::has problems array",
+          "id": "0c4326b19c817e8da3e0e2915a19a6ea",
+          "passes": 1438,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  }
+}

--- a/monitoring/k6/results/problem-set-entry-before-summary.md
+++ b/monitoring/k6/results/problem-set-entry-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - problem-set-entry-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 1439 |
+| iterations | 1438 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 10116954 |
+| data_sent bytes | 484814 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 721.61 | 70.24 | 769.64 | 1112.50 | 1245.24 | 1647.03 | 1897.88 |
+| http_req_waiting | 720.91 | 70.02 | 768.84 | 1111.69 | 1244.79 | 1646.57 | 1897.45 |
+| http_req_blocked | 0.14 | 0.00 | 0.01 | 0.01 | 0.03 | 4.00 | 7.15 |
+| http_req_connecting | 0.13 | 0 | 0 | 0 | 0 | 3.82 | 6.97 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 1438 pass / 0 fail |
+| has problemSetId | 1438 pass / 0 fail |
+| has problems array | 1438 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/submission-before-summary.json
+++ b/monitoring/k6/results/submission-before-summary.json
@@ -1,0 +1,265 @@
+{
+  "metrics": {
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.7949767206645894,
+        "min": 0.073574,
+        "med": 0.712122,
+        "p(90)": 1.2551462000000013,
+        "p(95)": 1.5382151,
+        "p(99)": 2.4075340599999997,
+        "max": 15.39482
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 875076,
+        "rate": 12265.574589020858
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 141.656392,
+        "med": 1889.878871,
+        "p(90)": 2470.5138648,
+        "p(95)": 2795.8858355,
+        "p(99)": 3108.40979658,
+        "max": 4285.662596,
+        "avg": 1673.9295488847367
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 140.431359,
+        "med": 1888.975464,
+        "p(90)": 2469.4024094000006,
+        "p(95)": 2795.1687552999997,
+        "p(99)": 3107.6885090799997,
+        "max": 4284.461824,
+        "avg": 1673.0523522388353
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.003442,
+        "med": 0.0093,
+        "p(90)": 0.013825400000000002,
+        "p(95)": 2.9562539999999973,
+        "p(99)": 5.5668415399999995,
+        "max": 7.352366,
+        "avg": 0.2571380623052959
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 962,
+        "rate": 13.483951970615198
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 50
+      }
+    },
+    "http_req_duration{type:submit}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1675.522348424118,
+        "min": 169.291046,
+        "med": 1891.8818895,
+        "p(90)": 2470.7868454,
+        "p(95)": 2796.00326875,
+        "p(99)": 3108.64215599,
+        "max": 4285.662596
+      },
+      "thresholds": {
+        "p(95)<2000": {
+          "ok": false
+        },
+        "p(99)<5000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 2.7730321999999967,
+        "p(99)": 5.35861388,
+        "max": 6.834393,
+        "avg": 0.2355172045690551
+      },
+      "type": "trend"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.075271,
+        "p(90)": 0.11996680000000005,
+        "p(95)": 0.1745649,
+        "p(99)": 0.24377188,
+        "max": 0.475864,
+        "avg": 0.0822199252336449,
+        "min": 0.019066
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 2886,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 963,
+        "rate": 13.497968552705235
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 963
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 408096,
+        "rate": 5720.111084615572
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 4246.6966548,
+        "p(99)": 4732.76407912,
+        "max": 6191.336576,
+        "avg": 2912.666478399793,
+        "min": 146.101057,
+        "med": 2984.655482,
+        "p(90)": 3996.8740072
+      }
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      },
+      "type": "gauge"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 4285.662596,
+        "avg": 1673.9295488847367,
+        "min": 141.656392,
+        "med": 1889.878871,
+        "p(90)": 2470.5138648,
+        "p(95)": 2795.8858355,
+        "p(99)": 3108.40979658
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE3NzI0MDAsImV4cCI6MTc4MTc3NjAwMH0.8I9j8yJuxCmCZ2rfguxA71iSDdw3HDyfCsPNSAp-4yM"
+  },
+  "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 962,
+          "fails": 0
+        },
+        {
+          "name": "has submissionId",
+          "path": "::has submissionId",
+          "id": "eb5bb4d2b9292b7d9f1c9a9b2a3e2751",
+          "passes": 962,
+          "fails": 0
+        },
+        {
+          "path": "::has executionStatus",
+          "id": "816623e0f4cf88ef43d5e943aa21f716",
+          "passes": 962,
+          "fails": 0,
+          "name": "has executionStatus"
+        }
+      ],
+    "name": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71344.069016
+  }
+}

--- a/monitoring/k6/results/submission-before-summary.md
+++ b/monitoring/k6/results/submission-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - submission-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 963 |
+| iterations | 962 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 875076 |
+| data_sent bytes | 408096 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 1673.93 | 141.66 | 1889.88 | 2470.51 | 2795.89 | 3108.41 | 4285.66 |
+| http_req_waiting | 1673.05 | 140.43 | 1888.98 | 2469.40 | 2795.17 | 3107.69 | 4284.46 |
+| http_req_blocked | 0.26 | 0.00 | 0.01 | 0.01 | 2.96 | 5.57 | 7.35 |
+| http_req_connecting | 0.24 | 0 | 0 | 0 | 2.77 | 5.36 | 6.83 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 962 pass / 0 fail |
+| has submissionId | 962 pass / 0 fail |
+| has executionStatus | 962 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/scripts/problems/01-problem-set-entry-baseline.js
+++ b/monitoring/k6/scripts/problems/01-problem-set-entry-baseline.js
@@ -1,0 +1,47 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+const PROBLEM_SET_ID = __ENV.PROBLEM_SET_ID || "4001";
+
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:entry}": ["p(95)<800", "p(99)<2000"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = {
+        type: "entry",
+        api: "GET /problem-sets/{problemSetId}",
+    };
+
+    const res = http.get(
+        `${BASE_URL}/api/v1/problem-sets/${PROBLEM_SET_ID}`,
+        params
+    );
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "has problemSetId": (r) => r.json("data.problemSetId") !== undefined,
+        "has problems array": (r) => Array.isArray(r.json("data.problems")),
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("problem-set-entry-baseline");

--- a/monitoring/k6/scripts/problems/02-submission-baseline.js
+++ b/monitoring/k6/scripts/problems/02-submission-baseline.js
@@ -1,0 +1,54 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+const PROBLEM_ID = __ENV.PROBLEM_ID || "5001";
+const SUBMISSION_CODE = __ENV.SUBMISSION_CODE || "result = None\n";
+
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:submit}": ["p(95)<2000", "p(99)<5000"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.headers = { "Content-Type": "application/json" };
+    params.tags = {
+        type: "submit",
+        api: "POST /problems/{problemId}/submissions",
+    };
+
+    const body = JSON.stringify({
+        code: SUBMISSION_CODE,
+    });
+
+    const res = http.post(
+        `${BASE_URL}/api/v1/problems/${PROBLEM_ID}/submissions`,
+        body,
+        params
+    );
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "has submissionId": (r) => r.json("data.submissionId") !== undefined,
+        "has executionStatus": (r) => r.json("data.executionStatus") !== undefined,
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("submission-baseline");

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/CourseJpaEntity.java
@@ -13,7 +13,19 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 @ToString
-@Table(name = "course")
+@Table(
+        name = "course",
+        indexes = {
+                @Index(
+                        name = "idx_course_status_deleted_at_course_id",
+                        columnList = "status, deleted_at, course_id"
+                ),
+                @Index(
+                        name = "idx_course_title",
+                        columnList = "title"
+                )
+        }
+)
 public class CourseJpaEntity {
 
     @Id

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.course.infrastructure.persistence;
 
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import java.time.LocalDateTime;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -17,6 +18,17 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
     List<CourseJpaEntity> findByDeletedAtIsNull();
 
     List<CourseJpaEntity> findByStatusAndDeletedAtIsNull(CourseStatus status);
+
+    List<CourseJpaEntity> findByStatusAndDeletedAtIsNullOrderByCourseIdDesc(
+            CourseStatus status,
+            Pageable pageable
+    );
+
+    List<CourseJpaEntity> findByStatusAndDeletedAtIsNullAndTitleContainingIgnoreCaseOrderByCourseIdDesc(
+            CourseStatus status,
+            String title,
+            Pageable pageable
+    );
 
     List<CourseJpaEntity> findByCourseCategory_CourseCategoryIdAndStatusAndDeletedAtIsNull(
             Long courseCategoryId,

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -29,6 +29,11 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
 
     List<CourseJpaEntity> findByCourseIdInAndDeletedAtIsNull(Set<Long> courseIds);
 
+    List<CourseJpaEntity> findByCourseIdInAndStatusAndDeletedAtIsNull(
+            Set<Long> courseIds,
+            CourseStatus status
+    );
+
     Optional<CourseJpaEntity> findByCourseIdAndStatusAndDeletedAtIsNull(Long courseId, CourseStatus status);
 
     List<CourseJpaEntity> findByInstructorIdAndDeletedAtIsNull(Long instructorId);

--- a/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/metrics/CodeExecutionMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/metrics/CodeExecutionMetrics.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.problems.execution.infrastructure.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Code Execution 도메인의 외부 Runner 호출 구간을 측정하는 메트릭 컴포넌트.
+ */
+@Component
+public class CodeExecutionMetrics {
+
+    private final Timer runnerExecutionTimer;
+
+    public CodeExecutionMetrics(MeterRegistry registry) {
+        this.runnerExecutionTimer = Timer.builder("code_execution_runner_duration")
+                .description("Python Runner를 호출해 사용자 코드를 실행하는 데 걸린 시간")
+                .register(registry);
+    }
+
+    public void recordRunnerExecution(long elapsedNanos) {
+        runnerExecutionTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/runner/CloudRunCodeRunnerAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/runner/CloudRunCodeRunnerAdapter.java
@@ -1,11 +1,12 @@
 package com.wanted.codebombalms.problems.execution.infrastructure.runner;
 
 import com.wanted.codebombalms.problems.execution.application.port.RunCodePort;
+import com.wanted.codebombalms.problems.execution.infrastructure.metrics.CodeExecutionMetrics;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 
 @Slf4j
 @Component
@@ -14,11 +15,12 @@ public class CloudRunCodeRunnerAdapter implements RunCodePort {
 
     private final CloudRunCodeRunnerProperties properties;
     private final RestClient restClient;
+    private final CodeExecutionMetrics codeExecutionMetrics;
 
     public CloudRunCodeRunnerAdapter(
             CloudRunCodeRunnerProperties properties,
-            RestClient.Builder restClientBuilder
-
+            RestClient.Builder restClientBuilder,
+            CodeExecutionMetrics codeExecutionMetrics
     ) {
         SimpleClientHttpRequestFactory requestFactory =
                 new SimpleClientHttpRequestFactory();
@@ -27,14 +29,16 @@ public class CloudRunCodeRunnerAdapter implements RunCodePort {
         requestFactory.setReadTimeout(properties.getReadTimeoutMs());
 
         this.properties = properties;
+        this.codeExecutionMetrics = codeExecutionMetrics;
         this.restClient = restClientBuilder
                 .requestFactory(requestFactory)
                 .build();
     }
 
     @Override
-    public CodeRunResult run(CodeRunCommand command)  {
+    public CodeRunResult run(CodeRunCommand command) {
         long startTime = System.currentTimeMillis();
+        long startNanos = System.nanoTime();
 
         try {
             CloudRunExecuteResponse response = restClient.post()
@@ -50,6 +54,12 @@ public class CloudRunCodeRunnerAdapter implements RunCodePort {
             long executionTimeMs = resolveExecutionTime(response, startTime);
 
             if (response == null) {
+                log.warn(
+                        "event=code_execution_runner_completed success=false reason=empty_response executionTimeMs={} durationMs={}",
+                        executionTimeMs,
+                        elapsedMillis(startNanos)
+                );
+
                 return new CodeRunResult(
                         null,
                         "코드 실행 서버 응답이 비어 있습니다.",
@@ -60,6 +70,13 @@ public class CloudRunCodeRunnerAdapter implements RunCodePort {
 
             boolean success = Boolean.TRUE.equals(response.success());
 
+            log.info(
+                    "event=code_execution_runner_completed success={} executionTimeMs={} durationMs={}",
+                    success,
+                    executionTimeMs,
+                    elapsedMillis(startNanos)
+            );
+
             return new CodeRunResult(
                     response.stdout(),
                     success ? null : response.stderr(),
@@ -67,8 +84,13 @@ public class CloudRunCodeRunnerAdapter implements RunCodePort {
                     success
             );
         } catch (Exception e) {
-            log.error("Cloud Run 코드 실행 서버 호출에 실패했습니다. endpoint={}",
-                    properties.getEndpoint(), e);
+            log.error(
+                    "event=code_execution_runner_failed endpoint={} exceptionType={} durationMs={}",
+                    properties.getEndpoint(),
+                    e.getClass().getSimpleName(),
+                    elapsedMillis(startNanos),
+                    e
+            );
 
             return new CodeRunResult(
                     null,
@@ -76,6 +98,8 @@ public class CloudRunCodeRunnerAdapter implements RunCodePort {
                     System.currentTimeMillis() - startTime,
                     false
             );
+        } finally {
+            codeExecutionMetrics.recordRunnerExecution(System.nanoTime() - startNanos);
         }
     }
 
@@ -84,6 +108,10 @@ public class CloudRunCodeRunnerAdapter implements RunCodePort {
             return response.executionTimeMs();
         }
         return System.currentTimeMillis() - startTime;
+    }
+
+    private long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
     }
 
     private String appendResultPrinter(String code) {

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/command/SaveProblemRecommendedCoursesCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/command/SaveProblemRecommendedCoursesCommand.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.recommendation.application.command;
+
+import java.util.List;
+
+public record SaveProblemRecommendedCoursesCommand(
+        Long problemId,
+        List<Long> courseIds
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadRecommendationCoursePort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadRecommendationCoursePort.java
@@ -7,7 +7,9 @@ public interface LoadRecommendationCoursePort {
 
     Set<Long> loadActiveCourseIds(Set<Long> courseIds);
 
-    List<SelectableCourseData> loadSelectableCourses();
+    List<SelectableCourseData> loadSelectableCourses(String keyword, int limit);
+
+    List<SelectableCourseData> loadActiveCoursesByIds(Set<Long> courseIds);
 
     record SelectableCourseData(
             Long courseId,

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadRecommendationCoursePort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadRecommendationCoursePort.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.problems.recommendation.application.port;
+
+import java.util.List;
+import java.util.Set;
+
+public interface LoadRecommendationCoursePort {
+
+    Set<Long> loadActiveCourseIds(Set<Long> courseIds);
+
+    List<SelectableCourseData> loadSelectableCourses();
+
+    record SelectableCourseData(
+            Long courseId,
+            String title,
+            String description,
+            String thumbnailUrl
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadRecommendationProblemPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadRecommendationProblemPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.recommendation.application.port;
+
+public interface LoadRecommendationProblemPort {
+
+    boolean existsActiveProblem(Long problemId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadSavedRecommendedCoursePort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/LoadSavedRecommendedCoursePort.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.problems.recommendation.application.port;
+
+import java.util.List;
+
+public interface LoadSavedRecommendedCoursePort {
+
+    List<SavedRecommendedCourseData> loadSavedRecommendedCourses(Long problemId);
+
+    record SavedRecommendedCourseData(
+            Long courseId,
+            Integer displayOrder
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/SaveProblemRecommendedCoursePort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/port/SaveProblemRecommendedCoursePort.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.problems.recommendation.application.port;
+
+import java.util.List;
+
+public interface SaveProblemRecommendedCoursePort {
+
+    void replaceRecommendedCourses(Long problemId, List<RecommendedCourseOrder> courses);
+
+    record RecommendedCourseOrder(
+            Long courseId,
+            Integer displayOrder
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/query/GetProblemRecommendedCoursesQuery.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/query/GetProblemRecommendedCoursesQuery.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.recommendation.application.query;
+
+public record GetProblemRecommendedCoursesQuery(
+        Long problemId
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/query/GetRecommendedCourseEditViewQuery.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/query/GetRecommendedCourseEditViewQuery.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.recommendation.application.query;
+
+public record GetRecommendedCourseEditViewQuery(
+        Long problemId
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/query/GetSelectableRecommendedCoursesQuery.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/query/GetSelectableRecommendedCoursesQuery.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.problems.recommendation.application.query;
+
+public record GetSelectableRecommendedCoursesQuery(
+        String keyword,
+        Integer limit
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseCommandService.java
@@ -53,6 +53,10 @@ public class ProblemRecommendedCourseCommandService implements SaveProblemRecomm
             throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
         }
 
+        if (command.problemId() <= 0) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+
         Set<Long> uniqueCourseIds = new HashSet<>(command.courseIds());
 
         if (uniqueCourseIds.size() != command.courseIds().size()) {

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseCommandService.java
@@ -1,0 +1,94 @@
+package com.wanted.codebombalms.problems.recommendation.application.service;
+
+import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.recommendation.application.command.SaveProblemRecommendedCoursesCommand;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationCoursePort;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationProblemPort;
+import com.wanted.codebombalms.problems.recommendation.application.port.SaveProblemRecommendedCoursePort;
+import com.wanted.codebombalms.problems.recommendation.application.port.SaveProblemRecommendedCoursePort.RecommendedCourseOrder;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.SaveProblemRecommendedCoursesUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProblemRecommendedCourseCommandService implements SaveProblemRecommendedCoursesUseCase {
+
+    private final LoadRecommendationProblemPort loadRecommendationProblemPort;
+    private final LoadRecommendationCoursePort loadRecommendationCoursePort;
+    private final SaveProblemRecommendedCoursePort saveProblemRecommendedCoursePort;
+
+    @Override
+    public SaveProblemRecommendedCoursesResult handle(SaveProblemRecommendedCoursesCommand command) {
+        validateCommand(command);
+        validateProblem(command.problemId());
+        validateCourses(command.courseIds());
+
+        List<RecommendedCourseOrder> courses = toRecommendedCourseOrders(command.courseIds());
+
+        saveProblemRecommendedCoursePort.replaceRecommendedCourses(
+                command.problemId(),
+                courses
+        );
+
+        return new SaveProblemRecommendedCoursesResult(
+                command.problemId(),
+                command.courseIds().size(),
+                command.courseIds()
+        );
+    }
+
+    private void validateCommand(SaveProblemRecommendedCoursesCommand command) {
+        if (command == null || command.problemId() == null || command.courseIds() == null) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+
+        Set<Long> uniqueCourseIds = new HashSet<>(command.courseIds());
+
+        if (uniqueCourseIds.size() != command.courseIds().size()) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+
+        if (command.courseIds().stream().anyMatch(courseId -> courseId == null || courseId <= 0)) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+    }
+
+    private void validateProblem(Long problemId) {
+        if (!loadRecommendationProblemPort.existsActiveProblem(problemId)) {
+            throw new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND);
+        }
+    }
+
+    private void validateCourses(List<Long> courseIds) {
+        if (courseIds.isEmpty()) {
+            return;
+        }
+
+        Set<Long> requestedCourseIds = new HashSet<>(courseIds);
+        Set<Long> activeCourseIds = loadRecommendationCoursePort.loadActiveCourseIds(requestedCourseIds);
+
+        if (activeCourseIds.size() != requestedCourseIds.size()) {
+            throw new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND);
+        }
+    }
+
+    private List<RecommendedCourseOrder> toRecommendedCourseOrders(List<Long> courseIds) {
+        return IntStream.range(0, courseIds.size())
+                .mapToObj(index -> new RecommendedCourseOrder(
+                        courseIds.get(index),
+                        index + 1
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseQueryService.java
@@ -1,0 +1,123 @@
+package com.wanted.codebombalms.problems.recommendation.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationCoursePort;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationProblemPort;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadSavedRecommendedCoursePort;
+import com.wanted.codebombalms.problems.recommendation.application.query.GetProblemRecommendedCoursesQuery;
+import com.wanted.codebombalms.problems.recommendation.application.query.GetRecommendedCourseEditViewQuery;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetProblemRecommendedCoursesUseCase;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetRecommendedCourseEditViewUseCase;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetSelectableRecommendedCoursesUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemRecommendedCourseQueryService implements GetRecommendedCourseEditViewUseCase,
+        GetProblemRecommendedCoursesUseCase, GetSelectableRecommendedCoursesUseCase {
+
+    private final LoadRecommendationProblemPort loadRecommendationProblemPort;
+    private final LoadSavedRecommendedCoursePort loadSavedRecommendedCoursePort;
+    private final LoadRecommendationCoursePort loadRecommendationCoursePort;
+
+    @Override
+    public RecommendedCourseEditView handle(GetRecommendedCourseEditViewQuery query) {
+        validateProblem(query.problemId());
+
+        var savedCourses = loadSavedRecommendedCoursePort.loadSavedRecommendedCourses(query.problemId());
+        var selectableCourses = loadRecommendationCoursePort.loadSelectableCourses();
+
+        Map<Long, LoadSavedRecommendedCoursePort.SavedRecommendedCourseData> savedCourseMap =
+                savedCourses.stream()
+                        .collect(Collectors.toMap(
+                                LoadSavedRecommendedCoursePort.SavedRecommendedCourseData::courseId,
+                                Function.identity()
+                        ));
+
+        var selectedCourseIds = savedCourses.stream()
+                .map(LoadSavedRecommendedCoursePort.SavedRecommendedCourseData::courseId)
+                .toList();
+
+        var courseViews = selectableCourses.stream()
+                .map(course -> {
+                    var savedCourse = savedCourseMap.get(course.courseId());
+
+                    return new SelectableCourseView(
+                            course.courseId(),
+                            course.title(),
+                            course.description(),
+                            course.thumbnailUrl(),
+                            savedCourse != null,
+                            savedCourse != null ? savedCourse.displayOrder() : null
+                    );
+                })
+                .toList();
+
+        return new RecommendedCourseEditView(
+                query.problemId(),
+                selectedCourseIds,
+                courseViews
+        );
+    }
+
+    @Override
+    public List<RecommendedCourseView> handle(GetProblemRecommendedCoursesQuery query) {
+        validateProblem(query.problemId());
+
+        var savedCourses = loadSavedRecommendedCoursePort.loadSavedRecommendedCourses(query.problemId());
+        var selectableCourses = loadRecommendationCoursePort.loadSelectableCourses();
+
+        var selectableCourseMap = selectableCourses.stream()
+                .collect(Collectors.toMap(
+                        LoadRecommendationCoursePort.SelectableCourseData::courseId,
+                        Function.identity()
+                ));
+
+        return savedCourses.stream()
+                .map(savedCourse -> {
+                    var course = selectableCourseMap.get(savedCourse.courseId());
+
+                    if (course == null) {
+                        return null;
+                    }
+
+                    return new RecommendedCourseView(
+                            course.courseId(),
+                            course.title(),
+                            course.description(),
+                            course.thumbnailUrl(),
+                            savedCourse.displayOrder()
+                    );
+                })
+                .filter(java.util.Objects::nonNull)
+                .toList();
+    }
+
+    @Override
+    public List<SelectableRecommendedCourseView> handle() {
+        return loadRecommendationCoursePort.loadSelectableCourses()
+                .stream()
+                .map(course -> new SelectableRecommendedCourseView(
+                        course.courseId(),
+                        course.title(),
+                        course.description(),
+                        course.thumbnailUrl()
+                ))
+                .toList();
+    }
+
+    private void validateProblem(Long problemId) {
+        if (!loadRecommendationProblemPort.existsActiveProblem(problemId)) {
+            throw new NotFoundException(ProblemErrorCode.PROBLEM_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/service/ProblemRecommendedCourseQueryService.java
@@ -7,6 +7,7 @@ import com.wanted.codebombalms.problems.recommendation.application.port.LoadReco
 import com.wanted.codebombalms.problems.recommendation.application.port.LoadSavedRecommendedCoursePort;
 import com.wanted.codebombalms.problems.recommendation.application.query.GetProblemRecommendedCoursesQuery;
 import com.wanted.codebombalms.problems.recommendation.application.query.GetRecommendedCourseEditViewQuery;
+import com.wanted.codebombalms.problems.recommendation.application.query.GetSelectableRecommendedCoursesQuery;
 import com.wanted.codebombalms.problems.recommendation.application.usecase.GetProblemRecommendedCoursesUseCase;
 import com.wanted.codebombalms.problems.recommendation.application.usecase.GetRecommendedCourseEditViewUseCase;
 import com.wanted.codebombalms.problems.recommendation.application.usecase.GetSelectableRecommendedCoursesUseCase;
@@ -14,8 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -24,6 +27,9 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ProblemRecommendedCourseQueryService implements GetRecommendedCourseEditViewUseCase,
         GetProblemRecommendedCoursesUseCase, GetSelectableRecommendedCoursesUseCase {
+
+    private static final int DEFAULT_SELECTABLE_COURSE_LIMIT = 20;
+    private static final int MAX_SELECTABLE_COURSE_LIMIT = 100;
 
     private final LoadRecommendationProblemPort loadRecommendationProblemPort;
     private final LoadSavedRecommendedCoursePort loadSavedRecommendedCoursePort;
@@ -34,13 +40,18 @@ public class ProblemRecommendedCourseQueryService implements GetRecommendedCours
         validateProblem(query.problemId());
 
         var savedCourses = loadSavedRecommendedCoursePort.loadSavedRecommendedCourses(query.problemId());
-        var selectableCourses = loadRecommendationCoursePort.loadSelectableCourses();
+        var selectableCourses = loadRecommendationCoursePort.loadSelectableCourses(
+                null,
+                MAX_SELECTABLE_COURSE_LIMIT
+        );
+        selectableCourses = mergeSelectedCoursesIfMissing(savedCourses, selectableCourses);
 
         Map<Long, LoadSavedRecommendedCoursePort.SavedRecommendedCourseData> savedCourseMap =
                 savedCourses.stream()
                         .collect(Collectors.toMap(
                                 LoadSavedRecommendedCoursePort.SavedRecommendedCourseData::courseId,
-                                Function.identity()
+                                Function.identity(),
+                                (first, second) -> first
                         ));
 
         var selectedCourseIds = savedCourses.stream()
@@ -74,7 +85,8 @@ public class ProblemRecommendedCourseQueryService implements GetRecommendedCours
         validateProblem(query.problemId());
 
         var savedCourses = loadSavedRecommendedCoursePort.loadSavedRecommendedCourses(query.problemId());
-        var selectableCourses = loadRecommendationCoursePort.loadSelectableCourses();
+        var savedCourseIds = toCourseIds(savedCourses);
+        var selectableCourses = loadRecommendationCoursePort.loadActiveCoursesByIds(savedCourseIds);
 
         var selectableCourseMap = selectableCourses.stream()
                 .collect(Collectors.toMap(
@@ -103,8 +115,13 @@ public class ProblemRecommendedCourseQueryService implements GetRecommendedCours
     }
 
     @Override
-    public List<SelectableRecommendedCourseView> handle() {
-        return loadRecommendationCoursePort.loadSelectableCourses()
+    public List<SelectableRecommendedCourseView> handle(GetSelectableRecommendedCoursesQuery query) {
+        int limit = resolveLimit(query.limit());
+
+        return loadRecommendationCoursePort.loadSelectableCourses(
+                        query.keyword(),
+                        limit
+                )
                 .stream()
                 .map(course -> new SelectableRecommendedCourseView(
                         course.courseId(),
@@ -113,6 +130,48 @@ public class ProblemRecommendedCourseQueryService implements GetRecommendedCours
                         course.thumbnailUrl()
                 ))
                 .toList();
+    }
+
+    private int resolveLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_SELECTABLE_COURSE_LIMIT;
+        }
+
+        if (limit <= 0) {
+            return DEFAULT_SELECTABLE_COURSE_LIMIT;
+        }
+
+        return Math.min(limit, MAX_SELECTABLE_COURSE_LIMIT);
+    }
+
+    private List<LoadRecommendationCoursePort.SelectableCourseData> mergeSelectedCoursesIfMissing(
+            List<LoadSavedRecommendedCoursePort.SavedRecommendedCourseData> savedCourses,
+            List<LoadRecommendationCoursePort.SelectableCourseData> selectableCourses
+    ) {
+        Set<Long> selectableCourseIds = selectableCourses.stream()
+                .map(LoadRecommendationCoursePort.SelectableCourseData::courseId)
+                .collect(Collectors.toSet());
+
+        Set<Long> missingSelectedCourseIds = toCourseIds(savedCourses);
+        missingSelectedCourseIds.removeAll(selectableCourseIds);
+
+        if (missingSelectedCourseIds.isEmpty()) {
+            return selectableCourses;
+        }
+
+        var missingCourses = loadRecommendationCoursePort.loadActiveCoursesByIds(missingSelectedCourseIds);
+
+        return java.util.stream.Stream.concat(
+                        selectableCourses.stream(),
+                        missingCourses.stream()
+                )
+                .toList();
+    }
+
+    private Set<Long> toCourseIds(List<LoadSavedRecommendedCoursePort.SavedRecommendedCourseData> savedCourses) {
+        return savedCourses.stream()
+                .map(LoadSavedRecommendedCoursePort.SavedRecommendedCourseData::courseId)
+                .collect(Collectors.toCollection(HashSet::new));
     }
 
     private void validateProblem(Long problemId) {

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetProblemRecommendedCoursesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetProblemRecommendedCoursesUseCase.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.problems.recommendation.application.usecase;
+
+import com.wanted.codebombalms.problems.recommendation.application.query.GetProblemRecommendedCoursesQuery;
+
+import java.util.List;
+
+public interface GetProblemRecommendedCoursesUseCase {
+
+    List<RecommendedCourseView> handle(GetProblemRecommendedCoursesQuery query);
+
+    record RecommendedCourseView(
+            Long courseId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            Integer displayOrder
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetRecommendedCourseEditViewUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetRecommendedCourseEditViewUseCase.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms.problems.recommendation.application.usecase;
+
+import com.wanted.codebombalms.problems.recommendation.application.query.GetRecommendedCourseEditViewQuery;
+
+import java.util.List;
+
+public interface GetRecommendedCourseEditViewUseCase {
+
+    RecommendedCourseEditView handle(GetRecommendedCourseEditViewQuery query);
+
+    record RecommendedCourseEditView(
+            Long problemId,
+            List<Long> selectedCourseIds,
+            List<SelectableCourseView> courses
+    ) {
+    }
+
+    record SelectableCourseView(
+            Long courseId,
+            String title,
+            String description,
+            String thumbnailUrl,
+            Boolean selected,
+            Integer displayOrder
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetSelectableRecommendedCoursesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetSelectableRecommendedCoursesUseCase.java
@@ -1,10 +1,12 @@
 package com.wanted.codebombalms.problems.recommendation.application.usecase;
 
+import com.wanted.codebombalms.problems.recommendation.application.query.GetSelectableRecommendedCoursesQuery;
+
 import java.util.List;
 
 public interface GetSelectableRecommendedCoursesUseCase {
 
-    List<SelectableRecommendedCourseView> handle();
+    List<SelectableRecommendedCourseView> handle(GetSelectableRecommendedCoursesQuery query);
 
     record SelectableRecommendedCourseView(
             Long courseId,

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetSelectableRecommendedCoursesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/GetSelectableRecommendedCoursesUseCase.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.problems.recommendation.application.usecase;
+
+import java.util.List;
+
+public interface GetSelectableRecommendedCoursesUseCase {
+
+    List<SelectableRecommendedCourseView> handle();
+
+    record SelectableRecommendedCourseView(
+            Long courseId,
+            String title,
+            String description,
+            String thumbnailUrl
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/SaveProblemRecommendedCoursesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/application/usecase/SaveProblemRecommendedCoursesUseCase.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.problems.recommendation.application.usecase;
+
+import com.wanted.codebombalms.problems.recommendation.application.command.SaveProblemRecommendedCoursesCommand;
+
+public interface SaveProblemRecommendedCoursesUseCase {
+
+    SaveProblemRecommendedCoursesResult handle(SaveProblemRecommendedCoursesCommand command);
+
+    record SaveProblemRecommendedCoursesResult(
+            Long problemId,
+            Integer connectedCourseCount,
+            java.util.List<Long> courseIds
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/course/RecommendationCourseAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/course/RecommendationCourseAdapter.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCours
 import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationCoursePort;
 import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationCoursePort.SelectableCourseData;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -29,8 +30,40 @@ public class RecommendationCourseAdapter implements LoadRecommendationCoursePort
     }
 
     @Override
-    public List<SelectableCourseData> loadSelectableCourses() {
-        return courseRepository.findByStatusAndDeletedAtIsNull(CourseStatus.ACTIVE)
+    public List<SelectableCourseData> loadSelectableCourses(String keyword, int limit) {
+        var pageable = PageRequest.of(0, limit);
+
+        var courses = isBlank(keyword)
+                ? courseRepository.findByStatusAndDeletedAtIsNullOrderByCourseIdDesc(
+                CourseStatus.ACTIVE,
+                pageable
+        )
+                : courseRepository.findByStatusAndDeletedAtIsNullAndTitleContainingIgnoreCaseOrderByCourseIdDesc(
+                CourseStatus.ACTIVE,
+                keyword.trim(),
+                pageable
+        );
+
+        return courses.stream()
+                .map(course -> new SelectableCourseData(
+                        course.getCourseId(),
+                        course.getTitle(),
+                        course.getDescription(),
+                        course.getThumbnailUrl()
+                ))
+                .toList();
+    }
+
+    @Override
+    public List<SelectableCourseData> loadActiveCoursesByIds(Set<Long> courseIds) {
+        if (courseIds == null || courseIds.isEmpty()) {
+            return List.of();
+        }
+
+        return courseRepository.findByCourseIdInAndStatusAndDeletedAtIsNull(
+                        courseIds,
+                        CourseStatus.ACTIVE
+                )
                 .stream()
                 .map(course -> new SelectableCourseData(
                         course.getCourseId(),
@@ -39,5 +72,9 @@ public class RecommendationCourseAdapter implements LoadRecommendationCoursePort
                         course.getThumbnailUrl()
                 ))
                 .toList();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/course/RecommendationCourseAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/course/RecommendationCourseAdapter.java
@@ -1,0 +1,43 @@
+package com.wanted.codebombalms.problems.recommendation.infrastructure.course;
+
+import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.course.infrastructure.persistence.SpringDataCourseRepository;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationCoursePort;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationCoursePort.SelectableCourseData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class RecommendationCourseAdapter implements LoadRecommendationCoursePort {
+
+    private final SpringDataCourseRepository courseRepository;
+
+    @Override
+    public Set<Long> loadActiveCourseIds(Set<Long> courseIds) {
+        return courseRepository.findByCourseIdInAndStatusAndDeletedAtIsNull(
+                        courseIds,
+                        CourseStatus.ACTIVE
+                )
+                .stream()
+                .map(course -> course.getCourseId())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public List<SelectableCourseData> loadSelectableCourses() {
+        return courseRepository.findByStatusAndDeletedAtIsNull(CourseStatus.ACTIVE)
+                .stream()
+                .map(course -> new SelectableCourseData(
+                        course.getCourseId(),
+                        course.getTitle(),
+                        course.getDescription(),
+                        course.getThumbnailUrl()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/ProblemRecommendedCourseJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/ProblemRecommendedCourseJpaEntity.java
@@ -38,6 +38,8 @@ public class ProblemRecommendedCourseJpaEntity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    private static final String ACTIVE_STATUS = "ACTIVE";
+
     protected ProblemRecommendedCourseJpaEntity() {
     }
 
@@ -49,7 +51,7 @@ public class ProblemRecommendedCourseJpaEntity {
         this.problemId = problemId;
         this.courseId = courseId;
         this.displayOrder = displayOrder;
-        this.status = "ACTIVE";
+        this.status = ACTIVE_STATUS;
     }
 
     @PrePersist
@@ -59,7 +61,7 @@ public class ProblemRecommendedCourseJpaEntity {
         this.updatedAt = now;
 
         if (this.status == null) {
-            this.status = "ACTIVE";
+            this.status = ACTIVE_STATUS;
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/ProblemRecommendedCourseJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/ProblemRecommendedCourseJpaEntity.java
@@ -1,0 +1,78 @@
+package com.wanted.codebombalms.problems.recommendation.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "problem_recommended_course")
+public class ProblemRecommendedCourseJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "problem_recommended_course_id")
+    private Long problemRecommendedCourseId;
+
+    @Column(name = "problem_id", nullable = false)
+    private Long problemId;
+
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected ProblemRecommendedCourseJpaEntity() {
+    }
+
+    public ProblemRecommendedCourseJpaEntity(
+            Long problemId,
+            Long courseId,
+            Integer displayOrder
+    ) {
+        this.problemId = problemId;
+        this.courseId = courseId;
+        this.displayOrder = displayOrder;
+        this.status = "ACTIVE";
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+
+        if (this.status == null) {
+            this.status = "ACTIVE";
+        }
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getCourseId() {
+        return courseId;
+    }
+
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/ProblemRecommendedCoursePersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/ProblemRecommendedCoursePersistenceAdapter.java
@@ -1,0 +1,49 @@
+package com.wanted.codebombalms.problems.recommendation.infrastructure.persistence;
+
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadSavedRecommendedCoursePort;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadSavedRecommendedCoursePort.SavedRecommendedCourseData;
+import com.wanted.codebombalms.problems.recommendation.application.port.SaveProblemRecommendedCoursePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemRecommendedCoursePersistenceAdapter implements
+        SaveProblemRecommendedCoursePort,
+        LoadSavedRecommendedCoursePort {
+
+    private static final String ACTIVE_STATUS = "ACTIVE";
+
+    private final SpringDataProblemRecommendedCourseRepository repository;
+
+    @Override
+    public void replaceRecommendedCourses(Long problemId, List<RecommendedCourseOrder> courses) {
+        repository.deleteByProblemId(problemId);
+
+        List<ProblemRecommendedCourseJpaEntity> entities = courses.stream()
+                .map(course -> new ProblemRecommendedCourseJpaEntity(
+                        problemId,
+                        course.courseId(),
+                        course.displayOrder()
+                ))
+                .toList();
+
+        repository.saveAll(entities);
+    }
+
+    @Override
+    public List<SavedRecommendedCourseData> loadSavedRecommendedCourses(Long problemId) {
+        return repository.findByProblemIdAndStatusOrderByDisplayOrderAsc(
+                        problemId,
+                        ACTIVE_STATUS
+                )
+                .stream()
+                .map(entity -> new SavedRecommendedCourseData(
+                        entity.getCourseId(),
+                        entity.getDisplayOrder()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/SpringDataProblemRecommendedCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/SpringDataProblemRecommendedCourseRepository.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.problems.recommendation.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpringDataProblemRecommendedCourseRepository
+        extends JpaRepository<ProblemRecommendedCourseJpaEntity, Long> {
+
+    void deleteByProblemId(Long problemId);
+
+    List<ProblemRecommendedCourseJpaEntity> findByProblemIdAndStatusOrderByDisplayOrderAsc(
+            Long problemId,
+            String status
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/SpringDataProblemRecommendedCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/persistence/SpringDataProblemRecommendedCourseRepository.java
@@ -1,13 +1,21 @@
 package com.wanted.codebombalms.problems.recommendation.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SpringDataProblemRecommendedCourseRepository
         extends JpaRepository<ProblemRecommendedCourseJpaEntity, Long> {
 
-    void deleteByProblemId(Long problemId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from ProblemRecommendedCourseJpaEntity recommendation
+            where recommendation.problemId = :problemId
+            """)
+    void deleteByProblemId(@Param("problemId") Long problemId);
 
     List<ProblemRecommendedCourseJpaEntity> findByProblemIdAndStatusOrderByDisplayOrderAsc(
             Long problemId,

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/problem/RecommendationProblemAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/infrastructure/problem/RecommendationProblemAdapter.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.problems.recommendation.infrastructure.problem;
+
+import com.wanted.codebombalms.problems.problem.infrastructure.persistence.SpringDataProblemRepository;
+import com.wanted.codebombalms.problems.recommendation.application.port.LoadRecommendationProblemPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RecommendationProblemAdapter implements LoadRecommendationProblemPort {
+
+    private static final String ACTIVE_STATUS = "ACTIVE";
+
+    private final SpringDataProblemRepository problemRepository;
+
+    @Override
+    public boolean existsActiveProblem(Long problemId) {
+        return problemRepository.findByProblemIdAndStatus(problemId, ACTIVE_STATUS)
+                .isPresent();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/ProblemRecommendedCourseController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/ProblemRecommendedCourseController.java
@@ -23,10 +23,13 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -36,6 +39,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 public class ProblemRecommendedCourseController {
 
     private final SaveProblemRecommendedCoursesUseCase saveProblemRecommendedCoursesUseCase;
@@ -172,7 +176,7 @@ public class ProblemRecommendedCourseController {
             @RequestParam(required = false) String keyword,
 
             @Parameter(description = "최대 조회 개수. 기본 20, 최대 100", example = "20")
-            @RequestParam(required = false) Integer limit
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) Integer limit
     ) {
         var result = getSelectableRecommendedCoursesUseCase.handle(
                 new GetSelectableRecommendedCoursesQuery(keyword, limit)

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/ProblemRecommendedCourseController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/ProblemRecommendedCourseController.java
@@ -1,0 +1,298 @@
+package com.wanted.codebombalms.problems.recommendation.presentation;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.problems.recommendation.application.command.SaveProblemRecommendedCoursesCommand;
+import com.wanted.codebombalms.problems.recommendation.application.query.GetProblemRecommendedCoursesQuery;
+import com.wanted.codebombalms.problems.recommendation.application.query.GetRecommendedCourseEditViewQuery;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetProblemRecommendedCoursesUseCase;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetRecommendedCourseEditViewUseCase;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetSelectableRecommendedCoursesUseCase;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.SaveProblemRecommendedCoursesUseCase;
+import com.wanted.codebombalms.problems.recommendation.presentation.api.request.SaveProblemRecommendedCoursesRequest;
+import com.wanted.codebombalms.problems.recommendation.presentation.api.response.RecommendedCourseEditViewResponse;
+import com.wanted.codebombalms.problems.recommendation.presentation.api.response.RecommendedCourseResponse;
+import com.wanted.codebombalms.problems.recommendation.presentation.api.response.SaveProblemRecommendedCoursesResponse;
+import com.wanted.codebombalms.problems.recommendation.presentation.api.response.SelectableRecommendedCourseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProblemRecommendedCourseController {
+
+    private final SaveProblemRecommendedCoursesUseCase saveProblemRecommendedCoursesUseCase;
+    private final GetRecommendedCourseEditViewUseCase getRecommendedCourseEditViewUseCase;
+    private final GetProblemRecommendedCoursesUseCase getProblemRecommendedCoursesUseCase;
+    private final GetSelectableRecommendedCoursesUseCase getSelectableRecommendedCoursesUseCase;
+
+    @Operation(
+            summary = "문제 추천 코스 연결 저장",
+            description = "특정 문제에 추천할 코스 목록을 저장합니다. 기존 연결은 요청값 기준으로 교체됩니다."
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = SaveProblemRecommendedCoursesRequest.class),
+                    examples = @ExampleObject(
+                            name = "추천 코스 연결 저장 요청",
+                            value = """
+                                    {
+                                      "courseIds": [10, 11]
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "추천 코스 연결 저장 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SaveProblemRecommendedCoursesResponse.class),
+                            examples = @ExampleObject(
+                                    name = "추천 코스 연결 저장 성공",
+                                    value = """
+                                            {
+                                              "timestamp": "2026-06-17T12:10:00",
+                                              "status": 200,
+                                              "code": "COMMON-SUCCESS",
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "problemId": 5164,
+                                                "connectedCourseCount": 2,
+                                                "courseIds": [10, 11]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "추천 코스 입력값 오류"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "추천 코스 연결 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문제 또는 코스를 찾을 수 없음")
+    })
+    @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
+    @PutMapping("/api/v1/problems/{problemId}/recommended-courses")
+    public ResponseEntity<ApiResponse<SaveProblemRecommendedCoursesResponse>> saveRecommendedCourses(
+            @Parameter(description = "추천 코스를 연결할 문제 ID", example = "5164")
+            @PathVariable Long problemId,
+            @RequestBody @Valid SaveProblemRecommendedCoursesRequest request
+    ) {
+        var result = saveProblemRecommendedCoursesUseCase.handle(
+                new SaveProblemRecommendedCoursesCommand(
+                        problemId,
+                        request.courseIds()
+                )
+        );
+
+        var response = SaveProblemRecommendedCoursesResponse.from(result);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+
+    @Operation(
+            summary = "문제 추천 코스 수정 정보 조회",
+            description = "추천 코스 수정 화면에서 선택 가능한 코스 목록과 현재 연결된 코스 상태를 함께 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "추천 코스 수정 정보 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RecommendedCourseEditViewResponse.class),
+                            examples = @ExampleObject(
+                                    name = "추천 코스 수정 정보 조회 성공",
+                                    value = """
+                                            {
+                                              "timestamp": "2026-06-17T12:20:00",
+                                              "status": 200,
+                                              "code": "COMMON-SUCCESS",
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "problemId": 5164,
+                                                "selectedCourseIds": [10],
+                                                "courses": [
+                                                  {
+                                                    "courseId": 10,
+                                                    "title": "Pandas 데이터 분석 입문",
+                                                    "description": "Pandas를 활용한 데이터 분석 기초 코스입니다.",
+                                                    "thumbnailUrl": "/images/courses/pandas.png",
+                                                    "selected": true,
+                                                    "displayOrder": 1
+                                                  },
+                                                  {
+                                                    "courseId": 11,
+                                                    "title": "머신러닝 기초",
+                                                    "description": "머신러닝 모델 학습 과정을 다룹니다.",
+                                                    "thumbnailUrl": "/images/courses/ml.png",
+                                                    "selected": false,
+                                                    "displayOrder": null
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "추천 코스 수정 정보 조회 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문제를 찾을 수 없음")
+    })
+    @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
+    @GetMapping("/api/v1/problems/{problemId}/recommended-courses/edit")
+    public ResponseEntity<ApiResponse<RecommendedCourseEditViewResponse>> getRecommendedCourseEditView(
+            @Parameter(description = "추천 코스 연결 상태를 조회할 문제 ID", example = "5164")
+            @PathVariable Long problemId
+    ) {
+        var result = getRecommendedCourseEditViewUseCase.handle(
+                new GetRecommendedCourseEditViewQuery(problemId)
+        );
+
+        var response = RecommendedCourseEditViewResponse.from(result);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+
+    @Operation(
+            summary = "학생용 문제 추천 코스 조회",
+            description = "문제풀이 화면에서 해당 문제와 연결된 추천 코스 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "학생용 추천 코스 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RecommendedCourseResponse.class),
+                            examples = @ExampleObject(
+                                    name = "학생용 추천 코스 조회 성공",
+                                    value = """
+                                            {
+                                              "timestamp": "2026-06-17T12:30:00",
+                                              "status": 200,
+                                              "code": "COMMON-SUCCESS",
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "courses": [
+                                                  {
+                                                    "courseId": 10,
+                                                    "title": "Pandas 데이터 분석 입문",
+                                                    "description": "Pandas를 활용한 데이터 분석 기초 코스입니다.",
+                                                    "thumbnailUrl": "/images/courses/pandas.png",
+                                                    "displayOrder": 1
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문제를 찾을 수 없음")
+    })
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/api/v1/problems/{problemId}/recommended-courses")
+    public ResponseEntity<ApiResponse<RecommendedCourseResponse>> getRecommendedCourses(
+            @Parameter(description = "추천 코스를 조회할 문제 ID", example = "5164")
+            @PathVariable Long problemId
+    ) {
+        var result = getProblemRecommendedCoursesUseCase.handle(
+                new GetProblemRecommendedCoursesQuery(problemId)
+        );
+
+        var response = RecommendedCourseResponse.from(result);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+
+    @Operation(
+            summary = "추천 코스 선택 목록 조회",
+            description = "운영자가 문제에 추천 코스를 연결할 때 선택 가능한 ACTIVE 코스 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "추천 코스 선택 목록 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SelectableRecommendedCourseResponse.class),
+                            examples = @ExampleObject(
+                                    name = "추천 코스 선택 목록 조회 성공",
+                                    value = """
+                                            {
+                                              "timestamp": "2026-06-17T12:40:00",
+                                              "status": 200,
+                                              "code": "COMMON-SUCCESS",
+                                              "message": "요청이 성공적으로 처리되었습니다.",
+                                              "data": {
+                                                "courses": [
+                                                  {
+                                                    "courseId": 10,
+                                                    "title": "Pandas 데이터 분석 입문",
+                                                    "description": "Pandas를 활용한 데이터 분석 기초 코스입니다.",
+                                                    "thumbnailUrl": "/images/courses/pandas.png"
+                                                  },
+                                                  {
+                                                    "courseId": 11,
+                                                    "title": "머신러닝 기초",
+                                                    "description": "머신러닝 모델 학습 과정을 다룹니다.",
+                                                    "thumbnailUrl": "/images/courses/ml.png"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "추천 코스 선택 목록 조회 권한 없음")
+    })
+    @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
+    @GetMapping("/api/v1/recommended-courses/selectable")
+    public ResponseEntity<ApiResponse<SelectableRecommendedCourseResponse>> getSelectableRecommendedCourses() {
+        var result = getSelectableRecommendedCoursesUseCase.handle();
+
+        var response = SelectableRecommendedCourseResponse.from(result);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/ProblemRecommendedCourseController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/ProblemRecommendedCourseController.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage
 import com.wanted.codebombalms.problems.recommendation.application.command.SaveProblemRecommendedCoursesCommand;
 import com.wanted.codebombalms.problems.recommendation.application.query.GetProblemRecommendedCoursesQuery;
 import com.wanted.codebombalms.problems.recommendation.application.query.GetRecommendedCourseEditViewQuery;
+import com.wanted.codebombalms.problems.recommendation.application.query.GetSelectableRecommendedCoursesQuery;
 import com.wanted.codebombalms.problems.recommendation.application.usecase.GetProblemRecommendedCoursesUseCase;
 import com.wanted.codebombalms.problems.recommendation.application.usecase.GetRecommendedCourseEditViewUseCase;
 import com.wanted.codebombalms.problems.recommendation.application.usecase.GetSelectableRecommendedCoursesUseCase;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -43,7 +45,7 @@ public class ProblemRecommendedCourseController {
 
     @Operation(
             summary = "문제 추천 코스 연결 저장",
-            description = "특정 문제에 추천할 코스 목록을 저장합니다. 기존 연결은 요청값 기준으로 교체됩니다."
+            description = "운영자가 특정 문제에 추천 코스 목록을 연결합니다. 요청한 코스 ID 순서가 추천 노출 순서가 됩니다."
     )
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
             required = true,
@@ -114,55 +116,9 @@ public class ProblemRecommendedCourseController {
     }
 
     @Operation(
-            summary = "문제 추천 코스 수정 정보 조회",
-            description = "추천 코스 수정 화면에서 선택 가능한 코스 목록과 현재 연결된 코스 상태를 함께 조회합니다."
+            summary = "문제 추천 코스 수정 화면 조회",
+            description = "추천 코스 수정 화면에서 사용할 선택 가능 코스 목록과 현재 연결된 코스 상태를 함께 조회합니다."
     )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "추천 코스 수정 정보 조회 성공",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = RecommendedCourseEditViewResponse.class),
-                            examples = @ExampleObject(
-                                    name = "추천 코스 수정 정보 조회 성공",
-                                    value = """
-                                            {
-                                              "timestamp": "2026-06-17T12:20:00",
-                                              "status": 200,
-                                              "code": "COMMON-SUCCESS",
-                                              "message": "요청이 성공적으로 처리되었습니다.",
-                                              "data": {
-                                                "problemId": 5164,
-                                                "selectedCourseIds": [10],
-                                                "courses": [
-                                                  {
-                                                    "courseId": 10,
-                                                    "title": "Pandas 데이터 분석 입문",
-                                                    "description": "Pandas를 활용한 데이터 분석 기초 코스입니다.",
-                                                    "thumbnailUrl": "/images/courses/pandas.png",
-                                                    "selected": true,
-                                                    "displayOrder": 1
-                                                  },
-                                                  {
-                                                    "courseId": 11,
-                                                    "title": "머신러닝 기초",
-                                                    "description": "머신러닝 모델 학습 과정을 다룹니다.",
-                                                    "thumbnailUrl": "/images/courses/ml.png",
-                                                    "selected": false,
-                                                    "displayOrder": null
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "추천 코스 수정 정보 조회 권한 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문제를 찾을 수 없음")
-    })
     @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
     @GetMapping("/api/v1/problems/{problemId}/recommended-courses/edit")
     public ResponseEntity<ApiResponse<RecommendedCourseEditViewResponse>> getRecommendedCourseEditView(
@@ -184,42 +140,8 @@ public class ProblemRecommendedCourseController {
 
     @Operation(
             summary = "학생용 문제 추천 코스 조회",
-            description = "문제풀이 화면에서 해당 문제와 연결된 추천 코스 목록을 조회합니다."
+            description = "문제 풀이 화면에서 해당 문제와 연결된 추천 코스 목록을 조회합니다."
     )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "학생용 추천 코스 조회 성공",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = RecommendedCourseResponse.class),
-                            examples = @ExampleObject(
-                                    name = "학생용 추천 코스 조회 성공",
-                                    value = """
-                                            {
-                                              "timestamp": "2026-06-17T12:30:00",
-                                              "status": 200,
-                                              "code": "COMMON-SUCCESS",
-                                              "message": "요청이 성공적으로 처리되었습니다.",
-                                              "data": {
-                                                "courses": [
-                                                  {
-                                                    "courseId": 10,
-                                                    "title": "Pandas 데이터 분석 입문",
-                                                    "description": "Pandas를 활용한 데이터 분석 기초 코스입니다.",
-                                                    "thumbnailUrl": "/images/courses/pandas.png",
-                                                    "displayOrder": 1
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문제를 찾을 수 없음")
-    })
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/api/v1/problems/{problemId}/recommended-courses")
     public ResponseEntity<ApiResponse<RecommendedCourseResponse>> getRecommendedCourses(
@@ -241,51 +163,20 @@ public class ProblemRecommendedCourseController {
 
     @Operation(
             summary = "추천 코스 선택 목록 조회",
-            description = "운영자가 문제에 추천 코스를 연결할 때 선택 가능한 ACTIVE 코스 목록을 조회합니다."
+            description = "운영자가 문제에 추천 코스를 연결할 때 선택 가능한 ACTIVE 코스 목록을 조회합니다. 검색어와 최대 조회 개수를 지정할 수 있습니다."
     )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "추천 코스 선택 목록 조회 성공",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = SelectableRecommendedCourseResponse.class),
-                            examples = @ExampleObject(
-                                    name = "추천 코스 선택 목록 조회 성공",
-                                    value = """
-                                            {
-                                              "timestamp": "2026-06-17T12:40:00",
-                                              "status": 200,
-                                              "code": "COMMON-SUCCESS",
-                                              "message": "요청이 성공적으로 처리되었습니다.",
-                                              "data": {
-                                                "courses": [
-                                                  {
-                                                    "courseId": 10,
-                                                    "title": "Pandas 데이터 분석 입문",
-                                                    "description": "Pandas를 활용한 데이터 분석 기초 코스입니다.",
-                                                    "thumbnailUrl": "/images/courses/pandas.png"
-                                                  },
-                                                  {
-                                                    "courseId": 11,
-                                                    "title": "머신러닝 기초",
-                                                    "description": "머신러닝 모델 학습 과정을 다룹니다.",
-                                                    "thumbnailUrl": "/images/courses/ml.png"
-                                                  }
-                                                ]
-                                              }
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "추천 코스 선택 목록 조회 권한 없음")
-    })
     @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
     @GetMapping("/api/v1/recommended-courses/selectable")
-    public ResponseEntity<ApiResponse<SelectableRecommendedCourseResponse>> getSelectableRecommendedCourses() {
-        var result = getSelectableRecommendedCoursesUseCase.handle();
+    public ResponseEntity<ApiResponse<SelectableRecommendedCourseResponse>> getSelectableRecommendedCourses(
+            @Parameter(description = "코스 제목 검색어", example = "Pandas")
+            @RequestParam(required = false) String keyword,
+
+            @Parameter(description = "최대 조회 개수. 기본 20, 최대 100", example = "20")
+            @RequestParam(required = false) Integer limit
+    ) {
+        var result = getSelectableRecommendedCoursesUseCase.handle(
+                new GetSelectableRecommendedCoursesQuery(keyword, limit)
+        );
 
         var response = SelectableRecommendedCourseResponse.from(result);
 

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/request/SaveProblemRecommendedCoursesRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/request/SaveProblemRecommendedCoursesRequest.java
@@ -2,12 +2,14 @@ package com.wanted.codebombalms.problems.recommendation.presentation.api.request
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import java.util.List;
 
 public record SaveProblemRecommendedCoursesRequest(
         @Schema(description = "추천 코스 ID 목록. 배열 순서가 추천 노출 순서가 됩니다.", example = "[10, 11]")
         @NotNull(message = "추천 코스 목록은 필수입니다.")
-        List<Long> courseIds
+        List<@NotNull(message = "추천 코스 ID는 필수입니다.")
+        @Positive(message = "추천 코스 ID는 1 이상이어야 합니다.") Long> courseIds
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/request/SaveProblemRecommendedCoursesRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/request/SaveProblemRecommendedCoursesRequest.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.problems.recommendation.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record SaveProblemRecommendedCoursesRequest(
+        @Schema(description = "추천 코스 ID 목록. 배열 순서가 추천 노출 순서가 됩니다.", example = "[10, 11]")
+        @NotNull(message = "추천 코스 목록은 필수입니다.")
+        List<Long> courseIds
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/request/SaveProblemRecommendedCoursesRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/request/SaveProblemRecommendedCoursesRequest.java
@@ -3,12 +3,14 @@ package com.wanted.codebombalms.problems.recommendation.presentation.api.request
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record SaveProblemRecommendedCoursesRequest(
         @Schema(description = "추천 코스 ID 목록. 배열 순서가 추천 노출 순서가 됩니다.", example = "[10, 11]")
         @NotNull(message = "추천 코스 목록은 필수입니다.")
+        @Size(max = 20, message = "추천 코스는 최대 20개까지 연결할 수 있습니다.")
         List<@NotNull(message = "추천 코스 ID는 필수입니다.")
         @Positive(message = "추천 코스 ID는 1 이상이어야 합니다.") Long> courseIds
 ) {

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/RecommendedCourseEditViewResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/RecommendedCourseEditViewResponse.java
@@ -1,0 +1,59 @@
+package com.wanted.codebombalms.problems.recommendation.presentation.api.response;
+
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetRecommendedCourseEditViewUseCase.RecommendedCourseEditView;
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetRecommendedCourseEditViewUseCase.SelectableCourseView;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record RecommendedCourseEditViewResponse(
+        @Schema(description = "문제 ID", example = "5164")
+        Long problemId,
+
+        @Schema(description = "현재 문제에 연결된 추천 코스 ID 목록", example = "[10, 11]")
+        List<Long> selectedCourseIds,
+
+        @Schema(description = "선택 가능한 코스 목록")
+        List<SelectableCourseResponse> courses
+) {
+    public static RecommendedCourseEditViewResponse from(RecommendedCourseEditView view) {
+        return new RecommendedCourseEditViewResponse(
+                view.problemId(),
+                view.selectedCourseIds(),
+                view.courses().stream()
+                        .map(SelectableCourseResponse::from)
+                        .toList()
+        );
+    }
+
+    public record SelectableCourseResponse(
+            @Schema(description = "코스 ID", example = "10")
+            Long courseId,
+
+            @Schema(description = "코스 제목", example = "Pandas 데이터 분석 입문")
+            String title,
+
+            @Schema(description = "코스 설명", example = "Pandas를 활용한 데이터 분석 기초 코스입니다.")
+            String description,
+
+            @Schema(description = "코스 썸네일 URL", example = "/images/courses/pandas.png")
+            String thumbnailUrl,
+
+            @Schema(description = "현재 문제에 연결되어 있는지 여부", example = "true")
+            Boolean selected,
+
+            @Schema(description = "추천 노출 순서. 연결되지 않은 코스는 null", example = "1")
+            Integer displayOrder
+    ) {
+        private static SelectableCourseResponse from(SelectableCourseView view) {
+            return new SelectableCourseResponse(
+                    view.courseId(),
+                    view.title(),
+                    view.description(),
+                    view.thumbnailUrl(),
+                    view.selected(),
+                    view.displayOrder()
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/RecommendedCourseResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/RecommendedCourseResponse.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.problems.recommendation.presentation.api.response;
+
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetProblemRecommendedCoursesUseCase.RecommendedCourseView;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record RecommendedCourseResponse(
+        @Schema(description = "문제에 추천된 코스 목록")
+        List<CourseResponse> courses
+) {
+    public static RecommendedCourseResponse from(List<RecommendedCourseView> courses) {
+        return new RecommendedCourseResponse(
+                courses.stream()
+                        .map(CourseResponse::from)
+                        .toList()
+        );
+    }
+
+    public record CourseResponse(
+            @Schema(description = "코스 ID", example = "10")
+            Long courseId,
+
+            @Schema(description = "코스 제목", example = "Pandas 데이터 분석 입문")
+            String title,
+
+            @Schema(description = "코스 설명", example = "Pandas를 활용한 데이터 분석 기초 코스입니다.")
+            String description,
+
+            @Schema(description = "코스 썸네일 URL", example = "/images/courses/pandas.png")
+            String thumbnailUrl,
+
+            @Schema(description = "추천 노출 순서", example = "1")
+            Integer displayOrder
+    ) {
+        private static CourseResponse from(RecommendedCourseView view) {
+            return new CourseResponse(
+                    view.courseId(),
+                    view.title(),
+                    view.description(),
+                    view.thumbnailUrl(),
+                    view.displayOrder()
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/SaveProblemRecommendedCoursesResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/SaveProblemRecommendedCoursesResponse.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.problems.recommendation.presentation.api.response;
+
+import com.wanted.codebombalms.problems.recommendation.application.usecase.SaveProblemRecommendedCoursesUseCase.SaveProblemRecommendedCoursesResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SaveProblemRecommendedCoursesResponse(
+        @Schema(description = "문제 ID", example = "5164")
+        Long problemId,
+
+        @Schema(description = "저장된 추천 코스 개수", example = "2")
+        Integer connectedCourseCount,
+
+        @Schema(description = "저장된 추천 코스 ID 목록", example = "[10, 11]")
+        List<Long> courseIds
+) {
+    public static SaveProblemRecommendedCoursesResponse from(SaveProblemRecommendedCoursesResult result) {
+        return new SaveProblemRecommendedCoursesResponse(
+                result.problemId(),
+                result.connectedCourseCount(),
+                result.courseIds()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/SelectableRecommendedCourseResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/recommendation/presentation/api/response/SelectableRecommendedCourseResponse.java
@@ -1,0 +1,42 @@
+package com.wanted.codebombalms.problems.recommendation.presentation.api.response;
+
+import com.wanted.codebombalms.problems.recommendation.application.usecase.GetSelectableRecommendedCoursesUseCase.SelectableRecommendedCourseView;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SelectableRecommendedCourseResponse(
+        @Schema(description = "추천 코스로 선택 가능한 코스 목록")
+        List<CourseResponse> courses
+) {
+    public static SelectableRecommendedCourseResponse from(List<SelectableRecommendedCourseView> courses) {
+        return new SelectableRecommendedCourseResponse(
+                courses.stream()
+                        .map(CourseResponse::from)
+                        .toList()
+        );
+    }
+
+    public record CourseResponse(
+            @Schema(description = "코스 ID", example = "10")
+            Long courseId,
+
+            @Schema(description = "코스 제목", example = "Pandas 데이터 분석 입문")
+            String title,
+
+            @Schema(description = "코스 설명", example = "Pandas를 활용한 데이터 분석 기초 코스입니다.")
+            String description,
+
+            @Schema(description = "코스 썸네일 URL", example = "/images/courses/pandas.png")
+            String thumbnailUrl
+    ) {
+        private static CourseResponse from(SelectableRecommendedCourseView view) {
+            return new CourseResponse(
+                    view.courseId(),
+                    view.title(),
+                    view.description(),
+                    view.thumbnailUrl()
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
@@ -9,7 +9,9 @@ import com.wanted.codebombalms.problems.set.domain.model.ProblemDetail;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetEntry;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetProgressState;
 import com.wanted.codebombalms.problems.set.application.usecase.ValidateProblemSetAccessUseCase;
+import com.wanted.codebombalms.problems.set.infrastructure.metrics.ProblemSetMetrics;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ProblemSetEntryService implements EnterProblemSetUseCase {
 
     private final LoadProblemSetEntryPort loadProblemSetEntryPort;
@@ -28,10 +31,14 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
     private final LoadProgressProblemPort loadProgressProblemPort;
     private final IncreaseProblemSetStartedCountPort increaseProblemSetStartedCountPort;
     private final ValidateProblemSetAccessUseCase validateProblemSetAccessUseCase;
+    private final ProblemSetMetrics problemSetMetrics;
 
     @Override
     @Transactional
     public ProblemSetEntryView handle(EnterProblemSetQuery query) {
+        long startNanos = System.nanoTime();
+
+        try {
         validateProblemSetAccessUseCase.validate(
                 query.userId(),
                 query.problemSetId()
@@ -72,7 +79,7 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
                 .filter(problem -> "CORRECT".equals(problem.status()))
                 .count();
 
-        return new ProblemSetEntryView(
+        ProblemSetEntryView view = new ProblemSetEntryView(
                 problemSet.getProblemSetId(),
                 problemSet.getTitle(),
                 problemSet.getDescription(),
@@ -83,6 +90,34 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
                 progress.completed(),
                 problems
         );
+
+        log.info(
+                "event=problem_set_entered userId={} problemSetId={} problemCount={} solvedProblemCount={} durationMs={}",
+                query.userId(),
+                query.problemSetId(),
+                problems.size(),
+                solvedProblemCount,
+                elapsedMillis(startNanos)
+        );
+
+        return view;
+        } catch (RuntimeException e) {
+            log.warn(
+                    "event=problem_set_entry_failed userId={} problemSetId={} exceptionType={} durationMs={}",
+                    query.userId(),
+                    query.problemSetId(),
+                    e.getClass().getSimpleName(),
+                    elapsedMillis(startNanos),
+                    e
+            );
+            throw e;
+        } finally {
+            problemSetMetrics.recordEntry(System.nanoTime() - startNanos);
+        }
+    }
+
+    private long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
     }
 
     private ProblemDetailItemView toDetailItemView(

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemsLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemsLoadTestSeeder.java
@@ -9,6 +9,7 @@ import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -42,6 +43,7 @@ public class ProblemsLoadTestSeeder implements ApplicationRunner {
     private final PasswordEncoder passwordEncoder;
 
     @Override
+    @Transactional
     public void run(ApplicationArguments args) {
         Long alreadySeeded = jdbc.queryForObject(
                 "select count(*) from problem_set where problem_set_id = ?",

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemsLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemsLoadTestSeeder.java
@@ -1,0 +1,202 @@
+package com.wanted.codebombalms.problems.set.infrastructure.loadtest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * Problems 도메인 baseline 부하 테스트용 시드 데이터.
+ *
+ * <p>{@code loadtest} 프로파일에서만 실행한다. 운영 DB에는 절대 사용하지 않는다.
+ */
+@Slf4j
+@Component
+@Profile("loadtest")
+@RequiredArgsConstructor
+public class ProblemsLoadTestSeeder implements ApplicationRunner {
+
+    private static final String LOGIN_EMAIL = "u01@test.com";
+    private static final String LOGIN_PASSWORD = "Test1234!";
+    private static final long CATEGORY_ID = 3001L;
+    private static final long PROBLEM_SET_ID = 4001L;
+    private static final long FIRST_PROBLEM_ID = 5001L;
+    private static final int PROBLEM_COUNT = 20;
+
+    private static final String DATASET_ORIGINAL_FILE_NAME = "employee_performance.csv";
+    private static final String DATASET_OBJECT_NAME = "problem_dataset/"
+            + "7ecb57b8-51ff-48ee-ad72-63e81cea8d6d_"
+            + "28679fde-6075-4c2e-a3f0-190fa3d80db7_employee_performance.csv.csv";
+    private static final String DATASET_URL = "https://storage.googleapis.com/codebombalms/"
+            + DATASET_OBJECT_NAME;
+
+    private final JdbcTemplate jdbc;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Long alreadySeeded = jdbc.queryForObject(
+                "select count(*) from problem_set where problem_set_id = ?",
+                Long.class,
+                PROBLEM_SET_ID
+        );
+
+        if (alreadySeeded != null && alreadySeeded > 0) {
+            log.info(
+                    "event=problems_loadtest_seed_skipped reason=already_seeded problemSetId={}",
+                    PROBLEM_SET_ID
+            );
+            return;
+        }
+
+        long startNanos = System.nanoTime();
+
+        Long userId = findOrCreateLoginUser();
+        seedCategory();
+        seedProblemSet(userId);
+        seedProblems();
+        seedDataset();
+        seedTestCases();
+        seedProgress(userId);
+
+        log.info(
+                "event=problems_loadtest_seed_completed userId={} problemSetId={} problems={} testCases={} durationMs={}",
+                userId,
+                PROBLEM_SET_ID,
+                PROBLEM_COUNT,
+                PROBLEM_COUNT,
+                elapsedMillis(startNanos)
+        );
+    }
+
+    private Long findOrCreateLoginUser() {
+        Long userId = jdbc.query(
+                "select user_id from users where email = ? limit 1",
+                rs -> rs.next() ? rs.getLong("user_id") : null,
+                LOGIN_EMAIL
+        );
+
+        if (userId != null) {
+            return userId;
+        }
+
+        String hash = passwordEncoder.encode(LOGIN_PASSWORD);
+        jdbc.update("""
+                insert into users
+                  (role, email, password, name, nickname, provider, email_verified, is_locked, created_at, updated_at)
+                values
+                  ('STUDENT', ?, ?, 'Loadtest User', 'loadtester-problems', 'LOCAL', true, false, now(6), now(6))
+                """, LOGIN_EMAIL, hash);
+
+        return jdbc.queryForObject(
+                "select user_id from users where email = ?",
+                Long.class,
+                LOGIN_EMAIL
+        );
+    }
+
+    private void seedCategory() {
+        jdbc.update("""
+                insert ignore into problem_category
+                  (category_id, category_name, description, status)
+                values
+                  (?, 'Loadtest Python Data Analysis', 'Problems loadtest category', 'ACTIVE')
+                """, CATEGORY_ID);
+    }
+
+    private void seedProblemSet(Long userId) {
+        jdbc.update("""
+                insert into problem_set
+                  (problem_set_id, category_id, title, description, difficulty, status,
+                   total_problem_count, completed_user_count, started_user_count, created_by, created_at)
+                values
+                  (?, ?, 'Problems Loadtest Problem Set',
+                   'Problem set entry and submission baseline data.',
+                   'MEDIUM', 'ACTIVE', ?, 0, 0, ?, now(6))
+                """, PROBLEM_SET_ID, CATEGORY_ID, PROBLEM_COUNT, userId);
+    }
+
+    private void seedProblems() {
+        jdbc.batchUpdate("""
+                insert into problem
+                  (problem_id, problem_set_id, title, content, problem_type, difficulty,
+                   explanation, point, attempt_limit, is_retriable, status, problem_order)
+                values
+                  (?, ?, ?, ?, 'CODE', 'EASY', ?, 10, 999, true, 'ACTIVE', ?)
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                long problemId = FIRST_PROBLEM_ID + i;
+                int order = i + 1;
+
+                ps.setLong(1, problemId);
+                ps.setLong(2, PROBLEM_SET_ID);
+                ps.setString(3, "Loadtest Problem " + order);
+                ps.setString(4, "Load employee_performance.csv and assign len(df) to result.");
+                ps.setString(5, "Use len(df) to count rows.");
+                ps.setInt(6, order);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return PROBLEM_COUNT;
+            }
+        });
+    }
+
+    private void seedDataset() {
+        jdbc.update("""
+                insert into problem_dataset
+                  (problem_set_id, original_file_name, stored_file_name, file_url, file_path,
+                   file_size, meta_data, status, created_at, updated_at)
+                values
+                  (?, ?, ?, ?, ?, 20480, '{}', 'ACTIVE', now(6), now(6))
+                """,
+                PROBLEM_SET_ID,
+                DATASET_ORIGINAL_FILE_NAME,
+                DATASET_OBJECT_NAME.substring(DATASET_OBJECT_NAME.lastIndexOf('/') + 1),
+                DATASET_URL,
+                DATASET_OBJECT_NAME
+        );
+    }
+
+    private void seedTestCases() {
+        jdbc.batchUpdate("""
+                insert into problem_test_case
+                  (problem_id, test_code, test_order, is_hidden, timeout_ms, status, created_at, updated_at)
+                values
+                  (?, 'assert result == len(df)', 1, false, 3000, 'ACTIVE', now(6), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, FIRST_PROBLEM_ID + i);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return PROBLEM_COUNT;
+            }
+        });
+    }
+
+    private void seedProgress(Long userId) {
+        jdbc.update("""
+                insert into problem_progress
+                  (user_id, problem_set_id, current_problem_number, is_completed, completed_at, updated_at)
+                values
+                  (?, ?, 1, false, null, now(6))
+                """, userId, PROBLEM_SET_ID);
+    }
+
+    private long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/metrics/ProblemSetMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/metrics/ProblemSetMetrics.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.problems.set.infrastructure.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Problem Set 도메인의 문제세트 진입 조회 구간을 측정하는 메트릭 컴포넌트.
+ */
+@Component
+public class ProblemSetMetrics {
+
+    private final Timer entryTimer;
+
+    public ProblemSetMetrics(MeterRegistry registry) {
+        this.entryTimer = Timer.builder("problem_set_entry_duration")
+                .description("문제세트 진입 화면을 구성하는 데 걸린 시간")
+                .register(registry);
+    }
+
+    public void recordEntry(long elapsedNanos) {
+        entryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetWithDatasetCreateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetWithDatasetCreateResponse.java
@@ -1,6 +1,6 @@
 package com.wanted.codebombalms.problems.set.presentation.response;
 
-import com.wanted.codebombalms.problems.set.domain.model.CreatedProblemSummary;
+import  com.wanted.codebombalms.problems.set.domain.model.CreatedProblemSummary;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
@@ -14,12 +14,15 @@ import com.wanted.codebombalms.submission.application.port.ProblemSolvedEventPor
 import com.wanted.codebombalms.submission.application.port.SubmissionCommandPort;
 import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase;
 import com.wanted.codebombalms.submission.domain.model.CodeSubmission;
+import com.wanted.codebombalms.submission.infrastructure.metrics.SubmissionMetrics;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SubmissionService implements SubmissionCommandUseCase {
 
     private final SubmissionCommandPort submissionCommandPort;
@@ -33,10 +36,14 @@ public class SubmissionService implements SubmissionCommandUseCase {
     private final ProblemSolvedEventPort problemSolvedEventPort;
     private final LoadActiveDatasetFilePathPort loadActiveDatasetFilePathPort;
     private final GenerateDatasetAccessUrlPort generateDatasetAccessUrlPort;
+    private final SubmissionMetrics submissionMetrics;
 
     @Override
     @Transactional
     public SubmissionView handle(Long problemId, SubmitCodeCommand command) {
+        long startNanos = System.nanoTime();
+
+        try {
         submissionCodePolicy.validate(command.code());
 
         ProblemForSubmission problem =
@@ -146,7 +153,7 @@ public class SubmissionService implements SubmissionCommandUseCase {
             }
         }
 
-        return new SubmissionView(
+        SubmissionView view = new SubmissionView(
                 submissionId,
                 problem.problemId(),
                 isCorrect,
@@ -163,7 +170,39 @@ public class SubmissionService implements SubmissionCommandUseCase {
                 pointGranted,
                 isCorrect ? problem.explanation() : null
         );
+
+        log.info(
+                "event=submission_completed userId={} problemId={} submissionId={} isCorrect={} passedTestCount={} totalTestCount={} durationMs={}",
+                command.userId(),
+                problem.problemId(),
+                submissionId,
+                isCorrect,
+                gradingResult.passedTestCount(),
+                gradingResult.totalTestCount(),
+                elapsedMillis(startNanos)
+        );
+
+        return view;
+        } catch (RuntimeException e) {
+            submissionMetrics.incrementFailure();
+            log.warn(
+                    "event=submission_failed userId={} problemId={} exceptionType={} durationMs={}",
+                    command.userId(),
+                    problemId,
+                    e.getClass().getSimpleName(),
+                    elapsedMillis(startNanos),
+                    e
+            );
+            throw e;
+        } finally {
+            submissionMetrics.recordGrading(System.nanoTime() - startNanos);
+        }
     }
+
+    private long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+
     private void validateNotAlreadySolved(Long userId, Long problemId) {
         boolean alreadySolved =
                 submissionCommandPort.existsCorrectSubmission(

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/metrics/SubmissionMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/metrics/SubmissionMetrics.java
@@ -1,0 +1,36 @@
+package com.wanted.codebombalms.submission.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Submission 도메인의 제출/채점 병목 후보 구간을 측정하는 메트릭 컴포넌트.
+ */
+@Component
+public class SubmissionMetrics {
+
+    private final Timer gradingTimer;
+    private final Counter failureCounter;
+
+    public SubmissionMetrics(MeterRegistry registry) {
+        this.gradingTimer = Timer.builder("submission_grading_duration")
+                .description("코드 제출 후 테스트케이스 채점과 제출 결과 저장까지 걸린 시간")
+                .register(registry);
+
+        this.failureCounter = Counter.builder("submission_failed_total")
+                .description("코드 제출 및 채점 실패 횟수")
+                .register(registry);
+    }
+
+    public void recordGrading(long elapsedNanos) {
+        gradingTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void incrementFailure() {
+        failureCounter.increment();
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #434 
-- Closes #435 
- Closes #436 

---

## 🛠️ 기능 관련 작업 내용
- 문제별 추천 코스 연결 저장 API를 구현했습니다.
- 추천 코스 선택 목록, 수정 화면 조회, 학생용 추천 코스 조회 API를 추가했습니다.
- `problem_recommended_course` 매핑 테이블 기반 저장/조회 흐름을 구현했습니다.
- Swagger 예시와 `ai/API.md` 추천 코스 API 명세를 최신화했습니다.

---

## ♻️ 패키지 변경 사항
- `project/problems/recommendation`: 추천 코스 연결 저장, 수정 조회, 학생용 조회 UseCase/Service/Controller 추가
- `project/problems/recommendation/infrastructure`: 추천 코스 매핑 JPA 엔티티, Repository, Adapter 추가
- `project/course/infrastructure`: 추천 가능한 ACTIVE 코스 조회용 Repository 메서드 추가
- `project/ai`: 추천 코스 API 명세 최신화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 운영/관리자가 문제에 추천 코스를 저장(노출 순서 포함)하고, 편집 화면에서 선택/선택 가능 목록을 함께 확인할 수 있습니다.
  * 학생은 문제별 추천 코스 목록을 조회할 수 있습니다.
  * 선택 가능 코스는 키워드 검색과 최대 개수 제한으로 조회됩니다.
* **Documentation**
  * 추천 코스 저장 API의 요청/응답 스펙과 예시, 응답 코드(200/400/401/403/404)가 문서에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->