### PR TITLE
[Fix] 점수 없는 사용자 랭킹 조회 404 응답 문제 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
@@ -93,31 +93,42 @@ public class RankingQueryAdapter implements RankingQueryPort {
     @Override
     public Optional<RankingItem> findMyTotalPointRanking(Long userId) {
         String sql = """
-            select *
+        select
+            ranked.ranking,
+            u.user_id,
+            u.name,
+            u.nickname,
+            null as badge_image_url,
+            coalesce(weekly.weekly_point, 0) as weekly_point,
+            coalesce(up.total_point, 0) as total_point
+        from users u
+        left join user_point up on up.user_id = u.user_id
+        left join (
+            select
+                ranked_user.user_id,
+                ranked_user.ranking
             from (
                 select
-                    dense_rank() over (order by up.total_point desc) as ranking,
-                    u.user_id,
-                    u.name,
-                    u.nickname,
-                    null as badge_image_url,
-                    coalesce(weekly.weekly_point, 0) as weekly_point,
-                    up.total_point
-                from user_point up
-                join users u on u.user_id = up.user_id
-                left join (
-                    select
-                        ph.user_id,
-                        sum(ph.point) as weekly_point
-                    from point_history ph
-                    where ph.created_at >= date_sub(now(), interval 7 day)
-                    group by ph.user_id
-                ) weekly on weekly.user_id = u.user_id
-                where u.deleted_at is null
-                  and u.role = 'STUDENT'
-            ) ranked
-            where ranked.user_id = :userId
-            """;
+                    dense_rank() over (order by up2.total_point desc) as ranking,
+                    up2.user_id
+                from user_point up2
+                join users u2 on u2.user_id = up2.user_id
+                where u2.deleted_at is null
+                  and u2.role = 'STUDENT'
+            ) ranked_user
+        ) ranked on ranked.user_id = u.user_id
+        left join (
+            select
+                ph.user_id,
+                sum(ph.point) as weekly_point
+            from point_history ph
+            where ph.created_at >= date_sub(now(), interval 7 day)
+            group by ph.user_id
+        ) weekly on weekly.user_id = u.user_id
+        where u.user_id = :userId
+          and u.deleted_at is null
+          and u.role = 'STUDENT'
+        """;
 
         Query query = entityManager.createNativeQuery(sql)
                 .setParameter("userId", userId);
@@ -137,16 +148,28 @@ public class RankingQueryAdapter implements RankingQueryPort {
             LocalDateTime from
     ) {
         String sql = """
-        select *
-        from (
+        select
+            ranked.ranking,
+            u.user_id,
+            u.name,
+            u.nickname,
+            null as badge_image_url,
+            coalesce(my_weekly.weekly_point, 0) as weekly_point,
+            coalesce(up.total_point, 0) as total_point
+        from users u
+        left join user_point up on up.user_id = u.user_id
+        left join (
             select
-                dense_rank() over (order by weekly.weekly_point desc) as ranking,
-                u.user_id,
-                u.name,
-                u.nickname,
-                null as badge_image_url,
-                weekly.weekly_point,
-                coalesce(up.total_point, 0) as total_point
+                ph.user_id,
+                sum(ph.point) as weekly_point
+            from point_history ph
+            where ph.created_at >= :from
+            group by ph.user_id
+        ) my_weekly on my_weekly.user_id = u.user_id
+        left join (
+            select
+                weekly.user_id,
+                dense_rank() over (order by weekly.weekly_point desc) as ranking
             from (
                 select
                     ph.user_id,
@@ -155,12 +178,13 @@ public class RankingQueryAdapter implements RankingQueryPort {
                 where ph.created_at >= :from
                 group by ph.user_id
             ) weekly
-            join users u on u.user_id = weekly.user_id
-            left join user_point up on up.user_id = u.user_id
-            where u.deleted_at is null
-              and u.role = 'STUDENT'
-        ) ranked
-        where ranked.user_id = :userId
+            join users ranked_user on ranked_user.user_id = weekly.user_id
+            where ranked_user.deleted_at is null
+              and ranked_user.role = 'STUDENT'
+        ) ranked on ranked.user_id = u.user_id
+        where u.user_id = :userId
+          and u.deleted_at is null
+          and u.role = 'STUDENT'
         """;
 
         Query query = entityManager.createNativeQuery(sql)
@@ -178,7 +202,7 @@ public class RankingQueryAdapter implements RankingQueryPort {
 
     private RankingItem toRankingItem(Object[] row) {
         return new RankingItem(
-                ((Number) row[0]).intValue(),
+                row[0] == null ? null : ((Number) row[0]).intValue(),
                 ((Number) row[1]).longValue(),
                 (String) row[2],
                 (String) row[3],

--- a/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
@@ -34,11 +34,10 @@ public class RankingQueryAdapter implements RankingQueryPort {
                 select
                     ph.user_id,
                     sum(ph.point) as weekly_point
-            from point_history ph
-            where ph.created_at >= date_sub(now(), interval 7 day)
-              and ph.user_id = :userId
-            group by ph.user_id
-        ) weekly on weekly.user_id = u.user_id
+                from point_history ph
+                where ph.created_at >= date_sub(now(), interval 7 day)
+                group by ph.user_id
+            ) weekly on weekly.user_id = u.user_id
             where u.deleted_at is null
               and u.role = 'STUDENT'
             order by ranking asc, u.user_id asc
@@ -124,8 +123,9 @@ public class RankingQueryAdapter implements RankingQueryPort {
                 sum(ph.point) as weekly_point
             from point_history ph
             where ph.created_at >= date_sub(now(), interval 7 day)
+              and ph.user_id = :userId
             group by ph.user_id
-        ) 
+        ) weekly on weekly.user_id = u.user_id
         where u.user_id = :userId
           and u.deleted_at is null
           and u.role = 'STUDENT'

--- a/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/ranking/infrastructure/persistence/RankingQueryAdapter.java
@@ -34,10 +34,11 @@ public class RankingQueryAdapter implements RankingQueryPort {
                 select
                     ph.user_id,
                     sum(ph.point) as weekly_point
-                from point_history ph
-                where ph.created_at >= date_sub(now(), interval 7 day)
-                group by ph.user_id
-            ) weekly on weekly.user_id = u.user_id
+            from point_history ph
+            where ph.created_at >= date_sub(now(), interval 7 day)
+              and ph.user_id = :userId
+            group by ph.user_id
+        ) weekly on weekly.user_id = u.user_id
             where u.deleted_at is null
               and u.role = 'STUDENT'
             order by ranking asc, u.user_id asc
@@ -124,7 +125,7 @@ public class RankingQueryAdapter implements RankingQueryPort {
             from point_history ph
             where ph.created_at >= date_sub(now(), interval 7 day)
             group by ph.user_id
-        ) weekly on weekly.user_id = u.user_id
+        ) 
         where u.user_id = :userId
           and u.deleted_at is null
           and u.role = 'STUDENT'
@@ -164,6 +165,7 @@ public class RankingQueryAdapter implements RankingQueryPort {
                 sum(ph.point) as weekly_point
             from point_history ph
             where ph.created_at >= :from
+              and ph.user_id = :userId
             group by ph.user_id
         ) my_weekly on my_weekly.user_id = u.user_id
         left join (


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #이슈번호

---

## 🛠️ 기능 관련 작업 내용
- 점수 데이터가 없는 사용자가 내 랭킹을 조회할 때 404가 발생하던 문제를 수정했습니다.
- 내 전체 랭킹과 내 주간 랭킹 조회 기준을 `user_point` / `point_history`가 아닌 `users` 기준으로 보완했습니다.
- 점수가 없는 사용자는 `rank: null`, `weeklyPoint: 0`, `totalPoint: 0`으로 정상 응답하도록 변경했습니다.
- 랭킹 응답 변환 로직에서 `rank`가 null일 수 있도록 처리했습니다.

---

## ♻️ 패키지 변경 사항
- `codebombalms/ranking/infrastructure/persistence`: 내 전체/주간 랭킹 조회 쿼리 보완
- `codebombalms/ranking/application/query`: 랭킹 응답에서 null rank 허용
- `codebombalms/ranking/presentation`: 기존 응답 구조 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 내 랭킹/주간 랭킹 조회 시 랭킹 값이 없는 경우 `null`로 안정적으로 반환되도록 개선
  * 사용자별 주간 포인트 집계가 정확히 반영되도록 조회 조건을 보강

* **개선**
  * 랭킹 조회 쿼리를 명시적으로 재구성해 불필요한 선택을 줄이고 가시성과 성능을 향상
  * 삭제되지 않은 학생만 랭킹 대상에 포함되도록 사용자 및 집계 범위 필터를 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->