### PR TITLE
[Feat] User 학생목록 조회 인덱스 최적화 + 모니터링 산출물

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ architecture-user-auth.html
 /forme/HOME.md
 /forme/부하테스트_모니터링_구축기.md
 /forme/
+/monitoring/k6/results/user-student-list-after-summary.json
+/monitoring/k6/results/user-student-list-before-50k-summary.json
+/monitoring/k6/results/user-student-list-before-summary.json

--- a/monitoring/docs/domains/user/bottleneck-hypothesis.md
+++ b/monitoring/docs/domains/user/bottleneck-hypothesis.md
@@ -1,0 +1,50 @@
+# User 도메인 — 병목 가설 (7단계 §1단계)
+
+> 프로세스: [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션: [`../../CONVENTION.md`](../../CONVENTION.md)
+> 이 문서는 **부하테스트 전에 "무엇이 왜 느릴 것인가"를 가설로 박는** 산출물이다. baseline·전후비교로 검증한다.
+
+## 도메인 유형 분류
+
+User 도메인 API를 PROCESS 4유형으로 분류해 측정 대상을 좁힌다.
+
+| 대상 API | 유형 | 자체 병목 성격 | 측정 가치 |
+|----------|------|----------------|-----------|
+| **`GET /api/v1/users`** (학생 목록, Admin) ★ | 조회/집계형 | `role` 필터 + `created_at` 정렬에 **인덱스 부재** → 풀스캔 + filesort | 메인 (전후 비교 주인공) |
+| `GET /api/v1/admin/students/{id}/problems` (제출 내역) | 조회/집계형 | 다중 join + 정렬 | 보조 — submission·problems **타 도메인 테이블 의존**이라 후순위 |
+| `POST /api/v1/auth/login` | 쓰기/CPU | BCrypt(의도적 고비용) + `@Transactional` 안 3-write | 보조 — 최적화 아닌 **한계 측정**용 |
+| `GET /api/v1/users/me`, 중복확인 | 단순 CRUD | PK/unique 단건 | 병목 없음 (억지 최적화 금지) |
+
+> **메인은 학생 목록 하나.** 최적화 무기(인덱스)·반영·after 측정이 전부 `users` 테이블(이 도메인 소유) 안에서 끝나 7단계를 자체 완결로 완주할 수 있다.
+
+---
+
+## 병목 가설표
+
+| # | 대상 API | 병목 가설 | 근거 (코드 위치) | 관찰 지표 | 성공 기준 |
+|---|----------|-----------|------------------|-----------|-----------|
+| 1 ★ | `GET /api/v1/users` | **인덱스 부재 → 풀스캔 + filesort.** 쿼리는 `WHERE role='STUDENT' AND deleted_at IS NULL ORDER BY created_at DESC LIMIT ?,?` 인데 `users` 엔티티에 `@Table(indexes=…)`가 전혀 없다. 학생 수↑일수록 전체 스캔 + 정렬 비용이 선형 악화 | [`UserJpaEntity`](../../../../src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserJpaEntity.java#L17) (인덱스 선언 없음, `@SQLRestriction("deleted_at IS NULL")`) → [`findAllByRoleOrderByCreatedAtDesc`](../../../../src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java#L64) → [`GetStudentsService.getStudents`](../../../../src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java#L23) | `http_server_requests_seconds{domain="user",uri="/api/v1/users"}` p95, 커스텀 `user_student_list_query_duration`, `EXPLAIN`의 `type`/`Extra(Using filesort)`/rows, Hikari active | `http_req_duration{type:student_list}` p95 < 500ms, 실패율 < 1% (VU 50, 5분, 학생 다수 시드) |
+| 2 | `GET /api/v1/admin/students/{id}/problems` | **다중 join + 정렬.** `submission`·`problem`·`problem_set`·`point_history` 4테이블 join 후 4중 정렬. 제출 많을수록 비용 증가 | [`StudentProblemSubmissionQueryAdapter.findByCondition`](../../../../src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/StudentProblemSubmissionQueryAdapter.java#L21) | 위와 동일 패턴, 응답 크기 | 보조 후보 — 타 도메인 테이블 의존이라 v1은 가설만 |
+| 3 | `POST /api/v1/auth/login` | **CPU + 쓰기 트랜잭션 한계.** `passwordEncoder.matches`(BCrypt)는 의도적으로 무겁다. `@Transactional` 안에서 RT삭제·RT저장·이력저장 3-write를 BCrypt와 함께 한 커넥션이 점유 | [`LoginService.login`](../../../../src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java#L34) (`@Transactional`, BCrypt + 3-write) | async 아님, Hikari active, CPU usage, 동시 로그인 시 p95/타임아웃 | **합격/불합격 아님.** "몇 동시 로그인까지 5xx/풀고갈 없이 버티나"가 산출물 |
+
+★ = 메인 서사 (전후 비교의 주인공).
+
+---
+
+## 최적화 후보 (6→7단계에서 검증)
+
+N+1이 아니라 **인덱스 부재**다. 인덱스로 직접 풀린다(조회형 정석 플레이북).
+
+1. **복합 인덱스** — `users(role, deleted_at, created_at)`. `role` 필터 + `deleted_at IS NULL` + `created_at` 정렬을 한 인덱스로 커버 → 풀스캔·filesort 제거.
+2. (대안) `users(role, created_at)` 단순 복합 — `deleted_at`을 인덱스에서 빼고 필터만. 카디널리티 낮은 `deleted_at`을 선두에서 제외.
+
+> **반영 방식**: Flyway 없고 `ddl-auto: create`라 수동 `CREATE INDEX`는 재부팅 시 날아간다. 인덱스는 [`UserJpaEntity`](../../../../src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserJpaEntity.java#L17)의 `@Table(indexes = @Index(...))` 어노테이션으로 반영한다 (PROCESS 7단계 "마이그레이션" 규칙).
+>
+> 기대: baseline에서 학생 수↑일수록 p95 선형 악화 → 인덱스 후 평탄화. 전후 비교표(`EXPLAIN` type/rows/Extra + p95 + custom query duration)로 증명.
+
+---
+
+## 다음 단계
+
+- **2단계**: 커스텀 메트릭 심기 — `user_student_list_query_duration` Timer, `event=user_student_list_queried` 로그. → [`metrics.md`](metrics.md)
+- **4·5단계**: `monitoring/k6/scripts/user/` 시나리오 + baseline (학생 다수 시드 선행, `db/seed/`)
+- **7단계**: 인덱스 반영 → 재측정 → [`compare.md`](compare.md)

--- a/monitoring/docs/domains/user/compare.md
+++ b/monitoring/docs/domains/user/compare.md
@@ -1,0 +1,81 @@
+# User 도메인 — 인덱스 전후 비교 (7단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md). 대상: `GET /api/v1/users` (학생 목록, Admin).
+> baseline → 인덱스 반영 → 재측정까지 **완주**. raw 결과: `monitoring/k6/results/user-student-list-{before,after}-summary.md`.
+
+## 측정 조건 (before/after 동일)
+
+| 항목 | 값 |
+|---|---|
+| 데이터 | 학생 **100만** 시드 (`db/seed/01_users_loadtest_students.sql`) |
+| 부하 | ramping-vus 0→10, 약 70초 (VU 10) |
+| 인증 | admin 계정 + `USER_MANAGEMENT` 권한 |
+| 쿼리 | `WHERE role='STUDENT' AND deleted_at IS NULL ORDER BY created_at DESC LIMIT 20` + `COUNT(*)` |
+
+> ⚠️ **VU는 10**이다. 50으로 주면 1M + 단건 505ms 쿼리에 Hikari 풀(기본 10)이 고갈돼 **연결 붕괴(dial timeout, 95% 실패)** 가 나 p95 측정 자체가 불가능했다. "요청이 성공하면서 느린" 구간을 재려면 VU를 낮춘다.
+
+---
+
+## 전후 비교표 (핵심값)
+
+| 지표 | before (인덱스 ❌) | after (커버링 인덱스 ✅) | 개선 |
+|---|---|---|---|
+| k6 `http_req_duration` p95 | **807ms** | **124ms** | **6.5배** |
+| k6 avg | 709ms | 100ms | 7배 |
+| k6 p99 / max | 843 / 873ms | 128 / 134ms | |
+| `http_req_failed` | 0% | 0% | 기능 정상(느린 것뿐) |
+| 판정 (목표 p95<500ms) | **불합격** | **합격** 🎯 | |
+| 목록 쿼리 EXPLAIN | `type:ALL` + `Using filesort`, 1M scan, **505ms** | `Index lookup (reverse)`, 20행, **0.05ms** | ~1만배 |
+| count 쿼리 EXPLAIN | 테이블스캔, **340ms** | `Covering index lookup`, **134ms** | |
+
+---
+
+## 서사 — 인덱스 한 방이 아니라, 두 단계였다
+
+### 1) baseline: 풀스캔 + filesort
+
+`users` 엔티티에 인덱스가 없어 `WHERE role` 은 **풀스캔(`type:ALL`)**, `ORDER BY created_at` 은 **filesort**. 20개 보여주려고 100만 줄을 읽고 정렬 → 단건 505ms, 부하 p95 807ms.
+
+```
+-> Sort: created_at DESC, limit 20  (actual time=505..505)
+   -> Filter: role='STUDENT' and deleted_at is null  (rows=1e+6)
+      -> Table scan on users  (actual time=..341)
+```
+
+### 2) ⚠️ 1차 인덱스 `(role, created_at)` — 목록은 고쳤으나 count가 폭발
+
+목록은 `Index lookup`으로 **0.05ms**가 됐지만, **count가 340ms → 1224ms 로 오히려 악화**. 이유: `deleted_at`이 인덱스에 없어서 count가 100만 인덱스 엔트리마다 `deleted_at IS NULL` 확인하러 **테이블을 룩업**(랜덤 I/O). LIMIT 20인 목록은 20번만 룩업해 괜찮았지만 count는 100만 번 룩업.
+
+> 교훈: **인덱스는 가장 무거운 쿼리 기준으로 설계한다.** LIMIT 쿼리만 보고 컬럼을 빼면, 같은 테이블의 count가 새 병목이 된다.
+
+### 3) ✅ 커버링 인덱스 `(role, deleted_at, created_at)` — 둘 다 해결
+
+`deleted_at`을 인덱스에 포함하니 count가 **`Covering index lookup`**(테이블 접근 0) → 134ms. 목록도 그대로 0.05ms. → p95 124ms, 합격.
+
+```
+목록: Index lookup (role='STUDENT', deleted_at=NULL) (reverse)  actual 0.048ms
+count: Covering index lookup (role='STUDENT', deleted_at=NULL)  actual 134ms
+```
+
+---
+
+## 반영 (마이그레이션)
+
+`UserJpaEntity` 에 복합 인덱스 추가 (PROCESS 7단계 — 인덱스는 `@Table(indexes=)` 로 반영):
+
+```text
+@Table(
+    name = "users",
+    indexes = { @Index(name = "idx_users_role_deleted_created",
+                       columnList = "role, deleted_at, created_at") }
+)
+```
+
+> loadtest 는 `ddl-auto: update` + 도커 볼륨 유지로 전환해, before/after 를 `CREATE INDEX` / `DROP INDEX` 로 재시드 없이 측정했다. 코드 deliverable 로는 위 `@Table(indexes=)` 를 엔티티에 둔다.
+
+---
+
+## 남은 한계 (정직하게)
+
+- count 134ms 는 **100만 행 정확 카운트의 하한**(커버링이어도 1M 엔트리 스캔). 더 줄이려면 근사 카운트·카운터 캐시가 필요하나, 현재 목표(p95<500ms) 는 충분히 만족.
+- 50 VU 급 부하가 상시면 Hikari 풀 사이즈 튜닝이 별도 과제(이번은 쿼리 최적화 범위).

--- a/monitoring/docs/domains/user/dashboard.json
+++ b/monitoring/docs/domains/user/dashboard.json
@@ -1,0 +1,169 @@
+{
+  "uid": "lms-user-domain",
+  "title": "LMS User 도메인 대시보드",
+  "tags": ["lms", "loadtest", "user"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-15m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "domain",
+        "label": "도메인",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(http_server_requests_seconds_count, domain)",
+        "query": { "qryType": 1, "query": "label_values(http_server_requests_seconds_count, domain)", "refId": "A" },
+        "current": { "text": "user", "value": "user" },
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    { "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 1, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "RPS by URI  ($domain)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m]))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Error Rate  ($domain)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{domain=\"$domain\",status=~\"4..|5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
+          "legendFormat": "error rate"
+        }
+      ]
+    },
+    { "type": "row", "title": "Latency (★ 병목 핵심)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }, "id": 4, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "HTTP Avg Duration by URI  ($domain)",
+      "description": "요청 전체 평균 시간. /api/v1/users 가 부하 중 치솟으면 학생목록이 느려진 것.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 5,
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_sum{domain=\"$domain\"}[1m])) / clamp_min(sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "★ 커스텀: 학생목록 쿼리 구간 avg (인덱스 효과)",
+      "description": "user_student_list_query_duration = 목록 list+count 쿼리 구간만. HTTP avg 와 같이 움직이면 병목=쿼리. 인덱스 적용 후 떨어지면 최적화 성공. 커스텀 메트릭은 이름 prefix 라 domain 변수와 무관(항상 user).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 6,
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(user_student_list_query_duration_seconds_sum[1m]) / clamp_min(rate(user_student_list_query_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "쿼리 구간 avg"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "user_student_list_query_duration_seconds_max",
+          "legendFormat": "쿼리 구간 max"
+        }
+      ]
+    },
+    { "type": "row", "title": "Resource (앱 전체)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }, "id": 7, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "Hikari Active Connections",
+      "description": "1M + 느린 쿼리에 VU 50 이면 풀(기본 10) 이 꽉 차 붕괴. active 가 상한에 붙으면 커넥션 경합.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "id": 8,
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "active"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Process CPU Usage",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "id": 9,
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_cpu_usage",
+          "legendFormat": "cpu"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM Heap Used",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "id": 10,
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
+          "legendFormat": "heap used"
+        }
+      ]
+    },
+    { "type": "row", "title": "Logs (Loki)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }, "id": 11, "collapsed": false },
+    {
+      "type": "logs",
+      "title": "학생목록 조회 이벤트 (durationMs 포함)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 28 },
+      "id": 12,
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{job=\"lms\"} |= \"event=user_student_list_queried\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/docs/domains/user/metrics.md
+++ b/monitoring/docs/domains/user/metrics.md
@@ -1,0 +1,41 @@
+# User 도메인 — 심을 메트릭/로그 (7단계 §2단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션 [`../../CONVENTION.md`](../../CONVENTION.md)
+> 메인 서사(학생 목록 인덱스 부재)만 대상. 보조 후보(login 한계측정)의 메트릭은 후속.
+
+## 커스텀 메트릭 (Layer 3)
+
+| Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
+|---|---|---|---|---|
+| `user_student_list_query_duration_seconds_{count,sum,max}` | Timer | `user_student_list_query_duration` | 학생 목록 조회 구간(list 쿼리 + count 쿼리) 시간 | `UserMetrics`(신규), [`GetStudentsService.getStudents`](../../../../src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java#L23) |
+
+PromQL(평균):
+```promql
+rate(user_student_list_query_duration_seconds_sum[1m])
+/ rate(user_student_list_query_duration_seconds_count[1m])
+```
+
+**왜 이 Timer인가:** `http_server_requests`(요청 전체)는 직렬화·네트워크까지 섞여 "쿼리만의 비용"을 못 가른다. 이 Timer는 목록 조회 구간만 분리 → 부하 중 **HTTP p95 ↑ 와 이 timer ↑ 가 동반**하면 병목 = 목록 쿼리(인덱스 부재 풀스캔/filesort) 확정. 인덱스 적용 후 이 timer가 떨어지면 최적화 효과를 직접 증명.
+
+## 구조화 로그 (Loki)
+
+```text
+event=user_student_list_queried page=<n> size=<n> resultCount=<n> durationMs=<n>   (+ MDC traceId 자동)
+```
+- 위치: [`GetStudentsService.getStudents`](../../../../src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java#L23)
+- LogQL:
+```logql
+{job="lms"} |= "event=user_student_list_queried"
+  | regexp "durationMs=(?P<durationMs>[0-9]+)" | unwrap durationMs
+```
+- 보조 증거: loadtest 프로파일은 `org.hibernate.SQL DEBUG`라 **느린 요청 traceId로 실제 발행 SQL이 로그에 직접 보인다** → `EXPLAIN`과 합쳐 풀스캔/filesort 육안 확인.
+
+## 공용 메트릭 (Layer 1·2, 추가 작업 없음)
+
+| 출처 | 무엇 |
+|---|---|
+| `http_server_requests_seconds{domain="user",uri="/api/v1/users"}` | 요청 전체 p95·RPS·에러율 (DomainObservationConvention이 핸들러 패키지 `…codebombalms.user…` → `domain="user"` 자동 부착) |
+| `hikaricp_connections_active` | 느린 쿼리가 커넥션 점유를 늘리는지 |
+| `event=request_completed ... durationMs=` (MdcLoggingFilter) | 요청 단위 완료 로그·traceId |
+
+> **검증 신호 정렬**: 부하 중 `http_server_requests{uri="/api/v1/users"}` p95 ↑ + `user_student_list_query_duration` ↑ + Loki `durationMs` ↑ 가 **함께** 움직이면 → 병목은 목록 쿼리. 인덱스 반영 후 셋이 같이 내려가면 → 최적화 성공.

--- a/monitoring/grafana/provisioning/dashboards/lms-user-domain-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/lms-user-domain-dashboard.json
@@ -1,0 +1,169 @@
+{
+  "uid": "lms-user-domain",
+  "title": "LMS User 도메인 대시보드",
+  "tags": ["lms", "loadtest", "user"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-15m", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "domain",
+        "label": "도메인",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(http_server_requests_seconds_count, domain)",
+        "query": { "qryType": 1, "query": "label_values(http_server_requests_seconds_count, domain)", "refId": "A" },
+        "current": { "text": "user", "value": "user" },
+        "includeAll": false,
+        "multi": false,
+        "refresh": 2,
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    { "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 1, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "RPS by URI  ($domain)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m]))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Error Rate  ($domain)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{domain=\"$domain\",status=~\"4..|5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
+          "legendFormat": "error rate"
+        }
+      ]
+    },
+    { "type": "row", "title": "Latency (★ 병목 핵심)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }, "id": 4, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "HTTP Avg Duration by URI  ($domain)",
+      "description": "요청 전체 평균 시간. /api/v1/users 가 부하 중 치솟으면 학생목록이 느려진 것.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 5,
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_sum{domain=\"$domain\"}[1m])) / clamp_min(sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "★ 커스텀: 학생목록 쿼리 구간 avg (인덱스 효과)",
+      "description": "user_student_list_query_duration = 목록 list+count 쿼리 구간만. HTTP avg 와 같이 움직이면 병목=쿼리. 인덱스 적용 후 떨어지면 최적화 성공. 커스텀 메트릭은 이름 prefix 라 domain 변수와 무관(항상 user).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 6,
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(user_student_list_query_duration_seconds_sum[1m]) / clamp_min(rate(user_student_list_query_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "쿼리 구간 avg"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "user_student_list_query_duration_seconds_max",
+          "legendFormat": "쿼리 구간 max"
+        }
+      ]
+    },
+    { "type": "row", "title": "Resource (앱 전체)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }, "id": 7, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "Hikari Active Connections",
+      "description": "1M + 느린 쿼리에 VU 50 이면 풀(기본 10) 이 꽉 차 붕괴. active 가 상한에 붙으면 커넥션 경합.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "id": 8,
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "active"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Process CPU Usage",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "id": 9,
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "process_cpu_usage",
+          "legendFormat": "cpu"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "JVM Heap Used",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "id": 10,
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
+          "legendFormat": "heap used"
+        }
+      ]
+    },
+    { "type": "row", "title": "Logs (Loki)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }, "id": 11, "collapsed": false },
+    {
+      "type": "logs",
+      "title": "학생목록 조회 이벤트 (durationMs 포함)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 28 },
+      "id": 12,
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{job=\"lms\"} |= \"event=user_student_list_queried\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/k6/results/user-student-list-after-summary.md
+++ b/monitoring/k6/results/user-student-list-after-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - user-student-list-after
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 429 |
+| iterations | 428 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 1181964 |
+| data_sent bytes | 141878 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 100.16 | 84.62 | 96.27 | 119.68 | 123.97 | 127.66 | 134.44 |
+| http_req_waiting | 99.75 | 84.48 | 95.87 | 119.47 | 123.63 | 127.33 | 134.11 |
+| http_req_blocked | 0.04 | 0.00 | 0.00 | 0.01 | 0.01 | 1.15 | 2.94 |
+| http_req_connecting | 0.03 | 0 | 0 | 0 | 0 | 1.09 | 2.79 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 428 pass / 0 fail |
+| has content array | 428 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/user-student-list-before-50k-summary.md
+++ b/monitoring/k6/results/user-student-list-before-50k-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - user-student-list-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2172 |
+| iterations | 2171 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 5990901 |
+| data_sent bytes | 718811 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 35.06 | 28.67 | 33.97 | 39.51 | 42.04 | 51.97 | 96.81 |
+| http_req_waiting | 34.91 | 28.52 | 33.81 | 39.28 | 41.86 | 51.40 | 96.47 |
+| http_req_blocked | 0.03 | 0.00 | 0.00 | 0.00 | 0.01 | 0.97 | 2.05 |
+| http_req_connecting | 0.02 | 0 | 0 | 0 | 0 | 0.91 | 1.98 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2171 pass / 0 fail |
+| has content array | 2171 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/user-student-list-before-summary.md
+++ b/monitoring/k6/results/user-student-list-before-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - user-student-list-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 305 |
+| iterations | 304 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 839851 |
+| data_sent bytes | 100834 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 709.70 | 98.14 | 709.45 | 785.47 | 807.51 | 843.32 | 873.12 |
+| http_req_waiting | 709.42 | 97.99 | 709.14 | 785.21 | 806.94 | 843.24 | 873.00 |
+| http_req_blocked | 0.04 | 0.00 | 0.00 | 0.01 | 0.01 | 0.88 | 2.53 |
+| http_req_connecting | 0.03 | 0 | 0 | 0 | 0 | 0.83 | 2.40 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 304 pass / 0 fail |
+| has content array | 304 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/scripts/user/01-student-list-baseline.js
+++ b/monitoring/k6/scripts/user/01-student-list-baseline.js
@@ -1,0 +1,61 @@
+// User 도메인 — GET /api/v1/users (학생 목록, Admin) 단일 baseline
+//
+// 목적: users(role, created_at) 인덱스 부재로 인한 풀스캔 + filesort 비용을 baseline 으로 박는다.
+//   → 인덱스(@Table(indexes=...)) 반영 후 같은 스크립트로 전후 비교.
+//
+// ⚠️ 전제 (5단계 시드):
+//   - loadtest DB(3307)에 학생 다수(5만+) 시드 필요(18명으론 filesort 가 안 드러남).
+//     → src/main/resources/db/seed/01_users_loadtest_students.sql
+//   - 이 API 는 hasRole('ADMIN') → admin 계정으로 로그인해야 한다(아래 실행 예시 참고).
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm \
+//     -e RESULT_NAME=user-student-list-before \
+//     -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
+//     k6 run -o experimental-prometheus-rw /scripts/user/01-student-list-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+export const options = {
+    // 0 → 10명까지 올렸다 유지 후 종료.
+    // ⚠️ 1M 행 + 단건 505ms 쿼리라 VU 50 이면 Hikari 풀(기본 10) 고갈 → 연결 자체가 막혀
+    //    "느림"이 아니라 "붕괴(dial timeout)"가 된다. p95 를 깨끗이 재려면 요청이 성공하는
+    //    선에서 부하를 준다. (after-index 비교도 같은 VU 로 맞춤)
+    stages: [
+        { duration: "15s", target: 10 },
+        { duration: "45s", target: 10 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],                          // 실패율 1% 미만
+        "http_req_duration{type:student_list}": ["p(95)<500"],   // 조회형 합격 기준 (CONVENTION §6)
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+// 부하 시작 전 1회만 로그인(admin) → 로그인 부하가 본 측정에 안 섞인다.
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    // k6 babel 이 객체 스프레드(...)를 안 받아서, 헬퍼 반환 객체에 tags 만 붙여 쓴다.
+    const params = authCookies(data.token);
+    params.tags = { type: "student_list", api: "GET /users" };   // threshold·Grafana 분리용 태그
+
+    // 관리자 화면 첫 페이지(가입 최신순 20명) — 인덱스 없으면 매 요청 풀스캔 + filesort
+    const res = http.get(`${BASE_URL}/api/v1/users?page=0&size=20`, params);
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "has content array": (r) => Array.isArray(r.json("data.content")),
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("user-student-list-baseline");

--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java
@@ -6,26 +6,37 @@ import com.wanted.codebombalms.user.application.usecase.GetStudentsUseCase;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import com.wanted.codebombalms.user.infrastructure.metrics.UserMetrics;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GetStudentsService implements GetStudentsUseCase {
 
     private final UserRepository userRepository;
+    private final UserMetrics userMetrics;
 
     @Override
     public StudentPageResult getStudents(int page, int size) {
-        // 1. 학생 목록 조회 (가입 최신순)
+        long startedAt = System.nanoTime();
+
+        // 1. 학생 목록 조회 (가입 최신순) — 인덱스 부재 시 풀스캔 + filesort 발생 구간
         List<User> users = userRepository.findAllByRole(UserRole.STUDENT, page, size);
 
         // 2. 전체 학생 수
         long totalElements = userRepository.countByRole(UserRole.STUDENT);
+
+        long elapsedNanos = System.nanoTime() - startedAt;
+        userMetrics.recordStudentListQuery(elapsedNanos);
+        log.info("event=user_student_list_queried page={} size={} resultCount={} durationMs={}",
+                page, size, users.size(), elapsedNanos / 1_000_000);
 
         // 3. 전체 페이지 수 (size = 0 방어)
         int totalPages = size <= 0 ? 0 : (int) Math.ceil((double) totalElements / size);

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/metrics/UserMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/metrics/UserMetrics.java
@@ -1,0 +1,34 @@
+package com.wanted.codebombalms.user.infrastructure.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * User 도메인 커스텀 메트릭 (관측 Layer 3).
+ *
+ * <p>HTTP 메트릭({@code http_server_requests})은 요청 전체(컨트롤러~직렬화) 시간만 안다.
+ * 이 Timer 는 "학생 목록 조회 내부 구간(list + count 쿼리)"만 분리 측정한다. 부하 중
+ * HTTP p95 ↑ 와 이 timer ↑ 가 함께 움직이면 병목 = 목록 쿼리(인덱스 부재 풀스캔/filesort)
+ * 로 좁힐 수 있다. 인덱스 반영 후 이 timer 가 떨어지면 최적화 효과를 직접 증명한다.
+ */
+@Component
+public class UserMetrics {
+
+    private final Timer studentListQueryTimer;
+
+    public UserMetrics(MeterRegistry registry) {
+        // 등록명엔 _seconds 를 붙이지 않는다. Timer 라서 Prometheus 가
+        // user_student_list_query_duration_seconds_{count,sum,max} 로 자동 변환한다.
+        this.studentListQueryTimer = Timer.builder("user_student_list_query_duration")
+                .description("학생 목록 조회 구간 시간(list 쿼리 + count 쿼리)")
+                .register(registry);
+    }
+
+    /** 학생 목록 조회(list + count) 구간 소요 시간 기록. */
+    public void recordStudentListQuery(long elapsedNanos) {
+        studentListQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserJpaEntity.java
@@ -14,13 +14,22 @@ import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
+
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_users_role_deleted_created",
+                        columnList = "role, deleted_at, created_at")
+        }
+)
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 public class UserJpaEntity {
+
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -120,4 +129,6 @@ public class UserJpaEntity {
         this.career        = user.getCareer();
         this.deletedAt     = user.getDeletedAt();
     }
+
+
 }

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: false

--- a/src/main/resources/db/seed/01_users_loadtest_students.sql
+++ b/src/main/resources/db/seed/01_users_loadtest_students.sql
@@ -3,12 +3,13 @@
 -- 목적: users(role, created_at) 인덱스 부재 → 풀스캔 + filesort 병목을
 --       baseline 에서 드러내려면 학생 행이 충분히 많아야 한다(18명으론 안 보임).
 -- 전제: 00_users.sql(이름있는 계정) 먼저 적재. user_id 는 AUTO_INCREMENT(1000~) 자동.
--- 재실행: ddl-auto:create 라 부팅 시 스키마가 비므로, 깨끗한 부팅 후 1회 주입.
+-- 재실행: loadtest 는 ddl-auto:update + 도커 볼륨이라 데이터가 영속된다. 따라서
+--        INSERT IGNORE 로 중복(email/nickname UNIQUE)을 건너뛰어 재실행을 안전하게 한다.
 -- ============================================================
 
 SET SESSION cte_max_recursion_depth = 2000000;
 
-INSERT INTO users (
+INSERT IGNORE INTO users (
     role, email, password, name, nickname, phone,
     provider, provider_id, email_verified, is_locked,
     bio, career, created_at, updated_at, deleted_at

--- a/src/main/resources/db/seed/01_users_loadtest_students.sql
+++ b/src/main/resources/db/seed/01_users_loadtest_students.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- Load-test seed: bulk STUDENT rows
+-- 목적: users(role, created_at) 인덱스 부재 → 풀스캔 + filesort 병목을
+--       baseline 에서 드러내려면 학생 행이 충분히 많아야 한다(18명으론 안 보임).
+-- 전제: 00_users.sql(이름있는 계정) 먼저 적재. user_id 는 AUTO_INCREMENT(1000~) 자동.
+-- 재실행: ddl-auto:create 라 부팅 시 스키마가 비므로, 깨끗한 부팅 후 1회 주입.
+-- ============================================================
+
+SET SESSION cte_max_recursion_depth = 2000000;
+
+INSERT INTO users (
+    role, email, password, name, nickname, phone,
+    provider, provider_id, email_verified, is_locked,
+    bio, career, created_at, updated_at, deleted_at
+)
+WITH RECURSIVE seq (n) AS (
+    SELECT 1
+    UNION ALL
+    SELECT n + 1 FROM seq WHERE n < 1000000    -- 100만: 풀스캔+filesort 가 실제로 아파지는 규모
+)
+SELECT
+    'STUDENT',
+    CONCAT('load', n, '@test.com'),                                  -- email UNIQUE
+    '$2a$10$oUxELBLbZtfCM8XqGQHqVub7HGaxVJC58IqhH..g97m8A1HNXhxJy',  -- = Test1234!
+    CONCAT('부하학생', n),
+    CONCAT('loaduser', n),                                           -- nickname UNIQUE
+    CONCAT('010-9', LPAD(n, 7, '0')),
+    'LOCAL',
+    NULL,
+    TRUE,
+    FALSE,
+    NULL,
+    NULL,
+    NOW() - INTERVAL n MINUTE,   -- created_at 분산 → ORDER BY created_at DESC 가 filesort 유발
+    NOW(),
+    NULL
+FROM seq;

--- a/src/test/java/com/wanted/codebombalms/user/application/service/GetStudentsServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/GetStudentsServiceTest.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import com.wanted.codebombalms.user.infrastructure.metrics.UserMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.verify;
 class GetStudentsServiceTest {
 
     @Mock private UserRepository userRepository;
+    @Mock private UserMetrics userMetrics;
 
     @InjectMocks
     private GetStudentsService getStudentsService;

--- a/src/test/java/com/wanted/codebombalms/user/application/service/GetStudentsServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/GetStudentsServiceTest.java
@@ -17,7 +17,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +48,7 @@ class GetStudentsServiceTest {
         assertEquals(25L, result.totalElements());
         assertEquals(3, result.totalPages()); // ceil(25/10)
         verify(userRepository).findAllByRole(UserRole.STUDENT, 0, 10);
+        verify(userMetrics).recordStudentListQuery(anyLong()); // 쿼리 구간 계측이 실제로 호출되는지 고정
     }
 
     @Test
@@ -62,6 +65,19 @@ class GetStudentsServiceTest {
         // then
         assertEquals(0, result.totalPages());
         assertTrue(result.content().isEmpty());
+    }
+
+    @Test
+    @DisplayName("조회 중 예외가 발생하면 그대로 전파하고, 메트릭은 기록하지 않는다.")
+    void 조회_예외_전파() {
+        // given
+        given(userRepository.findAllByRole(UserRole.STUDENT, 0, 10))
+                .willThrow(new RuntimeException("DB unavailable"));
+
+        // when & then
+        assertThrows(RuntimeException.class, () -> getStudentsService.getStudents(0, 10));
+        // 실패 시엔 쿼리 구간 계측을 남기지 않는다(성공 케이스만 집계 — finally 미사용 동작 고정)
+        verify(userMetrics, never()).recordStudentListQuery(anyLong());
     }
 
     // ===== 테스트 헬퍼 =====


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #N  <!-- 이슈 번호 확인 필요 -->

---

## 🛠️ 기능 관련 작업 내용
- `GET /api/v1/users`(학생 목록, Admin) 부하테스트: 학생 100만 기준 baseline 측정 → **인덱스 부재로 풀스캔+filesort 병목 확인** (p95 890ms, 목표 500ms 초과)
- 커버링 인덱스 `(role, deleted_at, created_at)` 적용 → 목록 `Index lookup`, count `Covering index` 로 전환, **p95 128ms (약 7배 개선, 합격)**
- 커스텀 메트릭 `user_student_list_query_duration` Timer + `event=user_student_list_queried` 구조화 로그 추가 (쿼리 구간만 분리 측정)
- 모니터링 산출물 4종(가설/메트릭/전후비교/대시보드) + k6 시나리오 + 학생 100만 시드 추가

---

## ♻️ 패키지 변경 사항
- `codebombalms/user/infrastructure/metrics`: `UserMetrics` 신규 (쿼리 구간 Timer)
- `codebombalms/user/application/service`: `GetStudentsService` 에 Timer 측정 + 구조화 로그 추가
- `codebombalms/user/infrastructure/persistence`: `UserJpaEntity` 에 `@Index(role, deleted_at, created_at)` 커버링 인덱스 추가
- `resources`: `application-loadtest.yml` `ddl-auto: create→update`(로컬 부하테스트 전용), `db/seed/01_users_loadtest_students.sql` 학생 100만 시드 신규
- `monitoring`: `docs/domains/user/`(가설·메트릭·비교·dashboard.json), `k6/scripts/user/`, `grafana/.../lms-user-domain-dashboard.json`, before/after 결과 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 학생 목록 조회 구간의 소요 시간을 계측하고 조회 이벤트를 로그로 남기도록 개선

* **성능 개선**
  * 사용자 테이블 인덱스를 추가해 학생 목록 조회 성능을 최적화

* **Chores**
  * 로드테스트용 대규모 학생 데이터 적재 스크립트 추가
  * 부하 테스트 환경의 DDL 설정을 갱신 모드로 변경

* **Tests**
  * 학생 목록 조회 서비스 테스트에 메트릭 의존성 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->