### PR TITLE
[Feat] 이메일 찾기 구현

### DIFF
--- a/src/main/java/com/wanted/codebombalms/user/application/service/FindEmailService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/FindEmailService.java
@@ -1,0 +1,50 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.user.application.usecase.FindEmailUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FindEmailService implements FindEmailUseCase {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public String findEmail(String name, String phone) {
+
+        // 1. 이름 + 전화번호가 모두 일치하는 활성 회원 조회 (없으면 404)
+        User user = userRepository.findByNameAndPhone(name, phone)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+
+        // 2. 이메일 마스킹 후 반환 (평문 노출 방지)
+        return maskEmail(user.getEmail());
+    }
+
+    /**
+     * 이메일 마스킹 — 로컬 파트 앞 2자만 남기고 나머지는 '*' 처리.
+     * (예: user@example.com → us**@example.com)
+     * 로컬 파트가 2자 이하면 첫 1자만 노출.
+     */
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 0) {
+            return email; // 형식 비정상 — 그대로 반환 (방어적 처리)
+        }
+
+        String local  = email.substring(0, atIndex);
+        String domain = email.substring(atIndex); // '@' 포함
+
+        int visible = local.length() <= 2 ? 1 : 2;
+        String masked = local.substring(0, visible)
+                + "*".repeat(local.length() - visible);
+
+        return masked + domain;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/FindEmailService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/FindEmailService.java
@@ -35,7 +35,7 @@ public class FindEmailService implements FindEmailUseCase {
     private String maskEmail(String email) {
         int atIndex = email.indexOf('@');
         if (atIndex <= 0) {
-            return email; // 형식 비정상 — 그대로 반환 (방어적 처리)
+            return "***"; // 형식 비정상 — 평문 노출 대신 비식별 문자열 반환
         }
 
         String local  = email.substring(0, atIndex);

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/FindEmailUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/FindEmailUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+public interface FindEmailUseCase {
+
+    String findEmail(String name, String phone);
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
@@ -12,6 +12,8 @@ public interface UserRepository {
 
     Optional<User> findByUserId(Long userId);
 
+    Optional<User> findByNameAndPhone(String name, String phone);
+
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -14,8 +14,8 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
 
     Optional<UserJpaEntity> findByEmail(String email);
 
-    Optional<UserJpaEntity> findByNameAndPhoneAndDeletedAtIsNull(String name, String phone);
-
+    List<UserJpaEntity> findByNameAndPhoneAndDeletedAtIsNullOrderByCreatedAtDesc(String name, String phone);
+    
     Optional<UserJpaEntity> findByUserId(Long userId);
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -14,6 +14,8 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
 
     Optional<UserJpaEntity> findByEmail(String email);
 
+    Optional<UserJpaEntity> findByNameAndPhoneAndDeletedAtIsNull(String name, String phone);
+
     Optional<UserJpaEntity> findByUserId(Long userId);
 
     boolean existsByEmail(String email);

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -29,6 +29,12 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByNameAndPhone(String name, String phone) {
+        return springDataUserRepository.findByNameAndPhoneAndDeletedAtIsNull(name, phone)
+                .map(UserJpaEntity::toDomain);
+    }
+
+    @Override
     public boolean existsByEmail(String email) {
         return springDataUserRepository.existsByEmail(email);
     }

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -30,7 +30,10 @@ public class UserRepositoryAdapter implements UserRepository {
 
     @Override
     public Optional<User> findByNameAndPhone(String name, String phone) {
-        return springDataUserRepository.findByNameAndPhoneAndDeletedAtIsNull(name, phone)
+        return springDataUserRepository
+                .findByNameAndPhoneAndDeletedAtIsNullOrderByCreatedAtDesc(name, phone)
+                .stream()
+                .findFirst()                 // 중복 시 가장 최근 가입 회원 1건 선택 (500 방어)
                 .map(UserJpaEntity::toDomain);
     }
 

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/FindEmailController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/FindEmailController.java
@@ -1,0 +1,43 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.usecase.FindEmailUseCase;
+import com.wanted.codebombalms.user.presentation.api.request.FindEmailRequest;
+import com.wanted.codebombalms.user.presentation.api.response.FindEmailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User - 이메일 찾기", description = "이름 + 전화번호로 가입 이메일 조회 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class FindEmailController {
+
+    private final FindEmailUseCase findEmailUseCase;
+
+    @Operation(
+            summary = "이메일 찾기",
+            description = "이름 + 전화번호가 일치하는 회원의 이메일을 마스킹 처리하여 반환. (탈퇴 회원 제외)"
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USR-001 일치하는 회원 없음")
+    @PostMapping("/find-email")
+    public ResponseEntity<ApiResponse<FindEmailResponse>> findEmail(
+            @Valid @RequestBody FindEmailRequest request
+    ) {
+        String maskedEmail = findEmailUseCase.findEmail(request.name(), request.phone());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.EMAIL_FOUND,
+                UserResponseMessage.EMAIL_FOUND,
+                FindEmailResponse.of(maskedEmail)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
@@ -12,4 +12,5 @@ public class UserResponseCode {
     public static final String PASSWORD_VERIFIED = "USER-ME-PASSWORD-VERIFIED";
     public static final String PROFILE_UPDATED = "USER-ME-PROFILE-UPDATED";
     public static final String PASSWORD_CHANGED = "USER-ME-PASSWORD-CHANGED";
+    public static final String EMAIL_FOUND = "USER-EMAIL-FOUND";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
@@ -12,4 +12,5 @@ public class UserResponseMessage {
     public static final String PASSWORD_VERIFIED = "비밀번호 인증 성공";
     public static final String PROFILE_UPDATED = "개인정보 수정 성공";
     public static final String PASSWORD_CHANGED = "비밀번호 변경 성공";
+    public static final String EMAIL_FOUND = "이메일 찾기 성공";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/FindEmailRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/FindEmailRequest.java
@@ -1,13 +1,16 @@
 package com.wanted.codebombalms.user.presentation.api.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record FindEmailRequest(
 
         @NotBlank(message = "이름은 필수입니다.")
+        @Size(max = 50, message = "이름은 50자 이하여야 합니다.")
         String name,
 
         @NotBlank(message = "전화번호는 필수입니다.")
+        @Size(max = 20, message = "전화번호 형식이 올바르지 않습니다.")
         String phone
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/FindEmailRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/FindEmailRequest.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.user.presentation.api.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FindEmailRequest(
+
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @NotBlank(message = "전화번호는 필수입니다.")
+        String phone
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/response/FindEmailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/response/FindEmailResponse.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.presentation.api.response;
+
+public record FindEmailResponse(
+        String email
+) {
+
+    public static FindEmailResponse of(String maskedEmail) {
+        return new FindEmailResponse(maskedEmail);
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #112

---

## 🛠️ 기능 관련 작업 내용
- 보류 상태였던 이메일 찾기를 B안(휴대폰 OTP 생략)으로 구현 — 이름+전화번호 매칭으로 마스킹된 이메일 반환
- SMS 인프라 복귀 시 컨트롤러 앞단에 OTP 플래그 확인만 추가하면 원래 명세(AUT-018)와 합쳐지는 구조로 설계
- 마스킹은 service 계층에서 처리하여 평문 이메일(PII) 노출 방지, 탈퇴 회원은 `deletedAt IS NULL`로 제외

---

## ♻️ 패키지 변경 사항
- `codebombalms/user/domain/repository`: `findByNameAndPhone` 포트 추가
- `codebombalms/user/infrastructure/persistence`: 어댑터 구현 + `findByNameAndPhoneAndDeletedAtIsNull` 파생 쿼리
- `codebombalms/user/application`: `FindEmailUseCase` / `FindEmailService` 추가
- `codebombalms/user/presentation/api`: 컨트롤러 + 요청/응답 DTO + 응답 코드·메시지 상수 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 이름과 전화번호로 가입자의 이메일을 조회할 수 있는 기능이 추가되었습니다.
  * 보안을 위해 조회된 이메일 주소가 마스킹되어 반환됩니다.
  * 새로운 API 엔드포인트를 통해 이메일 찾기 요청을 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->