### PR TITLE
[Update] Admin 운영 규칙 조회 권한 정책 변경 & 관리자, 추천 모니터링 설계

### DIFF
--- a/monitoring/docs/domains/admin/bottleneck-hypothesis.md
+++ b/monitoring/docs/domains/admin/bottleneck-hypothesis.md
@@ -1,0 +1,57 @@
+# Admin 도메인 — 병목 가설 (7단계 §1단계)
+
+> 프로세스: [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션: [`../../CONVENTION.md`](../../CONVENTION.md)
+> 이 문서는 부하테스트 전에 "무엇이 왜 느릴 것인가"를 가설로 고정하는 산출물이다. baseline과 전후 비교로 검증한다.
+
+## 도메인 유형 분류
+
+Admin 도메인은 운영자 화면용 조회 API와 운영 자동화 배치를 함께 가진다.
+
+| 트랙 | 대상 | 유형 | 6단계 처리 방식 |
+|------|------|------|------------------|
+| **A. 목록 조회** | `GET /api/v1/admin/operation-alerts` | 조회/집계형 | 필터 + 페이징 + 정렬 쿼리의 인덱스/정렬 비용 확인 |
+| **B. 상세 조회** | `GET /api/v1/admin/operation-alerts/{operationAlertId}` | 단건 조회 + 타 도메인 조합 | alert 상세 조회 후 target type별 추가 조회 비용 확인 |
+| **C. 자동화 실행** | `OperationRuleExecutionService.run()` | 조회/집계형 + 배치형 | 학생/강좌/제출 지표 조회, 탐지 결과 upsert 반복 비용 확인 |
+
+---
+
+## 병목 가설표
+
+| # | 대상 | 병목 가설 | 근거 (코드 위치) | 관찰 지표 | 성공 기준 |
+|---|------|-----------|------------------|-----------|-----------|
+| 1 ★ | `OperationRuleExecutionService.run()` | **USER 규칙 N+1.** 학생 전체 조회 후 학생마다 최신 로그인 이력을 개별 조회한다. 학생 수가 늘면 `1 + N` 형태로 DB 조회가 증가한다. | [`UserOperationMetricAdapter.findInactiveUsers`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/automation/infrastructure/adapter/UserOperationMetricAdapter.java) → `findStudents()` 후 `findLatestLoginAt(student.userId())` 반복 | `admin_operation_rule_run_duration`, `admin_operation_rule_detect_duration{ruleCode=...}`, Hikari active, SQL 로그 수 | 학생 대량 시드 기준 실행시간이 선형 급증하지 않을 것, Hikari 포화 없음 |
+| 2 ★ | `OperationRuleExecutionService.run()` | **탐지 결과별 alert upsert 반복 비용.** 탐지 결과마다 open alert 조회 후 save를 수행한다. 결과 수가 많으면 조회/쓰기/락 비용이 커질 수 있다. | [`OperationRuleExecutionService.saveAlert`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java) → `findOpenByRuleIdAndTarget()` + `save()` | `admin_operation_alert_upsert_duration`, 탐지 결과 수, Hikari active, transaction duration | 탐지 결과 N건 증가 시 upsert 시간이 과도하게 증가하지 않을 것 |
+| 3 | `GET /api/v1/admin/operation-alerts` | **필터 + 정렬 인덱스 부재 가능성.** `deletedAt`, `targetType`, `status` 조건 후 `lastDetectedAt desc`, `operationAlertId desc` 정렬을 수행한다. alert row가 많으면 filesort/scan 비용이 커질 수 있다. | [`SpringDataOperationAlertRepository.findAlerts`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/SpringDataOperationAlertRepository.java), [`OperationAlertQueryAdapter.findAlerts`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/persistence/OperationAlertQueryAdapter.java) | `http_server_requests_seconds{domain="admin",uri="/api/v1/admin/operation-alerts"}`, `admin_operation_alert_list_query_duration`, EXPLAIN rows/key | VU 30~50, alert 대량 시드 기준 p95 < 500~800ms, 실패율 < 1% |
+| 4 | `GET /api/v1/admin/operation-alerts/{operationAlertId}` | **상세 조회 후 target detail 조합 비용.** alert + rule 조회 뒤 target type에 따라 course/problem/user 상세를 추가 조회한다. target 도메인 상태에 따라 tail latency가 튈 수 있다. | [`OperationAlertQueryService.getAlertDetail`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/alert/application/service/OperationAlertQueryService.java), [`OperationAlertTargetDetailAdapter.loadTargetDetail`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/adapter/OperationAlertTargetDetailAdapter.java) | `admin_operation_alert_detail_query_duration`, `admin_operation_alert_target_detail_duration`, Loki `durationMs`, traceId | 단건 상세 조회 p95 < 300~500ms, target type별 outlier 확인 |
+
+★ = admin 도메인 메인 측정 후보.
+
+---
+
+## 트랙별 검증 관점
+
+### A. 운영 알림 목록 조회
+
+- alert row를 충분히 시드한 뒤 필터 조건별 p95를 비교한다.
+- `targetType`, `status`가 있을 때와 없을 때를 나눠 EXPLAIN을 확인한다.
+- `lastDetectedAt desc`, `operationAlertId desc` 정렬이 인덱스를 타는지 확인한다.
+
+### B. 운영 알림 상세 조회
+
+- `COURSE`, `PROBLEM`, `USER` target type별 상세 조회 시간을 따로 본다.
+- 공통 alert 상세 query와 target detail query 시간을 분리한다.
+- traceId로 alert 조회 이후 타 도메인 조회가 몇 번 발생하는지 확인한다.
+
+### C. 자동화 실행
+
+- `USER_INACTIVE_NO_COURSE` 계열은 학생 수에 따른 N+1 여부가 핵심이다.
+- `COURSE_LOW_ENROLLMENT`는 전체 active enrollment와 전체 course를 메모리에서 조합한다.
+- `PROBLEM_HIGH_WRONG_RATE`는 제출 통계 집계 쿼리 비용을 확인한다.
+- 탐지 결과가 많을수록 alert upsert가 반복되므로 detect와 save 구간을 분리해 본다.
+
+---
+
+## 다음 단계
+
+- **2단계**: `admin_operation_*` Timer/Counter와 `event=admin_*` 로그 설계 → [`metrics.md`](metrics.md)
+- **4·5단계**: 운영 알림/학생/로그인 이력 시드 후 baseline 측정

--- a/monitoring/docs/domains/admin/compare.md
+++ b/monitoring/docs/domains/admin/compare.md
@@ -1,0 +1,93 @@
+# Admin 도메인 — baseline/전후 비교 템플릿 (7단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md).
+> 아직 baseline 측정 전이므로, 이 문서는 admin 도메인의 비교 기준과 결과 기입 위치를 먼저 고정한다.
+
+## 측정 대상
+
+| 트랙 | 대상 | 목적 |
+|------|------|------|
+| A. 목록 조회 | `GET /api/v1/admin/operation-alerts` | alert 대량 상황에서 필터/정렬 query 병목 확인 |
+| B. 상세 조회 | `GET /api/v1/admin/operation-alerts/{operationAlertId}` | target type별 상세 조합 비용 확인 |
+| C. 자동화 실행 | `OperationRuleExecutionService.run()` | USER N+1, 집계 query, alert upsert 반복 비용 확인 |
+
+---
+
+## baseline 조건
+
+| 항목 | 값 |
+|------|----|
+| 프로파일 | `loadtest` |
+| DB | 도커 MySQL 3307 |
+| 목록 조회 부하 | VU 30~50, 1~5분 |
+| 상세 조회 부하 | target type별 대표 alert ID 순환 |
+| 자동화 실행 데이터 | 학생/로그인 이력/강좌/수강신청/제출/alert 대량 시드 |
+| 성공 기준 | 목록 p95 < 500~800ms, 상세 p95 < 300~500ms, 실패율 < 1% |
+
+---
+
+## A. 운영 알림 목록 조회 비교
+
+| 지표 | before | after | 판정 |
+|---|---:|---:|---|
+| k6 `http_req_duration{type=list}` p95 | 측정 전 | 측정 전 | - |
+| k6 `http_req_waiting{type=list}` p95 | 측정 전 | 측정 전 | - |
+| `admin_operation_alert_list_query_duration` avg | 측정 전 | 측정 전 | - |
+| `http_req_failed` | 측정 전 | 측정 전 | - |
+| EXPLAIN rows/key | 측정 전 | 측정 전 | - |
+
+확인할 변경 후보:
+
+| 후보 | 기대 효과 |
+|------|-----------|
+| `operation_alert(deleted_at, target_type, status, last_detected_at, operation_alert_id)` 계열 인덱스 검토 | 필터 + 정렬 비용 감소 |
+| 목록 응답 projection 유지 | 과조회 방지 |
+
+---
+
+## B. 운영 알림 상세 조회 비교
+
+| targetType | before p95 | after p95 | 주요 병목 후보 |
+|------------|-----------:|----------:|----------------|
+| `COURSE` | 측정 전 | 측정 전 | course 상세 + instructor 조회 |
+| `PROBLEM` | 측정 전 | 측정 전 | problem/problemSet 상세 + creator 조회 |
+| `USER` | 측정 전 | 측정 전 | student detail 조회 |
+
+확인할 변경 후보:
+
+| 후보 | 기대 효과 |
+|------|-----------|
+| target detail 구간 Timer 분리 | 어떤 target type이 느린지 식별 |
+| 상세 조회 projection 유지 | alert + rule 기본 정보 과조회 방지 |
+
+---
+
+## C. 자동화 실행 비교
+
+| 지표 | before | after | 판정 |
+|---|---:|---:|---|
+| `admin_operation_rule_run_duration` avg/max | 측정 전 | 측정 전 | - |
+| `admin_operation_rule_detect_duration{ruleCode=USER_INACTIVE_NO_COURSE}` avg | 측정 전 | 측정 전 | - |
+| SQL count per run | 측정 전 | 측정 전 | - |
+| `admin_operation_alert_upsert_duration` avg | 측정 전 | 측정 전 | - |
+| Hikari active max | 측정 전 | 측정 전 | - |
+| detectedCount | 측정 전 | 측정 전 | - |
+
+확인할 변경 후보:
+
+| 후보 | 기대 효과 |
+|------|-----------|
+| 학생별 최신 로그인 조회 batch/집계 query | USER 규칙 N+1 제거 |
+| alert open 상태 조회용 복합 인덱스 | `findOpenByRuleIdAndTarget` 반복 비용 감소 |
+| rule detect와 alert save 구간 분리 | 병목 위치 명확화 |
+
+---
+
+## 결론 기입 위치
+
+baseline 측정 후 아래 형식으로 결론을 쓴다.
+
+```text
+결론: admin 도메인의 주 병목은 <목록 조회 / 상세 target detail / 자동화 USER rule / alert upsert> 이다.
+근거: k6 p95, custom timer, Hikari active, Loki durationMs, SQL count가 함께 증가했다.
+```

--- a/monitoring/docs/domains/admin/metrics.md
+++ b/monitoring/docs/domains/admin/metrics.md
@@ -1,0 +1,96 @@
+# Admin 도메인 — 심은 메트릭/로그 (7단계 §2단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션 [`../../CONVENTION.md`](../../CONVENTION.md)
+> admin 도메인은 A. 운영 알림 조회, B. target detail 조합, C. 자동화 규칙 실행/alert upsert를 분리해서 관측한다.
+
+## 커스텀 메트릭 (Layer 3)
+
+| Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
+|---|---|---|---|---|
+| `admin_operation_alert_list_query_duration_seconds_{count,sum,max}` | Timer | `admin_operation_alert_list_query_duration` | 운영 알림 목록 조회 DB 구간 시간 | [`AdminMetrics`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java), [`OperationAlertQueryService.getAlerts`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/alert/application/service/OperationAlertQueryService.java) |
+| `admin_operation_alert_detail_query_duration_seconds_{count,sum,max}` | Timer | `admin_operation_alert_detail_query_duration` | 운영 알림 상세 기본 정보 조회 시간 | [`AdminMetrics`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java), [`OperationAlertQueryService.getAlertDetail`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/alert/application/service/OperationAlertQueryService.java) |
+| `admin_operation_alert_target_detail_duration_seconds_{count,sum,max}` | Timer | `admin_operation_alert_target_detail_duration` | `COURSE`/`PROBLEM`/`USER` 대상 상세 조합 시간 | [`AdminMetrics`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java), [`OperationAlertTargetDetailAdapter.loadTargetDetail`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/adapter/OperationAlertTargetDetailAdapter.java) |
+| `admin_operation_rule_run_duration_seconds_{count,sum,max}` | Timer | `admin_operation_rule_run_duration` | 활성화된 운영 자동화 규칙 전체 실행 시간 | [`AdminMetrics`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java), [`OperationRuleExecutionService.run`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java) |
+| `admin_operation_rule_detect_duration_seconds_{count,sum,max}` | Timer | `admin_operation_rule_detect_duration` | 규칙별 handler 탐지 실행 시간 | [`AdminMetrics`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java), [`OperationRuleExecutionService.executeRule`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java) |
+| `admin_operation_alert_upsert_duration_seconds_{count,sum,max}` | Timer | `admin_operation_alert_upsert_duration` | 탐지 결과 1건의 open alert 조회 + 저장 시간 | [`AdminMetrics`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java), [`OperationRuleExecutionService.saveAlert`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java) |
+| `admin_operation_rule_detected_total` | Counter | `admin_operation_rule_detected_total` | 규칙별 탐지 결과 누적 수 | [`AdminMetrics`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java), [`OperationRuleExecutionService.executeRule`](../../../../src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java) |
+
+## Metric Tag
+
+| 메트릭 | tag | 허용 값 |
+|--------|-----|---------|
+| `admin_operation_alert_target_detail_duration` | `targetType` | `COURSE`, `PROBLEM`, `USER` |
+| `admin_operation_rule_detect_duration` | `ruleCode` | `USER_INACTIVE_NO_COURSE`, `COURSE_LOW_ENROLLMENT`, `PROBLEM_HIGH_WRONG_RATE` |
+| `admin_operation_rule_detected_total` | `ruleCode` | enum 값 |
+
+`operationAlertId`, `targetId`, `userId`, `traceId`는 metric tag에 넣지 않는다.
+
+---
+
+## 구조화 로그 (Loki)
+
+```text
+event=admin_operation_alert_list_queried targetType=<type|null> status=<status|null> resultCount=<n> totalElements=<n> durationMs=<n>
+event=admin_operation_alert_detail_queried targetType=<type> durationMs=<n>
+event=admin_operation_alert_target_detail_loaded targetType=<type> durationMs=<n>
+event=admin_operation_rule_run_completed enabledRuleCount=<n> detectedCount=<n> durationMs=<n>
+event=admin_operation_rule_detected ruleCode=<code> detectedCount=<n> durationMs=<n>
+event=admin_operation_alert_upserted ruleCode=<code> targetType=<type> alertCount=1 durationMs=<n>
+```
+
+`traceId`는 `MdcLoggingFilter`가 MDC로 자동 부착한다.
+
+---
+
+## PromQL / LogQL 후보
+
+### 운영 알림 목록 조회 평균
+
+```promql
+rate(admin_operation_alert_list_query_duration_seconds_sum[1m])
+/
+rate(admin_operation_alert_list_query_duration_seconds_count[1m])
+```
+
+### target type별 상세 조합 평균
+
+```promql
+sum by (targetType) (rate(admin_operation_alert_target_detail_duration_seconds_sum[1m]))
+/
+sum by (targetType) (rate(admin_operation_alert_target_detail_duration_seconds_count[1m]))
+```
+
+### 규칙별 탐지 구간 평균
+
+```promql
+sum by (ruleCode) (rate(admin_operation_rule_detect_duration_seconds_sum[1m]))
+/
+sum by (ruleCode) (rate(admin_operation_rule_detect_duration_seconds_count[1m]))
+```
+
+### 규칙별 탐지 결과 수
+
+```promql
+sum by (ruleCode) (increase(admin_operation_rule_detected_total[5m]))
+```
+
+### 느린 admin 이벤트 로그
+
+```logql
+{job="lms"} |= "event=admin_operation_rule_detected"
+  | regexp "durationMs=(?P<durationMs>[0-9]+)" | unwrap durationMs
+```
+
+---
+
+## 해석 기준
+
+| 관찰 | 해석 |
+|------|------|
+| 목록 API p95 상승 + `admin_operation_alert_list_query_duration` 상승 | 운영 알림 목록 query/정렬 병목 |
+| 상세 API p95 상승 + `target_detail_duration{targetType=...}` 특정 타입만 상승 | 해당 target 도메인 조합 조회 병목 |
+| `rule_run_duration` 상승 + 특정 `rule_detect_duration{ruleCode=...}` 상승 | 특정 자동화 규칙 handler 병목 |
+| `rule_run_duration` 상승 + `alert_upsert_duration` 상승 + Hikari active 상승 | alert upsert 반복 또는 DB write/lock 병목 |
+| `rule_detected_total` 증가와 upsert 시간이 같이 증가 | 탐지 결과 수 증가가 저장 비용을 키우는 상황 |
+
+`admin_operation_alert_upsert_duration`은 사용 중인 metric이다. `OperationRuleExecutionService.saveAlert()`에서 탐지 결과 1건마다 `recordAlertUpsert()`를 호출해 open alert 조회 + 저장 시간을 기록한다.

--- a/monitoring/docs/domains/admin/success-criteria.md
+++ b/monitoring/docs/domains/admin/success-criteria.md
@@ -1,0 +1,129 @@
+# Admin 도메인 — 성공 기준 (7단계 §3단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션 [`../../CONVENTION.md`](../../CONVENTION.md)
+> 로컬 `loadtest` 프로파일, 도커 MySQL 3307, 단일 Spring Boot 앱 기준이다.
+
+## 병목 가설별 측정 방식
+
+| 가설 | 대상 | 측정 방식 | 산출물 |
+|------|------|-----------|--------|
+| #1 USER 규칙 N+1 | `OperationRuleExecutionService.run()` | loadtest trigger API로 스케줄러 본체 실행 | `monitoring/k6/scripts/admin/03-operation-rule-run-baseline.js`, `admin_operation_rule_detect_duration{ruleCode="USER_INACTIVE_NO_COURSE"}` |
+| #2 alert upsert 반복 비용 | `OperationRuleExecutionService.saveAlert()` | loadtest trigger API로 자동화 실행 후 탐지 결과 수와 upsert timer 관찰 | `admin_operation_alert_upsert_duration`, `admin_operation_rule_detected_total` |
+| #3 목록 query/정렬 | `GET /api/v1/admin/operation-alerts` | k6 목록 단독 baseline | `monitoring/k6/scripts/admin/01-alert-list-baseline.js` |
+| #4 상세 + target detail | `GET /api/v1/admin/operation-alerts/{operationAlertId}` | k6 상세 단독 baseline | `monitoring/k6/scripts/admin/02-alert-detail-baseline.js` |
+
+---
+
+## k6 대상과 트래픽 조건
+
+| 스크립트 | 대상 | 유형 | 트래픽 조건 | 측정 기간 |
+|----------|------|------|-------------|-----------|
+| `01-alert-list-baseline.js` | `GET /api/v1/admin/operation-alerts?page=0&size=20` | 조회/집계형 | 0→50 VU ramp-up 20s, 50 VU 유지 40s, ramp-down 10s | 총 70s |
+| `02-alert-detail-baseline.js` | `GET /api/v1/admin/operation-alerts/{operationAlertId}` | 단건 조회 + target detail 조합 | 0→50 VU ramp-up 20s, 50 VU 유지 40s, ramp-down 10s | 총 70s |
+| `03-operation-rule-run-baseline.js` | `POST /internal/loadtest/admin/operation-rules/run` | 스케줄러/배치 실행형 | 기본 1 VU, 1 iteration | 1회 실행 기준 |
+
+전제:
+
+- `LOGIN_EMAIL=admin@test.com`, `LOGIN_PASSWORD=Test1234!`를 사용한다.
+- loadtest DB에 admin 계정, `RULE_MANAGEMENT` 권한, 운영 알림 200건이 seed 되어 있어야 한다.
+- 자동화 trigger baseline은 추가로 휴면 사용자 240명, 저수강 강의 40개, 문제 제출 2,000건이 seed 되어 있어야 한다.
+- 상세 조회는 `OPERATION_ALERT_ID` 환경변수로 대상 알림을 고정한다. 기본 seed 기준 `1`은 COURSE target이다.
+
+---
+
+## 목록 조회 Threshold
+
+```javascript
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:list}": ["p(95)<800"],
+    },
+};
+```
+
+## 상세 조회 Threshold
+
+```javascript
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:detail}": ["p(95)<500"],
+    },
+};
+```
+
+## 자동화 trigger Threshold
+
+```javascript
+export const options = {
+    vus: 1,
+    iterations: 1,
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:operation_rule_run}": ["p(95)<10000"],
+    },
+};
+```
+
+---
+
+## 중단 기준
+
+| 조건 | 판단 |
+|------|------|
+| `http_req_failed >= 1%` | 테스트 데이터/권한/서버 오류 확인 후 중단 |
+| 목록 p95 1.5s 이상 지속 | 목록 query/정렬/인덱스 병목 우선 확인 |
+| 상세 p95 1s 이상 지속 | alert 기본 조회와 target detail timer를 분리 확인 |
+| 상세 조회 404 반복 | `OPERATION_ALERT_ID` 또는 target domain seed 정합성 확인 |
+| 자동화 trigger 10s 이상 지속 | rule detect와 alert upsert 중 어느 timer가 높은지 분리 확인 |
+| Hikari active가 풀 상한에 근접 | DB 커넥션 경합 가능성 확인 |
+
+---
+
+## 비즈니스 실패와 시스템 장애 구분
+
+| 응답 | 해석 |
+|------|------|
+| `200` | 정상 성공 |
+| `400` invalid page | k6 스크립트 오류 |
+| `401` / `403` | admin 로그인 계정 또는 권한 seed 문제 |
+| `404` detail not found | 상세 조회 seed 데이터 문제 |
+| `5xx` | 시스템 장애로 실패율에 포함 |
+
+---
+
+## 관찰 지표
+
+| 가설 | 도구 | 지표 |
+|------|------|------|
+| #3 목록 | k6 | `http_req_duration{type=list}`, `http_req_failed` |
+| #3 목록 | Prometheus | `http_server_requests_seconds{domain="admin", uri="/api/v1/admin/operation-alerts"}` |
+| #3 목록 | Prometheus | `admin_operation_alert_list_query_duration_seconds_*` |
+| #3 목록 | Loki | `event=admin_operation_alert_list_queried resultCount=... totalElements=... durationMs=...` |
+| #4 상세 | k6 | `http_req_duration{type=detail}`, `http_req_failed` |
+| #4 상세 | Prometheus | `admin_operation_alert_detail_query_duration_seconds_*` |
+| #4 상세 | Prometheus | `admin_operation_alert_target_detail_duration_seconds_*` |
+| #4 상세 | Loki | `event=admin_operation_alert_detail_queried`, `event=admin_operation_alert_target_detail_loaded` |
+| #1·#2 자동화 | Prometheus | `admin_operation_rule_run_duration_seconds_*`, `admin_operation_rule_detect_duration_seconds_*`, `admin_operation_alert_upsert_duration_seconds_*` |
+| #1·#2 자동화 | Loki | `event=admin_operation_rule_run_completed`, `event=admin_operation_rule_detected`, `event=admin_operation_alert_upserted` |
+
+## 결론 기준
+
+| 결과 | 판단 |
+|------|------|
+| 목록 p95 통과 + list query timer 안정 | 목록 baseline 기준 충족 |
+| 목록 HTTP p95 상승 + list query timer 상승 | 목록 query/정렬 병목 |
+| 상세 p95 통과 + detail/target timer 안정 | 상세 baseline 기준 충족 |
+| 상세 p95 상승 + target detail timer 상승 | target type별 외부 도메인 조회 병목 |
+| rule run 상승 + detect/upsert timer 상승 | 자동화 규칙 또는 alert upsert 병목 |

--- a/monitoring/docs/domains/recommendation/bottleneck-hypothesis.md
+++ b/monitoring/docs/domains/recommendation/bottleneck-hypothesis.md
@@ -1,0 +1,82 @@
+# Recommendation 도메인 — 병목 가설 (7단계 §1단계)
+
+> 프로세스: [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션: [`../../CONVENTION.md`](../../CONVENTION.md)
+> Recommendation 도메인은 단순 API 성능뿐 아니라 추천 생성 배치, Python 호출, 추천 효과 신호까지 함께 본다.
+
+## 도메인 유형 분류
+
+추천 도메인은 세 트랙으로 나눠 관측한다.
+
+| 트랙 | 대상 | 유형 | 6단계 처리 방식 |
+|------|------|------|------------------|
+| **A. 사용자 조회 성능** | `GET /api/v1/recommendations/problem-sets/me` | 조회/집계형 | 숨김 조회 + 추천 목록 native join query의 인덱스/조인 비용 확인 |
+| **B. 배치/Python 병목** | `ProblemRecommendationGenerationService.generate()` | 외부연동 + 쓰기/트랜잭션형 | Python FastAPI 호출 시간과 Java DB 저장 시간을 분리 측정 |
+| **C. 추천 효과 관측** | 추천 노출/클릭/score 분포 | 제품 효과 관측 | Grafana로 실시간 효과 신호를 보고, 장기 분석은 BI/분석 DB 확장 후보로 둠 |
+
+---
+
+## 병목 가설표
+
+| # | 대상 | 병목 가설 | 근거 (코드 위치) | 관찰 지표 | 성공 기준 |
+|---|------|-----------|------------------|-----------|-----------|
+| 1 ★ | `GET /api/v1/recommendations/problem-sets/me` | **추천 목록 조인/인덱스 병목.** 숨김 상태 조회 후 ACTIVE 추천, 문제세트, 카테고리, 완료 progress를 조인한다. 추천/진행 row가 많아지면 `user_id`, `status`, `rank_no`, `problem_set_id` 계열 인덱스가 없을 때 느려질 수 있다. | [`ProblemRecommendationQueryService.getRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java), [`SpringDataProblemRecommendationRepository.findActiveProblemSetRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataProblemRecommendationRepository.java) | HTTP p95, `recommendation_problem_set_list_query_duration`, EXPLAIN rows/key, Hikari active | VU 50, 추천 row 대량 시드 기준 p95 < 500ms, 실패율 < 1% |
+| 2 ★ | `ProblemRecommendationGenerationService.generate()` | **Python FastAPI 호출이 배치 시간을 지배할 수 있음.** Java 배치는 `.block()`으로 Python 응답을 기다린 뒤 다음 저장 단계로 넘어간다. Python 계산/네트워크/응답 크기가 전체 시간의 주요 원인일 수 있다. | [`FastApiProblemRecommendationGenerationClient.generateProblemSetRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java), [`ProblemRecommendationGenerationService.generate`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java) | `recommendation_generation_external_duration`, batch total duration, timeout/error 로그, 응답 userCount | Python 호출 timeout 0건, 외부 호출 시간이 허용 범위 내, batch total과 external 시간을 분리 설명 가능 |
+| 3 ★ | `replaceActiveRecommendations()` | **사용자별 추천 교체 저장 반복 비용.** Python 응답 사용자마다 lock → deactivate → saveAll을 반복한다. 대상 사용자가 많으면 DB write/lock 비용과 Hikari 사용량이 증가할 수 있다. | [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) | `recommendation_generation_save_duration`, Hikari active, lock wait, generated user count | 사용자 수 증가 대비 저장 시간이 과도하게 증가하지 않을 것 |
+| 4 | `POST /api/v1/recommendations/problem-sets/hide-today` | 단순 upsert라 병목 가능성은 낮다. 다만 `recommendation_hide(user_id, hide_type, target_id)` 조회 인덱스가 없으면 숨김 조회/저장 비용이 커질 수 있다. | [`RecommendationHideService.hideToday`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java), [`SpringDataRecommendationHideRepository.findByUserIdAndHideTypeAndTargetIdIsNull`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/SpringDataRecommendationHideRepository.java) | hide lookup Timer, HTTP p95 | p95 < 300ms, 실패율 < 1% |
+| 5 | 추천 효과 관측 | **추천이 실제로 쓰이는지 알 수 있는 이벤트가 부족함.** 추천 조회는 있지만 추천 카드 클릭/문제 진입 source 이벤트가 없으면 CTR을 정확히 볼 수 없다. | 현재 추천 조회 API와 문제 진입 API 사이에 추천 클릭 이벤트 없음 | `recommendation_problem_set_exposed_total`, `recommendation_problem_set_clicked_total`, CTR | 2차 확장: 노출 대비 클릭률/문제 시작률을 Grafana에서 추세로 확인 |
+
+★ = recommendation 도메인 메인 측정 후보.
+
+---
+
+## 트랙 A. 사용자 조회 성능
+
+추천 목록 API는 사용자 화면에 직접 노출되므로 p95를 기준으로 본다.
+
+- 숨김 상태면 추천 DB 조회를 건너뛰는지 확인한다.
+- 숨김 상태가 아니면 native query의 조인/LEFT JOIN anti join 비용을 확인한다.
+- `limit`은 최대 3이라 응답 row는 작지만, source table이 커지면 인덱스 영향이 커질 수 있다.
+
+---
+
+## 트랙 B. 배치/Python 병목
+
+추천 배치는 아래 구간을 반드시 분리해서 본다.
+
+```text
+Scheduler
+→ DB named lock
+→ Java → Python FastAPI 호출
+→ 응답 검증
+→ 사용자별 추천 교체 저장
+```
+
+해석 기준:
+
+| 관찰 | 해석 |
+|------|------|
+| batch total ↑ + external duration ↑ + save 정상 | Python/네트워크/응답 크기 병목 |
+| batch total ↑ + external 정상 + save duration ↑ | Java DB 저장/락 병목 |
+| timeout/error 증가 | Python 서버 과부하 또는 연결 문제 |
+| userCount 증가와 external 급증 | Python 알고리즘 계산량 또는 payload 병목 |
+
+---
+
+## 트랙 C. 추천 효과 관측
+
+Grafana에서도 추천 효과의 실시간 신호는 볼 수 있다. 단, 장기 코호트/A-B 분석은 BI나 분석 DB가 더 적합하다.
+
+| 관측 항목 | Grafana 적합도 | 필요 이벤트/메트릭 |
+|----------|----------------|--------------------|
+| 추천 노출 수 | 높음 | `recommendation_problem_set_exposed_total` |
+| 추천 클릭 수 | 높음 | `recommendation_problem_set_clicked_total` |
+| 추천 CTR | 높음 | clicked / exposed |
+| 추천 score 분포 | 중간 | support/confidence/lift DistributionSummary |
+| 장기 완료율/리텐션 | 낮음~중간 | 별도 분석 DB/BI 권장 |
+
+---
+
+## 다음 단계
+
+- **2단계**: 추천 조회, Python 호출, 저장, 효과 관측 메트릭/로그 설계 → [`metrics.md`](metrics.md)
+- **4·5단계**: 추천 row/진행 row/숨김 row 시드 후 조회 baseline, Python mock 또는 실제 loadtest FastAPI로 배치 baseline 측정

--- a/monitoring/docs/domains/recommendation/compare.md
+++ b/monitoring/docs/domains/recommendation/compare.md
@@ -1,0 +1,108 @@
+# Recommendation 도메인 — baseline/전후 비교 템플릿 (7단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md).
+> 아직 baseline 측정 전이므로, 이 문서는 recommendation 도메인의 비교 기준과 결과 기입 위치를 먼저 고정한다.
+
+## 측정 대상
+
+| 트랙 | 대상 | 목적 |
+|------|------|------|
+| A. 사용자 조회 성능 | `GET /api/v1/recommendations/problem-sets/me` | 추천 목록 조회 p95와 DB query 병목 확인 |
+| B. 배치/Python 병목 | `ProblemRecommendationGenerationService.generate()` | Python 호출 시간과 Java 저장 시간을 분리 |
+| C. 추천 효과 관측 | 노출/클릭/score | 추천이 실제로 쓰이는지 실시간 신호 확인 |
+
+---
+
+## baseline 조건
+
+| 항목 | 값 |
+|------|----|
+| 프로파일 | `loadtest` |
+| DB | 도커 MySQL 3307 |
+| 추천 목록 부하 | VU 50, 1~5분 |
+| 추천 조회 데이터 | 사용자별 ACTIVE 추천 3개 이상, 완료 progress/숨김 row 혼합 |
+| 배치 데이터 | Python mock 또는 loadtest FastAPI 응답으로 추천 대상 사용자 다수 |
+| 성공 기준 | 추천 목록 p95 < 500ms, 실패율 < 1%, 배치 timeout 0건 |
+
+---
+
+## A. 사용자 조회 성능 비교
+
+| 지표 | before | after | 판정 |
+|---|---:|---:|---|
+| k6 `http_req_duration{type=list}` p95 | 측정 전 | 측정 전 | - |
+| k6 `http_req_waiting{type=list}` p95 | 측정 전 | 측정 전 | - |
+| `recommendation_problem_set_list_duration` avg | 측정 전 | 측정 전 | - |
+| `recommendation_problem_set_list_query_duration` avg | 측정 전 | 측정 전 | - |
+| `recommendation_hide_lookup_duration` avg | 측정 전 | 측정 전 | - |
+| `http_req_failed` | 측정 전 | 측정 전 | - |
+| EXPLAIN rows/key | 측정 전 | 측정 전 | - |
+
+확인할 변경 후보:
+
+| 후보 | 기대 효과 |
+|------|-----------|
+| `problem_recommendation(user_id, status, rank_no, recommendation_id)` 계열 인덱스 검토 | 사용자별 ACTIVE 추천 정렬 조회 비용 감소 |
+| `problem_progress(user_id, problem_set_id, is_completed)` 계열 인덱스 검토 | 완료 문제세트 제외 LEFT JOIN 비용 감소 |
+| `recommendation_hide(user_id, hide_type, target_id)` 계열 인덱스 검토 | 숨김 조회 비용 감소 |
+
+---
+
+## B. 배치/Python 병목 비교
+
+| 지표 | before | after | 판정 |
+|---|---:|---:|---|
+| `recommendation_generation_batch_duration` avg/max | 측정 전 | 측정 전 | - |
+| `recommendation_generation_external_duration` avg/max | 측정 전 | 측정 전 | - |
+| `recommendation_generation_save_duration` avg/max | 측정 전 | 측정 전 | - |
+| generated user count | 측정 전 | 측정 전 | - |
+| `recommendation_generation_failed_total` | 측정 전 | 측정 전 | - |
+| Hikari active max | 측정 전 | 측정 전 | - |
+
+해석표:
+
+| 관찰 | 결론 |
+|------|------|
+| batch total ↑ + external ↑ + save 정상 | Python 추천 서버/네트워크/payload 병목 |
+| batch total ↑ + external 정상 + save ↑ | Java DB 저장/락 병목 |
+| external timeout 발생 | Python 서버 과부하 또는 timeout 설정 확인 |
+| save ↑ + Hikari active ↑ | 추천 교체 저장의 DB write 병목 |
+
+확인할 변경 후보:
+
+| 후보 | 기대 효과 |
+|------|-----------|
+| Python 호출 Timer와 Java 저장 Timer 분리 | 병목 위치 명확화 |
+| 사용자별 저장 batch 개선 | DB write 왕복 감소 |
+| lock/deactivate 조회용 인덱스 검토 | 사용자별 ACTIVE 추천 교체 비용 감소 |
+| Python mock 고정 지연 테스트 | 외부 지연 상황에서 Java 배치 한계 측정 |
+
+---
+
+## C. 추천 효과 관측 비교
+
+| 지표 | before | after | 판정 |
+|---|---:|---:|---|
+| `recommendation_problem_set_exposed_total` | 구현 전 | 구현 후 | - |
+| `recommendation_problem_set_clicked_total` | 구현 전 | 구현 후 | - |
+| CTR(clicked/exposed) | 구현 전 | 구현 후 | - |
+| confidence avg/p95 | 측정 전 | 측정 전 | - |
+| lift avg/p95 | 측정 전 | 측정 전 | - |
+| support avg/p95 | 측정 전 | 측정 전 | - |
+
+주의:
+
+- 추천 클릭/문제 진입 비율은 현재 API만으로 정확히 추론하기 어렵다.
+- 프론트 클릭 이벤트 API 또는 문제 진입 `source=recommendation` 같은 명시적 이벤트가 필요하다.
+- Grafana는 실시간 효과 신호 확인에 적합하고, 장기 코호트/학습 완료율/A-B 테스트는 BI 또는 분석 DB가 더 적합하다.
+
+---
+
+## 결론 기입 위치
+
+baseline 측정 후 아래 형식으로 결론을 쓴다.
+
+```text
+결론: recommendation 도메인의 주 병목은 <추천 목록 query / Python external call / DB save / 추천 효과 이벤트 부재> 이다.
+근거: k6 p95, custom timer, Hikari active, Loki durationMs, generated user count가 함께 설명한다.
+```

--- a/monitoring/docs/domains/recommendation/generation-scale-test.md
+++ b/monitoring/docs/domains/recommendation/generation-scale-test.md
@@ -1,0 +1,99 @@
+# Recommendation Generation Scale Test
+
+추천 생성 배치에서 Python FastAPI 내부 병목이 입력 규모에 따라 어떻게 증가하는지 확인하기 위한 절차다.
+
+---
+
+## 측정 구간
+
+| 구간 | Metric |
+|------|--------|
+| Python DB 조회 | `recommendation_python_generation_stage_last_duration_seconds{stage="db_fetch"}` |
+| transaction 구성 | `recommendation_python_generation_stage_last_duration_seconds{stage="transaction_build"}` |
+| frequent itemset 계산 | `recommendation_python_generation_stage_last_duration_seconds{stage="frequent_itemset"}` |
+| association rule 생성 | `recommendation_python_generation_stage_last_duration_seconds{stage="rule_generation"}` |
+| 사용자별 추천 선택 | `recommendation_python_generation_stage_last_duration_seconds{stage="user_pick"}` |
+| 응답 DTO 생성 | `recommendation_python_generation_stage_last_duration_seconds{stage="response_build"}` |
+| Python 전체 | `recommendation_python_generation_stage_last_duration_seconds{stage="total"}` |
+
+---
+
+## 입력 규모 Metric
+
+| 항목 | Metric |
+|------|--------|
+| 입력 사용자 수 | `recommendation_python_generation_scale{type="input_users"}` |
+| transaction 수 | `recommendation_python_generation_scale{type="transactions"}` |
+| 활성 문제셋 수 | `recommendation_python_generation_scale{type="active_problem_sets"}` |
+| frequent itemset 수 | `recommendation_python_generation_scale{type="frequent_itemsets"}` |
+| association rule 수 | `recommendation_python_generation_scale{type="association_rules"}` |
+| 추천 생성 사용자 수 | `recommendation_python_generation_scale{type="generated_users"}` |
+
+---
+
+## 실행 전 조건
+
+| 서버 | 조건 |
+|------|------|
+| Backend | `loadtest` profile, loadtest MySQL 사용 |
+| Python | `http://localhost:8000`, 같은 loadtest MySQL 사용 |
+| Prometheus | `host.docker.internal:8080/actuator/prometheus`, `host.docker.internal:8000/metrics` scrape |
+| Grafana | `LMS Recommendation Load Test Dashboard` 확인 |
+
+---
+
+## Scale별 권장 실행
+
+각 규모는 seed 데이터가 달라져야 하므로, 가장 단순한 방식은 scale별로 loadtest DB를 초기화하고 Backend를 해당 환경변수로 다시 실행하는 것이다.
+
+| 테스트 | 환경변수 |
+|--------|----------|
+| 120명 | `LOADTEST_RECOMMENDATION_BATCH_USERS=120` |
+| 300명 | `LOADTEST_RECOMMENDATION_BATCH_USERS=300` |
+| 500명 | `LOADTEST_RECOMMENDATION_BATCH_USERS=500` |
+| 1000명 | `LOADTEST_RECOMMENDATION_BATCH_USERS=1000` |
+
+문제셋 수와 사용자별 완료 수를 같이 키우고 싶으면 아래 값도 조정한다.
+
+| 환경변수 | 기본값 | 설명 |
+|----------|--------|------|
+| `LOADTEST_RECOMMENDATION_SETS` | `200` | 활성 문제셋 수 |
+| `LOADTEST_RECOMMENDATION_COMPLETED_PER_USER` | `12` | 추천 대상 사용자별 완료 문제셋 수 |
+| `LOADTEST_RECOMMENDATION_EXISTING_RECOMMENDATIONS_PER_USER` | `3` | 기존 ACTIVE 추천 수 |
+| `LOADTEST_RECOMMENDATION_COMPLETED_EVERY` | `10` | 목록 조회용 로그인 사용자의 완료 progress 간격 |
+
+---
+
+## k6 실행
+
+```bash
+docker compose run --rm \
+  -e RESULT_NAME=recommendation-generation-scale-120 \
+  -e SCALE_USERS=120 \
+  -e LOGIN_EMAIL=admin@test.com \
+  -e LOGIN_PASSWORD=Test1234! \
+  k6 run -o experimental-prometheus-rw /scripts/recommendation/03-generation-baseline.js
+```
+
+scale만 바꿔서 반복한다.
+
+```bash
+docker compose run --rm \
+  -e RESULT_NAME=recommendation-generation-scale-300 \
+  -e SCALE_USERS=300 \
+  -e LOGIN_EMAIL=admin@test.com \
+  -e LOGIN_PASSWORD=Test1234! \
+  k6 run -o experimental-prometheus-rw /scripts/recommendation/03-generation-baseline.js
+```
+
+---
+
+## 해석 표
+
+| 사용자 수 | Java 전체 | FastAPI 호출 | Python DB | transaction | frequent itemset | rule | user pick | response | 생성 사용자 |
+|----------:|----------:|-------------:|----------:|------------:|-----------------:|-----:|----------:|---------:|------------:|
+| 120 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 |
+| 300 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 |
+| 500 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 |
+| 1000 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 | 확인 |
+

--- a/monitoring/docs/domains/recommendation/metrics.md
+++ b/monitoring/docs/domains/recommendation/metrics.md
@@ -1,0 +1,122 @@
+# Recommendation 도메인 — 심은 메트릭/로그 (7단계 §2단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션 [`../../CONVENTION.md`](../../CONVENTION.md)
+> 추천 도메인은 A. 사용자 조회 성능, B. 배치/Python 병목, C. 추천 효과 관측을 분리해서 관측한다.
+
+## A. 사용자 조회 성능 메트릭
+
+| Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
+|---|---|---|---|---|
+| `recommendation_problem_set_list_duration_seconds_{count,sum,max}` | Timer | `recommendation_problem_set_list_duration` | 추천 목록 조회 전체 시간(숨김 확인 포함) | [`RecommendationMetrics`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java), [`ProblemRecommendationQueryService.getRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java) |
+| `recommendation_hide_lookup_duration_seconds_{count,sum,max}` | Timer | `recommendation_hide_lookup_duration` | 추천 숨김 상태 조회 시간 | [`RecommendationMetrics`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java), [`RecommendationHidePersistenceAdapter.findHide`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/RecommendationHidePersistenceAdapter.java) |
+| `recommendation_problem_set_list_query_duration_seconds_{count,sum,max}` | Timer | `recommendation_problem_set_list_query_duration` | ACTIVE 추천 목록 native query 시간 | [`RecommendationMetrics`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java), [`ProblemRecommendationQueryAdapter.findActiveProblemSetRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationQueryAdapter.java) |
+
+### 로그
+
+```text
+event=recommendation_problem_set_list_queried hidden=<true|false> resultCount=<n> durationMs=<n>
+event=recommendation_hide_lookup_completed hidden=<true|false> durationMs=<n>
+event=recommendation_problem_set_list_query_completed resultCount=<n> durationMs=<n>
+```
+
+---
+
+## B. 배치/Python 병목 메트릭
+
+| Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
+|---|---|---|---|---|
+| `recommendation_generation_batch_duration_seconds_{count,sum,max}` | Timer | `recommendation_generation_batch_duration` | 추천 생성 배치 전체 시간 | [`RecommendationMetrics`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java), [`ProblemRecommendationGenerationService.generate`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java) |
+| `recommendation_generation_external_duration_seconds_{count,sum,max}` | Timer | `recommendation_generation_external_duration` | Java → Python FastAPI 호출 round-trip 시간 | [`RecommendationMetrics`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java), [`FastApiProblemRecommendationGenerationClient.generateProblemSetRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java) |
+| `recommendation_generation_save_duration_seconds_{count,sum,max}` | Timer | `recommendation_generation_save_duration` | 사용자별 추천 교체 저장 시간 | [`RecommendationMetrics`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java), [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) |
+| `recommendation_generation_user_total` | Counter | `recommendation_generation_user_total` | 추천이 생성된 사용자 수 누적 | [`ProblemRecommendationGenerationService.generate`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java) |
+| `recommendation_generation_failed_total` | Counter | `recommendation_generation_failed_total` | 추천 생성 실패 수 | [`ProblemRecommendationGenerationService`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java), [`FastApiProblemRecommendationGenerationClient`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java) |
+
+### Metric Tag
+
+| 메트릭 | tag | 허용 값 |
+|--------|-----|---------|
+| `recommendation_generation_save_duration` | `status` | `success`, `failed` |
+| `recommendation_generation_failed_total` | `reason` | `timeout`, `external_error`, `invalid_response`, `save_error` |
+
+`userId`, `problemSetId`, exception message는 metric tag에 넣지 않는다.
+
+### 로그
+
+```text
+event=recommendation_generation_batch_completed userCount=<n> durationMs=<n>
+event=recommendation_generation_external_called userCount=<n> durationMs=<n>
+event=recommendation_generation_saved userId=<id> itemCount=<n> durationMs=<n>
+event=recommendation_generation_failed reason=<reason> exceptionType=<type>
+```
+
+---
+
+## C. 추천 효과 관측 메트릭
+
+| Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
+|---|---|---|---|---|
+| `recommendation_problem_set_exposed_total` | Counter | `recommendation_problem_set_exposed_total` | 추천 목록에서 사용자에게 노출된 추천 카드 수 | [`ProblemRecommendationQueryService.getRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java) |
+| `recommendation_score_confidence_{count,sum,max}` | DistributionSummary | `recommendation_score_confidence` | 생성된 추천 confidence 분포 | [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) |
+| `recommendation_score_lift_{count,sum,max}` | DistributionSummary | `recommendation_score_lift` | 생성된 추천 lift 분포 | [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) |
+| `recommendation_score_support_{count,sum,max}` | DistributionSummary | `recommendation_score_support` | 생성된 추천 support 분포 | [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) |
+
+`recommendation_problem_set_clicked_total`은 아직 클릭 이벤트 API/source 파라미터가 없어 이번 2단계에서는 심지 않았다.
+
+---
+
+## PromQL / LogQL 후보
+
+### 추천 목록 query 평균
+
+```promql
+rate(recommendation_problem_set_list_query_duration_seconds_sum[1m])
+/
+rate(recommendation_problem_set_list_query_duration_seconds_count[1m])
+```
+
+### Python 호출 평균
+
+```promql
+rate(recommendation_generation_external_duration_seconds_sum[1m])
+/
+rate(recommendation_generation_external_duration_seconds_count[1m])
+```
+
+### 저장 상태별 평균
+
+```promql
+sum by (status) (rate(recommendation_generation_save_duration_seconds_sum[1m]))
+/
+sum by (status) (rate(recommendation_generation_save_duration_seconds_count[1m]))
+```
+
+### 실패 사유별 증가량
+
+```promql
+sum by (reason) (increase(recommendation_generation_failed_total[5m]))
+```
+
+### 추천 노출 수
+
+```promql
+sum(increase(recommendation_problem_set_exposed_total[5m]))
+```
+
+### 배치 실패 로그
+
+```logql
+{job="lms"} |= "event=recommendation_generation_failed"
+```
+
+---
+
+## 해석 기준
+
+| 관찰 | 해석 |
+|------|------|
+| 추천 목록 p95 상승 + `problem_set_list_query_duration` 상승 | 추천 native query/조인/인덱스 병목 |
+| `problem_set_list_duration` 상승 + `hide_lookup_duration`만 상승 | 숨김 조회 병목 |
+| batch total 상승 + external duration 상승 | Python/FastAPI/네트워크 병목 |
+| batch total 상승 + save duration 상승 | Java DB 저장/락 병목 |
+| `generation_failed_total{reason="timeout"}` 증가 | Python 응답 지연 또는 연결 timeout |
+| exposed 증가 대비 클릭 이벤트 없음 | CTR은 후속 클릭 이벤트 API/source 파라미터 도입 후 측정 |

--- a/monitoring/docs/domains/recommendation/success-criteria.md
+++ b/monitoring/docs/domains/recommendation/success-criteria.md
@@ -1,0 +1,133 @@
+# Recommendation 도메인 — 성공 기준 (7단계 §3단계)
+
+> 프로세스 [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션 [`../../CONVENTION.md`](../../CONVENTION.md)
+> 로컬 `loadtest` 프로파일, 도커 MySQL 3307, 단일 Spring Boot 앱 기준이다.
+
+## 병목 가설별 측정 방식
+
+| 가설 | 대상 | 측정 방식 | 산출물 |
+|------|------|-----------|--------|
+| #1 추천 목록 조인/인덱스 | `GET /api/v1/recommendations/problem-sets/me` | k6 목록 단독 baseline | `monitoring/k6/scripts/recommendation/01-list-baseline.js` |
+| #2 Python FastAPI 호출 | `ProblemRecommendationGenerationService.generate()` | loadtest trigger API로 배치 본체 실행 | `monitoring/k6/scripts/recommendation/03-generation-baseline.js`, `recommendation_generation_external_duration`, `recommendation_generation_batch_duration` |
+| #3 추천 교체 저장 반복 | `ProblemRecommendationCommandAdapter.replaceActiveRecommendations()` | loadtest trigger API 실행 중 save timer 관찰 | `recommendation_generation_save_duration{status=...}` |
+| #4 hide today upsert | `POST /api/v1/recommendations/problem-sets/hide-today` | k6 hide 단독 baseline | `monitoring/k6/scripts/recommendation/02-hide-today-baseline.js` |
+
+---
+
+## k6 대상과 트래픽 조건
+
+| 스크립트 | 대상 | 유형 | 트래픽 조건 | 측정 기간 |
+|----------|------|------|-------------|-----------|
+| `01-list-baseline.js` | `GET /api/v1/recommendations/problem-sets/me?limit=3` | 조회/집계형 | 0→50 VU ramp-up 20s, 50 VU 유지 40s, ramp-down 10s | 총 70s |
+| `02-hide-today-baseline.js` | `POST /api/v1/recommendations/problem-sets/hide-today` | 단순 쓰기/upsert | 0→30 VU ramp-up 20s, 30 VU 유지 40s, ramp-down 10s | 총 70s |
+| `03-generation-baseline.js` | `POST /internal/loadtest/recommendations/generate` | 추천 배치 실행형 | 기본 1 VU, 1 iteration | 1회 실행 기준 |
+
+전제:
+
+- `LOGIN_EMAIL=u01@test.com`, `LOGIN_PASSWORD=Test1234!`를 사용한다.
+- 추천 목록 baseline에서는 hide API를 호출하지 않는다.
+- hide baseline은 목록 baseline과 분리해서 실행한다. hide 실행 후에는 목록 API가 `hidden=true`가 되어 추천 native query를 건너뛴다.
+- loadtest DB에 `problem_recommendation`, `problem_set`, `problem_category`, `problem_progress` row가 충분히 있어야 한다.
+- 배치 baseline에서는 Java 앱의 `fastapi.url`이 추천 FastAPI 서버를 바라봐야 하고, Python 서버도 같은 loadtest MySQL 데이터를 읽어야 한다.
+- 배치용 seed는 추천 대상 사용자 120명, 사용자별 완료 progress 12건, 기존 ACTIVE 추천 3건을 만든다.
+
+---
+
+## 추천 목록 Threshold
+
+```javascript
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:list}": ["p(95)<500"],
+    },
+};
+```
+
+## hide today Threshold
+
+```javascript
+export const options = {
+    stages: [
+        { duration: "20s", target: 30 },
+        { duration: "40s", target: 30 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:hide}": ["p(95)<300"],
+    },
+};
+```
+
+## 추천 배치 trigger Threshold
+
+```javascript
+export const options = {
+    vus: 1,
+    iterations: 1,
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:recommendation_generation}": ["p(95)<300000"],
+    },
+};
+```
+
+---
+
+## 중단 기준
+
+| 조건 | 판단 |
+|------|------|
+| `http_req_failed >= 1%` | 인증/seed/서버 오류 확인 후 중단 |
+| 추천 목록 p95 1s 이상 지속 | native query/인덱스 병목 우선 확인 |
+| 목록 응답이 계속 `hidden=true` | hide seed 상태 확인. 목록 query baseline으로 부적합 |
+| 목록 `problemSets`가 계속 빈 배열 | 추천 row seed 또는 완료 progress 조건 확인 |
+| hide p95 800ms 이상 지속 | hide 조회/저장 upsert 병목 가능성 확인 |
+| 배치 trigger 5분 이상 지속 | FastAPI 호출 timeout, Python 계산 시간, Java save timer를 분리 확인 |
+| `generatedUserCount=0` 반복 | Python 서버가 3개 추천을 만들 수 있는 사용자를 찾지 못한 상태. progress/문제세트 seed와 Python DB 연결 확인 |
+
+---
+
+## 비즈니스 실패와 시스템 장애 구분
+
+| 응답 | 해석 |
+|------|------|
+| `200` + `hidden=false` | 추천 목록 조회 baseline 정상 |
+| `200` + `hidden=true` | 시스템 장애는 아니지만 목록 query 병목 측정에는 부적합 |
+| `200` + hide response | hide upsert 정상 |
+| `401` | 로그인 seed 문제 |
+| `5xx` | 시스템 장애로 실패율에 포함 |
+
+---
+
+## 관찰 지표
+
+| 가설 | 도구 | 지표 |
+|------|------|------|
+| #1 목록 | k6 | `http_req_duration{type=list}`, `http_req_failed` |
+| #1 목록 | Prometheus | `http_server_requests_seconds{domain="recommendation"}` |
+| #1 목록 | Prometheus | `recommendation_problem_set_list_duration_seconds_*` |
+| #1 목록 | Prometheus | `recommendation_hide_lookup_duration_seconds_*` |
+| #1 목록 | Prometheus | `recommendation_problem_set_list_query_duration_seconds_*` |
+| #1 목록 | Loki | `event=recommendation_problem_set_list_queried`, `event=recommendation_problem_set_list_query_completed` |
+| #4 hide | k6 | `http_req_duration{type=hide}`, `http_req_failed` |
+| #4 hide | Prometheus | `http_server_requests_seconds{domain="recommendation"}` |
+| #4 hide | Loki | `event=request_completed uri=/api/v1/recommendations/problem-sets/hide-today` |
+| #2·#3 배치 | Prometheus | `recommendation_generation_batch_duration_seconds_*`, `recommendation_generation_external_duration_seconds_*`, `recommendation_generation_save_duration_seconds_*` |
+| #2·#3 배치 | Loki | `event=recommendation_generation_batch_completed`, `event=recommendation_generation_external_called`, `event=recommendation_generation_saved` |
+
+## 결론 기준
+
+| 결과 | 판단 |
+|------|------|
+| 목록 p95 통과 + custom query timer 안정 | 추천 목록 baseline 기준 충족 |
+| HTTP p95 상승 + list query timer 상승 | native query/인덱스 병목 |
+| list duration 상승 + hide lookup만 상승 | 숨김 조회 병목 |
+| batch total 상승 + external duration 상승 | Python/FastAPI/네트워크 병목 |
+| batch total 상승 + save duration 상승 | Java DB 저장/락 병목 |

--- a/monitoring/grafana/provisioning/dashboards/lms-admin-loadtest-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/lms-admin-loadtest-dashboard.json
@@ -1,0 +1,204 @@
+{
+  "uid": "lms-admin-loadtest",
+  "title": "LMS Admin Load Test Dashboard",
+  "tags": ["lms", "loadtest", "admin"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-30m", "to": "now" },
+  "panels": [
+    { "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 1, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "URI별 초당 요청 수",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"admin\"}[1m]))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "4xx/5xx 에러 비율",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{domain=\"admin\",status=~\"4..|5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"admin\"}[1m])), 0.0001)",
+          "legendFormat": "error rate"
+        }
+      ]
+    },
+    { "type": "row", "title": "Operation Alert", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }, "id": 4, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "운영 알림 목록 조회 내부 query 평균 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 10 },
+      "id": 5,
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(admin_operation_alert_list_query_duration_seconds_sum[1m]) / clamp_min(rate(admin_operation_alert_list_query_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "list query avg"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "운영 알림 상세 기본 alert + rule 조회 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
+      "id": 6,
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(admin_operation_alert_detail_query_duration_seconds_sum[1m]) / clamp_min(rate(admin_operation_alert_detail_query_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "detail base avg"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "target type별 상세 조합 평균 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
+      "id": 7,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (targetType) (rate(admin_operation_alert_target_detail_duration_seconds_sum[1m])) / clamp_min(sum by (targetType) (rate(admin_operation_alert_target_detail_duration_seconds_count[1m])), 0.0001)",
+          "legendFormat": "{{targetType}}"
+        }
+      ]
+    },
+    { "type": "row", "title": "Admin Automation", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }, "id": 8, "collapsed": false },
+    {
+      "type": "stat",
+      "title": "운영 자동화 규칙 전체 실행 시간",
+      "description": "단발성 batch 실행은 increase()가 0으로 보일 수 있어 range 내 누적 sum/count의 max 값으로 표시한다.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 19 },
+      "id": 9,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3 }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "area", "justifyMode": "auto" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "max_over_time(admin_operation_rule_run_duration_seconds_sum[$__range]) / clamp_min(max_over_time(admin_operation_rule_run_duration_seconds_count[$__range]), 1)",
+          "legendFormat": "rule run avg"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "자동화 규칙별 실행 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 10, "x": 6, "y": 19 },
+      "id": 10,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3 }, "overrides": [] },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (ruleCode) (max_over_time(admin_operation_rule_detect_duration_seconds_sum[$__range])) / clamp_min(sum by (ruleCode) (max_over_time(admin_operation_rule_detect_duration_seconds_count[$__range])), 1)",
+          "legendFormat": "{{ruleCode}}"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "자동화 규칙별 탐지 결과 수",
+      "description": "Counter 최초 생성 직후 increase()가 0으로 보이는 문제를 피하기 위해 range 내 max counter 값을 표시한다.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 19 },
+      "id": 11,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (ruleCode) (max_over_time(admin_operation_rule_detected_total[$__range]))",
+          "legendFormat": "{{ruleCode}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "탐지 결과 1건을 운영 알림으로 조회/저장하는 평균 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 12,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(admin_operation_alert_upsert_duration_seconds_sum[1m]) / clamp_min(rate(admin_operation_alert_upsert_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "alert upsert avg"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Hikari Active Connections",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 13,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "active"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_pending",
+          "legendFormat": "pending"
+        }
+      ]
+    },
+    { "type": "row", "title": "Logs", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 }, "id": 14, "collapsed": false },
+    {
+      "type": "logs",
+      "title": "Admin operation 로그",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 34 },
+      "id": 15,
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{job=\"lms\"} |= \"event=admin_operation\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/lms-recommendation-loadtest-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/lms-recommendation-loadtest-dashboard.json
@@ -1,0 +1,280 @@
+{
+  "uid": "lms-recommendation-loadtest",
+  "title": "LMS Recommendation Load Test Dashboard",
+  "tags": ["lms", "loadtest", "recommendation"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-30m", "to": "now" },
+  "panels": [
+    { "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 1, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "URI별 초당 요청 수",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"recommendation\"}[1m]))",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "4xx/5xx 에러 비율",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{domain=\"recommendation\",status=~\"4..|5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"recommendation\"}[1m])), 0.0001)",
+          "legendFormat": "error rate"
+        }
+      ]
+    },
+    { "type": "row", "title": "Recommendation List / Hide", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }, "id": 4, "collapsed": false },
+    {
+      "type": "timeseries",
+      "title": "추천 목록 조회 전체 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 10 },
+      "id": 5,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(recommendation_problem_set_list_duration_seconds_sum[1m]) / clamp_min(rate(recommendation_problem_set_list_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "list total avg"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "추천 목록 조회 전 숨김 상태 확인 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 10 },
+      "id": 6,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(recommendation_hide_lookup_duration_seconds_sum[1m]) / clamp_min(rate(recommendation_hide_lookup_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "hide lookup avg"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "추천 목록 Native Query 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 10 },
+      "id": 7,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(recommendation_problem_set_list_query_duration_seconds_sum[1m]) / clamp_min(rate(recommendation_problem_set_list_query_duration_seconds_count[1m]), 0.0001)",
+          "legendFormat": "native query avg"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "추천 노출 수",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 18 },
+      "id": 8,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "area", "justifyMode": "auto" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "max_over_time(recommendation_problem_set_exposed_total[$__range])",
+          "legendFormat": "exposed"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "추천 hide today HTTP 평균 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 16, "x": 8, "y": 18 },
+      "id": 9,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_sum{domain=\"recommendation\",uri=~\".*hide-today.*\"}[1m])) / clamp_min(sum by (uri) (rate(http_server_requests_seconds_count{domain=\"recommendation\",uri=~\".*hide-today.*\"}[1m])), 0.0001)",
+          "legendFormat": "{{uri}}"
+        }
+      ]
+    },
+    { "type": "row", "title": "Recommendation Generation Batch", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 }, "id": 10, "collapsed": false },
+    {
+      "type": "stat",
+      "title": "추천 배치 전체 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 24 },
+      "id": 11,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3 }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "area", "justifyMode": "auto" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(recommendation_generation_batch_duration_seconds_sum[$__range]) / clamp_min(increase(recommendation_generation_batch_duration_seconds_count[$__range]), 1)",
+          "legendFormat": "batch avg"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "FastAPI 호출 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 24 },
+      "id": 12,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3 }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "area", "justifyMode": "auto" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(recommendation_generation_external_duration_seconds_sum[$__range]) / clamp_min(increase(recommendation_generation_external_duration_seconds_count[$__range]), 1)",
+          "legendFormat": "external avg"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "추천 저장 시간(status별)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 24 },
+      "id": 13,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (status) (increase(recommendation_generation_save_duration_seconds_sum[$__range])) / clamp_min(sum by (status) (increase(recommendation_generation_save_duration_seconds_count[$__range])), 1)",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "추천 생성 사용자 수",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 24 },
+      "id": 14,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "area", "justifyMode": "auto" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(recommendation_generation_user_total[$__range])",
+          "legendFormat": "generated users"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "추천 생성 실패 수(reason별)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 30 },
+      "id": 15,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (reason) (increase(recommendation_generation_failed_total[$__range]))",
+          "legendFormat": "{{reason}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "추천 score 평균 분포",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 30 },
+      "id": 16,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(recommendation_score_support_sum[$__range]) / clamp_min(increase(recommendation_score_support_count[$__range]), 1)",
+          "legendFormat": "support avg"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(recommendation_score_confidence_sum[$__range]) / clamp_min(increase(recommendation_score_confidence_count[$__range]), 1)",
+          "legendFormat": "confidence avg"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "increase(recommendation_score_lift_sum[$__range]) / clamp_min(increase(recommendation_score_lift_count[$__range]), 1)",
+          "legendFormat": "lift avg"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Hikari Active Connections",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 30 },
+      "id": 17,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_active",
+          "legendFormat": "active"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "hikaricp_connections_pending",
+          "legendFormat": "pending"
+        }
+      ]
+    },
+    { "type": "row", "title": "Logs", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 }, "id": 18, "collapsed": false },
+    {
+      "type": "logs",
+      "title": "Recommendation 로그",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 37 },
+      "id": 19,
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{job=\"lms\"} |= \"event=recommendation\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/lms-recommendation-loadtest-dashboard.json
+++ b/monitoring/grafana/provisioning/dashboards/lms-recommendation-loadtest-dashboard.json
@@ -259,12 +259,140 @@
         }
       ]
     },
-    { "type": "row", "title": "Logs", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 }, "id": 18, "collapsed": false },
+    { "type": "row", "title": "Python Recommendation Generation", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 }, "id": 20, "collapsed": false },
+    {
+      "type": "stat",
+      "title": "Python 추천 생성 전체 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 37 },
+      "id": 21,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3 }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "value", "graphMode": "area", "justifyMode": "auto" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "recommendation_python_generation_stage_last_duration_seconds{stage=\"total\"}",
+          "legendFormat": "{{scale_users}} users"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Python stage별 최근 처리 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 12, "x": 6, "y": 37 },
+      "id": 22,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "recommendation_python_generation_stage_last_duration_seconds{stage=~\"db_fetch|transaction_build|frequent_itemset|rule_generation|user_pick|response_build\"}",
+          "legendFormat": "{{scale_users}} users / {{stage}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Python 입력/산출 규모",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 37 },
+      "id": 23,
+      "fieldConfig": { "defaults": { "unit": "none", "decimals": 0 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "recommendation_python_generation_scale{type=~\"input_users|transactions|active_problem_sets|frequent_itemsets|association_rules|generated_users\"}",
+          "legendFormat": "{{type}}"
+        }
+      ]
+    },
+    {
+      "type": "bargauge",
+      "title": "Python stage별 평균 처리 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 43 },
+      "id": 24,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (scale_users, stage) (increase(recommendation_python_generation_stage_duration_seconds_sum[$__range])) / clamp_min(sum by (scale_users, stage) (increase(recommendation_python_generation_stage_duration_seconds_count[$__range])), 1)",
+          "legendFormat": "{{scale_users}} users / {{stage}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "k6 인원수별 추천 생성 trigger 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 43 },
+      "id": 25,
+      "fieldConfig": { "defaults": { "unit": "ms", "decimals": 2 }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "avg by (scale_users) (k6_http_req_duration_p99{type=\"recommendation_generation\"})",
+          "legendFormat": "{{scale_users}} users"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "Python 사용자 수별 stage 응답 시간",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 50 },
+      "id": 26,
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 4 }, "overrides": [] },
+      "options": {
+        "orientation": "auto",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0,
+        "showValue": "auto",
+        "stacking": "none",
+        "groupWidth": 0.7,
+        "barWidth": 0.97,
+        "barRadius": 0,
+        "fullHighlight": false,
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "showLegend": true, "displayMode": "list", "placement": "bottom", "calcs": [] }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "avg by (scale_users, stage) (recommendation_python_generation_stage_last_duration_seconds{stage=~\"db_fetch|transaction_build|frequent_itemset|rule_generation|user_pick|response_build\"})",
+          "legendFormat": "{{scale_users}} users / {{stage}}",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": { "mode": "columns" }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "__name__": true, "job": true, "instance": true, "application": true },
+            "indexByName": { "scale_users": 0, "stage": 1, "Value": 2 },
+            "renameByName": { "scale_users": "users", "stage": "stage", "Value": "seconds" }
+          }
+        }
+      ]
+    },
+    { "type": "row", "title": "Logs", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 59 }, "id": 18, "collapsed": false },
     {
       "type": "logs",
       "title": "Recommendation 로그",
       "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 37 },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 60 },
       "id": 19,
       "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
       "targets": [

--- a/monitoring/k6/results/admin-alert-detail-before-summary.json
+++ b/monitoring/k6/results/admin-alert-detail-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "metrics": {
+    "http_req_tls_handshaking": {
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      },
+      "type": "trend"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 1263.5718120000001,
+        "p(90)": 1876.8206966999999,
+        "p(95)": 1949.1995309,
+        "p(99)": 2019.72386194,
+        "max": 2053.056557,
+        "avg": 1275.4228696484024,
+        "min": 122.277107
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 6.668612,
+        "avg": 0.4979984178082188,
+        "min": 0.036317,
+        "med": 0.45787750000000005,
+        "p(90)": 0.8554331000000001,
+        "p(95)": 1.00763455,
+        "p(99)": 1.6508689500000016
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 3.791482020000001,
+        "max": 7.666978,
+        "avg": 0.08967532420091325,
+        "min": 0,
+        "med": 0
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 74.48819406,
+        "max": 117.596043,
+        "avg": 34.43698093607305,
+        "min": 19.955343,
+        "med": 32.004391,
+        "p(90)": 45.17653050000002,
+        "p(95)": 51.49314314999999
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 32.588976,
+        "p(90)": 45.7564834,
+        "p(95)": 52.20762054999994,
+        "p(99)": 75.25316486000004,
+        "max": 118.071731,
+        "avg": 34.97834470684933,
+        "min": 20.37429
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 6567,
+        "fails": 0
+      }
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      },
+      "type": "gauge"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.002058,
+        "med": 0.0067385,
+        "p(90)": 0.010120500000000003,
+        "p(95)": 0.013057149999999997,
+        "p(99)": 3.984682420000001,
+        "max": 7.872573,
+        "avg": 0.10122975022831034
+      }
+    },
+    "http_req_duration{type:detail}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 74.82015623999995,
+        "max": 102.374538,
+        "avg": 34.9403851882138,
+        "min": 20.37429,
+        "med": 32.587945,
+        "p(90)": 45.7522168,
+        "p(95)": 52.057724199999996
+      },
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
+      }
+    },
+    "http_reqs": {
+      "contains": "default",
+      "values": {
+        "count": 2190,
+        "rate": 30.703521509952626
+      },
+      "type": "counter"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 30.689501637117033,
+        "count": 2189
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 759793,
+        "rate": 10652.201241375085
+      }
+    },
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2190
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 3741429,
+        "rate": 52454.35880340664
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 34.97834470684933,
+        "min": 20.37429,
+        "med": 32.588976,
+        "p(90)": 45.7564834,
+        "p(95)": 52.20762054999994,
+        "p(99)": 75.25316486000004,
+        "max": 118.071731
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.16187420000000013,
+        "max": 3.213304,
+        "avg": 0.04336535296803657,
+        "min": 0.007235,
+        "med": 0.037948499999999996,
+        "p(90)": 0.06544710000000002,
+        "p(95)": 0.08843999999999995
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 2,
+        "max": 50
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MDczMCwiZXhwIjoxNzgxODQ0MzMwfQ.Qxx82SqzPqFNCOgHbBgjCZt099k2MEZ4oYPSQqMFk8M"
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2189,
+          "fails": 0
+        },
+        {
+          "name": "data exists",
+          "path": "::data exists",
+          "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
+          "passes": 2189,
+          "fails": 0
+        },
+        {
+          "passes": 2189,
+          "fails": 0,
+          "name": "has target detail",
+          "path": "::has target detail",
+          "id": "bf66eafe5d6983c70e58071498d09af9"
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 71327.323131,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  }
+}

--- a/monitoring/k6/results/admin-alert-detail-before-summary.md
+++ b/monitoring/k6/results/admin-alert-detail-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - admin-alert-detail-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2190 |
+| iterations | 2189 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 3741429 |
+| data_sent bytes | 759793 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 34.98 | 20.37 | 32.59 | 45.76 | 52.21 | 75.25 | 118.07 |
+| http_req_waiting | 34.44 | 19.96 | 32.00 | 45.18 | 51.49 | 74.49 | 117.60 |
+| http_req_blocked | 0.10 | 0.00 | 0.01 | 0.01 | 0.01 | 3.98 | 7.87 |
+| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.79 | 7.67 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2189 pass / 0 fail |
+| data exists | 2189 pass / 0 fail |
+| has target detail | 2189 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/admin-alert-detail-course-before-summary.json
+++ b/monitoring/k6/results/admin-alert-detail-course-before-summary.json
@@ -1,32 +1,32 @@
 {
   "root_group": {
+    "checks": [
+      {
+        "name": "status is 200",
+        "path": "::status is 200",
+        "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+        "passes": 2218,
+        "fails": 0
+      },
+      {
+        "passes": 2218,
+        "fails": 0,
+        "name": "data exists",
+        "path": "::data exists",
+        "id": "5383ecdb29afb1a64ae2c425b60f2ffc"
+      },
+      {
+        "name": "has target detail",
+        "path": "::has target detail",
+        "id": "bf66eafe5d6983c70e58071498d09af9",
+        "passes": 2218,
+        "fails": 0
+      }
+    ],
+    "name": "",
     "path": "",
     "id": "d41d8cd98f00b204e9800998ecf8427e",
-    "groups": [],
-    "checks": [
-        {
-          "fails": 0,
-          "name": "status is 200",
-          "path": "::status is 200",
-          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
-          "passes": 2172
-        },
-        {
-          "fails": 0,
-          "name": "data exists",
-          "path": "::data exists",
-          "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
-          "passes": 2172
-        },
-        {
-          "name": "has target detail",
-          "path": "::has target detail",
-          "id": "bf66eafe5d6983c70e58071498d09af9",
-          "passes": 2172,
-          "fails": 0
-        }
-      ],
-    "name": ""
+    "groups": []
   },
   "options": {
     "summaryTrendStats": [
@@ -42,11 +42,165 @@
     "noColor": false
   },
   "state": {
-    "testRunDurationMs": 71410.731668,
     "isStdOutTTY": true,
-    "isStdErrTTY": true
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71242.848843
   },
   "metrics": {
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 50
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 2.37029162,
+        "max": 6.676909,
+        "avg": 0.0573462266786841,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      },
+      "type": "trend"
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 774292,
+        "rate": 10868.346964989152
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 3795523,
+        "rate": 53275.845388556925
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.10656258000000011,
+        "max": 0.325805,
+        "avg": 0.027391043713384307,
+        "min": 0.008434,
+        "med": 0.026205,
+        "p(90)": 0.041273800000000006,
+        "p(95)": 0.056793500000000004
+      }
+    },
+    "http_req_receiving": {
+      "values": {
+        "p(99)": 0.7576615000000005,
+        "max": 7.562831,
+        "avg": 0.24594661649391572,
+        "min": 0.026494,
+        "med": 0.20622,
+        "p(90)": 0.4556716,
+        "p(95)": 0.5428369
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 13.573416388012632,
+        "min": 8.526995,
+        "med": 12.646577,
+        "p(90)": 16.940607,
+        "p(95)": 19.652414099999994,
+        "p(99)": 28.93511704000001,
+        "max": 226.062374
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 226.062374,
+        "avg": 13.573416388012632,
+        "min": 8.526995,
+        "med": 12.646577,
+        "p(90)": 16.940607,
+        "p(95)": 19.652414099999994,
+        "p(99)": 28.93511704000001
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 19.125248499999998,
+        "p(99)": 28.63340590000005,
+        "max": 225.691135,
+        "avg": 13.300078727805303,
+        "min": 8.240604,
+        "med": 12.3806,
+        "p(90)": 16.5373172
+      }
+    },
+    "iteration_duration": {
+      "values": {
+        "avg": 1257.4688334042376,
+        "min": 158.711769,
+        "med": 1246.606605,
+        "p(90)": 1865.1101606,
+        "p(95)": 1931.9331548999999,
+        "p(99)": 1996.3320970000002,
+        "max": 2014.704968
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 6654,
+        "fails": 0
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2218,
+        "rate": 31.132949285729335
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2219,
+        "rate": 31.146985782251306
+      }
+    },
     "vus_max": {
       "type": "gauge",
       "contains": "default",
@@ -56,207 +210,53 @@
         "max": 50
       }
     },
-    "http_req_duration{expected_response:true}": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(99)": 57.52186108000006,
-        "max": 166.672508,
-        "avg": 33.240430178094755,
-        "min": 19.304873,
-        "med": 31.516755,
-        "p(90)": 43.0701526,
-        "p(95)": 47.94417220000001
-      }
-    },
     "http_req_duration{type:detail}": {
+      "values": {
+        "p(99)": 28.860922569999993,
+        "max": 226.062374,
+        "avg": 13.509955665464394,
+        "min": 8.526995,
+        "med": 12.646199,
+        "p(90)": 16.9363416,
+        "p(95)": 19.64175425
+      },
       "thresholds": {
         "p(95)<500": {
           "ok": true
         }
       },
       "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 33.178997361418006,
-        "min": 19.304873,
-        "med": 31.512124999999997,
-        "p(90)": 43.042469800000006,
-        "p(95)": 47.796455749999964,
-        "p(99)": 57.25942112999999,
-        "max": 81.532685
-      }
-    },
-    "data_sent": {
-      "type": "counter",
-      "contains": "data",
-      "values": {
-        "count": 753894,
-        "rate": 10557.15271907554
-      }
-    },
-    "data_received": {
-      "values": {
-        "count": 3712424,
-        "rate": 51986.92007889875
-      },
-      "type": "counter",
-      "contains": "data"
-    },
-    "http_req_connecting": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "min": 0,
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 3.7755630400000038,
-        "max": 11.899938,
-        "avg": 0.09455936539346525
-      }
-    },
-    "vus": {
-      "contains": "default",
-      "values": {
-        "value": 3,
-        "min": 3,
-        "max": 50
-      },
-      "type": "gauge"
-    },
-    "http_req_failed": {
-      "type": "rate",
-      "contains": "default",
-      "values": {
-        "rate": 0,
-        "passes": 0,
-        "fails": 2173
-      },
-      "thresholds": {
-        "rate<0.01": {
-          "ok": true
-        }
-      }
-    },
-    "iteration_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(95)": 1959.6907922,
-        "p(99)": 2018.8154212000002,
-        "max": 2059.197724,
-        "avg": 1283.9459982494257,
-        "min": 170.94645,
-        "med": 1292.740522,
-        "p(90)": 1884.2801198
-      }
-    },
-    "http_req_duration": {
-      "contains": "time",
-      "values": {
-        "avg": 33.240430178094755,
-        "min": 19.304873,
-        "med": 31.516755,
-        "p(90)": 43.0701526,
-        "p(95)": 47.94417220000001,
-        "p(99)": 57.52186108000006,
-        "max": 166.672508
-      },
-      "type": "trend"
-    },
-    "http_reqs": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "count": 2173,
-        "rate": 30.42959999489471
-      }
+      "contains": "time"
     },
     "http_req_blocked": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "med": 0.00651,
-        "p(90)": 0.010011,
-        "p(95)": 0.012331200000000025,
-        "p(99)": 3.9285616400000074,
-        "max": 12.097601,
-        "avg": 0.1054937031753334,
-        "min": 0.001822
+        "p(90)": 0.0064010000000000004,
+        "p(95)": 0.012040799999999923,
+        "p(99)": 2.475282640000004,
+        "max": 7.845792,
+        "avg": 0.06580867372690387,
+        "min": 0.001802,
+        "med": 0.004454
       }
     },
-    "http_req_waiting": {
-      "values": {
-        "min": 18.693156,
-        "med": 30.999107,
-        "p(90)": 42.525378399999994,
-        "p(95)": 47.3553672,
-        "p(99)": 57.06758576000004,
-        "max": 164.519894,
-        "avg": 32.697216476760225
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
       },
-      "type": "trend",
-      "contains": "time"
-    },
-    "http_req_sending": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(95)": 0.08617220000000005,
-        "p(99)": 0.16051776000000015,
-        "max": 0.700202,
-        "avg": 0.04177259687068577,
-        "min": 0.008744,
-        "med": 0.037607,
-        "p(90)": 0.0671518
-      }
-    },
-    "checks": {
       "type": "rate",
       "contains": "default",
       "values": {
-        "rate": 1,
-        "passes": 6516,
-        "fails": 0
+        "fails": 2219,
+        "rate": 0,
+        "passes": 0
       }
-    },
-    "http_req_tls_handshaking": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 0,
-        "avg": 0,
-        "min": 0,
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 0
-      }
-    },
-    "http_req_receiving": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 0.5014411044638746,
-        "min": 0.035592,
-        "med": 0.459379,
-        "p(90)": 0.8378988,
-        "p(95)": 0.9914686000000001,
-        "p(99)": 1.564162280000004,
-        "max": 10.424534
-      }
-    },
-    "iterations": {
-      "values": {
-        "count": 2172,
-        "rate": 30.41559649742812
-      },
-      "type": "counter",
-      "contains": "default"
     }
   },
   "setup_data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MTYzNiwiZXhwIjoxNzgxODQ1MjM2fQ.M_azq9PnLKuyPnMGp9Wt7vscUuUN07Mrbh447KkoLug"
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjIiLCJ0eXAiOiJhY2Nlc3MiLCJuaWNrbmFtZSI6ImxvYWR0ZXN0LWFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNzgxOTY2MDAyLCJleHAiOjE3ODE5Njk2MDJ9.3zap-JNorWPpqTcUanZrNeYwhiioi_QPUopHVfF8P78"
   }
 }

--- a/monitoring/k6/results/admin-alert-detail-course-before-summary.json
+++ b/monitoring/k6/results/admin-alert-detail-course-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2172
+        },
+        {
+          "fails": 0,
+          "name": "data exists",
+          "path": "::data exists",
+          "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
+          "passes": 2172
+        },
+        {
+          "name": "has target detail",
+          "path": "::has target detail",
+          "id": "bf66eafe5d6983c70e58071498d09af9",
+          "passes": 2172,
+          "fails": 0
+        }
+      ],
+    "name": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 71410.731668,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 57.52186108000006,
+        "max": 166.672508,
+        "avg": 33.240430178094755,
+        "min": 19.304873,
+        "med": 31.516755,
+        "p(90)": 43.0701526,
+        "p(95)": 47.94417220000001
+      }
+    },
+    "http_req_duration{type:detail}": {
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 33.178997361418006,
+        "min": 19.304873,
+        "med": 31.512124999999997,
+        "p(90)": 43.042469800000006,
+        "p(95)": 47.796455749999964,
+        "p(99)": 57.25942112999999,
+        "max": 81.532685
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 753894,
+        "rate": 10557.15271907554
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 3712424,
+        "rate": 51986.92007889875
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 3.7755630400000038,
+        "max": 11.899938,
+        "avg": 0.09455936539346525
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "value": 3,
+        "min": 3,
+        "max": 50
+      },
+      "type": "gauge"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2173
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 1959.6907922,
+        "p(99)": 2018.8154212000002,
+        "max": 2059.197724,
+        "avg": 1283.9459982494257,
+        "min": 170.94645,
+        "med": 1292.740522,
+        "p(90)": 1884.2801198
+      }
+    },
+    "http_req_duration": {
+      "contains": "time",
+      "values": {
+        "avg": 33.240430178094755,
+        "min": 19.304873,
+        "med": 31.516755,
+        "p(90)": 43.0701526,
+        "p(95)": 47.94417220000001,
+        "p(99)": 57.52186108000006,
+        "max": 166.672508
+      },
+      "type": "trend"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2173,
+        "rate": 30.42959999489471
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.00651,
+        "p(90)": 0.010011,
+        "p(95)": 0.012331200000000025,
+        "p(99)": 3.9285616400000074,
+        "max": 12.097601,
+        "avg": 0.1054937031753334,
+        "min": 0.001822
+      }
+    },
+    "http_req_waiting": {
+      "values": {
+        "min": 18.693156,
+        "med": 30.999107,
+        "p(90)": 42.525378399999994,
+        "p(95)": 47.3553672,
+        "p(99)": 57.06758576000004,
+        "max": 164.519894,
+        "avg": 32.697216476760225
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.08617220000000005,
+        "p(99)": 0.16051776000000015,
+        "max": 0.700202,
+        "avg": 0.04177259687068577,
+        "min": 0.008744,
+        "med": 0.037607,
+        "p(90)": 0.0671518
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 6516,
+        "fails": 0
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.5014411044638746,
+        "min": 0.035592,
+        "med": 0.459379,
+        "p(90)": 0.8378988,
+        "p(95)": 0.9914686000000001,
+        "p(99)": 1.564162280000004,
+        "max": 10.424534
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 2172,
+        "rate": 30.41559649742812
+      },
+      "type": "counter",
+      "contains": "default"
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MTYzNiwiZXhwIjoxNzgxODQ1MjM2fQ.M_azq9PnLKuyPnMGp9Wt7vscUuUN07Mrbh447KkoLug"
+  }
+}

--- a/monitoring/k6/results/admin-alert-detail-course-before-summary.md
+++ b/monitoring/k6/results/admin-alert-detail-course-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - admin-alert-detail-course-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2173 |
+| iterations | 2172 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 3712424 |
+| data_sent bytes | 753894 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 33.24 | 19.30 | 31.52 | 43.07 | 47.94 | 57.52 | 166.67 |
+| http_req_waiting | 32.70 | 18.69 | 31.00 | 42.53 | 47.36 | 57.07 | 164.52 |
+| http_req_blocked | 0.11 | 0.00 | 0.01 | 0.01 | 0.01 | 3.93 | 12.10 |
+| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.78 | 11.90 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2172 pass / 0 fail |
+| data exists | 2172 pass / 0 fail |
+| has target detail | 2172 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/admin-alert-detail-problem-before-summary.json
+++ b/monitoring/k6/results/admin-alert-detail-problem-before-summary.json
@@ -6,24 +6,24 @@
     "groups": [],
     "checks": [
         {
-          "fails": 0,
           "name": "status is 200",
           "path": "::status is 200",
           "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
-          "passes": 2176
+          "passes": 2214,
+          "fails": 0
         },
         {
           "name": "data exists",
           "path": "::data exists",
           "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
-          "passes": 2176,
+          "passes": 2214,
           "fails": 0
         },
         {
           "name": "has target detail",
           "path": "::has target detail",
           "id": "bf66eafe5d6983c70e58071498d09af9",
-          "passes": 2176,
+          "passes": 2214,
           "fails": 0
         }
       ]
@@ -44,164 +44,15 @@
   "state": {
     "isStdOutTTY": true,
     "isStdErrTTY": true,
-    "testRunDurationMs": 71558.318313
+    "testRunDurationMs": 71098.084769
   },
   "metrics": {
-    "http_req_blocked": {
-      "contains": "time",
-      "values": {
-        "min": 0.002614,
-        "med": 0.006645,
-        "p(90)": 0.0104492,
-        "p(95)": 0.01589079999999999,
-        "p(99)": 3.87714312,
-        "max": 11.059619,
-        "avg": 0.10700647496554919
-      },
-      "type": "trend"
-    },
-    "http_req_failed": {
-      "type": "rate",
-      "contains": "default",
-      "values": {
-        "rate": 0,
-        "passes": 0,
-        "fails": 2177
-      },
-      "thresholds": {
-        "rate<0.01": {
-          "ok": true
-        }
-      }
-    },
-    "http_reqs": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "count": 2177,
-        "rate": 30.42273842263429
-      }
-    },
-    "vus": {
-      "type": "gauge",
-      "contains": "default",
-      "values": {
-        "max": 50,
-        "value": 1,
-        "min": 1
-      }
-    },
-    "checks": {
-      "values": {
-        "rate": 1,
-        "passes": 6528,
-        "fails": 0
-      },
-      "type": "rate",
-      "contains": "default"
-    },
-    "http_req_duration{expected_response:true}": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(95)": 45.882482399999994,
-        "p(99)": 56.496362599999635,
-        "max": 122.205736,
-        "avg": 31.14351366559487,
-        "min": 19.002906,
-        "med": 29.36513,
-        "p(90)": 40.284265600000005
-      }
-    },
-    "http_req_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(99)": 56.496362599999635,
-        "max": 122.205736,
-        "avg": 31.14351366559487,
-        "min": 19.002906,
-        "med": 29.36513,
-        "p(90)": 40.284265600000005,
-        "p(95)": 45.882482399999994
-      }
-    },
-    "http_req_connecting": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 0.09505708589802478,
-        "min": 0,
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 3.672472679999999,
-        "max": 10.789879
-      }
-    },
-    "http_req_tls_handshaking": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 0,
-        "avg": 0,
-        "min": 0,
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 0
-      }
-    },
     "data_sent": {
       "type": "counter",
       "contains": "data",
       "values": {
-        "count": 755282,
-        "rate": 10554.775710300446
-      }
-    },
-    "iteration_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 1282.3251967234758,
-        "min": 127.900027,
-        "med": 1286.772974,
-        "p(90)": 1886.046686,
-        "p(95)": 1962.1049546,
-        "p(99)": 2016.8575206799999,
-        "max": 2056.391771
-      }
-    },
-    "http_req_receiving": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 10.659769,
-        "avg": 0.5021250509875972,
-        "min": 0.046477,
-        "med": 0.468355,
-        "p(90)": 0.8615504,
-        "p(95)": 1.0390818,
-        "p(99)": 1.5273860799999939
-      }
-    },
-    "http_req_duration{type:detail}": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 31.101665217830902,
-        "min": 19.002906,
-        "med": 29.362388000000003,
-        "p(90)": 40.264502,
-        "p(95)": 45.864600249999995,
-        "p(99)": 55.991663,
-        "max": 75.286031
-      },
-      "thresholds": {
-        "p(95)<500": {
-          "ok": true
-        }
+        "count": 772896,
+        "rate": 10870.841352635087
       }
     },
     "vus_max": {
@@ -213,50 +64,199 @@
         "max": 50
       }
     },
-    "http_req_sending": {
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 0,
+        "rate": 1,
+        "passes": 6642
+      }
+    },
+    "http_req_blocked": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "med": 0.03935,
-        "p(90)": 0.06892980000000001,
-        "p(95)": 0.08796119999999999,
-        "p(99)": 0.17084443999999838,
-        "max": 0.45636,
-        "avg": 0.0433485631603123,
-        "min": 0.007758
+        "p(99)": 2.477560040000001,
+        "max": 3.631105,
+        "avg": 0.06196401264108331,
+        "min": 0.002064,
+        "med": 0.004839,
+        "p(90)": 0.006539800000000003,
+        "p(95)": 0.008477699999999993
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 10.757719,
+        "avg": 0.29837380722347595,
+        "min": 0.028019,
+        "med": 0.259806,
+        "p(90)": 0.4820746,
+        "p(95)": 0.5482033999999999,
+        "p(99)": 0.7582568400000007
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0
       }
     },
     "http_req_waiting": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "avg": 30.598040051446922,
-        "min": 18.741643,
-        "med": 28.847564,
-        "p(90)": 39.7496298,
-        "p(95)": 45.26417299999999,
-        "p(99)": 55.868395919999855,
-        "max": 121.35215
+        "max": 106.065372,
+        "avg": 12.0101776609481,
+        "min": 6.990093,
+        "med": 11.595743,
+        "p(90)": 14.922840800000003,
+        "p(95)": 16.271193199999992,
+        "p(99)": 21.13663344000001
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2214,
+        "rate": 31.14007933115721
+      }
+    },
+    "http_req_connecting": {
+      "values": {
+        "p(99)": 2.3937829800000014,
+        "max": 3.124703,
+        "avg": 0.05432300902934538,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2215
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 50
+      }
+    },
+    "http_req_duration": {
+      "values": {
+        "p(99)": 21.786007440000006,
+        "max": 106.470679,
+        "avg": 12.334981390067707,
+        "min": 7.12431,
+        "med": 11.906226,
+        "p(90)": 15.3560434,
+        "p(95)": 16.708307499999993
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2215,
+        "rate": 31.154144407639215
       }
     },
     "data_received": {
-      "values": {
-        "count": 3721454,
-        "rate": 52005.889569989005
-      },
       "type": "counter",
-      "contains": "data"
+      "contains": "data",
+      "values": {
+        "count": 3786423,
+        "rate": 53256.32908821964
+      }
     },
-    "iterations": {
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
       "values": {
-        "count": 2176,
-        "rate": 30.408763806914198
+        "max": 106.470679,
+        "avg": 12.334981390067707,
+        "min": 7.12431,
+        "med": 11.906226,
+        "p(90)": 15.3560434,
+        "p(95)": 16.708307499999993,
+        "p(99)": 21.786007440000006
       },
-      "type": "counter",
-      "contains": "default"
+      "type": "trend"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.026319,
+        "p(90)": 0.0383652,
+        "p(95)": 0.04917549999999994,
+        "p(99)": 0.0854954200000002,
+        "max": 0.534779,
+        "avg": 0.02642992189616254,
+        "min": 0.006156
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 1856.5400786,
+        "p(95)": 1944.3541997999996,
+        "p(99)": 2000.5246344000002,
+        "max": 2014.920411,
+        "avg": 1259.919535891197,
+        "min": 110.816148,
+        "med": 1260.299801
+      }
+    },
+    "http_req_duration{type:detail}": {
+      "values": {
+        "avg": 12.292463008130069,
+        "min": 7.12431,
+        "med": 11.906190500000001,
+        "p(90)": 15.351289600000001,
+        "p(95)": 16.675310949999997,
+        "p(99)": 21.752154309999998,
+        "max": 33.496342
+      },
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time"
     }
   },
   "setup_data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MTg4MSwiZXhwIjoxNzgxODQ1NDgxfQ.M6D6p50aLTVUnvo9sTn4RoPtKcB7b_x0saDmJ0Ho41w"
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjIiLCJ0eXAiOiJhY2Nlc3MiLCJuaWNrbmFtZSI6ImxvYWR0ZXN0LWFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNzgxOTY2MTYzLCJleHAiOjE3ODE5Njk3NjN9.V33lPSQixNBQPdItR3xD4VLYGDLzwsoBPXbcNFrKyQQ"
   }
 }

--- a/monitoring/k6/results/admin-alert-detail-problem-before-summary.json
+++ b/monitoring/k6/results/admin-alert-detail-problem-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2176
+        },
+        {
+          "name": "data exists",
+          "path": "::data exists",
+          "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
+          "passes": 2176,
+          "fails": 0
+        },
+        {
+          "name": "has target detail",
+          "path": "::has target detail",
+          "id": "bf66eafe5d6983c70e58071498d09af9",
+          "passes": 2176,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71558.318313
+  },
+  "metrics": {
+    "http_req_blocked": {
+      "contains": "time",
+      "values": {
+        "min": 0.002614,
+        "med": 0.006645,
+        "p(90)": 0.0104492,
+        "p(95)": 0.01589079999999999,
+        "p(99)": 3.87714312,
+        "max": 11.059619,
+        "avg": 0.10700647496554919
+      },
+      "type": "trend"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2177
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2177,
+        "rate": 30.42273842263429
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 50,
+        "value": 1,
+        "min": 1
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 6528,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 45.882482399999994,
+        "p(99)": 56.496362599999635,
+        "max": 122.205736,
+        "avg": 31.14351366559487,
+        "min": 19.002906,
+        "med": 29.36513,
+        "p(90)": 40.284265600000005
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 56.496362599999635,
+        "max": 122.205736,
+        "avg": 31.14351366559487,
+        "min": 19.002906,
+        "med": 29.36513,
+        "p(90)": 40.284265600000005,
+        "p(95)": 45.882482399999994
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.09505708589802478,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 3.672472679999999,
+        "max": 10.789879
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 755282,
+        "rate": 10554.775710300446
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1282.3251967234758,
+        "min": 127.900027,
+        "med": 1286.772974,
+        "p(90)": 1886.046686,
+        "p(95)": 1962.1049546,
+        "p(99)": 2016.8575206799999,
+        "max": 2056.391771
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 10.659769,
+        "avg": 0.5021250509875972,
+        "min": 0.046477,
+        "med": 0.468355,
+        "p(90)": 0.8615504,
+        "p(95)": 1.0390818,
+        "p(99)": 1.5273860799999939
+      }
+    },
+    "http_req_duration{type:detail}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 31.101665217830902,
+        "min": 19.002906,
+        "med": 29.362388000000003,
+        "p(90)": 40.264502,
+        "p(95)": 45.864600249999995,
+        "p(99)": 55.991663,
+        "max": 75.286031
+      },
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.03935,
+        "p(90)": 0.06892980000000001,
+        "p(95)": 0.08796119999999999,
+        "p(99)": 0.17084443999999838,
+        "max": 0.45636,
+        "avg": 0.0433485631603123,
+        "min": 0.007758
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 30.598040051446922,
+        "min": 18.741643,
+        "med": 28.847564,
+        "p(90)": 39.7496298,
+        "p(95)": 45.26417299999999,
+        "p(99)": 55.868395919999855,
+        "max": 121.35215
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 3721454,
+        "rate": 52005.889569989005
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "iterations": {
+      "values": {
+        "count": 2176,
+        "rate": 30.408763806914198
+      },
+      "type": "counter",
+      "contains": "default"
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MTg4MSwiZXhwIjoxNzgxODQ1NDgxfQ.M6D6p50aLTVUnvo9sTn4RoPtKcB7b_x0saDmJ0Ho41w"
+  }
+}

--- a/monitoring/k6/results/admin-alert-detail-problem-before-summary.md
+++ b/monitoring/k6/results/admin-alert-detail-problem-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - admin-alert-detail-problem-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2177 |
+| iterations | 2176 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 3721454 |
+| data_sent bytes | 755282 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 31.14 | 19.00 | 29.37 | 40.28 | 45.88 | 56.50 | 122.21 |
+| http_req_waiting | 30.60 | 18.74 | 28.85 | 39.75 | 45.26 | 55.87 | 121.35 |
+| http_req_blocked | 0.11 | 0.00 | 0.01 | 0.01 | 0.02 | 3.88 | 11.06 |
+| http_req_connecting | 0.10 | 0 | 0 | 0 | 0 | 3.67 | 10.79 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2176 pass / 0 fail |
+| data exists | 2176 pass / 0 fail |
+| has target detail | 2176 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/admin-alert-detail-problem-before-summary.md
+++ b/monitoring/k6/results/admin-alert-detail-problem-before-summary.md
@@ -4,21 +4,21 @@
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 2177 |
-| iterations | 2176 |
+| http_reqs | 2215 |
+| iterations | 2214 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 3721454 |
-| data_sent bytes | 755282 |
+| data_received bytes | 3786423 |
+| data_sent bytes | 772896 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 31.14 | 19.00 | 29.37 | 40.28 | 45.88 | 56.50 | 122.21 |
-| http_req_waiting | 30.60 | 18.74 | 28.85 | 39.75 | 45.26 | 55.87 | 121.35 |
-| http_req_blocked | 0.11 | 0.00 | 0.01 | 0.01 | 0.02 | 3.88 | 11.06 |
-| http_req_connecting | 0.10 | 0 | 0 | 0 | 0 | 3.67 | 10.79 |
+| http_req_duration | 12.33 | 7.12 | 11.91 | 15.36 | 16.71 | 21.79 | 106.47 |
+| http_req_waiting | 12.01 | 6.99 | 11.60 | 14.92 | 16.27 | 21.14 | 106.07 |
+| http_req_blocked | 0.06 | 0.00 | 0.00 | 0.01 | 0.01 | 2.48 | 3.63 |
+| http_req_connecting | 0.05 | 0 | 0 | 0 | 0 | 2.39 | 3.12 |
 
 ## Metric Meaning
 
@@ -36,9 +36,9 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 2176 pass / 0 fail |
-| data exists | 2176 pass / 0 fail |
-| has target detail | 2176 pass / 0 fail |
+| status is 200 | 2214 pass / 0 fail |
+| data exists | 2214 pass / 0 fail |
+| has target detail | 2214 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/results/admin-alert-detail-user-before-summary.json
+++ b/monitoring/k6/results/admin-alert-detail-user-before-summary.json
@@ -1,32 +1,245 @@
 {
+  "metrics": {
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2232
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "max": 50,
+        "value": 4,
+        "min": 3
+      },
+      "type": "gauge"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 778829,
+        "rate": 11033.36410348729
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.006922000000000004,
+        "p(95)": 0.014688599999999963,
+        "p(99)": 2.46334313,
+        "max": 3.311143,
+        "avg": 0.06186744399641597,
+        "min": 0.001537,
+        "med": 0.004709
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0.711237,
+        "avg": 0.028482013440860238,
+        "min": 0.005631,
+        "med": 0.026606,
+        "p(90)": 0.04106630000000001,
+        "p(95)": 0.05254409999999999,
+        "p(99)": 0.12466287000000002
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 20.750407810000006,
+        "max": 82.869127,
+        "avg": 10.99705713844087,
+        "min": 6.796744,
+        "med": 10.5595815,
+        "p(90)": 13.3820245,
+        "p(95)": 14.618013149999998
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 10.99705713844087,
+        "min": 6.796744,
+        "med": 10.5595815,
+        "p(90)": 13.3820245,
+        "p(95)": 14.618013149999998,
+        "p(99)": 20.750407810000006,
+        "max": 82.869127
+      }
+    },
+    "checks": {
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 6693,
+        "fails": 0
+      },
+      "type": "rate"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 1928.4586685999998,
+        "p(99)": 1998.07238022,
+        "max": 2012.487049,
+        "avg": 1249.905421748212,
+        "min": 86.464563,
+        "med": 1229.6326159999999,
+        "p(90)": 1863.2179167000002
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.27650186648745506,
+        "min": 0.02827,
+        "med": 0.248936,
+        "p(90)": 0.47664,
+        "p(95)": 0.5526795499999996,
+        "p(99)": 0.8001317500000004,
+        "max": 9.024001
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "count": 2232,
+        "rate": 31.6198660796961
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_waiting": {
+      "contains": "time",
+      "values": {
+        "med": 10.298893,
+        "p(90)": 13.0113239,
+        "p(95)": 14.187148399999998,
+        "p(99)": 19.957294070000003,
+        "max": 82.42516,
+        "avg": 10.69207325851254,
+        "min": 6.521037
+      },
+      "type": "trend"
+    },
+    "http_req_duration{type:detail}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 10.964841956969975,
+        "min": 6.796744,
+        "med": 10.559239,
+        "p(90)": 13.379743,
+        "p(95)": 14.61153,
+        "p(99)": 20.604444699999956,
+        "max": 44.938141
+      },
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 50,
+        "value": 50,
+        "min": 50
+      }
+    },
+    "iterations": {
+      "values": {
+        "rate": 31.605699473029567,
+        "count": 2231
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 3677210,
+        "rate": 52093.58770023265
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 2.38693908,
+        "max": 3.11994,
+        "avg": 0.05320491218637992,
+        "min": 0
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjIiLCJ0eXAiOiJhY2Nlc3MiLCJuaWNrbmFtZSI6ImxvYWR0ZXN0LWFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNzgxOTY2MDc4LCJleHAiOjE3ODE5Njk2Nzh9.S6q6D178FjTfyNYK1IJSGkwmdzTC30ELqEVgRnHC7SM"
+  },
   "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
     "groups": [],
     "checks": [
         {
           "name": "status is 200",
           "path": "::status is 200",
           "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
-          "passes": 2177,
+          "passes": 2231,
           "fails": 0
         },
         {
+          "fails": 0,
           "name": "data exists",
           "path": "::data exists",
           "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
-          "passes": 2177,
-          "fails": 0
+          "passes": 2231
         },
         {
           "fails": 0,
           "name": "has target detail",
           "path": "::has target detail",
           "id": "bf66eafe5d6983c70e58071498d09af9",
-          "passes": 2177
+          "passes": 2231
         }
       ],
-    "name": "",
-    "path": "",
-    "id": "d41d8cd98f00b204e9800998ecf8427e"
+    "name": ""
   },
   "options": {
     "summaryTrendStats": [
@@ -44,219 +257,6 @@
   "state": {
     "isStdOutTTY": true,
     "isStdErrTTY": true,
-    "testRunDurationMs": 70821.177626
-  },
-  "metrics": {
-    "http_req_failed": {
-      "contains": "default",
-      "values": {
-        "fails": 2178,
-        "rate": 0,
-        "passes": 0
-      },
-      "thresholds": {
-        "rate<0.01": {
-          "ok": true
-        }
-      },
-      "type": "rate"
-    },
-    "http_req_blocked": {
-      "values": {
-        "med": 0.00689,
-        "p(90)": 0.011840699999999997,
-        "p(95)": 0.024882050000000006,
-        "p(99)": 3.7302835400000003,
-        "max": 15.042131,
-        "avg": 0.10496942561983494,
-        "min": 0.002154
-      },
-      "type": "trend",
-      "contains": "time"
-    },
-    "http_req_duration{type:detail}": {
-      "contains": "time",
-      "values": {
-        "avg": 30.02115681993574,
-        "min": 16.560442,
-        "med": 28.040877,
-        "p(90)": 39.4099692,
-        "p(95)": 44.71097759999998,
-        "p(99)": 57.85544347999996,
-        "max": 94.058745
-      },
-      "thresholds": {
-        "p(95)<500": {
-          "ok": true
-        }
-      },
-      "type": "trend"
-    },
-    "http_reqs": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "count": 2178,
-        "rate": 30.753512904032945
-      }
-    },
-    "http_req_tls_handshaking": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 0,
-        "max": 0,
-        "avg": 0,
-        "min": 0
-      }
-    },
-    "vus": {
-      "contains": "default",
-      "values": {
-        "value": 5,
-        "min": 3,
-        "max": 50
-      },
-      "type": "gauge"
-    },
-    "vus_max": {
-      "contains": "default",
-      "values": {
-        "value": 50,
-        "min": 50,
-        "max": 50
-      },
-      "type": "gauge"
-    },
-    "http_req_sending": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(95)": 0.09440940000000003,
-        "p(99)": 0.21128106000000005,
-        "max": 8.073166,
-        "avg": 0.05015348025711662,
-        "min": 0.009175,
-        "med": 0.0400615,
-        "p(90)": 0.0706545
-      }
-    },
-    "http_req_duration{expected_response:true}": {
-      "contains": "time",
-      "values": {
-        "min": 16.560442,
-        "med": 28.043523,
-        "p(90)": 39.430869,
-        "p(95)": 44.84193950000003,
-        "p(99)": 58.042103690000005,
-        "max": 139.597564,
-        "avg": 30.071467383379304
-      },
-      "type": "trend"
-    },
-    "http_req_waiting": {
-      "values": {
-        "p(90)": 38.717115299999996,
-        "p(95)": 44.228947100000006,
-        "p(99)": 57.14263357,
-        "max": 138.517285,
-        "avg": 29.50406322176309,
-        "min": 16.257887,
-        "med": 27.4908795
-      },
-      "type": "trend",
-      "contains": "time"
-    },
-    "iteration_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(90)": 1881.7115073,
-        "p(95)": 1961.9069433500001,
-        "p(99)": 2017.48946977,
-        "max": 2041.110717,
-        "avg": 1282.3351590619868,
-        "min": 145.810994,
-        "med": 1274.249543
-      }
-    },
-    "http_req_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(90)": 39.430869,
-        "p(95)": 44.84193950000003,
-        "p(99)": 58.042103690000005,
-        "max": 139.597564,
-        "avg": 30.071467383379304,
-        "min": 16.560442,
-        "med": 28.043523
-      }
-    },
-    "data_received": {
-      "contains": "data",
-      "values": {
-        "count": 3583809,
-        "rate": 50603.63467726786
-      },
-      "type": "counter"
-    },
-    "http_req_receiving": {
-      "contains": "time",
-      "values": {
-        "max": 11.451045,
-        "avg": 0.5172506813590446,
-        "min": 0.031138,
-        "med": 0.46328,
-        "p(90)": 0.8677155999999999,
-        "p(95)": 1.0657828500000002,
-        "p(99)": 1.7060350800000004
-      },
-      "type": "trend"
-    },
-    "data_sent": {
-      "contains": "data",
-      "values": {
-        "count": 755629,
-        "rate": 10669.534528081502
-      },
-      "type": "counter"
-    },
-    "checks": {
-      "type": "rate",
-      "contains": "default",
-      "values": {
-        "passes": 6531,
-        "fails": 0,
-        "rate": 1
-      }
-    },
-    "iterations": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "count": 2177,
-        "rate": 30.739392833829072
-      }
-    },
-    "http_req_connecting": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 0.0870431331496786,
-        "min": 0,
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 3.4293433500000017,
-        "max": 10.813601
-      }
-    }
-  },
-  "setup_data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MTc4MiwiZXhwIjoxNzgxODQ1MzgyfQ.OO6cPUM9gm-PJXWs0Y7pRCVVbyuoW74Y-OKmzlFAQlY"
+    "testRunDurationMs": 70588.534258
   }
 }

--- a/monitoring/k6/results/admin-alert-detail-user-before-summary.json
+++ b/monitoring/k6/results/admin-alert-detail-user-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2177,
+          "fails": 0
+        },
+        {
+          "name": "data exists",
+          "path": "::data exists",
+          "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
+          "passes": 2177,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "has target detail",
+          "path": "::has target detail",
+          "id": "bf66eafe5d6983c70e58071498d09af9",
+          "passes": 2177
+        }
+      ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 70821.177626
+  },
+  "metrics": {
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "fails": 2178,
+        "rate": 0,
+        "passes": 0
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "http_req_blocked": {
+      "values": {
+        "med": 0.00689,
+        "p(90)": 0.011840699999999997,
+        "p(95)": 0.024882050000000006,
+        "p(99)": 3.7302835400000003,
+        "max": 15.042131,
+        "avg": 0.10496942561983494,
+        "min": 0.002154
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{type:detail}": {
+      "contains": "time",
+      "values": {
+        "avg": 30.02115681993574,
+        "min": 16.560442,
+        "med": 28.040877,
+        "p(90)": 39.4099692,
+        "p(95)": 44.71097759999998,
+        "p(99)": 57.85544347999996,
+        "max": 94.058745
+      },
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
+      },
+      "type": "trend"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2178,
+        "rate": 30.753512904032945
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "value": 5,
+        "min": 3,
+        "max": 50
+      },
+      "type": "gauge"
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      },
+      "type": "gauge"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.09440940000000003,
+        "p(99)": 0.21128106000000005,
+        "max": 8.073166,
+        "avg": 0.05015348025711662,
+        "min": 0.009175,
+        "med": 0.0400615,
+        "p(90)": 0.0706545
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "min": 16.560442,
+        "med": 28.043523,
+        "p(90)": 39.430869,
+        "p(95)": 44.84193950000003,
+        "p(99)": 58.042103690000005,
+        "max": 139.597564,
+        "avg": 30.071467383379304
+      },
+      "type": "trend"
+    },
+    "http_req_waiting": {
+      "values": {
+        "p(90)": 38.717115299999996,
+        "p(95)": 44.228947100000006,
+        "p(99)": 57.14263357,
+        "max": 138.517285,
+        "avg": 29.50406322176309,
+        "min": 16.257887,
+        "med": 27.4908795
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 1881.7115073,
+        "p(95)": 1961.9069433500001,
+        "p(99)": 2017.48946977,
+        "max": 2041.110717,
+        "avg": 1282.3351590619868,
+        "min": 145.810994,
+        "med": 1274.249543
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 39.430869,
+        "p(95)": 44.84193950000003,
+        "p(99)": 58.042103690000005,
+        "max": 139.597564,
+        "avg": 30.071467383379304,
+        "min": 16.560442,
+        "med": 28.043523
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 3583809,
+        "rate": 50603.63467726786
+      },
+      "type": "counter"
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "max": 11.451045,
+        "avg": 0.5172506813590446,
+        "min": 0.031138,
+        "med": 0.46328,
+        "p(90)": 0.8677155999999999,
+        "p(95)": 1.0657828500000002,
+        "p(99)": 1.7060350800000004
+      },
+      "type": "trend"
+    },
+    "data_sent": {
+      "contains": "data",
+      "values": {
+        "count": 755629,
+        "rate": 10669.534528081502
+      },
+      "type": "counter"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 6531,
+        "fails": 0,
+        "rate": 1
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2177,
+        "rate": 30.739392833829072
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.0870431331496786,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 3.4293433500000017,
+        "max": 10.813601
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MTc4MiwiZXhwIjoxNzgxODQ1MzgyfQ.OO6cPUM9gm-PJXWs0Y7pRCVVbyuoW74Y-OKmzlFAQlY"
+  }
+}

--- a/monitoring/k6/results/admin-alert-detail-user-before-summary.md
+++ b/monitoring/k6/results/admin-alert-detail-user-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - admin-alert-detail-user-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2178 |
+| iterations | 2177 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 3583809 |
+| data_sent bytes | 755629 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 30.07 | 16.56 | 28.04 | 39.43 | 44.84 | 58.04 | 139.60 |
+| http_req_waiting | 29.50 | 16.26 | 27.49 | 38.72 | 44.23 | 57.14 | 138.52 |
+| http_req_blocked | 0.10 | 0.00 | 0.01 | 0.01 | 0.02 | 3.73 | 15.04 |
+| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.43 | 10.81 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2177 pass / 0 fail |
+| data exists | 2177 pass / 0 fail |
+| has target detail | 2177 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/admin-alert-detail-user-before-summary.md
+++ b/monitoring/k6/results/admin-alert-detail-user-before-summary.md
@@ -4,21 +4,21 @@
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 2178 |
-| iterations | 2177 |
+| http_reqs | 2232 |
+| iterations | 2231 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 3583809 |
-| data_sent bytes | 755629 |
+| data_received bytes | 3677210 |
+| data_sent bytes | 778829 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 30.07 | 16.56 | 28.04 | 39.43 | 44.84 | 58.04 | 139.60 |
-| http_req_waiting | 29.50 | 16.26 | 27.49 | 38.72 | 44.23 | 57.14 | 138.52 |
-| http_req_blocked | 0.10 | 0.00 | 0.01 | 0.01 | 0.02 | 3.73 | 15.04 |
-| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.43 | 10.81 |
+| http_req_duration | 11.00 | 6.80 | 10.56 | 13.38 | 14.62 | 20.75 | 82.87 |
+| http_req_waiting | 10.69 | 6.52 | 10.30 | 13.01 | 14.19 | 19.96 | 82.43 |
+| http_req_blocked | 0.06 | 0.00 | 0.00 | 0.01 | 0.01 | 2.46 | 3.31 |
+| http_req_connecting | 0.05 | 0 | 0 | 0 | 0 | 2.39 | 3.12 |
 
 ## Metric Meaning
 
@@ -36,9 +36,9 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 2177 pass / 0 fail |
-| data exists | 2177 pass / 0 fail |
-| has target detail | 2177 pass / 0 fail |
+| status is 200 | 2231 pass / 0 fail |
+| data exists | 2231 pass / 0 fail |
+| has target detail | 2231 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/results/admin-alert-list-before-summary.json
+++ b/monitoring/k6/results/admin-alert-list-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 70999.718242,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "http_reqs": {
+      "values": {
+        "count": 2182,
+        "rate": 30.732516325807534
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.046259,
+        "med": 0.49013249999999997,
+        "p(90)": 0.9010518,
+        "p(95)": 1.099459349999999,
+        "p(99)": 1.9384690000000004,
+        "max": 11.869143,
+        "avg": 0.5586121640696604
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 785370,
+        "rate": 11061.59319285035
+      }
+    },
+    "vus": {
+      "values": {
+        "min": 1,
+        "max": 50,
+        "value": 1
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 50,
+        "max": 50,
+        "value": 50
+      }
+    },
+    "http_req_duration{type:list}": {
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 38.052481,
+        "p(95)": 43.588441,
+        "p(99)": 64.48987079999976,
+        "max": 124.848929,
+        "avg": 29.054291370013775,
+        "min": 16.517339,
+        "med": 26.883698
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 2181,
+        "rate": 30.718431762871784
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 3.572085370000002,
+        "max": 14.047285,
+        "avg": 0.1042479560036663,
+        "min": 0.001737,
+        "med": 0.0065595,
+        "p(90)": 0.010085000000000002,
+        "p(95)": 0.013182349999999987
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 79383.08967352929,
+        "count": 5636177
+      }
+    },
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 2182,
+        "rate": 0
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 3.461473010000001,
+        "max": 13.966892,
+        "avg": 0.09373649129239232,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 26.8847335,
+        "p(90)": 38.060896,
+        "p(95)": 43.6239254,
+        "p(99)": 65.56128497,
+        "max": 124.848929,
+        "avg": 29.095622054078845,
+        "min": 16.517339
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 6543,
+        "fails": 0
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "values": {
+        "avg": 29.095622054078845,
+        "min": 16.517339,
+        "med": 26.8847335,
+        "p(90)": 38.060896,
+        "p(95)": 43.6239254,
+        "p(99)": 65.56128497,
+        "max": 124.848929
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 28.494311365719547,
+        "min": 15.992625,
+        "med": 26.249481000000003,
+        "p(90)": 37.4792902,
+        "p(95)": 42.903957899999995,
+        "p(99)": 64.99314838000001,
+        "max": 124.705449
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1280.368974859759,
+        "min": 122.876147,
+        "med": 1281.041909,
+        "p(90)": 1882.7710287,
+        "p(95)": 1964.0008665999994,
+        "p(99)": 2012.57889943,
+        "max": 2038.774998
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.04269852428964244,
+        "min": 0.008852,
+        "med": 0.0388315,
+        "p(90)": 0.0700062,
+        "p(95)": 0.09070489999999999,
+        "p(99)": 0.14704106000000003,
+        "max": 0.541275
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MjE2NiwiZXhwIjoxNzgxODQ1NzY2fQ.zJR1XN8HmFuWG2rT_UgPkoXM74S5lYbGFwlu3uGF5UY"
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 2181,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
+        },
+        {
+          "name": "content is array",
+          "path": "::content is array",
+          "id": "3f37adde3b588bfb6e6de2b030acb282",
+          "passes": 2181,
+          "fails": 0
+        },
+        {
+          "name": "has alert seed",
+          "path": "::has alert seed",
+          "id": "130369eec5949ef701c7c15295167010",
+          "passes": 2181,
+          "fails": 0
+        }
+      ]
+  }
+}

--- a/monitoring/k6/results/admin-alert-list-before-summary.json
+++ b/monitoring/k6/results/admin-alert-list-before-summary.json
@@ -1,4 +1,33 @@
 {
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2210,
+          "fails": 0
+        },
+        {
+          "path": "::content is array",
+          "id": "3f37adde3b588bfb6e6de2b030acb282",
+          "passes": 2210,
+          "fails": 0,
+          "name": "content is array"
+        },
+        {
+          "name": "has alert seed",
+          "path": "::has alert seed",
+          "id": "130369eec5949ef701c7c15295167010",
+          "passes": 2210,
+          "fails": 0
+        }
+      ]
+  },
   "options": {
     "summaryTrendStats": [
       "avg",
@@ -13,49 +42,11 @@
     "noColor": false
   },
   "state": {
-    "testRunDurationMs": 70999.718242,
     "isStdOutTTY": true,
-    "isStdErrTTY": true
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71981.773552
   },
   "metrics": {
-    "http_reqs": {
-      "values": {
-        "count": 2182,
-        "rate": 30.732516325807534
-      },
-      "type": "counter",
-      "contains": "default"
-    },
-    "http_req_receiving": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "min": 0.046259,
-        "med": 0.49013249999999997,
-        "p(90)": 0.9010518,
-        "p(95)": 1.099459349999999,
-        "p(99)": 1.9384690000000004,
-        "max": 11.869143,
-        "avg": 0.5586121640696604
-      }
-    },
-    "data_sent": {
-      "type": "counter",
-      "contains": "data",
-      "values": {
-        "count": 785370,
-        "rate": 11061.59319285035
-      }
-    },
-    "vus": {
-      "values": {
-        "min": 1,
-        "max": 50,
-        "value": 1
-      },
-      "type": "gauge",
-      "contains": "default"
-    },
     "vus_max": {
       "type": "gauge",
       "contains": "default",
@@ -65,91 +56,150 @@
         "value": 50
       }
     },
-    "http_req_duration{type:list}": {
-      "thresholds": {
-        "p(95)<800": {
-          "ok": true
-        }
-      },
-      "type": "trend",
-      "contains": "time",
+    "data_sent": {
+      "contains": "data",
       "values": {
-        "p(90)": 38.052481,
-        "p(95)": 43.588441,
-        "p(99)": 64.48987079999976,
-        "max": 124.848929,
-        "avg": 29.054291370013775,
-        "min": 16.517339,
-        "med": 26.883698
-      }
+        "count": 800230,
+        "rate": 11117.119800082583
+      },
+      "type": "counter"
     },
     "iterations": {
-      "values": {
-        "count": 2181,
-        "rate": 30.718431762871784
-      },
       "type": "counter",
-      "contains": "default"
-    },
-    "http_req_blocked": {
-      "type": "trend",
-      "contains": "time",
+      "contains": "default",
       "values": {
-        "p(99)": 3.572085370000002,
-        "max": 14.047285,
-        "avg": 0.1042479560036663,
-        "min": 0.001737,
-        "med": 0.0065595,
-        "p(90)": 0.010085000000000002,
-        "p(95)": 0.013182349999999987
+        "count": 2210,
+        "rate": 30.702216560466997
       }
     },
     "data_received": {
       "type": "counter",
       "contains": "data",
       "values": {
-        "rate": 79383.08967352929,
-        "count": 5636177
+        "count": 5711072,
+        "rate": 79340.52911150198
       }
     },
-    "http_req_failed": {
-      "contains": "default",
+    "http_req_receiving": {
+      "contains": "time",
       "values": {
-        "passes": 0,
-        "fails": 2182,
-        "rate": 0
+        "p(95)": 1.4713829999999999,
+        "p(99)": 2.878334300000027,
+        "max": 11.530529,
+        "avg": 0.6338865961103575,
+        "min": 0.035628,
+        "med": 0.524996,
+        "p(90)": 1.171677
       },
-      "thresholds": {
-        "rate<0.01": {
-          "ok": true
-        }
-      },
-      "type": "rate"
+      "type": "trend"
     },
-    "http_req_connecting": {
+    "iteration_duration": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "p(95)": 0,
-        "p(99)": 3.461473010000001,
-        "max": 13.966892,
-        "avg": 0.09373649129239232,
-        "min": 0,
-        "med": 0,
-        "p(90)": 0
+        "min": 178.546514,
+        "med": 1266.486718,
+        "p(90)": 1861.882029,
+        "p(95)": 1937.721206,
+        "p(99)": 2007.6397658,
+        "max": 2033.313273,
+        "avg": 1262.4845871117147
       }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 2,
+        "max": 50
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "values": {
+        "p(95)": 34.276652999999996,
+        "p(99)": 42.45940530000002,
+        "max": 167.577824,
+        "avg": 22.10890404748986,
+        "min": 11.566403,
+        "med": 20.533141,
+        "p(90)": 30.762653
+      },
+      "type": "trend",
+      "contains": "time"
     },
     "http_req_duration": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "med": 26.8847335,
-        "p(90)": 38.060896,
-        "p(95)": 43.6239254,
-        "p(99)": 65.56128497,
-        "max": 124.848929,
-        "avg": 29.095622054078845,
-        "min": 16.517339
+        "avg": 22.10890404748986,
+        "min": 11.566403,
+        "med": 20.533141,
+        "p(90)": 30.762653,
+        "p(95)": 34.276652999999996,
+        "p(99)": 42.45940530000002,
+        "max": 167.577824
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2211,
+        "rate": 30.71610896615047
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2211
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 5.173673000000001,
+        "max": 14.811302,
+        "avg": 0.12438993396653097
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 29.706187,
+        "p(95)": 33.1716895,
+        "p(99)": 41.4757585,
+        "max": 166.20974,
+        "avg": 21.43284021709628,
+        "min": 11.364328,
+        "med": 19.809776
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.007666,
+        "p(90)": 0.011027,
+        "p(95)": 0.016241,
+        "p(99)": 5.332330100000004,
+        "max": 14.98414,
+        "avg": 0.13891837630031656,
+        "min": 0.002909
       }
     },
     "checks": {
@@ -157,34 +207,26 @@
       "contains": "default",
       "values": {
         "rate": 1,
-        "passes": 6543,
+        "passes": 6630,
         "fails": 0
       }
     },
-    "http_req_duration{expected_response:true}": {
-      "values": {
-        "avg": 29.095622054078845,
-        "min": 16.517339,
-        "med": 26.8847335,
-        "p(90)": 38.060896,
-        "p(95)": 43.6239254,
-        "p(99)": 65.56128497,
-        "max": 124.848929
-      },
-      "type": "trend",
-      "contains": "time"
-    },
-    "http_req_waiting": {
+    "http_req_duration{type:list}": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "avg": 28.494311365719547,
-        "min": 15.992625,
-        "med": 26.249481000000003,
-        "p(90)": 37.4792902,
-        "p(95)": 42.903957899999995,
-        "p(99)": 64.99314838000001,
-        "max": 124.705449
+        "avg": 22.04308100678737,
+        "min": 11.566403,
+        "med": 20.5325165,
+        "p(90)": 30.748291700000003,
+        "p(95)": 34.16494244999996,
+        "p(99)": 42.25087592999998,
+        "max": 66.478292
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
       }
     },
     "http_req_tls_handshaking": {
@@ -200,63 +242,21 @@
         "max": 0
       }
     },
-    "iteration_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 1280.368974859759,
-        "min": 122.876147,
-        "med": 1281.041909,
-        "p(90)": 1882.7710287,
-        "p(95)": 1964.0008665999994,
-        "p(99)": 2012.57889943,
-        "max": 2038.774998
-      }
-    },
     "http_req_sending": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "avg": 0.04269852428964244,
-        "min": 0.008852,
-        "med": 0.0388315,
-        "p(90)": 0.0700062,
-        "p(95)": 0.09070489999999999,
-        "p(99)": 0.14704106000000003,
-        "max": 0.541275
+        "p(95)": 0.0947315,
+        "p(99)": 0.1526099,
+        "max": 0.506814,
+        "avg": 0.04217723428312982,
+        "min": 0.00948,
+        "med": 0.031994,
+        "p(90)": 0.072261
       }
     }
   },
   "setup_data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTg0MjE2NiwiZXhwIjoxNzgxODQ1NzY2fQ.zJR1XN8HmFuWG2rT_UgPkoXM74S5lYbGFwlu3uGF5UY"
-  },
-  "root_group": {
-    "name": "",
-    "path": "",
-    "id": "d41d8cd98f00b204e9800998ecf8427e",
-    "groups": [],
-    "checks": [
-        {
-          "passes": 2181,
-          "fails": 0,
-          "name": "status is 200",
-          "path": "::status is 200",
-          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
-        },
-        {
-          "name": "content is array",
-          "path": "::content is array",
-          "id": "3f37adde3b588bfb6e6de2b030acb282",
-          "passes": 2181,
-          "fails": 0
-        },
-        {
-          "name": "has alert seed",
-          "path": "::has alert seed",
-          "id": "130369eec5949ef701c7c15295167010",
-          "passes": 2181,
-          "fails": 0
-        }
-      ]
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjIiLCJ0eXAiOiJhY2Nlc3MiLCJuaWNrbmFtZSI6ImxvYWR0ZXN0LWFkbWluIiwicm9sZSI6IkFETUlOIiwiaWF0IjoxNzgxOTYxMjM5LCJleHAiOjE3ODE5NjQ4Mzl9.ip4ro55b33Syl3lbcGiUZz7lOt-2G70e2WGecGzQpmQ"
   }
 }

--- a/monitoring/k6/results/admin-alert-list-before-summary.md
+++ b/monitoring/k6/results/admin-alert-list-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - admin-alert-list-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2182 |
+| iterations | 2181 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 5636177 |
+| data_sent bytes | 785370 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 29.10 | 16.52 | 26.88 | 38.06 | 43.62 | 65.56 | 124.85 |
+| http_req_waiting | 28.49 | 15.99 | 26.25 | 37.48 | 42.90 | 64.99 | 124.71 |
+| http_req_blocked | 0.10 | 0.00 | 0.01 | 0.01 | 0.01 | 3.57 | 14.05 |
+| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.46 | 13.97 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2181 pass / 0 fail |
+| content is array | 2181 pass / 0 fail |
+| has alert seed | 2181 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/admin-alert-list-before-summary.md
+++ b/monitoring/k6/results/admin-alert-list-before-summary.md
@@ -4,21 +4,21 @@
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 2182 |
-| iterations | 2181 |
+| http_reqs | 2211 |
+| iterations | 2210 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 5636177 |
-| data_sent bytes | 785370 |
+| data_received bytes | 5711072 |
+| data_sent bytes | 800230 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 29.10 | 16.52 | 26.88 | 38.06 | 43.62 | 65.56 | 124.85 |
-| http_req_waiting | 28.49 | 15.99 | 26.25 | 37.48 | 42.90 | 64.99 | 124.71 |
-| http_req_blocked | 0.10 | 0.00 | 0.01 | 0.01 | 0.01 | 3.57 | 14.05 |
-| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.46 | 13.97 |
+| http_req_duration | 22.11 | 11.57 | 20.53 | 30.76 | 34.28 | 42.46 | 167.58 |
+| http_req_waiting | 21.43 | 11.36 | 19.81 | 29.71 | 33.17 | 41.48 | 166.21 |
+| http_req_blocked | 0.14 | 0.00 | 0.01 | 0.01 | 0.02 | 5.33 | 14.98 |
+| http_req_connecting | 0.12 | 0 | 0 | 0 | 0 | 5.17 | 14.81 |
 
 ## Metric Meaning
 
@@ -36,9 +36,9 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 2181 pass / 0 fail |
-| content is array | 2181 pass / 0 fail |
-| has alert seed | 2181 pass / 0 fail |
+| status is 200 | 2210 pass / 0 fail |
+| content is array | 2210 pass / 0 fail |
+| has alert seed | 2210 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/results/admin-operation-rule-run-before-summary.json
+++ b/monitoring/k6/results/admin-operation-rule-run-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 1,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "trigger completed",
+          "path": "::trigger completed",
+          "id": "0348f4e6314173dbd4ffbdf52b721fe7",
+          "passes": 1
+        },
+        {
+          "id": "13bc69bef285a9c0ace3546daef1e609",
+          "passes": 1,
+          "fails": 0,
+          "name": "duration exists",
+          "path": "::duration exists"
+        }
+      ],
+    "name": "",
+    "path": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 5192.046602,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "http_req_receiving": {
+      "values": {
+        "min": 0.623188,
+        "med": 1.084559,
+        "p(90)": 1.4536558,
+        "p(95)": 1.4997929,
+        "p(99)": 1.53670258,
+        "max": 1.54593,
+        "avg": 1.084559
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 1,
+        "max": 1,
+        "value": 1
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 3750.4451194,
+        "p(99)": 3897.9230566799997,
+        "max": 3934.792541,
+        "avg": 2091.3183249999997,
+        "min": 247.844109,
+        "med": 2091.3183249999997,
+        "p(90)": 3566.0976978
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 2092.808255,
+        "min": 249.196002,
+        "med": 2092.808255,
+        "p(90)": 3567.6980574000004,
+        "p(95)": 3752.0592827,
+        "p(99)": 3899.5482629400003,
+        "max": 3936.420508
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.6963716,
+        "p(99)": 0.72223832,
+        "max": 0.728705,
+        "avg": 0.40537100000000004,
+        "min": 0.082037,
+        "med": 0.40537100000000004,
+        "p(90)": 0.6640382
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 3,
+        "fails": 0
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2,
+        "rate": 0.3852045548338474
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "avg": 2.7195085,
+        "min": 2.32575,
+        "med": 2.7195085,
+        "p(90)": 3.0345153,
+        "p(95)": 3.07389115,
+        "p(99)": 3.10539183,
+        "max": 3.113267
+      },
+      "type": "trend"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1563,
+        "rate": 301.03735960265175
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "p(90)": 3567.6980574000004,
+        "p(95)": 3752.0592827,
+        "p(99)": 3899.5482629400003,
+        "max": 3936.420508,
+        "avg": 2092.808255,
+        "min": 249.196002,
+        "med": 2092.808255
+      },
+      "type": "trend"
+    },
+    "http_req_blocked": {
+      "values": {
+        "avg": 2.9884199999999996,
+        "min": 2.402776,
+        "med": 2.9884199999999996,
+        "p(90)": 3.4569352,
+        "p(95)": 3.5154996,
+        "p(99)": 3.5623511199999998,
+        "max": 3.574064
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{type:operation_rule_run}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 3936.420508,
+        "med": 3936.420508,
+        "p(90)": 3936.420508,
+        "p(95)": 3936.420508,
+        "p(99)": 3936.420508,
+        "max": 3936.420508,
+        "avg": 3936.420508
+      },
+      "thresholds": {
+        "p(95)<10000": {
+          "ok": true
+        }
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 253.078181,
+        "med": 2596.711734,
+        "p(90)": 4471.6185764,
+        "p(95)": 4705.9819317,
+        "p(99)": 4893.47261594,
+        "max": 4940.345287,
+        "avg": 2596.711734
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1,
+        "rate": 0.1926022774169237
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 589,
+        "rate": 113.44274139856806
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTk3MTc3NywiZXhwIjoxNzgxOTc1Mzc3fQ.8g4d-lD2wWonWVQVwqHZFrZRNqBtg6IDMmFpocv322s"
+  }
+}

--- a/monitoring/k6/results/admin-operation-rule-run-before-summary.md
+++ b/monitoring/k6/results/admin-operation-rule-run-before-summary.md
@@ -1,24 +1,24 @@
-# k6 Result - admin-alert-detail-course-before
+# k6 Result - admin-operation-rule-run-before
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 2219 |
-| iterations | 2218 |
+| http_reqs | 2 |
+| iterations | 1 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 3795523 |
-| data_sent bytes | 774292 |
+| data_received bytes | 1563 |
+| data_sent bytes | 589 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 13.57 | 8.53 | 12.65 | 16.94 | 19.65 | 28.94 | 226.06 |
-| http_req_waiting | 13.30 | 8.24 | 12.38 | 16.54 | 19.13 | 28.63 | 225.69 |
-| http_req_blocked | 0.07 | 0.00 | 0.00 | 0.01 | 0.01 | 2.48 | 7.85 |
-| http_req_connecting | 0.06 | 0 | 0 | 0 | 0 | 2.37 | 6.68 |
+| http_req_duration | 2092.81 | 249.20 | 2092.81 | 3567.70 | 3752.06 | 3899.55 | 3936.42 |
+| http_req_waiting | 2091.32 | 247.84 | 2091.32 | 3566.10 | 3750.45 | 3897.92 | 3934.79 |
+| http_req_blocked | 2.99 | 2.40 | 2.99 | 3.46 | 3.52 | 3.56 | 3.57 |
+| http_req_connecting | 2.72 | 2.33 | 2.72 | 3.03 | 3.07 | 3.11 | 3.11 |
 
 ## Metric Meaning
 
@@ -36,9 +36,9 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 2218 pass / 0 fail |
-| data exists | 2218 pass / 0 fail |
-| has target detail | 2218 pass / 0 fail |
+| status is 200 | 1 pass / 0 fail |
+| trigger completed | 1 pass / 0 fail |
+| duration exists | 1 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/results/recommendation-generation-before-summary.json
+++ b/monitoring/k6/results/recommendation-generation-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 1
+        },
+        {
+          "fails": 0,
+          "name": "trigger completed",
+          "path": "::trigger completed",
+          "id": "0348f4e6314173dbd4ffbdf52b721fe7",
+          "passes": 1
+        },
+        {
+          "id": "a2538663867a517527128c4a8b8d3016",
+          "passes": 1,
+          "fails": 0,
+          "name": "generated user count exists",
+          "path": "::generated user count exists"
+        }
+      ],
+    "name": "",
+    "path": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 12016.721365
+  },
+  "metrics": {
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "data_sent": {
+      "contains": "data",
+      "values": {
+        "count": 588,
+        "rate": 48.93181610356828
+      },
+      "type": "counter"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 3.08602425,
+        "p(99)": 3.1103440499999997,
+        "max": 3.116424,
+        "avg": 2.8124265,
+        "min": 2.508429,
+        "med": 2.8124265,
+        "p(90)": 3.0556245
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 3,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_duration{type:recommendation_generation}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 10736.094887,
+        "p(90)": 10736.094887,
+        "p(95)": 10736.094887,
+        "p(99)": 10736.094887,
+        "max": 10736.094887,
+        "avg": 10736.094887,
+        "min": 10736.094887
+      },
+      "thresholds": {
+        "p(95)<300000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 0.11298135,
+        "max": 0.113438,
+        "avg": 0.0906055,
+        "min": 0.067773,
+        "med": 0.0906055,
+        "p(90)": 0.1088715,
+        "p(95)": 0.11115475
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 273.119757,
+        "med": 5504.607322,
+        "p(90)": 9689.797374,
+        "p(95)": 10212.946130499999,
+        "p(99)": 10631.465135699998,
+        "max": 10736.094887,
+        "avg": 5504.607322
+      }
+    },
+    "http_req_blocked": {
+      "contains": "time",
+      "values": {
+        "avg": 2.9353845,
+        "min": 2.561839,
+        "med": 2.9353845,
+        "p(90)": 3.2342209000000004,
+        "p(95)": 3.2715754500000003,
+        "p(99)": 3.3014590900000003,
+        "max": 3.30893
+      },
+      "type": "trend"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 5504.607322,
+        "p(90)": 9689.797374,
+        "p(95)": 10212.946130499999,
+        "p(99)": 10631.465135699998,
+        "max": 10736.094887,
+        "avg": 5504.607322,
+        "min": 273.119757
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1589,
+        "rate": 132.23240780369048
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2,
+        "rate": 0.16643474865159277
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.8674425,
+        "p(90)": 0.9755941,
+        "p(95)": 0.9891130499999999,
+        "p(99)": 0.99992821,
+        "max": 1.002632,
+        "avg": 0.8674425,
+        "min": 0.732253
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 11624.95156876,
+        "max": 11739.580165,
+        "avg": 6008.150353,
+        "min": 276.720541,
+        "med": 6008.150352999999,
+        "p(90)": 10593.2942026,
+        "p(95)": 11166.437183799999
+      }
+    },
+    "vus": {
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "http_req_waiting": {
+      "values": {
+        "avg": 5503.649274,
+        "min": 272.274066,
+        "med": 5503.649274,
+        "p(90)": 9688.7494404,
+        "p(95)": 10211.8869612,
+        "p(99)": 10630.39697784,
+        "max": 10735.024482
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1,
+        "rate": 0.08321737432579639
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MjA0MDMxOSwiZXhwIjoxNzgyMDQzOTE5fQ.XRjqAga0D1FWQ6eUSWSmmew8lmLr0wmj8qcRSgINhiQ"
+  }
+}

--- a/monitoring/k6/results/recommendation-generation-before-summary.md
+++ b/monitoring/k6/results/recommendation-generation-before-summary.md
@@ -1,24 +1,24 @@
-# k6 Result - admin-alert-detail-course-before
+# k6 Result - recommendation-generation-before
 
 ## Summary
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 2219 |
-| iterations | 2218 |
+| http_reqs | 2 |
+| iterations | 1 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 3795523 |
-| data_sent bytes | 774292 |
+| data_received bytes | 1589 |
+| data_sent bytes | 588 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 13.57 | 8.53 | 12.65 | 16.94 | 19.65 | 28.94 | 226.06 |
-| http_req_waiting | 13.30 | 8.24 | 12.38 | 16.54 | 19.13 | 28.63 | 225.69 |
-| http_req_blocked | 0.07 | 0.00 | 0.00 | 0.01 | 0.01 | 2.48 | 7.85 |
-| http_req_connecting | 0.06 | 0 | 0 | 0 | 0 | 2.37 | 6.68 |
+| http_req_duration | 5504.61 | 273.12 | 5504.61 | 9689.80 | 10212.95 | 10631.47 | 10736.09 |
+| http_req_waiting | 5503.65 | 272.27 | 5503.65 | 9688.75 | 10211.89 | 10630.40 | 10735.02 |
+| http_req_blocked | 2.94 | 2.56 | 2.94 | 3.23 | 3.27 | 3.30 | 3.31 |
+| http_req_connecting | 2.81 | 2.51 | 2.81 | 3.06 | 3.09 | 3.11 | 3.12 |
 
 ## Metric Meaning
 
@@ -36,9 +36,9 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 2218 pass / 0 fail |
-| data exists | 2218 pass / 0 fail |
-| has target detail | 2218 pass / 0 fail |
+| status is 200 | 1 pass / 0 fail |
+| trigger completed | 1 pass / 0 fail |
+| generated user count exists | 1 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/results/recommendation-generation-scale-1000-summary.json
+++ b/monitoring/k6/results/recommendation-generation-scale-1000-summary.json
@@ -1,0 +1,262 @@
+{
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 1655.978321
+  },
+  "metrics": {
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2,
+        "rate": 1.2077452794141983
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 402.95493380000005,
+        "p(95)": 412.7963929,
+        "p(99)": 420.66956018,
+        "max": 422.637852,
+        "avg": 324.223261,
+        "min": 225.80867,
+        "med": 324.223261
+      }
+    },
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "http_req_duration{type:recommendation_generation}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 422.637852,
+        "min": 422.637852,
+        "med": 422.637852,
+        "p(90)": 422.637852,
+        "p(95)": 422.637852,
+        "p(99)": 422.637852,
+        "max": 422.637852
+      },
+      "thresholds": {
+        "p(95)<300000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 2.46318605,
+        "p(99)": 2.46378521,
+        "max": 2.463935,
+        "avg": 2.4564455,
+        "min": 2.448956,
+        "med": 2.4564455,
+        "p(90)": 2.4624371000000003
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 0.6038726397070991,
+        "count": 1
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 1,
+        "max": 1,
+        "value": 1
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 355.0771121477743,
+        "count": 588
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 400.51312099999996,
+        "p(95)": 410.2835125,
+        "p(99)": 418.0998257,
+        "max": 420.053904,
+        "avg": 322.349989,
+        "min": 224.646074,
+        "med": 322.349989
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 1307.0866316,
+        "p(95)": 1366.9969282999998,
+        "p(99)": 1414.92516566,
+        "max": 1426.907225,
+        "avg": 827.804258,
+        "min": 228.701291,
+        "med": 827.8042579999999
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 1.7844440000000001,
+        "p(90)": 2.3692488000000003,
+        "p(95)": 2.4423494,
+        "p(99)": 2.50082988,
+        "max": 2.51545,
+        "avg": 1.7844440000000001,
+        "min": 1.053438
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1586,
+        "rate": 957.7420065754592
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 3,
+        "fails": 0,
+        "rate": 1
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.088828,
+        "p(90)": 0.105092,
+        "p(95)": 0.107125,
+        "p(99)": 0.1087514,
+        "max": 0.109158,
+        "avg": 0.088828,
+        "min": 0.068498
+      }
+    },
+    "http_req_tls_handshaking": {
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0
+      },
+      "type": "trend"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 2.566987,
+        "min": 2.530367,
+        "med": 2.566987,
+        "p(90)": 2.5962829999999997,
+        "p(95)": 2.599945,
+        "p(99)": 2.6028746,
+        "max": 2.603607
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 225.80867,
+        "med": 324.223261,
+        "p(90)": 402.95493380000005,
+        "p(95)": 412.7963929,
+        "p(99)": 420.66956018,
+        "max": 422.637852,
+        "avg": 324.223261
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MjExMjE0NywiZXhwIjoxNzgyMTE1NzQ3fQ.v3B44d8FEuxMHduqVSHrmsVF3TCWkSt2CKV0XYMHqho"
+  },
+  "root_group": {
+    "checks": [
+      {
+        "fails": 0,
+        "name": "status is 200",
+        "path": "::status is 200",
+        "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+        "passes": 1
+      },
+      {
+        "name": "trigger completed",
+        "path": "::trigger completed",
+        "id": "0348f4e6314173dbd4ffbdf52b721fe7",
+        "passes": 1,
+        "fails": 0
+      },
+      {
+        "path": "::generated user count exists",
+        "id": "a2538663867a517527128c4a8b8d3016",
+        "passes": 1,
+        "fails": 0,
+        "name": "generated user count exists"
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  }
+}

--- a/monitoring/k6/results/recommendation-generation-scale-1000-summary.md
+++ b/monitoring/k6/results/recommendation-generation-scale-1000-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - recommendation-generation-scale-1000
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2 |
+| iterations | 1 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 1586 |
+| data_sent bytes | 588 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 324.22 | 225.81 | 324.22 | 402.95 | 412.80 | 420.67 | 422.64 |
+| http_req_waiting | 322.35 | 224.65 | 322.35 | 400.51 | 410.28 | 418.10 | 420.05 |
+| http_req_blocked | 2.57 | 2.53 | 2.57 | 2.60 | 2.60 | 2.60 | 2.60 |
+| http_req_connecting | 2.46 | 2.45 | 2.46 | 2.46 | 2.46 | 2.46 | 2.46 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 1 pass / 0 fail |
+| trigger completed | 1 pass / 0 fail |
+| generated user count exists | 1 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/recommendation-generation-scale-120-summary.json
+++ b/monitoring/k6/results/recommendation-generation-scale-120-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "groups": [],
+    "checks": [
+        {
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 1
+        },
+        {
+          "name": "trigger completed",
+          "path": "::trigger completed",
+          "id": "0348f4e6314173dbd4ffbdf52b721fe7",
+          "passes": 1,
+          "fails": 0
+        },
+        {
+          "path": "::generated user count exists",
+          "id": "a2538663867a517527128c4a8b8d3016",
+          "passes": 1,
+          "fails": 0,
+          "name": "generated user count exists"
+        }
+      ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 22401.04389,
+    "isStdOutTTY": false,
+    "isStdErrTTY": false
+  },
+  "metrics": {
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "med": 2.870257,
+        "p(90)": 2.906257,
+        "p(95)": 2.910757,
+        "p(99)": 2.914357,
+        "max": 2.915257,
+        "avg": 2.870257,
+        "min": 2.825257
+      },
+      "type": "trend"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1,
+        "rate": 0.044640776783014466
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 3,
+        "fails": 0,
+        "rate": 1
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 20413.66810346,
+        "max": 20611.995356,
+        "avg": 10695.632728999999,
+        "min": 779.270102,
+        "med": 10695.632729,
+        "p(90)": 18628.7228306,
+        "p(95)": 19620.359093299998
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.16096195,
+        "p(99)": 0.16271238999999998,
+        "max": 0.16315,
+        "avg": 0.1412695,
+        "min": 0.119389,
+        "med": 0.1412695,
+        "p(90)": 0.1587739
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 3.009721,
+        "med": 3.7069345,
+        "p(90)": 4.2647053,
+        "p(95)": 4.33442665,
+        "p(99)": 4.39020373,
+        "max": 4.404148,
+        "avg": 3.7069345
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "count": 2,
+        "rate": 0.08928155356602893
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_receiving": {
+      "values": {
+        "avg": 2.326599,
+        "min": 1.622716,
+        "med": 2.326599,
+        "p(90)": 2.8897054000000004,
+        "p(95)": 2.9600937,
+        "p(99)": 3.0164043400000002,
+        "max": 3.030482
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 779.270102,
+        "med": 10695.632729,
+        "p(90)": 18628.7228306,
+        "p(95)": 19620.359093299998,
+        "p(99)": 20413.66810346,
+        "max": 20611.995356,
+        "avg": 10695.632728999999
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 18625.7093601,
+        "p(95)": 19617.27742255,
+        "p(99)": 20410.53187251,
+        "max": 20608.845485,
+        "avg": 10693.164860500001,
+        "min": 777.484236,
+        "med": 10693.164860500001
+      }
+    },
+    "vus_max": {
+      "values": {
+        "max": 1,
+        "value": 1,
+        "min": 1
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1590,
+        "rate": 70.978835084993
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 588,
+        "rate": 26.248776748412503
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 11200.782886,
+        "p(90)": 19534.111111600003,
+        "p(95)": 20575.7771398,
+        "p(99)": 21409.109962360002,
+        "max": 21617.443168,
+        "avg": 11200.782886,
+        "min": 784.122604
+      }
+    },
+    "http_req_duration{type:recommendation_generation}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 20611.995356,
+        "min": 20611.995356,
+        "med": 20611.995356,
+        "p(90)": 20611.995356,
+        "p(95)": 20611.995356,
+        "p(99)": 20611.995356,
+        "max": 20611.995356
+      },
+      "thresholds": {
+        "p(95)<300000": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MjExMjQ3MCwiZXhwIjoxNzgyMTE2MDcwfQ.hnNlWCnNft7OSXCnP9YDZVNC9keGg1unGjjfwXs5OuA"
+  }
+}

--- a/monitoring/k6/results/recommendation-generation-scale-120-summary.md
+++ b/monitoring/k6/results/recommendation-generation-scale-120-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - recommendation-generation-scale-120
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2 |
+| iterations | 1 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 1590 |
+| data_sent bytes | 588 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 10695.63 | 779.27 | 10695.63 | 18628.72 | 19620.36 | 20413.67 | 20612.00 |
+| http_req_waiting | 10693.16 | 777.48 | 10693.16 | 18625.71 | 19617.28 | 20410.53 | 20608.85 |
+| http_req_blocked | 3.71 | 3.01 | 3.71 | 4.26 | 4.33 | 4.39 | 4.40 |
+| http_req_connecting | 2.87 | 2.83 | 2.87 | 2.91 | 2.91 | 2.91 | 2.92 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 1 pass / 0 fail |
+| trigger completed | 1 pass / 0 fail |
+| generated user count exists | 1 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/recommendation-generation-scale-300-summary.json
+++ b/monitoring/k6/results/recommendation-generation-scale-300-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 1
+        },
+        {
+          "name": "trigger completed",
+          "path": "::trigger completed",
+          "id": "0348f4e6314173dbd4ffbdf52b721fe7",
+          "passes": 1,
+          "fails": 0
+        },
+        {
+          "path": "::generated user count exists",
+          "id": "a2538663867a517527128c4a8b8d3016",
+          "passes": 1,
+          "fails": 0,
+          "name": "generated user count exists"
+        }
+      ],
+    "name": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": false,
+    "isStdErrTTY": false,
+    "testRunDurationMs": 43566.648158
+  },
+  "metrics": {
+    "http_req_sending": {
+      "values": {
+        "p(99)": 0.25093205,
+        "max": 0.252375,
+        "avg": 0.1802275,
+        "min": 0.10808,
+        "med": 0.18022749999999998,
+        "p(90)": 0.23794550000000003,
+        "p(95)": 0.24516024999999997
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.994927,
+        "med": 1.4372345,
+        "p(90)": 1.7910805,
+        "p(95)": 1.83531125,
+        "p(99)": 1.8706958500000002,
+        "max": 1.879542,
+        "avg": 1.4372345
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 3.2094663,
+        "p(99)": 3.21275726,
+        "max": 3.21358,
+        "avg": 3.172443,
+        "min": 3.131306,
+        "med": 3.172443,
+        "p(90)": 3.2053526
+      }
+    },
+    "data_sent": {
+      "contains": "data",
+      "values": {
+        "count": 588,
+        "rate": 13.496562734584105
+      },
+      "type": "counter"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 42714.28070369,
+        "max": 43141.432525,
+        "avg": 21783.8414595,
+        "min": 426.250394,
+        "med": 21783.841459499996,
+        "p(90)": 38869.9143119,
+        "p(95)": 41005.673418449995
+      }
+    },
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "fails": 2,
+        "rate": 0,
+        "passes": 0
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 21276.697628,
+        "min": 420.199566,
+        "med": 21276.697627999998,
+        "p(90)": 37961.8960776,
+        "p(95)": 40047.5458838,
+        "p(99)": 41716.06572876,
+        "max": 42133.19569
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 4.3205775,
+        "p(99)": 4.368411500000001,
+        "max": 4.38037,
+        "avg": 3.782445,
+        "min": 3.18452,
+        "med": 3.782445,
+        "p(90)": 4.260785
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 3,
+        "fails": 0
+      }
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 42135.183312,
+        "avg": 21278.31509,
+        "min": 421.446868,
+        "med": 21278.31509,
+        "p(90)": 37963.8096676,
+        "p(95)": 40049.496489799996,
+        "p(99)": 41718.04594756
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1,
+        "rate": 0.02295333798398657
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1590,
+        "rate": 36.49580739453865
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 21278.31509,
+        "p(90)": 37963.8096676,
+        "p(95)": 40049.496489799996,
+        "p(99)": 41718.04594756,
+        "max": 42135.183312,
+        "avg": 21278.31509,
+        "min": 421.446868
+      }
+    },
+    "http_req_duration{type:recommendation_generation}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 42135.183312,
+        "min": 42135.183312,
+        "med": 42135.183312,
+        "p(90)": 42135.183312,
+        "p(95)": 42135.183312,
+        "p(99)": 42135.183312,
+        "max": 42135.183312
+      },
+      "thresholds": {
+        "p(95)<300000": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2,
+        "rate": 0.04590667596797314
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MjExMjY5NCwiZXhwIjoxNzgyMTE2Mjk0fQ.oe337-Y9amob9-9iIZeKYy6k4StJpKC8LmesTLU-zQw"
+  }
+}

--- a/monitoring/k6/results/recommendation-generation-scale-300-summary.md
+++ b/monitoring/k6/results/recommendation-generation-scale-300-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - recommendation-generation-scale-300
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2 |
+| iterations | 1 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 1590 |
+| data_sent bytes | 588 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 21278.32 | 421.45 | 21278.32 | 37963.81 | 40049.50 | 41718.05 | 42135.18 |
+| http_req_waiting | 21276.70 | 420.20 | 21276.70 | 37961.90 | 40047.55 | 41716.07 | 42133.20 |
+| http_req_blocked | 3.78 | 3.18 | 3.78 | 4.26 | 4.32 | 4.37 | 4.38 |
+| http_req_connecting | 3.17 | 3.13 | 3.17 | 3.21 | 3.21 | 3.21 | 3.21 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 1 pass / 0 fail |
+| trigger completed | 1 pass / 0 fail |
+| generated user count exists | 1 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/recommendation-generation-scale-500-summary.json
+++ b/monitoring/k6/results/recommendation-generation-scale-500-summary.json
@@ -1,0 +1,255 @@
+{
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MjExMzAxNSwiZXhwIjoxNzgyMTE2NjE1fQ.FdL_W-sR-nEkIMPQyC9qgD7D5WJAgQDo7iTLZX7bdQ8"
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 0,
+          "fails": 1
+        },
+        {
+          "name": "trigger completed",
+          "path": "::trigger completed",
+          "id": "0348f4e6314173dbd4ffbdf52b721fe7",
+          "passes": 0,
+          "fails": 1
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdErrTTY": false,
+    "testRunDurationMs": 60802.049125,
+    "isStdOutTTY": false
+  },
+  "metrics": {
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.2361725,
+        "min": 0.22349,
+        "med": 0.2361725,
+        "p(90)": 0.2463185,
+        "p(95)": 0.24758675,
+        "p(99)": 0.24860135,
+        "max": 0.248855
+      }
+    },
+    "http_req_failed": {
+      "values": {
+        "fails": 1,
+        "rate": 0.5,
+        "passes": 1
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": false
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1140,
+        "rate": 18.74936809541285
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 54073.6750724,
+        "p(95)": 57033.4973462,
+        "p(99)": 59401.35516524,
+        "max": 59993.31962,
+        "avg": 30395.096882,
+        "min": 796.874144,
+        "med": 30395.096882
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 2.770262,
+        "med": 3.345455,
+        "p(90)": 3.8056094,
+        "p(95)": 3.8631287,
+        "p(99)": 3.90914414,
+        "max": 3.920648,
+        "avg": 3.345455
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 0.016446814118783203,
+        "count": 1
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 60002.337218,
+        "avg": 30401.9946615,
+        "min": 801.652105,
+        "med": 30401.9946615,
+        "p(90)": 54082.2687067,
+        "p(95)": 57042.30296235,
+        "p(99)": 59410.33036687
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 1.176598,
+        "p(90)": 2.1178764,
+        "p(95)": 2.2355362,
+        "p(99)": 2.32966404,
+        "max": 2.353196,
+        "avg": 1.176598
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      }
+    },
+    "data_sent": {
+      "contains": "data",
+      "values": {
+        "count": 588,
+        "rate": 9.670726701844524
+      },
+      "type": "counter"
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      },
+      "type": "gauge"
+    },
+    "checks": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_duration{type:recommendation_generation}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 59993.31962,
+        "p(99)": 59993.31962,
+        "max": 59993.31962,
+        "avg": 59993.31962,
+        "min": 59993.31962,
+        "med": 59993.31962,
+        "p(90)": 59993.31962
+      },
+      "thresholds": {
+        "p(95)<300000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 54073.2137263,
+        "p(95)": 57033.15492815,
+        "p(99)": 59401.107889629995,
+        "max": 59993.09613,
+        "avg": 30393.6841115,
+        "min": 794.272093,
+        "med": 30393.6841115
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 796.874144,
+        "p(90)": 796.874144,
+        "p(95)": 796.874144,
+        "p(99)": 796.874144,
+        "max": 796.874144,
+        "avg": 796.874144,
+        "min": 796.874144
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "rate": 0.032893628237566405,
+        "count": 2
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 4.165152,
+        "avg": 3.8035195,
+        "min": 3.441887,
+        "med": 3.8035195,
+        "p(90)": 4.0928255,
+        "p(95)": 4.1289887499999995,
+        "p(99)": 4.15791935
+      }
+    }
+  }
+}

--- a/monitoring/k6/results/recommendation-generation-scale-500-summary.md
+++ b/monitoring/k6/results/recommendation-generation-scale-500-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - recommendation-generation-scale-500
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2 |
+| iterations | 1 |
+| checks success rate | 0.00% |
+| http_req_failed | 50.00% |
+| data_received bytes | 1140 |
+| data_sent bytes | 588 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 30395.10 | 796.87 | 30395.10 | 54073.68 | 57033.50 | 59401.36 | 59993.32 |
+| http_req_waiting | 30393.68 | 794.27 | 30393.68 | 54073.21 | 57033.15 | 59401.11 | 59993.10 |
+| http_req_blocked | 3.80 | 3.44 | 3.80 | 4.09 | 4.13 | 4.16 | 4.17 |
+| http_req_connecting | 3.35 | 2.77 | 3.35 | 3.81 | 3.86 | 3.91 | 3.92 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 0 pass / 1 fail |
+| trigger completed | 0 pass / 1 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/recommendation-generation-scale-800-summary.json
+++ b/monitoring/k6/results/recommendation-generation-scale-800-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "checks": [
+      {
+        "name": "status is 200",
+        "path": "::status is 200",
+        "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+        "passes": 0,
+        "fails": 1
+      },
+      {
+        "name": "trigger completed",
+        "path": "::trigger completed",
+        "id": "0348f4e6314173dbd4ffbdf52b721fe7",
+        "passes": 0,
+        "fails": 1
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 60801.717622,
+    "isStdOutTTY": false,
+    "isStdErrTTY": false
+  },
+  "metrics": {
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 795.732435,
+        "med": 30394.916744000002,
+        "p(90)": 54074.264191199996,
+        "p(95)": 57034.182622099994,
+        "p(99)": 59402.11736682,
+        "max": 59994.101053,
+        "avg": 30394.916744
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 1140,
+        "rate": 18.749470320679094
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "count": 2,
+        "rate": 0.03289380758013876
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 1,
+        "value": 1,
+        "min": 1
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 3.9306563,
+        "p(95)": 3.98715465,
+        "p(99)": 4.032353329999999,
+        "max": 4.043653,
+        "avg": 3.4786695,
+        "min": 2.913686,
+        "med": 3.4786695
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 1.414942,
+        "p(90)": 2.5468956,
+        "p(95)": 2.6883898,
+        "p(99)": 2.8015851599999997,
+        "max": 2.829884,
+        "avg": 1.414942,
+        "min": 0
+      }
+    },
+    "iteration_duration": {
+      "values": {
+        "avg": 30402.537634,
+        "min": 802.221955,
+        "med": 30402.537634,
+        "p(90)": 54082.790177200004,
+        "p(95)": 57042.821745099995,
+        "p(99)": 59410.84699942,
+        "max": 60002.853313
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 5.5729671,
+        "p(95)": 5.71221105,
+        "p(99)": 5.8236062099999995,
+        "max": 5.851455,
+        "avg": 4.4590155,
+        "min": 3.066576,
+        "med": 4.4590155
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 1,
+        "rate": 0.01644690379006938
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_duration{type:recommendation_generation}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 59994.101053,
+        "min": 59994.101053,
+        "med": 59994.101053,
+        "p(90)": 59994.101053,
+        "p(95)": 59994.101053,
+        "p(99)": 59994.101053,
+        "max": 59994.101053
+      },
+      "thresholds": {
+        "p(95)<300000": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 795.732435,
+        "avg": 795.732435,
+        "min": 795.732435,
+        "med": 795.732435,
+        "p(90)": 795.732435,
+        "p(95)": 795.732435,
+        "p(99)": 795.732435
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.13617600000000002,
+        "p(90)": 0.1417808,
+        "p(95)": 0.1424814,
+        "p(99)": 0.14304188,
+        "max": 0.143182,
+        "avg": 0.13617600000000002,
+        "min": 0.12917
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 30393.365626,
+        "min": 792.759369,
+        "med": 30393.365626,
+        "p(90)": 54073.8506316,
+        "p(95)": 57033.911257299995,
+        "p(99)": 59401.95975786,
+        "max": 59993.971883
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 588,
+        "rate": 9.670779428560795
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0.5,
+        "passes": 1,
+        "fails": 1
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": false
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 2,
+        "rate": 0,
+        "passes": 0
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MjExMzI3MSwiZXhwIjoxNzgyMTE2ODcxfQ.a-tzblsOv1yQi05WmayN70uKmVDuMzVrDOZFf9_B_4M"
+  }
+}

--- a/monitoring/k6/results/recommendation-generation-scale-800-summary.md
+++ b/monitoring/k6/results/recommendation-generation-scale-800-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - recommendation-generation-scale-800
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2 |
+| iterations | 1 |
+| checks success rate | 0.00% |
+| http_req_failed | 50.00% |
+| data_received bytes | 1140 |
+| data_sent bytes | 588 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 30394.92 | 795.73 | 30394.92 | 54074.26 | 57034.18 | 59402.12 | 59994.10 |
+| http_req_waiting | 30393.37 | 792.76 | 30393.37 | 54073.85 | 57033.91 | 59401.96 | 59993.97 |
+| http_req_blocked | 4.46 | 3.07 | 4.46 | 5.57 | 5.71 | 5.82 | 5.85 |
+| http_req_connecting | 3.48 | 2.91 | 3.48 | 3.93 | 3.99 | 4.03 | 4.04 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 0 pass / 1 fail |
+| trigger completed | 0 pass / 1 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/recommendation-hide-before-summary.json
+++ b/monitoring/k6/results/recommendation-hide-before-summary.json
@@ -1,0 +1,262 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 1313,
+          "fails": 0
+        },
+        {
+          "path": "::hidden is true",
+          "id": "670355dadab539a17251dbf149e5f8f6",
+          "passes": 1313,
+          "fails": 0,
+          "name": "hidden is true"
+        },
+        {
+          "path": "::hiddenUntil exists",
+          "id": "cce2df97a17b3da66aadbf7dfdca8106",
+          "passes": 1313,
+          "fails": 0,
+          "name": "hiddenUntil exists"
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 70962.145014
+  },
+  "metrics": {
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 791158,
+        "rate": 11149.01472952817
+      },
+      "type": "counter"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 3,
+        "min": 2,
+        "max": 30
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 18.502822874660293,
+        "count": 1313
+      }
+    },
+    "http_req_duration": {
+      "values": {
+        "med": 21.976337,
+        "p(90)": 30.441708700000003,
+        "p(95)": 34.9936934,
+        "p(99)": 46.43233571999996,
+        "max": 134.707748,
+        "avg": 23.323593488584486,
+        "min": 11.99156
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus_max": {
+      "values": {
+        "value": 30,
+        "min": 30,
+        "max": 30
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.002688,
+        "med": 0.0070245,
+        "p(90)": 0.0132964,
+        "p(95)": 0.029127349999999864,
+        "p(99)": 4.436688739999986,
+        "max": 6.309146,
+        "avg": 0.11211656164383552
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1314
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration{type:hide}": {
+      "contains": "time",
+      "values": {
+        "min": 11.99156,
+        "med": 21.969827,
+        "p(90)": 30.4285762,
+        "p(95)": 34.88054939999997,
+        "p(99)": 45.81964451999974,
+        "max": 64.207984,
+        "avg": 23.23876168773801
+      },
+      "thresholds": {
+        "p(95)<300": {
+          "ok": true
+        }
+      },
+      "type": "trend"
+    },
+    "http_req_connecting": {
+      "values": {
+        "avg": 0.09882392313546426,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 4.2374601799999905,
+        "max": 6.105403
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1314,
+        "rate": 18.516914895128426
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 1885.2614739,
+        "p(95)": 1957.23667635,
+        "p(99)": 2013.24553443,
+        "max": 2039.271418,
+        "avg": 1276.3317182579942,
+        "min": 138.25936,
+        "med": 1273.299742
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.5852815,
+        "p(90)": 1.0391752,
+        "p(95)": 1.242775,
+        "p(99)": 2.044631959999986,
+        "max": 5.716502,
+        "avg": 0.6248376674277009,
+        "min": 0.073254
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 3939,
+        "fails": 0
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 34.1553068,
+        "p(99)": 45.85505593999998,
+        "max": 134.01189,
+        "avg": 22.649827783866087,
+        "min": 11.615522,
+        "med": 21.335985,
+        "p(90)": 29.595917500000002
+      }
+    },
+    "data_sent": {
+      "values": {
+        "count": 497835,
+        "rate": 7015.501009753622
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "p(99)": 46.43233571999996,
+        "max": 134.707748,
+        "avg": 23.323593488584486,
+        "min": 11.99156,
+        "med": 21.976337,
+        "p(90)": 30.441708700000003,
+        "p(95)": 34.9936934
+      },
+      "type": "trend"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0
+      }
+    },
+    "http_req_sending": {
+      "contains": "time",
+      "values": {
+        "p(90)": 0.08400060000000001,
+        "p(95)": 0.10780059999999994,
+        "p(99)": 0.18711956999999949,
+        "max": 0.462694,
+        "avg": 0.0489280372907154,
+        "min": 0.011971,
+        "med": 0.0432145
+      },
+      "type": "trend"
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE4NDExMjksImV4cCI6MTc4MTg0NDcyOX0.KatCYdOSoCgMgyBpsfwtBXlxyjSnMkT2xP_pKGbhIXo"
+  }
+}

--- a/monitoring/k6/results/recommendation-hide-before-summary.json
+++ b/monitoring/k6/results/recommendation-hide-before-summary.json
@@ -1,33 +1,4 @@
 {
-  "root_group": {
-    "name": "",
-    "path": "",
-    "id": "d41d8cd98f00b204e9800998ecf8427e",
-    "groups": [],
-    "checks": [
-        {
-          "name": "status is 200",
-          "path": "::status is 200",
-          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
-          "passes": 1313,
-          "fails": 0
-        },
-        {
-          "path": "::hidden is true",
-          "id": "670355dadab539a17251dbf149e5f8f6",
-          "passes": 1313,
-          "fails": 0,
-          "name": "hidden is true"
-        },
-        {
-          "path": "::hiddenUntil exists",
-          "id": "cce2df97a17b3da66aadbf7dfdca8106",
-          "passes": 1313,
-          "fails": 0,
-          "name": "hiddenUntil exists"
-        }
-      ]
-  },
   "options": {
     "summaryTrendStats": [
       "avg",
@@ -42,148 +13,169 @@
     "noColor": false
   },
   "state": {
+    "testRunDurationMs": 70630.97873,
     "isStdOutTTY": true,
-    "isStdErrTTY": true,
-    "testRunDurationMs": 70962.145014
+    "isStdErrTTY": true
   },
   "metrics": {
-    "data_received": {
-      "contains": "data",
-      "values": {
-        "count": 791158,
-        "rate": 11149.01472952817
-      },
-      "type": "counter"
-    },
-    "vus": {
-      "type": "gauge",
-      "contains": "default",
-      "values": {
-        "value": 3,
-        "min": 2,
-        "max": 30
-      }
-    },
-    "iterations": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "rate": 18.502822874660293,
-        "count": 1313
-      }
-    },
-    "http_req_duration": {
-      "values": {
-        "med": 21.976337,
-        "p(90)": 30.441708700000003,
-        "p(95)": 34.9936934,
-        "p(99)": 46.43233571999996,
-        "max": 134.707748,
-        "avg": 23.323593488584486,
-        "min": 11.99156
-      },
-      "type": "trend",
-      "contains": "time"
-    },
-    "vus_max": {
-      "values": {
-        "value": 30,
-        "min": 30,
-        "max": 30
-      },
-      "type": "gauge",
-      "contains": "default"
-    },
-    "http_req_blocked": {
-      "type": "trend",
+    "iteration_duration": {
       "contains": "time",
       "values": {
-        "min": 0.002688,
-        "med": 0.0070245,
-        "p(90)": 0.0132964,
-        "p(95)": 0.029127349999999864,
-        "p(99)": 4.436688739999986,
-        "max": 6.309146,
-        "avg": 0.11211656164383552
-      }
-    },
-    "http_req_failed": {
-      "type": "rate",
-      "contains": "default",
-      "values": {
-        "rate": 0,
-        "passes": 0,
-        "fails": 1314
-      },
-      "thresholds": {
-        "rate<0.01": {
-          "ok": true
-        }
-      }
-    },
-    "http_req_duration{type:hide}": {
-      "contains": "time",
-      "values": {
-        "min": 11.99156,
-        "med": 21.969827,
-        "p(90)": 30.4285762,
-        "p(95)": 34.88054939999997,
-        "p(99)": 45.81964451999974,
-        "max": 64.207984,
-        "avg": 23.23876168773801
-      },
-      "thresholds": {
-        "p(95)<300": {
-          "ok": true
-        }
+        "min": 184.076742,
+        "med": 1288.769232,
+        "p(90)": 1887.0233292000003,
+        "p(95)": 1959.1788404999998,
+        "p(99)": 2015.21877002,
+        "max": 2104.468826,
+        "avg": 1290.283628398
       },
       "type": "trend"
     },
     "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
       "values": {
-        "avg": 0.09882392313546426,
+        "avg": 0.1231000038491147,
         "min": 0,
         "med": 0,
         "p(90)": 0,
         "p(95)": 0,
-        "p(99)": 4.2374601799999905,
-        "max": 6.105403
+        "p(99)": 4.559806379999993,
+        "max": 14.656326
+      }
+    },
+    "http_req_sending": {
+      "values": {
+        "min": 0.012649,
+        "med": 0.04728,
+        "p(90)": 0.0766774,
+        "p(95)": 0.09986309999999995,
+        "p(99)": 0.18681141999999995,
+        "max": 1.309256,
+        "avg": 0.051044572748267854
       },
       "type": "trend",
       "contains": "time"
-    },
-    "http_reqs": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "count": 1314,
-        "rate": 18.516914895128426
-      }
-    },
-    "iteration_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(90)": 1885.2614739,
-        "p(95)": 1957.23667635,
-        "p(99)": 2013.24553443,
-        "max": 2039.271418,
-        "avg": 1276.3317182579942,
-        "min": 138.25936,
-        "med": 1273.299742
-      }
     },
     "http_req_receiving": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "med": 0.5852815,
-        "p(90)": 1.0391752,
-        "p(95)": 1.242775,
-        "p(99)": 2.044631959999986,
-        "max": 5.716502,
-        "avg": 0.6248376674277009,
-        "min": 0.073254
+        "med": 0.641515,
+        "p(90)": 1.1842742000000002,
+        "p(95)": 1.4453837999999999,
+        "p(99)": 2.169094699999999,
+        "max": 7.512847,
+        "avg": 0.6980297413394925,
+        "min": 0.069236
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 492150,
+        "rate": 6967.90571006151
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 782176,
+        "rate": 11074.120931978201
+      }
+    },
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1299
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0
+      }
+    },
+    "http_req_blocked": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0.017190699999999986,
+        "p(99)": 5.066084079999997,
+        "max": 14.917808,
+        "avg": 0.13851041570438827,
+        "min": 0.003467,
+        "med": 0.008018,
+        "p(90)": 0.011764400000000001
+      },
+      "type": "trend"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 18.39136344075973,
+        "count": 1299
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 42.97537649999999,
+        "p(99)": 63.35920599999999,
+        "max": 177.323635,
+        "avg": 29.400528835257845,
+        "min": 14.741248,
+        "med": 27.587572,
+        "p(90)": 37.8723428
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 4,
+        "min": 2,
+        "max": 30
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 30,
+        "min": 30,
+        "max": 30
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 63.35920599999999,
+        "max": 177.323635,
+        "avg": 29.400528835257845,
+        "min": 14.741248,
+        "med": 27.587572,
+        "p(90)": 37.8723428,
+        "p(95)": 42.97537649999999
       }
     },
     "checks": {
@@ -191,7 +183,7 @@
       "contains": "default",
       "values": {
         "rate": 1,
-        "passes": 3939,
+        "passes": 3894,
         "fails": 0
       }
     },
@@ -199,64 +191,72 @@
       "type": "trend",
       "contains": "time",
       "values": {
-        "p(95)": 34.1553068,
-        "p(99)": 45.85505593999998,
-        "max": 134.01189,
-        "avg": 22.649827783866087,
-        "min": 11.615522,
-        "med": 21.335985,
-        "p(90)": 29.595917500000002
+        "p(95)": 42.33730819999999,
+        "p(99)": 62.53614236,
+        "max": 176.517677,
+        "avg": 28.651454521170113,
+        "min": 14.32158,
+        "med": 26.871211,
+        "p(90)": 37.1397298
       }
     },
-    "data_sent": {
-      "values": {
-        "count": 497835,
-        "rate": 7015.501009753622
-      },
+    "iterations": {
       "type": "counter",
-      "contains": "data"
-    },
-    "http_req_duration{expected_response:true}": {
-      "contains": "time",
+      "contains": "default",
       "values": {
-        "p(99)": 46.43233571999996,
-        "max": 134.707748,
-        "avg": 23.323593488584486,
-        "min": 11.99156,
-        "med": 21.976337,
-        "p(90)": 30.441708700000003,
-        "p(95)": 34.9936934
-      },
-      "type": "trend"
+        "count": 1298,
+        "rate": 18.377205347271847
+      }
     },
-    "http_req_tls_handshaking": {
+    "http_req_duration{type:hide}": {
+      "thresholds": {
+        "p(95)<300": {
+          "ok": true
+        }
+      },
       "type": "trend",
       "contains": "time",
       "values": {
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 0,
-        "max": 0,
-        "avg": 0,
-        "min": 0
+        "avg": 29.286566503852036,
+        "min": 14.741248,
+        "med": 27.587357,
+        "p(90)": 37.8570293,
+        "p(95)": 42.93195125,
+        "p(99)": 62.84591325999998,
+        "max": 140.625847
       }
-    },
-    "http_req_sending": {
-      "contains": "time",
-      "values": {
-        "p(90)": 0.08400060000000001,
-        "p(95)": 0.10780059999999994,
-        "p(99)": 0.18711956999999949,
-        "max": 0.462694,
-        "avg": 0.0489280372907154,
-        "min": 0.011971,
-        "med": 0.0432145
-      },
-      "type": "trend"
     }
   },
   "setup_data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE4NDExMjksImV4cCI6MTc4MTg0NDcyOX0.KatCYdOSoCgMgyBpsfwtBXlxyjSnMkT2xP_pKGbhIXo"
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE5NjA3NjMsImV4cCI6MTc4MTk2NDM2M30.WozHioO90aYSse8z62N0Bujh59WfZTdmWPXDNiNld5k"
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 1298,
+          "fails": 0
+        },
+        {
+          "path": "::hidden is true",
+          "id": "670355dadab539a17251dbf149e5f8f6",
+          "passes": 1298,
+          "fails": 0,
+          "name": "hidden is true"
+        },
+        {
+          "name": "hiddenUntil exists",
+          "path": "::hiddenUntil exists",
+          "id": "cce2df97a17b3da66aadbf7dfdca8106",
+          "passes": 1298,
+          "fails": 0
+        }
+      ]
   }
 }

--- a/monitoring/k6/results/recommendation-hide-before-summary.md
+++ b/monitoring/k6/results/recommendation-hide-before-summary.md
@@ -4,21 +4,21 @@
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 1314 |
-| iterations | 1313 |
+| http_reqs | 1299 |
+| iterations | 1298 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 791158 |
-| data_sent bytes | 497835 |
+| data_received bytes | 782176 |
+| data_sent bytes | 492150 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 23.32 | 11.99 | 21.98 | 30.44 | 34.99 | 46.43 | 134.71 |
-| http_req_waiting | 22.65 | 11.62 | 21.34 | 29.60 | 34.16 | 45.86 | 134.01 |
-| http_req_blocked | 0.11 | 0.00 | 0.01 | 0.01 | 0.03 | 4.44 | 6.31 |
-| http_req_connecting | 0.10 | 0 | 0 | 0 | 0 | 4.24 | 6.11 |
+| http_req_duration | 29.40 | 14.74 | 27.59 | 37.87 | 42.98 | 63.36 | 177.32 |
+| http_req_waiting | 28.65 | 14.32 | 26.87 | 37.14 | 42.34 | 62.54 | 176.52 |
+| http_req_blocked | 0.14 | 0.00 | 0.01 | 0.01 | 0.02 | 5.07 | 14.92 |
+| http_req_connecting | 0.12 | 0 | 0 | 0 | 0 | 4.56 | 14.66 |
 
 ## Metric Meaning
 
@@ -36,9 +36,9 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 1313 pass / 0 fail |
-| hidden is true | 1313 pass / 0 fail |
-| hiddenUntil exists | 1313 pass / 0 fail |
+| status is 200 | 1298 pass / 0 fail |
+| hidden is true | 1298 pass / 0 fail |
+| hiddenUntil exists | 1298 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/results/recommendation-hide-before-summary.md
+++ b/monitoring/k6/results/recommendation-hide-before-summary.md
@@ -1,0 +1,52 @@
+# k6 Result - recommendation-hide-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 1314 |
+| iterations | 1313 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 791158 |
+| data_sent bytes | 497835 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 23.32 | 11.99 | 21.98 | 30.44 | 34.99 | 46.43 | 134.71 |
+| http_req_waiting | 22.65 | 11.62 | 21.34 | 29.60 | 34.16 | 45.86 | 134.01 |
+| http_req_blocked | 0.11 | 0.00 | 0.01 | 0.01 | 0.03 | 4.44 | 6.31 |
+| http_req_connecting | 0.10 | 0 | 0 | 0 | 0 | 4.24 | 6.11 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 1313 pass / 0 fail |
+| hidden is true | 1313 pass / 0 fail |
+| hiddenUntil exists | 1313 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/recommendation-list-before-summary.json
+++ b/monitoring/k6/results/recommendation-list-before-summary.json
@@ -1,0 +1,269 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 2208,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
+        },
+        {
+          "passes": 2208,
+          "fails": 0,
+          "name": "data exists",
+          "path": "::data exists",
+          "id": "5383ecdb29afb1a64ae2c425b60f2ffc"
+        },
+        {
+          "name": "not hidden for query baseline",
+          "path": "::not hidden for query baseline",
+          "id": "8e99c4c08e7f30a50514435909e17c93",
+          "passes": 2208,
+          "fails": 0
+        },
+        {
+          "name": "problemSets is array",
+          "path": "::problemSets is array",
+          "id": "f3fa220fc5a5287469ead2713bcd536f",
+          "passes": 2208,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTimeUnit": "",
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ]
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 70961.918534
+  },
+  "metrics": {
+    "http_req_duration{type:list}": {
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 26.167282099999994,
+        "p(95)": 29.49215245,
+        "p(99)": 37.77186730999992,
+        "max": 60.000689,
+        "avg": 20.578403006340604,
+        "min": 12.170684,
+        "med": 19.605456500000003
+      }
+    },
+    "http_reqs": {
+      "values": {
+        "count": 2209,
+        "rate": 31.129372565393666
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 28.97448599999999,
+        "p(99)": 37.66025416,
+        "max": 123.931378,
+        "avg": 20.094616340878268,
+        "min": 11.877697,
+        "med": 19.081211,
+        "p(90)": 25.670013200000003
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0.55913,
+        "avg": 0.04140987686736075,
+        "min": 0.008068,
+        "med": 0.037467,
+        "p(90)": 0.0674348,
+        "p(95)": 0.0862756,
+        "p(99)": 0.13822396000000012
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 2930517,
+        "rate": 41297.0373482208
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 26.2462928,
+        "p(95)": 29.517355199999997,
+        "p(99)": 38.148568080000025,
+        "max": 124.590576,
+        "avg": 20.625488643730215,
+        "min": 12.170684,
+        "med": 19.605668
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 20.625488643730215,
+        "min": 12.170684,
+        "med": 19.605668,
+        "p(90)": 26.2462928,
+        "p(95)": 29.517355199999997,
+        "p(99)": 38.148568080000025,
+        "max": 124.590576
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 18.217896,
+        "avg": 0.09930262788592126,
+        "min": 0.002303,
+        "med": 0.006273,
+        "p(90)": 0.009738600000000002,
+        "p(95)": 0.012680799999999983,
+        "p(99)": 3.5755702400000042
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 8832,
+        "fails": 0
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 9.422015,
+        "avg": 0.4894624259846083,
+        "min": 0.031404,
+        "med": 0.450407,
+        "p(90)": 0.8512546000000001,
+        "p(95)": 1.0154902,
+        "p(99)": 1.4526450800000001
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2208,
+        "rate": 31.115280499949847
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 128.755777,
+        "med": 1258.991006,
+        "p(90)": 1861.779303,
+        "p(95)": 1939.6432992,
+        "p(99)": 2004.89287332,
+        "max": 2025.632567,
+        "avg": 1263.9147174680857
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 4,
+        "min": 3,
+        "max": 50
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 50,
+        "max": 50,
+        "value": 50
+      }
+    },
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2209
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 3.4201714800000005,
+        "max": 18.064667,
+        "avg": 0.08869719601629698,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 792880,
+        "rate": 11173.31684909431
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE4NDEwNDMsImV4cCI6MTc4MTg0NDY0M30.zye1ve_CHI89LyZo___vbk3tJaejU-NkO1MWm-qTqls"
+  }
+}

--- a/monitoring/k6/results/recommendation-list-before-summary.json
+++ b/monitoring/k6/results/recommendation-list-before-summary.json
@@ -1,156 +1,63 @@
 {
-  "root_group": {
-    "name": "",
-    "path": "",
-    "id": "d41d8cd98f00b204e9800998ecf8427e",
-    "groups": [],
-    "checks": [
-        {
-          "passes": 2208,
-          "fails": 0,
-          "name": "status is 200",
-          "path": "::status is 200",
-          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
-        },
-        {
-          "passes": 2208,
-          "fails": 0,
-          "name": "data exists",
-          "path": "::data exists",
-          "id": "5383ecdb29afb1a64ae2c425b60f2ffc"
-        },
-        {
-          "name": "not hidden for query baseline",
-          "path": "::not hidden for query baseline",
-          "id": "8e99c4c08e7f30a50514435909e17c93",
-          "passes": 2208,
-          "fails": 0
-        },
-        {
-          "name": "problemSets is array",
-          "path": "::problemSets is array",
-          "id": "f3fa220fc5a5287469ead2713bcd536f",
-          "passes": 2208,
-          "fails": 0
-        }
-      ]
-  },
-  "options": {
-    "summaryTimeUnit": "",
-    "noColor": false,
-    "summaryTrendStats": [
-      "avg",
-      "min",
-      "med",
-      "p(90)",
-      "p(95)",
-      "p(99)",
-      "max"
-    ]
-  },
-  "state": {
-    "isStdOutTTY": true,
-    "isStdErrTTY": true,
-    "testRunDurationMs": 70961.918534
-  },
   "metrics": {
-    "http_req_duration{type:list}": {
-      "thresholds": {
-        "p(95)<500": {
-          "ok": true
-        }
-      },
-      "type": "trend",
+    "http_req_connecting": {
       "contains": "time",
       "values": {
-        "p(90)": 26.167282099999994,
-        "p(95)": 29.49215245,
-        "p(99)": 37.77186730999992,
-        "max": 60.000689,
-        "avg": 20.578403006340604,
-        "min": 12.170684,
-        "med": 19.605456500000003
-      }
-    },
-    "http_reqs": {
-      "values": {
-        "count": 2209,
-        "rate": 31.129372565393666
+        "avg": 0.09916258106884057,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 4.1098167499999985,
+        "max": 12.778398
       },
+      "type": "trend"
+    },
+    "http_req_sending": {
+      "contains": "time",
+      "values": {
+        "avg": 0.059012445652174075,
+        "min": 0.008322,
+        "med": 0.038803500000000005,
+        "p(90)": 0.075465,
+        "p(95)": 0.10397800000000013,
+        "p(99)": 0.24552860999999862,
+        "max": 10.617943
+      },
+      "type": "trend"
+    },
+    "iterations": {
       "type": "counter",
-      "contains": "default"
+      "contains": "default",
+      "values": {
+        "count": 2207,
+        "rate": 30.934542081604505
+      }
     },
     "http_req_waiting": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "p(95)": 28.97448599999999,
-        "p(99)": 37.66025416,
-        "max": 123.931378,
-        "avg": 20.094616340878268,
-        "min": 11.877697,
-        "med": 19.081211,
-        "p(90)": 25.670013200000003
-      }
-    },
-    "http_req_sending": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 0.55913,
-        "avg": 0.04140987686736075,
-        "min": 0.008068,
-        "med": 0.037467,
-        "p(90)": 0.0674348,
-        "p(95)": 0.0862756,
-        "p(99)": 0.13822396000000012
-      }
-    },
-    "data_received": {
-      "type": "counter",
-      "contains": "data",
-      "values": {
-        "count": 2930517,
-        "rate": 41297.0373482208
-      }
-    },
-    "http_req_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(90)": 26.2462928,
-        "p(95)": 29.517355199999997,
-        "p(99)": 38.148568080000025,
-        "max": 124.590576,
-        "avg": 20.625488643730215,
-        "min": 12.170684,
-        "med": 19.605668
-      }
-    },
-    "http_req_duration{expected_response:true}": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 20.625488643730215,
-        "min": 12.170684,
-        "med": 19.605668,
-        "p(90)": 26.2462928,
-        "p(95)": 29.517355199999997,
-        "p(99)": 38.148568080000025,
-        "max": 124.590576
+        "med": 20.735149,
+        "p(90)": 30.0380184,
+        "p(95)": 33.333916,
+        "p(99)": 40.82818975,
+        "max": 425.013002,
+        "avg": 22.382570656250046,
+        "min": 12.879749
       }
     },
     "http_req_blocked": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "max": 18.217896,
-        "avg": 0.09930262788592126,
-        "min": 0.002303,
-        "med": 0.006273,
-        "p(90)": 0.009738600000000002,
-        "p(95)": 0.012680799999999983,
-        "p(99)": 3.5755702400000042
+        "p(95)": 0.02852135000000002,
+        "p(99)": 4.329825569999993,
+        "max": 13.096387,
+        "avg": 0.11446485869565229,
+        "min": 0.003107,
+        "med": 0.006800499999999999,
+        "p(90)": 0.0116682
       }
     },
     "http_req_tls_handshaking": {
@@ -166,104 +73,197 @@
         "max": 0
       }
     },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 2929028,
+        "rate": 41054.88895523239
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2208
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
     "checks": {
       "type": "rate",
       "contains": "default",
       "values": {
+        "fails": 0,
         "rate": 1,
-        "passes": 8832,
-        "fails": 0
-      }
-    },
-    "http_req_receiving": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 9.422015,
-        "avg": 0.4894624259846083,
-        "min": 0.031404,
-        "med": 0.450407,
-        "p(90)": 0.8512546000000001,
-        "p(95)": 1.0154902,
-        "p(99)": 1.4526450800000001
-      }
-    },
-    "iterations": {
-      "type": "counter",
-      "contains": "default",
-      "values": {
-        "count": 2208,
-        "rate": 31.115280499949847
-      }
-    },
-    "iteration_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "min": 128.755777,
-        "med": 1258.991006,
-        "p(90)": 1861.779303,
-        "p(95)": 1939.6432992,
-        "p(99)": 2004.89287332,
-        "max": 2025.632567,
-        "avg": 1263.9147174680857
-      }
-    },
-    "vus": {
-      "type": "gauge",
-      "contains": "default",
-      "values": {
-        "value": 4,
-        "min": 3,
-        "max": 50
+        "passes": 8828
       }
     },
     "vus_max": {
       "type": "gauge",
       "contains": "default",
       "values": {
+        "value": 50,
         "min": 50,
-        "max": 50,
-        "value": 50
+        "max": 50
       }
     },
-    "http_req_failed": {
-      "thresholds": {
-        "rate<0.01": {
-          "ok": true
-        }
-      },
-      "type": "rate",
-      "contains": "default",
-      "values": {
-        "rate": 0,
-        "passes": 0,
-        "fails": 2209
-      }
-    },
-    "http_req_connecting": {
+    "http_req_duration{type:list}": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "p(95)": 0,
-        "p(99)": 3.4201714800000005,
-        "max": 18.064667,
-        "avg": 0.08869719601629698,
-        "min": 0,
-        "med": 0,
-        "p(90)": 0
+        "avg": 22.81024560308114,
+        "min": 13.462102,
+        "med": 21.307638,
+        "p(90)": 30.782750000000004,
+        "p(95)": 34.2448674,
+        "p(99)": 41.38426734000001,
+        "max": 126.043876
+      },
+      "thresholds": {
+        "p(95)<500": {
+          "ok": true
+        }
       }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 30.7963214,
+        "p(95)": 34.30840330000001,
+        "p(99)": 41.656576199999954,
+        "max": 426.197932,
+        "avg": 22.99293930163046,
+        "min": 13.462102,
+        "med": 21.3088975
+      }
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "max": 10.362016,
+        "avg": 0.5513561997282608,
+        "min": 0.032044,
+        "med": 0.4731385,
+        "p(90)": 0.9682203,
+        "p(95)": 1.1733765000000005,
+        "p(99)": 2.0162891999999877
+      },
+      "type": "trend"
     },
     "data_sent": {
       "type": "counter",
       "contains": "data",
       "values": {
-        "count": 792880,
-        "rate": 11173.31684909431
+        "count": 792521,
+        "rate": 11108.416051225775
       }
+    },
+    "http_req_duration{expected_response:true}": {
+      "values": {
+        "avg": 22.99293930163046,
+        "min": 13.462102,
+        "med": 21.3088975,
+        "p(90)": 30.7963214,
+        "p(95)": 34.30840330000001,
+        "p(99)": 41.656576199999954,
+        "max": 426.197932
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 3,
+        "min": 2,
+        "max": 50
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 1264.9379761209236,
+        "min": 438.075583,
+        "med": 1252.8779335,
+        "p(90)": 1868.2800307,
+        "p(95)": 1943.2602948,
+        "p(99)": 2011.2368882899998,
+        "max": 2031.446645
+      }
+    },
+    "http_reqs": {
+      "contains": "default",
+      "values": {
+        "count": 2208,
+        "rate": 30.948558638959106
+      },
+      "type": "counter"
     }
   },
   "setup_data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE4NDEwNDMsImV4cCI6MTc4MTg0NDY0M30.zye1ve_CHI89LyZo___vbk3tJaejU-NkO1MWm-qTqls"
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJsb2FkdGVzdGVyIiwicm9sZSI6IlNUVURFTlQiLCJpYXQiOjE3ODE5NjAzMjEsImV4cCI6MTc4MTk2MzkyMX0.fm1dnGybgH3xEZXljRLoxX-n4br7UFD3GY9H4CrDXhQ"
+  },
+  "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2207,
+          "fails": 0
+        },
+        {
+          "name": "data exists",
+          "path": "::data exists",
+          "id": "5383ecdb29afb1a64ae2c425b60f2ffc",
+          "passes": 2207,
+          "fails": 0
+        },
+        {
+          "id": "8e99c4c08e7f30a50514435909e17c93",
+          "passes": 2207,
+          "fails": 0,
+          "name": "not hidden for query baseline",
+          "path": "::not hidden for query baseline"
+        },
+        {
+          "path": "::problemSets is array",
+          "id": "f3fa220fc5a5287469ead2713bcd536f",
+          "passes": 2207,
+          "fails": 0,
+          "name": "problemSets is array"
+        }
+      ],
+    "name": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71344.194919
   }
 }

--- a/monitoring/k6/results/recommendation-list-before-summary.md
+++ b/monitoring/k6/results/recommendation-list-before-summary.md
@@ -4,21 +4,21 @@
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 2209 |
-| iterations | 2208 |
+| http_reqs | 2208 |
+| iterations | 2207 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 2930517 |
-| data_sent bytes | 792880 |
+| data_received bytes | 2929028 |
+| data_sent bytes | 792521 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 20.63 | 12.17 | 19.61 | 26.25 | 29.52 | 38.15 | 124.59 |
-| http_req_waiting | 20.09 | 11.88 | 19.08 | 25.67 | 28.97 | 37.66 | 123.93 |
-| http_req_blocked | 0.10 | 0.00 | 0.01 | 0.01 | 0.01 | 3.58 | 18.22 |
-| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.42 | 18.06 |
+| http_req_duration | 22.99 | 13.46 | 21.31 | 30.80 | 34.31 | 41.66 | 426.20 |
+| http_req_waiting | 22.38 | 12.88 | 20.74 | 30.04 | 33.33 | 40.83 | 425.01 |
+| http_req_blocked | 0.11 | 0.00 | 0.01 | 0.01 | 0.03 | 4.33 | 13.10 |
+| http_req_connecting | 0.10 | 0 | 0 | 0 | 0 | 4.11 | 12.78 |
 
 ## Metric Meaning
 
@@ -36,10 +36,10 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 2208 pass / 0 fail |
-| data exists | 2208 pass / 0 fail |
-| not hidden for query baseline | 2208 pass / 0 fail |
-| problemSets is array | 2208 pass / 0 fail |
+| status is 200 | 2207 pass / 0 fail |
+| data exists | 2207 pass / 0 fail |
+| not hidden for query baseline | 2207 pass / 0 fail |
+| problemSets is array | 2207 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/results/recommendation-list-before-summary.md
+++ b/monitoring/k6/results/recommendation-list-before-summary.md
@@ -1,0 +1,53 @@
+# k6 Result - recommendation-list-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2209 |
+| iterations | 2208 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 2930517 |
+| data_sent bytes | 792880 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 20.63 | 12.17 | 19.61 | 26.25 | 29.52 | 38.15 | 124.59 |
+| http_req_waiting | 20.09 | 11.88 | 19.08 | 25.67 | 28.97 | 37.66 | 123.93 |
+| http_req_blocked | 0.10 | 0.00 | 0.01 | 0.01 | 0.01 | 3.58 | 18.22 |
+| http_req_connecting | 0.09 | 0 | 0 | 0 | 0 | 3.42 | 18.06 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2208 pass / 0 fail |
+| data exists | 2208 pass / 0 fail |
+| not hidden for query baseline | 2208 pass / 0 fail |
+| problemSets is array | 2208 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/scripts/admin/01-alert-list-baseline.js
+++ b/monitoring/k6/scripts/admin/01-alert-list-baseline.js
@@ -1,0 +1,52 @@
+// Admin 가설 #3 — GET /api/v1/admin/operation-alerts 목록 조회 baseline
+//
+// 목적: 운영 알림 목록의 필터 + 페이징 + 정렬 query 비용을 단독으로 측정한다.
+//   → admin_operation_alert_list_query_duration 과 함께 보면 목록 query/정렬 병목을 분리할 수 있다.
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm -e RESULT_NAME=admin-alert-list-before \
+//     -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
+//     k6 run -o experimental-prometheus-rw /scripts/admin/01-alert-list-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:list}": ["p(95)<800"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = { type: "list", api: "GET /admin/operation-alerts" };
+
+    const res = http.get(`${BASE_URL}/api/v1/admin/operation-alerts?page=0&size=20`, params);
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "content is array": (r) => Array.isArray(r.json("data.content")),
+        "has alert seed": (r) => {
+            const content = r.json("data.content");
+            return Array.isArray(content) && content.length > 0;
+        },
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("admin-alert-list-baseline");

--- a/monitoring/k6/scripts/admin/02-alert-detail-baseline.js
+++ b/monitoring/k6/scripts/admin/02-alert-detail-baseline.js
@@ -1,0 +1,55 @@
+// Admin 가설 #4 — GET /api/v1/admin/operation-alerts/{operationAlertId} 상세 조회 baseline
+//
+// 목적: 운영 알림 상세 기본 조회 + target detail 조합 비용을 단독으로 측정한다.
+//   → admin_operation_alert_detail_query_duration 과
+//      admin_operation_alert_target_detail_duration{targetType=...} 을 함께 본다.
+//
+// ⚠️ OPERATION_ALERT_ID 는 상세 조회 대상 알림 ID 다. loadtest seed 기본값은 1번부터 생성된다.
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm -e RESULT_NAME=admin-alert-detail-before \
+//     -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
+//     -e OPERATION_ALERT_ID=1 \
+//     k6 run -o experimental-prometheus-rw /scripts/admin/02-alert-detail-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+const OPERATION_ALERT_ID = __ENV.OPERATION_ALERT_ID || "1";
+
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:detail}": ["p(95)<500"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = { type: "detail", api: "GET /admin/operation-alerts/{id}" };
+
+    const res = http.get(`${BASE_URL}/api/v1/admin/operation-alerts/${OPERATION_ALERT_ID}`, params);
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "data exists": (r) => r.json("data") !== null,
+        "has target detail": (r) => r.json("data.target") !== null,
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("admin-alert-detail-baseline");

--- a/monitoring/k6/scripts/admin/03-operation-rule-run-baseline.js
+++ b/monitoring/k6/scripts/admin/03-operation-rule-run-baseline.js
@@ -1,0 +1,50 @@
+// Admin 가설 #4 — POST /internal/loadtest/admin/operation-rules/run baseline
+//
+// 목적: 운영 자동화 스케줄러 본체를 cron 대기 없이 실행해 룰별 detect/upsert 병목을 측정한다.
+//   → admin_operation_rule_run_duration, admin_operation_rule_detect_duration,
+//      admin_operation_alert_upsert_duration 과 함께 before/after 비교.
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm -e RESULT_NAME=admin-operation-rule-run-before \
+//     -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
+//     k6 run -o experimental-prometheus-rw /scripts/admin/03-operation-rule-run-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+export const options = {
+    vus: Number(__ENV.VUS || 1),
+    iterations: Number(__ENV.ITERATIONS || 1),
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:operation_rule_run}": ["p(95)<10000"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = {
+        type: "operation_rule_run",
+        api: "POST /internal/loadtest/admin/operation-rules/run",
+    };
+
+    const res = http.post(`${BASE_URL}/internal/loadtest/admin/operation-rules/run`, null, params);
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "trigger completed": (r) => r.json("status") === "completed",
+        "duration exists": (r) => Number(r.json("durationMs")) >= 0,
+    });
+
+    sleep(1);
+}
+
+export const handleSummary = createSummaryHandler("admin-operation-rule-run-baseline");

--- a/monitoring/k6/scripts/recommendation/01-list-baseline.js
+++ b/monitoring/k6/scripts/recommendation/01-list-baseline.js
@@ -1,0 +1,55 @@
+// Recommendation 트랙 A — GET /api/v1/recommendations/problem-sets/me 단일 baseline
+//
+// 목적: 추천 목록 조회의 숨김 확인 + ACTIVE 추천 native query 비용을 baseline 으로 박는다.
+//   → 후속 인덱스/쿼리 최적화 후 같은 스크립트로 before/after 비교.
+//
+// ⚠️ 전제 (5단계 시드):
+//   - loadtest DB 에 로그인 계정(auth.js 의 LOGIN_EMAIL/PASSWORD)이 있어야 한다.
+//   - 그 계정에 ACTIVE 추천 row 와 ACTIVE 문제 세트/카테고리 데이터가 있어야 한다.
+//   - hide-today 상태면 추천 query 를 건너뛰므로 baseline 전에 숨김 row 를 비활성/만료 상태로 둔다.
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm -e RESULT_NAME=recommendation-list-before \
+//     -e LOGIN_EMAIL=u01@test.com -e LOGIN_PASSWORD=Test1234! \
+//     k6 run -o experimental-prometheus-rw /scripts/recommendation/01-list-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+export const options = {
+    stages: [
+        { duration: "20s", target: 50 },
+        { duration: "40s", target: 50 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:list}": ["p(95)<500"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = { type: "list", api: "GET /recommendations/problem-sets/me" };
+
+    const res = http.get(`${BASE_URL}/api/v1/recommendations/problem-sets/me?limit=3`, params);
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "data exists": (r) => r.json("data") !== null,
+        "not hidden for query baseline": (r) => r.json("data.hidden") === false,
+        "problemSets is array": (r) => Array.isArray(r.json("data.problemSets")),
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("recommendation-list-baseline");

--- a/monitoring/k6/scripts/recommendation/02-hide-today-baseline.js
+++ b/monitoring/k6/scripts/recommendation/02-hide-today-baseline.js
@@ -1,0 +1,49 @@
+// Recommendation 가설 #4 — POST /api/v1/recommendations/problem-sets/hide-today baseline
+//
+// 목적: 추천 숨김 upsert 성능을 추천 목록 조회와 분리해 측정한다.
+//   → 반복 실행 시 최초 1회는 insert, 이후는 update 경로를 탄다.
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm -e RESULT_NAME=recommendation-hide-before \
+//     -e LOGIN_EMAIL=u01@test.com -e LOGIN_PASSWORD=Test1234! \
+//     k6 run -o experimental-prometheus-rw /scripts/recommendation/02-hide-today-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+export const options = {
+    stages: [
+        { duration: "20s", target: 30 },
+        { duration: "40s", target: 30 },
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:hide}": ["p(95)<300"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = { type: "hide", api: "POST /recommendations/problem-sets/hide-today" };
+
+    const res = http.post(`${BASE_URL}/api/v1/recommendations/problem-sets/hide-today`, null, params);
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "hidden is true": (r) => r.json("data.hidden") === true,
+        "hiddenUntil exists": (r) => r.json("data.hiddenUntil") !== null,
+    });
+
+    sleep(randomSleep());
+}
+
+export const handleSummary = createSummaryHandler("recommendation-hide-today-baseline");

--- a/monitoring/k6/scripts/recommendation/03-generation-baseline.js
+++ b/monitoring/k6/scripts/recommendation/03-generation-baseline.js
@@ -1,0 +1,50 @@
+// Recommendation 트랙 B — POST /internal/loadtest/recommendations/generate baseline
+//
+// 목적: 추천 생성 배치 본체를 cron 대기 없이 실행해 FastAPI 호출/저장 병목을 분리 측정한다.
+//   → recommendation_generation_batch_duration, recommendation_generation_external_duration,
+//      recommendation_generation_save_duration 과 함께 before/after 비교.
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm -e RESULT_NAME=recommendation-generation-before \
+//     -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
+//     k6 run -o experimental-prometheus-rw /scripts/recommendation/03-generation-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+export const options = {
+    vus: Number(__ENV.VUS || 1),
+    iterations: Number(__ENV.ITERATIONS || 1),
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:recommendation_generation}": ["p(95)<300000"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export function setup() {
+    return { token: login() };
+}
+
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = {
+        type: "recommendation_generation",
+        api: "POST /internal/loadtest/recommendations/generate",
+    };
+
+    const res = http.post(`${BASE_URL}/internal/loadtest/recommendations/generate`, null, params);
+
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "trigger completed": (r) => r.json("status") === "completed",
+        "generated user count exists": (r) => Number(r.json("generatedUserCount")) >= 0,
+    });
+
+    sleep(1);
+}
+
+export const handleSummary = createSummaryHandler("recommendation-generation-baseline");

--- a/monitoring/k6/scripts/recommendation/03-generation-baseline.js
+++ b/monitoring/k6/scripts/recommendation/03-generation-baseline.js
@@ -6,6 +6,7 @@
 //
 // 실행 (monitoring/ 에서):
 //   docker compose run --rm -e RESULT_NAME=recommendation-generation-before \
+//     -e SCALE_USERS=120 \
 //     -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
 //     k6 run -o experimental-prometheus-rw /scripts/recommendation/03-generation-baseline.js
 
@@ -30,10 +31,12 @@ export function setup() {
 }
 
 export default function (data) {
+    const scaleUsers = String(__ENV.SCALE_USERS || "120");
     const params = authCookies(data.token);
     params.tags = {
         type: "recommendation_generation",
         api: "POST /internal/loadtest/recommendations/generate",
+        scale_users: scaleUsers,
     };
 
     const res = http.post(`${BASE_URL}/internal/loadtest/recommendations/generate`, null, params);

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -8,3 +8,9 @@ scrape_configs:
       - targets: ["host.docker.internal:8080"]
         labels:
           application: code-bomba-lms
+  - job_name: "lms-python"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["host.docker.internal:8000"]
+        labels:
+          application: code-bomba-python

--- a/src/main/java/com/wanted/codebombalms/admin/README.md
+++ b/src/main/java/com/wanted/codebombalms/admin/README.md
@@ -59,14 +59,14 @@ admin
 
 | Method | Path | 설명 | 권한 |
 | --- | --- | --- | --- |
-| `GET` | `/api/v1/admin/operation-alerts` | 운영 알림 목록 조회 | 운영자 |
-| `GET` | `/api/v1/admin/operation-alerts/{operationAlertId}` | 운영 알림 상세 조회 | 운영자 |
-| `PATCH` | `/api/v1/admin/operation-alerts/{operationAlertId}/memo` | 운영 알림 메모 수정 | 운영자 |
-| `PATCH` | `/api/v1/admin/operation-alerts/{operationAlertId}/status` | 운영 알림 상태 수정 | 운영자 |
-| `DELETE` | `/api/v1/admin/operation-alerts/{operationAlertId}` | 운영 알림 삭제 | 운영자 |
-| `GET` | `/api/v1/admin/automation-rules` | 자동화 규칙 목록 조회 | 운영자 |
-| `PATCH` | `/api/v1/admin/automation-rules` | 자동화 규칙 수정 | 운영자 |
-| `PATCH` | `/api/v1/admin/automation-rules/{automationRuleId}/enabled` | 자동화 규칙 활성화 변경 | 운영자 |
+| `GET` | `/api/v1/admin/operation-alerts` | 운영 알림 목록 조회 | `ADMIN` |
+| `GET` | `/api/v1/admin/operation-alerts/{operationAlertId}` | 운영 알림 상세 조회 | `ADMIN` |
+| `PATCH` | `/api/v1/admin/operation-alerts/{operationAlertId}/memo` | 운영 알림 메모 수정 | `ADMIN` + `RULE_MANAGEMENT` |
+| `PATCH` | `/api/v1/admin/operation-alerts/{operationAlertId}/status` | 운영 알림 상태 수정 | `ADMIN` + `RULE_MANAGEMENT` |
+| `DELETE` | `/api/v1/admin/operation-alerts/{operationAlertId}` | 운영 알림 삭제 | `ADMIN` + `RULE_MANAGEMENT` |
+| `GET` | `/api/v1/admin/automation-rules` | 자동화 규칙 목록 조회 | `ADMIN` |
+| `PATCH` | `/api/v1/admin/automation-rules` | 자동화 규칙 수정 | `ADMIN` + `RULE_MANAGEMENT` |
+| `PATCH` | `/api/v1/admin/automation-rules/{automationRuleId}/enabled` | 자동화 규칙 활성화 변경 | `ADMIN` + `RULE_MANAGEMENT` |
 
 ## 핵심 흐름
 

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/application/service/OperationAlertQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/application/service/OperationAlertQueryService.java
@@ -9,12 +9,15 @@ import com.wanted.codebombalms.admin.operation.alert.application.usecase.GetOper
 import com.wanted.codebombalms.admin.operation.alert.application.usecase.GetOperationAlertsUseCase;
 import com.wanted.codebombalms.admin.operation.alert.domain.exception.OperationAlertErrorCode;
 import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.admin.operation.metrics.AdminMetrics;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -22,18 +25,36 @@ public class OperationAlertQueryService implements GetOperationAlertsUseCase, Ge
 
     private final OperationAlertQueryRepository operationAlertQueryRepository;
     private final OperationAlertTargetDetailPort operationAlertTargetDetailPort;
+    private final AdminMetrics adminMetrics;
 
     @Override
     public PageResult<OperationAlertListItem> getAlerts(GetOperationAlertsQuery query) {
         validatePage(query.page(), query.size());
-        return operationAlertQueryRepository.findAlerts(query);
+
+        // 운영 알림 목록 조회, 조회 전후 시간을 재서 admin_operation_alert_list_query_duration에 기록하고, Loki 용 로그를 남김
+        long startedAt = System.nanoTime();
+        PageResult<OperationAlertListItem> result = operationAlertQueryRepository.findAlerts(query);
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        adminMetrics.recordAlertListQuery(elapsedNanos);
+        log.info("event=admin_operation_alert_list_queried targetType={} status={} resultCount={} totalElements={} durationMs={}",
+                query.targetType(), query.status(), result.getContent().size(), result.getTotalElements(),
+                elapsedNanos / 1_000_000);
+
+        return result;
     }
 
     @Override
     // 알림 상세 기본 정보와 대상 도메인 상세 정보를 조합해 반환한다.
     public OperationAlertDetail getAlertDetail(Long operationAlertId) {
+        long startedAt = System.nanoTime();
         OperationAlertDetail alertDetail = operationAlertQueryRepository.findAlertDetail(operationAlertId)
                 .orElseThrow(() -> new NotFoundException(OperationAlertErrorCode.OPERATION_ALERT_NOT_FOUND));
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        adminMetrics.recordAlertDetailQuery(elapsedNanos);
+        log.info("event=admin_operation_alert_detail_queried targetType={} durationMs={}",
+                alertDetail.targetType(), elapsedNanos / 1_000_000);
 
         return alertDetail.withTargetDetail(operationAlertTargetDetailPort.loadTargetDetail(
                 alertDetail.targetType(),

--- a/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/adapter/OperationAlertTargetDetailAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/alert/infrastructure/adapter/OperationAlertTargetDetailAdapter.java
@@ -8,6 +8,7 @@ import com.wanted.codebombalms.admin.operation.alert.application.query.Operation
 import com.wanted.codebombalms.admin.operation.alert.application.query.OperationAlertTargetInfo;
 import com.wanted.codebombalms.admin.operation.alert.domain.exception.OperationAlertErrorCode;
 import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+import com.wanted.codebombalms.admin.operation.metrics.AdminMetrics;
 import com.wanted.codebombalms.course.application.usecase.CourseQueryUseCase;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
@@ -16,11 +17,13 @@ import com.wanted.codebombalms.problems.problem.application.usecase.ProblemTarge
 import com.wanted.codebombalms.user.application.query.StudentDetail;
 import com.wanted.codebombalms.user.application.usecase.GetStudentDetailUseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -30,6 +33,7 @@ public class OperationAlertTargetDetailAdapter implements OperationAlertTargetDe
     private final CourseQueryUseCase courseQueryUseCase;
     private final ProblemTargetDetailQueryUseCase problemTargetDetailQueryUseCase;
     private final GetStudentDetailUseCase getStudentDetailUseCase;
+    private final AdminMetrics adminMetrics;
 
     @Override
     // 대상 타입에 따라 강좌, 문제 또는 사용자 상세 조회로 분기한다.
@@ -40,11 +44,19 @@ public class OperationAlertTargetDetailAdapter implements OperationAlertTargetDe
             BigDecimal thresholdValue,
             OperationAlertRuleInfo rule
     ) {
-        return switch (targetType) {
+        long startedAt = System.nanoTime();
+        OperationAlertTargetDetail result = switch (targetType) {
             case COURSE -> loadCourseDetail(targetId, detectedValue, thresholdValue, rule);
             case PROBLEM -> loadProblemDetail(targetId, detectedValue, thresholdValue, rule);
             case USER -> loadUserDetail(targetId, detectedValue, thresholdValue, rule);
         };
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        adminMetrics.recordTargetDetail(targetType, elapsedNanos);
+        log.info("event=admin_operation_alert_target_detail_loaded targetType={} durationMs={}",
+                targetType, elapsedNanos / 1_000_000);
+
+        return result;
     }
 
     // 강좌 알림의 강좌 정보와 강좌 담당자 정보를 조회한다.

--- a/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/automation/application/service/OperationRuleExecutionService.java
@@ -7,9 +7,11 @@ import com.wanted.codebombalms.admin.operation.automation.application.model.Oper
 import com.wanted.codebombalms.admin.operation.automation.application.policy.OperationAlertUpsertPolicy;
 import com.wanted.codebombalms.admin.operation.automation.application.policy.OperationRuleExecutionPolicy;
 import com.wanted.codebombalms.admin.operation.automation.application.usecase.RunOperationRuleUseCase;
+import com.wanted.codebombalms.admin.operation.metrics.AdminMetrics;
 import com.wanted.codebombalms.admin.operation.rule.domain.model.AutomationRule;
 import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
 import com.wanted.codebombalms.admin.operation.rule.domain.repository.AutomationRuleRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @Transactional
 // 활성화된 자동 규칙을 실행하고 탐지 결과를 운영 알림으로 반영한다.
@@ -32,6 +35,7 @@ public class OperationRuleExecutionService implements RunOperationRuleUseCase {
     private final OperationRuleExecutionPolicy operationRuleExecutionPolicy;
     private final OperationAlertUpsertPolicy operationAlertUpsertPolicy;
     private final Clock clock;
+    private final AdminMetrics adminMetrics;
 
     public OperationRuleExecutionService(
             AutomationRuleRepository automationRuleRepository,
@@ -39,13 +43,15 @@ public class OperationRuleExecutionService implements RunOperationRuleUseCase {
             List<OperationRuleHandler> handlers,
             OperationRuleExecutionPolicy operationRuleExecutionPolicy,
             OperationAlertUpsertPolicy operationAlertUpsertPolicy,
-            Clock clock
+            Clock clock,
+            AdminMetrics adminMetrics
     ) {
         this.automationRuleRepository = automationRuleRepository;
         this.operationAlertRepository = operationAlertRepository;
         this.operationRuleExecutionPolicy = operationRuleExecutionPolicy;
         this.operationAlertUpsertPolicy = operationAlertUpsertPolicy;
         this.clock = clock;
+        this.adminMetrics = adminMetrics;
         this.handlers = handlers.stream()
                 .collect(Collectors.toMap(
                         OperationRuleHandler::supports,
@@ -57,21 +63,39 @@ public class OperationRuleExecutionService implements RunOperationRuleUseCase {
 
     @Override
     public void run() {
-        automationRuleRepository.findEnabled()
-                .forEach(this::executeRule);
+        long startedAt = System.nanoTime();
+        List<AutomationRule> enabledRules = automationRuleRepository.findEnabled();
+        int detectedCount = enabledRules.stream()
+                .mapToInt(this::executeRule)
+                .sum();
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        adminMetrics.recordRuleRun(elapsedNanos);
+        log.info("event=admin_operation_rule_run_completed enabledRuleCount={} detectedCount={} durationMs={}",
+                enabledRules.size(), detectedCount, elapsedNanos / 1_000_000);
     }
 
-    private void executeRule(AutomationRule rule) {
+    private int executeRule(AutomationRule rule) {
         OperationRuleHandler handler = handlers.get(rule.getRuleCode());
         if (!operationRuleExecutionPolicy.canExecute(rule, handler)) {
-            return;
+            return 0;
         }
 
-        handler.detect(rule)
-                .forEach(result -> saveAlert(rule, result));
+        long startedAt = System.nanoTime();
+        List<OperationRuleDetectionResult> results = handler.detect(rule);
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        adminMetrics.recordRuleDetect(rule.getRuleCode(), elapsedNanos);
+        adminMetrics.incrementRuleDetected(rule.getRuleCode(), results.size());
+        log.info("event=admin_operation_rule_detected ruleCode={} detectedCount={} durationMs={}",
+                rule.getRuleCode(), results.size(), elapsedNanos / 1_000_000);
+
+        results.forEach(result -> saveAlert(rule, result));
+        return results.size();
     }
 
     private void saveAlert(AutomationRule rule, OperationRuleDetectionResult result) {
+        long startedAt = System.nanoTime();
         LocalDateTime detectedAt = LocalDateTime.now(clock);
 
         OperationAlert operationAlert = operationAlertUpsertPolicy.resolve(
@@ -86,5 +110,10 @@ public class OperationRuleExecutionService implements RunOperationRuleUseCase {
         );
 
         operationAlertRepository.save(operationAlert);
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        adminMetrics.recordAlertUpsert(elapsedNanos);
+        log.info("event=admin_operation_alert_upserted ruleCode={} targetType={} alertCount=1 durationMs={}",
+                rule.getRuleCode(), result.targetType(), elapsedNanos / 1_000_000);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/admin/operation/loadtest/AdminOperationLoadTestController.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/loadtest/AdminOperationLoadTestController.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.admin.operation.loadtest;
+
+import com.wanted.codebombalms.admin.operation.automation.application.usecase.RunOperationRuleUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@Profile("loadtest")
+@RequiredArgsConstructor
+@RequestMapping("/internal/loadtest/admin")
+public class AdminOperationLoadTestController {
+
+    private final RunOperationRuleUseCase runOperationRuleUseCase;
+
+    @PostMapping("/operation-rules/run")
+    public ResponseEntity<Map<String, Object>> runOperationRules() {
+        long startedAt = System.nanoTime();
+
+        runOperationRuleUseCase.run();
+
+        long durationMs = (System.nanoTime() - startedAt) / 1_000_000;
+        log.info("event=loadtest_admin_operation_rule_triggered durationMs={}", durationMs);
+
+        return ResponseEntity.ok(Map.of(
+                "status", "completed",
+                "durationMs", durationMs
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/loadtest/AdminOperationLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/loadtest/AdminOperationLoadTestSeeder.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -21,22 +20,25 @@ import java.util.List;
 /**
  * Admin 운영 알림 목록/상세 baseline 용 부하테스트 시드.
  *
- * <p>{@code loadtest} 프로파일에서만 실행한다. admin 로그인 계정과 RULE_MANAGEMENT 권한,
- * 상세 조회 target 이 실제로 바라볼 COURSE/PROBLEM/USER 데이터, 운영 알림 200건을 만든다.
+ * <p>{@code loadtest-admin} 프로파일에서만 실행한다. admin 로그인 계정과 RULE_MANAGEMENT 권한,
+ * 상세 조회 target 이 실제로 바라볼 COURSE/PROBLEM/USER 데이터, 운영 알림 210건을 만든다.
+ * 자동화 룰 baseline 은 도메인별 병목 위치를 보기 위한 테스트이므로
+ * COURSE/PROBLEM/USER 대상 규모를 같은 수준으로 맞춘다.
  */
 @Slf4j
 @Component
-@Profile("loadtest")
-@DependsOn("chatListLoadTestSeeder")
+@Profile("loadtest-admin")
 @RequiredArgsConstructor
 public class AdminOperationLoadTestSeeder implements ApplicationRunner {
 
     private static final String ADMIN_EMAIL = "admin@test.com";
     private static final String ADMIN_PASSWORD = "Test1234!";
-    private static final int ALERTS = 200;
-    private static final int COURSES = 40;
-    private static final int PROBLEMS = 80;
-    private static final int USERS = 240;
+    private static final int RULE_TARGETS = 200;
+    private static final int ALERTS = 210;
+    private static final int COURSES = RULE_TARGETS;
+    private static final int PROBLEMS = RULE_TARGETS;
+    private static final int USERS = RULE_TARGETS;
+    private static final int PROBLEM_SETS = PROBLEMS;
     private static final int SUBMISSIONS_PER_PROBLEM = 25;
 
     private final JdbcTemplate jdbc;
@@ -44,6 +46,9 @@ public class AdminOperationLoadTestSeeder implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
+        Long adminUserId = seedAdminUser();
+        seedAdminPermission(adminUserId);
+
         Long already = jdbc.queryForObject("select count(*) from operation_alert", Long.class);
         if (already != null && already > 0) {
             log.info("event=loadtest_admin_seed_skipped reason=already_seeded alerts={}", already);
@@ -52,14 +57,12 @@ public class AdminOperationLoadTestSeeder implements ApplicationRunner {
 
         long startedAt = System.nanoTime();
 
-        Long adminUserId = seedAdminUser();
-        seedAdminPermission(adminUserId);
         seedAutomationRules();
 
         Long courseCategoryId = seedCourseCategory();
         List<Long> courseIds = seedCourses(adminUserId, courseCategoryId);
         List<Long> targetUserIds = seedTargetUsers();
-        List<Long> problemIds = loadProblemIds();
+        List<Long> problemIds = seedProblems(adminUserId);
 
         seedOldLoginHistory(targetUserIds);
         seedLowEnrollments(courseIds, targetUserIds);
@@ -75,6 +78,18 @@ public class AdminOperationLoadTestSeeder implements ApplicationRunner {
     private Long seedAdminUser() {
         Long exists = jdbc.queryForObject("select count(*) from users where email = ?", Long.class, ADMIN_EMAIL);
         if (exists != null && exists > 0) {
+            jdbc.update("""
+                    update users
+                    set role = 'ADMIN',
+                        password = ?,
+                        name = '부하 관리자',
+                        nickname = 'loadtest-admin',
+                        provider = 'LOCAL',
+                        email_verified = true,
+                        is_locked = false,
+                        updated_at = now(6)
+                    where email = ?
+                    """, passwordEncoder.encode(ADMIN_PASSWORD), ADMIN_EMAIL);
             return jdbc.queryForObject("select user_id from users where email = ?", Long.class, ADMIN_EMAIL);
         }
 
@@ -89,6 +104,15 @@ public class AdminOperationLoadTestSeeder implements ApplicationRunner {
     }
 
     private void seedAdminPermission(Long adminUserId) {
+        Long exists = jdbc.queryForObject("""
+                select count(*)
+                from admin_permissions
+                where admin_user_id = ? and permission_type = 'RULE_MANAGEMENT'
+                """, Long.class, adminUserId);
+        if (exists != null && exists > 0) {
+            return;
+        }
+
         jdbc.update("""
                 insert into admin_permissions
                   (admin_user_id, permission_type, granted_by, created_at)
@@ -176,13 +200,58 @@ public class AdminOperationLoadTestSeeder implements ApplicationRunner {
                 """, Long.class);
     }
 
-    private List<Long> loadProblemIds() {
+    private List<Long> seedProblemSets(Long adminUserId) {
+        jdbc.batchUpdate("""
+                insert into problem_set
+                  (title, status, total_problem_count, completed_user_count, started_user_count, created_by, created_at)
+                values (?, 'ACTIVE', ?, 0, 0, ?, now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setString(1, "운영 부하 문제세트 " + (i + 1));
+                ps.setInt(2, 1);
+                ps.setLong(3, adminUserId);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return PROBLEM_SETS;
+            }
+        });
+
+        return jdbc.queryForList("""
+                select problem_set_id
+                from problem_set
+                where title like '운영 부하 문제세트 %'
+                order by problem_set_id
+                """, Long.class);
+    }
+
+    private List<Long> seedProblems(Long adminUserId) {
+        List<Long> problemSetIds = seedProblemSets(adminUserId);
+
+        jdbc.batchUpdate("""
+                insert into problem (problem_set_id, title, status, point)
+                values (?, ?, 'ACTIVE', 0)
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, problemSetIds.get(i));
+                ps.setString(2, "운영 부하 문제 " + (i + 1));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return PROBLEMS;
+            }
+        });
+
         return jdbc.queryForList("""
                 select problem_id
                 from problem
+                where title like '운영 부하 문제 %'
                 order by problem_id
-                limit ?
-                """, Long.class, PROBLEMS);
+                """, Long.class);
     }
 
     private void seedOldLoginHistory(List<Long> targetUserIds) {
@@ -300,34 +369,35 @@ public class AdminOperationLoadTestSeeder implements ApplicationRunner {
             List<Long> targetUserIds
     ) {
         int type = index % 3;
+        int targetIndex = index / 3;
         if (type == 0) {
             return new AlertTarget(
                     ruleIds.get(0),
                     "COURSE",
-                    courseIds.get(index % courseIds.size()),
+                    courseIds.get(targetIndex % courseIds.size()),
                     BigDecimal.valueOf(3),
                     BigDecimal.valueOf(10),
-                    targetUserIds.get(index % targetUserIds.size())
+                    targetUserIds.get(targetIndex % targetUserIds.size())
             );
         }
         if (type == 1) {
             return new AlertTarget(
                     ruleIds.get(1),
                     "USER",
-                    targetUserIds.get(index % targetUserIds.size()),
+                    targetUserIds.get(targetIndex % targetUserIds.size()),
                     BigDecimal.valueOf(45),
                     BigDecimal.valueOf(30),
-                    targetUserIds.get(index % targetUserIds.size())
+                    targetUserIds.get(targetIndex % targetUserIds.size())
             );
         }
 
         return new AlertTarget(
                 ruleIds.get(2),
                 "PROBLEM",
-                problemIds.get(index % problemIds.size()),
+                problemIds.get(targetIndex % problemIds.size()),
                 BigDecimal.valueOf(82),
                 BigDecimal.valueOf(70),
-                targetUserIds.get(index % targetUserIds.size())
+                targetUserIds.get(targetIndex % targetUserIds.size())
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/admin/operation/loadtest/AdminOperationLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/loadtest/AdminOperationLoadTestSeeder.java
@@ -1,0 +1,343 @@
+package com.wanted.codebombalms.admin.operation.loadtest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Admin 운영 알림 목록/상세 baseline 용 부하테스트 시드.
+ *
+ * <p>{@code loadtest} 프로파일에서만 실행한다. admin 로그인 계정과 RULE_MANAGEMENT 권한,
+ * 상세 조회 target 이 실제로 바라볼 COURSE/PROBLEM/USER 데이터, 운영 알림 200건을 만든다.
+ */
+@Slf4j
+@Component
+@Profile("loadtest")
+@DependsOn("chatListLoadTestSeeder")
+@RequiredArgsConstructor
+public class AdminOperationLoadTestSeeder implements ApplicationRunner {
+
+    private static final String ADMIN_EMAIL = "admin@test.com";
+    private static final String ADMIN_PASSWORD = "Test1234!";
+    private static final int ALERTS = 200;
+    private static final int COURSES = 40;
+    private static final int PROBLEMS = 80;
+    private static final int USERS = 240;
+    private static final int SUBMISSIONS_PER_PROBLEM = 25;
+
+    private final JdbcTemplate jdbc;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Long already = jdbc.queryForObject("select count(*) from operation_alert", Long.class);
+        if (already != null && already > 0) {
+            log.info("event=loadtest_admin_seed_skipped reason=already_seeded alerts={}", already);
+            return;
+        }
+
+        long startedAt = System.nanoTime();
+
+        Long adminUserId = seedAdminUser();
+        seedAdminPermission(adminUserId);
+        seedAutomationRules();
+
+        Long courseCategoryId = seedCourseCategory();
+        List<Long> courseIds = seedCourses(adminUserId, courseCategoryId);
+        List<Long> targetUserIds = seedTargetUsers();
+        List<Long> problemIds = loadProblemIds();
+
+        seedOldLoginHistory(targetUserIds);
+        seedLowEnrollments(courseIds, targetUserIds);
+        seedWrongRateSubmissions(problemIds, targetUserIds);
+        seedOperationAlerts(courseIds, problemIds, targetUserIds);
+
+        log.info("event=loadtest_admin_seed_completed adminUserId={} alerts={} courses={} problems={} users={} submissions={} durationMs={}",
+                adminUserId, ALERTS, courseIds.size(), problemIds.size(), targetUserIds.size(),
+                problemIds.size() * SUBMISSIONS_PER_PROBLEM,
+                (System.nanoTime() - startedAt) / 1_000_000);
+    }
+
+    private Long seedAdminUser() {
+        Long exists = jdbc.queryForObject("select count(*) from users where email = ?", Long.class, ADMIN_EMAIL);
+        if (exists != null && exists > 0) {
+            return jdbc.queryForObject("select user_id from users where email = ?", Long.class, ADMIN_EMAIL);
+        }
+
+        jdbc.update("""
+                insert into users
+                  (role, email, password, name, nickname, provider, email_verified, is_locked, created_at, updated_at)
+                values
+                  ('ADMIN', ?, ?, '부하 관리자', 'loadtest-admin', 'LOCAL', true, false, now(6), now(6))
+                """, ADMIN_EMAIL, passwordEncoder.encode(ADMIN_PASSWORD));
+
+        return jdbc.queryForObject("select user_id from users where email = ?", Long.class, ADMIN_EMAIL);
+    }
+
+    private void seedAdminPermission(Long adminUserId) {
+        jdbc.update("""
+                insert into admin_permissions
+                  (admin_user_id, permission_type, granted_by, created_at)
+                values (?, 'RULE_MANAGEMENT', ?, now(6))
+                """, adminUserId, adminUserId);
+    }
+
+    private void seedAutomationRules() {
+        jdbc.update("""
+                insert into automation_rule
+                  (rule_code, threshold_value, min_sample_count, severity, enabled, created_at)
+                values
+                  ('COURSE_LOW_ENROLLMENT', 10.00, null, 'MEDIUM', true, now(6)),
+                  ('USER_INACTIVE_NO_COURSE', 30.00, null, 'LOW', true, now(6)),
+                  ('PROBLEM_HIGH_WRONG_RATE', 70.00, 20, 'HIGH', true, now(6))
+                """);
+    }
+
+    private Long seedCourseCategory() {
+        jdbc.update("""
+                insert into course_category (name, status, display_order, created_at)
+                values ('운영 부하 카테고리', 'ACTIVE', 999, now(6))
+                """);
+        return jdbc.queryForObject("""
+                select course_category_id
+                from course_category
+                where name = '운영 부하 카테고리'
+                """, Long.class);
+    }
+
+    private List<Long> seedCourses(Long instructorId, Long courseCategoryId) {
+        jdbc.batchUpdate("""
+                insert into course
+                  (instructor_id, course_category_id, title, description, thumbnail_url, status, created_at)
+                values (?, ?, ?, 'admin operation loadtest course', null, 'ACTIVE', now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, instructorId);
+                ps.setLong(2, courseCategoryId);
+                ps.setString(3, "운영 부하 강좌 " + (i + 1));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return COURSES;
+            }
+        });
+
+        return jdbc.queryForList("""
+                select course_id
+                from course
+                where title like '운영 부하 강좌 %'
+                order by course_id
+                """, Long.class);
+    }
+
+    private List<Long> seedTargetUsers() {
+        jdbc.batchUpdate("""
+                insert into users
+                  (role, email, password, name, nickname, provider, email_verified, is_locked, created_at, updated_at)
+                values
+                  ('STUDENT', ?, ?, ?, ?, 'LOCAL', true, false, date_sub(now(6), interval 45 day), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                int no = i + 1;
+                ps.setString(1, "admin-target-" + no + "@test.com");
+                ps.setString(2, passwordEncoder.encode(ADMIN_PASSWORD));
+                ps.setString(3, "운영대상 " + no);
+                ps.setString(4, "admin-target-" + no);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return USERS;
+            }
+        });
+
+        return jdbc.queryForList("""
+                select user_id
+                from users
+                where email like 'admin-target-%@test.com'
+                order by user_id
+                """, Long.class);
+    }
+
+    private List<Long> loadProblemIds() {
+        return jdbc.queryForList("""
+                select problem_id
+                from problem
+                order by problem_id
+                limit ?
+                """, Long.class, PROBLEMS);
+    }
+
+    private void seedOldLoginHistory(List<Long> targetUserIds) {
+        jdbc.batchUpdate("""
+                insert into login_history
+                  (user_id, ip_address, user_agent, device_fp, country, city, is_suspicious, created_at)
+                values (?, '127.0.0.1', 'loadtest-admin-automation', null, 'KR', 'Seoul', false,
+                        date_sub(now(6), interval ? day))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, targetUserIds.get(i));
+                ps.setInt(2, 35 + (i % 20));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return targetUserIds.size();
+            }
+        });
+    }
+
+    private void seedLowEnrollments(List<Long> courseIds, List<Long> targetUserIds) {
+        int enrollmentCount = courseIds.size() * 3;
+        jdbc.batchUpdate("""
+                insert into enrollment
+                  (user_id, course_id, status, enrolled_at, canceled_at)
+                values (?, ?, 'ACTIVE', date_sub(now(6), interval ? day), null)
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, targetUserIds.get(i % targetUserIds.size()));
+                ps.setLong(2, courseIds.get(i / 3));
+                ps.setInt(3, 20 + (i % 10));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return enrollmentCount;
+            }
+        });
+    }
+
+    private void seedWrongRateSubmissions(List<Long> problemIds, List<Long> targetUserIds) {
+        int submissionCount = problemIds.size() * SUBMISSIONS_PER_PROBLEM;
+        jdbc.batchUpdate("""
+                insert into submission
+                  (user_id, problem_id, submitted_code, is_correct, attempt_no,
+                   passed_test_count, total_test_count, execution_status, error_message, submitted_at)
+                values (?, ?, 'print("loadtest")', ?, 1, ?, 10, 'COMPLETED', null,
+                        date_sub(now(6), interval ? minute))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                boolean correct = i % 5 == 0;
+                ps.setLong(1, targetUserIds.get(i % targetUserIds.size()));
+                ps.setLong(2, problemIds.get(i / SUBMISSIONS_PER_PROBLEM));
+                ps.setBoolean(3, correct);
+                ps.setInt(4, correct ? 10 : 3);
+                ps.setInt(5, submissionCount - i);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return submissionCount;
+            }
+        });
+    }
+
+    private void seedOperationAlerts(List<Long> courseIds, List<Long> problemIds, List<Long> targetUserIds) {
+        List<Long> ruleIds = jdbc.queryForList("""
+                select operation_rule_id
+                from automation_rule
+                order by operation_rule_id
+                """, Long.class);
+
+        jdbc.batchUpdate("""
+                insert into operation_alert
+                  (operation_rule_id, target_type, target_id, detected_value, threshold_value_snapshot,
+                   assignee_id, reason, recommended_action, first_detected_at, last_detected_at,
+                   status, resolved_by, resolved_at, admin_memo, created_at, updated_at, deleted_at)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, null, null, null, ?, null, null)
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                AlertTarget target = alertTarget(i, ruleIds, courseIds, problemIds, targetUserIds);
+                LocalDateTime detectedAt = LocalDateTime.now().minusMinutes(ALERTS - i);
+
+                ps.setLong(1, target.ruleId());
+                ps.setString(2, target.targetType());
+                ps.setLong(3, target.targetId());
+                ps.setBigDecimal(4, target.detectedValue());
+                ps.setBigDecimal(5, target.thresholdValue());
+                ps.setLong(6, target.assigneeId());
+                ps.setString(7, "loadtest alert reason " + (i + 1));
+                ps.setString(8, "loadtest recommended action " + (i + 1));
+                ps.setTimestamp(9, Timestamp.valueOf(detectedAt.minusMinutes(5)));
+                ps.setTimestamp(10, Timestamp.valueOf(detectedAt));
+                ps.setString(11, i % 7 == 0 ? "RESOLVED" : "OPEN");
+                ps.setTimestamp(12, Timestamp.valueOf(detectedAt));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return ALERTS;
+            }
+        });
+    }
+
+    private AlertTarget alertTarget(
+            int index,
+            List<Long> ruleIds,
+            List<Long> courseIds,
+            List<Long> problemIds,
+            List<Long> targetUserIds
+    ) {
+        int type = index % 3;
+        if (type == 0) {
+            return new AlertTarget(
+                    ruleIds.get(0),
+                    "COURSE",
+                    courseIds.get(index % courseIds.size()),
+                    BigDecimal.valueOf(3),
+                    BigDecimal.valueOf(10),
+                    targetUserIds.get(index % targetUserIds.size())
+            );
+        }
+        if (type == 1) {
+            return new AlertTarget(
+                    ruleIds.get(1),
+                    "USER",
+                    targetUserIds.get(index % targetUserIds.size()),
+                    BigDecimal.valueOf(45),
+                    BigDecimal.valueOf(30),
+                    targetUserIds.get(index % targetUserIds.size())
+            );
+        }
+
+        return new AlertTarget(
+                ruleIds.get(2),
+                "PROBLEM",
+                problemIds.get(index % problemIds.size()),
+                BigDecimal.valueOf(82),
+                BigDecimal.valueOf(70),
+                targetUserIds.get(index % targetUserIds.size())
+        );
+    }
+
+    private record AlertTarget(
+            Long ruleId,
+            String targetType,
+            Long targetId,
+            BigDecimal detectedValue,
+            BigDecimal thresholdValue,
+            Long assigneeId
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/admin/operation/metrics/AdminMetrics.java
@@ -1,0 +1,91 @@
+package com.wanted.codebombalms.admin.operation.metrics;
+
+import com.wanted.codebombalms.admin.operation.common.domain.model.OperationTargetType;
+import com.wanted.codebombalms.admin.operation.rule.domain.model.OperationRuleCode;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+/** Admin 운영 도메인 커스텀 메트릭을 기록합니다. */
+@Component
+public class AdminMetrics {
+
+    private final MeterRegistry registry;
+    private final Timer alertListQueryTimer;
+    private final Timer alertDetailQueryTimer;
+    private final Timer ruleRunTimer;
+    private final Timer alertUpsertTimer;
+
+    // admin 도메인에서 사용할 Micrometer Time/ Counter 등록 준비
+    public AdminMetrics(MeterRegistry registry) {
+        this.registry = registry;
+        this.alertListQueryTimer = Timer.builder("admin_operation_alert_list_query_duration")
+                .description("운영 알림 목록 조회 DB 구간 시간")
+                .register(registry);
+        this.alertDetailQueryTimer = Timer.builder("admin_operation_alert_detail_query_duration")
+                .description("운영 알림 상세 기본 정보 조회 시간")
+                .register(registry);
+        this.ruleRunTimer = Timer.builder("admin_operation_rule_run_duration")
+                .description("활성화된 운영 자동화 규칙 전체 실행 시간")
+                .register(registry);
+        this.alertUpsertTimer = Timer.builder("admin_operation_alert_upsert_duration")
+                .description("탐지 결과 1건의 open alert 조회와 저장 시간")
+                .register(registry);
+    }
+
+    // 운영 알림 목록 조회 시간이 얼마나 걸렸는지 기록
+    public void recordAlertListQuery(long elapsedNanos) {
+        alertListQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    // 운영 알림 상세 기본 정보 조회 시간을 기록
+    public void recordAlertDetailQuery(long elapsedNanos) {
+        alertDetailQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    // 알림 대상 상세 조회 시간을 COURSE, PROBLEM, USER 타입별로 기록
+    public void recordTargetDetail(OperationTargetType targetType, long elapsedNanos) {
+        registry.timer(
+                        "admin_operation_alert_target_detail_duration",
+                        "targetType",
+                        targetType.name()
+                )
+                .record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    // 자동화 규칙 전체 실행 시간을 기록
+    public void recordRuleRun(long elapsedNanos) {
+        ruleRunTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    // 특정 규칙 handler 실행 시간을 ruleCode 별로 기록
+    public void recordRuleDetect(OperationRuleCode ruleCode, long elapsedNanos) {
+        registry.timer(
+                        "admin_operation_rule_detect_duration",
+                        "ruleCode",
+                        ruleCode.name()
+                )
+                .record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    // 탐지 결과 1건을 alert로 저장/갱신하는 시간을 기록
+    public void recordAlertUpsert(long elapsedNanos) {
+        alertUpsertTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+
+    // 규칙별 탐지 결과 개수를 누적 Counter 로 기록
+    public void incrementRuleDetected(OperationRuleCode ruleCode, int detectedCount) {
+        if (detectedCount <= 0) {
+            return;
+        }
+
+        Counter.builder("admin_operation_rule_detected_total")
+                .description("규칙별 탐지 결과 누적 수")
+                .tag("ruleCode", ruleCode.name())
+                .register(registry)
+                .increment(detectedCount);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/admin/permission/infrastructure/web/AdminPermissionInterceptor.java
+++ b/src/main/java/com/wanted/codebombalms/admin/permission/infrastructure/web/AdminPermissionInterceptor.java
@@ -33,12 +33,9 @@ public class AdminPermissionInterceptor implements HandlerInterceptor {
             new AdminPermissionRule("GET", "^/api/v1/users/[0-9]+/enrollments$", AdminPermissionType.USER_MANAGEMENT),
             new AdminPermissionRule("GET", "^/api/v1/admin/students/[0-9]+/problems$", AdminPermissionType.USER_MANAGEMENT),
             new AdminPermissionRule("PATCH", "^/api/v1/users/[0-9]+/lock$", AdminPermissionType.USER_MANAGEMENT),
-            new AdminPermissionRule("GET", "^/api/v1/admin/operation-alerts$", AdminPermissionType.RULE_MANAGEMENT),
-            new AdminPermissionRule("GET", "^/api/v1/admin/operation-alerts/[0-9]+$", AdminPermissionType.RULE_MANAGEMENT),
             new AdminPermissionRule("PATCH", "^/api/v1/admin/operation-alerts/[0-9]+/memo$", AdminPermissionType.RULE_MANAGEMENT),
             new AdminPermissionRule("PATCH", "^/api/v1/admin/operation-alerts/[0-9]+/status$", AdminPermissionType.RULE_MANAGEMENT),
             new AdminPermissionRule("DELETE", "^/api/v1/admin/operation-alerts/[0-9]+$", AdminPermissionType.RULE_MANAGEMENT),
-            new AdminPermissionRule("GET", "^/api/v1/admin/automation-rules$", AdminPermissionType.RULE_MANAGEMENT),
             new AdminPermissionRule("PATCH", "^/api/v1/admin/automation-rules$", AdminPermissionType.RULE_MANAGEMENT),
             new AdminPermissionRule("PATCH", "^/api/v1/admin/automation-rules/[0-9]+/enabled$", AdminPermissionType.RULE_MANAGEMENT)
     );

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/loadtest/ChatListLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/loadtest/ChatListLoadTestSeeder.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 @Slf4j
 @Component
-@Profile("loadtest")
+@Profile("loadtest & !loadtest-admin")
 @RequiredArgsConstructor
 public class ChatListLoadTestSeeder implements ApplicationRunner {
 

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
@@ -4,11 +4,15 @@ import com.wanted.codebombalms.recommendation.application.command.GeneratedUserP
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationCommandPort;
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationGenerationClient;
 import com.wanted.codebombalms.recommendation.application.usecase.GenerateProblemSetRecommendationsUseCase;
+import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Python 추천 서버 호출 결과를 검증하고 problem_recommendation에 반영합니다. */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProblemRecommendationGenerationService implements GenerateProblemSetRecommendationsUseCase {
@@ -17,17 +21,30 @@ public class ProblemRecommendationGenerationService implements GenerateProblemSe
 
     private final ProblemRecommendationGenerationClient generationClient;
     private final ProblemRecommendationCommandPort commandPort;
+    private final RecommendationMetrics recommendationMetrics;
 
     /** 사용자별 추천 3개 반환을 전제로 기존 추천 교체 저장을 수행합니다. */
     @Override
     @Transactional
     public int generate() {
-        var generatedRecommendations = generationClient.generateProblemSetRecommendations();
+        long startedAt = System.nanoTime();
 
-        generatedRecommendations.forEach(this::validateRecommendationCount);
-        generatedRecommendations.forEach(commandPort::replaceActiveRecommendations);
+        try {
+            List<GeneratedUserProblemSetRecommendations> generatedRecommendations =
+                    generationClient.generateProblemSetRecommendations();
 
-        return generatedRecommendations.size();
+            generatedRecommendations.forEach(this::validateRecommendationCount);
+            generatedRecommendations.forEach(this::replaceActiveRecommendations);
+            recommendationMetrics.incrementGenerationUsers(generatedRecommendations.size());
+
+            long elapsedNanos = System.nanoTime() - startedAt;
+            log.info("event=recommendation_generation_batch_completed userCount={} durationMs={}",
+                    generatedRecommendations.size(), elapsedNanos / 1_000_000);
+
+            return generatedRecommendations.size();
+        } finally {
+            recommendationMetrics.recordGenerationBatch(System.nanoTime() - startedAt);
+        }
     }
 
     /** 추천 대상 사용자는 Python 서버에서 항상 3개의 문제 세트를 반환해야 합니다. */
@@ -35,12 +52,25 @@ public class ProblemRecommendationGenerationService implements GenerateProblemSe
         int actualCount = recommendations.problemSets() == null ? 0 : recommendations.problemSets().size();
 
         if (actualCount != EXPECTED_RECOMMENDATION_COUNT) {
+            recommendationMetrics.incrementGenerationFailed("invalid_response");
+            log.warn("event=recommendation_generation_failed reason=invalid_response exceptionType=IllegalStateException");
             throw new IllegalStateException(
                     "Python 추천 서버는 추천 대상 사용자별 문제 세트 3개를 반환해야 합니다. userId="
                             + recommendations.userId()
                             + ", actualCount="
                             + actualCount
             );
+        }
+    }
+
+    private void replaceActiveRecommendations(GeneratedUserProblemSetRecommendations recommendations) {
+        try {
+            commandPort.replaceActiveRecommendations(recommendations);
+        } catch (RuntimeException exception) {
+            recommendationMetrics.incrementGenerationFailed("save_error");
+            log.warn("event=recommendation_generation_failed reason=save_error exceptionType={}",
+                    exception.getClass().getSimpleName());
+            throw exception;
         }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java
@@ -5,14 +5,17 @@ import com.wanted.codebombalms.recommendation.application.port.RecommendationHid
 import com.wanted.codebombalms.recommendation.application.query.ProblemSetRecommendationResult;
 import com.wanted.codebombalms.recommendation.application.usecase.GetMyProblemSetRecommendationsUseCase;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** 문제 세트 추천 목록 조회와 숨김 상태 판정을 처리합니다. */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -24,13 +27,15 @@ public class ProblemRecommendationQueryService implements GetMyProblemSetRecomme
 
     private final ProblemRecommendationQueryPort problemRecommendationQueryPort;
     private final RecommendationHidePort recommendationHidePort;
+    private final RecommendationMetrics recommendationMetrics;
 
     /** 숨김 상태를 먼저 확인한 뒤 활성 추천 목록을 최대 3개까지 조회합니다. */
     @Override
     public ProblemSetRecommendationResult getRecommendations(Long userId, Integer limit) {
+        long startedAt = System.nanoTime();
         LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
 
-        return recommendationHidePort.findHide(userId, RecommendationHideType.PROBLEM_SET_RECOMMENDATION)
+        ProblemSetRecommendationResult result = recommendationHidePort.findHide(userId, RecommendationHideType.PROBLEM_SET_RECOMMENDATION)
                 .filter(hide -> hide.isHiddenAt(now))
                 .map(hide -> new ProblemSetRecommendationResult(true, hide.hiddenUntil(), List.of()))
                 .orElseGet(() -> new ProblemSetRecommendationResult(
@@ -38,6 +43,14 @@ public class ProblemRecommendationQueryService implements GetMyProblemSetRecomme
                         null,
                         problemRecommendationQueryPort.findActiveProblemSetRecommendations(userId, clampLimit(limit))
                 ));
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        recommendationMetrics.recordProblemSetList(elapsedNanos);
+        recommendationMetrics.incrementExposed(result.problemSets().size());
+        log.info("event=recommendation_problem_set_list_queried hidden={} resultCount={} durationMs={}",
+                result.hidden(), result.problemSets().size(), elapsedNanos / 1_000_000);
+
+        return result;
     }
 
     /** 요청 limit을 기본값 3, 최대값 3 범위로 보정합니다. */

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/client/FastApiProblemRecommendationGenerationClient.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.recommendation.application.command.GeneratedProbl
 import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationGenerationClient;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationAlgorithm;
+import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import io.netty.channel.ChannelOption;
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -23,6 +24,7 @@ import reactor.netty.http.client.HttpClient;
 public class FastApiProblemRecommendationGenerationClient implements ProblemRecommendationGenerationClient {
 
     private final RecommendationPythonProperties properties;
+    private final RecommendationMetrics recommendationMetrics;
 
     @Value("${fastapi.url}")
     private String fastApiBaseUrl;
@@ -30,26 +32,47 @@ public class FastApiProblemRecommendationGenerationClient implements ProblemReco
     /** 설정된 Python 추천 생성 endpoint를 호출해 사용자별 추천 결과를 가져옵니다. */
     @Override
     public List<GeneratedUserProblemSetRecommendations> generateProblemSetRecommendations() {
+        long startedAt = System.nanoTime();
+
         if (!properties.isEnabled()) {
             log.info("Python 추천 생성 호출이 비활성화되어 추천 생성 배치를 건너뜁니다.");
+            recommendationMetrics.recordGenerationExternal(System.nanoTime() - startedAt);
+            log.info("event=recommendation_generation_external_called userCount=0 durationMs={}",
+                    (System.nanoTime() - startedAt) / 1_000_000);
             return List.of();
         }
 
-        PythonRecommendationResponse response = webClient().post()
-                .uri(properties.getGeneratePath())
-                .bodyValue(new PythonRecommendationRequest(3))
-                .retrieve()
-                .bodyToMono(PythonRecommendationResponse.class)
-                .block();
+        int userCount = 0;
 
-        if (response == null || response.recommendations() == null) {
-            return List.of();
+        try {
+            PythonRecommendationResponse response = webClient().post()
+                    .uri(properties.getGeneratePath())
+                    .bodyValue(new PythonRecommendationRequest(3))
+                    .retrieve()
+                    .bodyToMono(PythonRecommendationResponse.class)
+                    .block();
+
+            if (response == null || response.recommendations() == null) {
+                return List.of();
+            }
+
+            userCount = response.recommendations().size();
+            return response.recommendations()
+                    .stream()
+                    .map(PythonUserRecommendations::toCommand)
+                    .toList();
+        } catch (RuntimeException exception) {
+            String reason = classifyFailure(exception);
+            recommendationMetrics.incrementGenerationFailed(reason);
+            log.warn("event=recommendation_generation_failed reason={} exceptionType={}",
+                    reason, exception.getClass().getSimpleName());
+            throw exception;
+        } finally {
+            long elapsedNanos = System.nanoTime() - startedAt;
+            recommendationMetrics.recordGenerationExternal(elapsedNanos);
+            log.info("event=recommendation_generation_external_called userCount={} durationMs={}",
+                    userCount, elapsedNanos / 1_000_000);
         }
-
-        return response.recommendations()
-                .stream()
-                .map(PythonUserRecommendations::toCommand)
-                .toList();
     }
 
     /** 추천 기능이 챗봇 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
@@ -62,6 +85,15 @@ public class FastApiProblemRecommendationGenerationClient implements ProblemReco
                 .baseUrl(fastApiBaseUrl)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .build();
+    }
+
+    private String classifyFailure(RuntimeException exception) {
+        String exceptionName = exception.getClass().getSimpleName().toLowerCase();
+        if (exceptionName.contains("timeout")) {
+            return "timeout";
+        }
+
+        return "external_error";
     }
 
     /** Python 서버에 요청하는 추천 개수 조건입니다. */

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestController.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestController.java
@@ -1,0 +1,39 @@
+package com.wanted.codebombalms.recommendation.infrastructure.loadtest;
+
+import com.wanted.codebombalms.recommendation.application.usecase.GenerateProblemSetRecommendationsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@Profile("loadtest")
+@RequiredArgsConstructor
+@RequestMapping("/internal/loadtest/recommendations")
+public class RecommendationLoadTestController {
+
+    private final GenerateProblemSetRecommendationsUseCase generateUseCase;
+
+    @PostMapping("/generate")
+    public ResponseEntity<Map<String, Object>> generateProblemSetRecommendations() {
+        long startedAt = System.nanoTime();
+
+        int generatedUserCount = generateUseCase.generate();
+
+        long durationMs = (System.nanoTime() - startedAt) / 1_000_000;
+        log.info("event=loadtest_recommendation_generation_triggered generatedUserCount={} durationMs={}",
+                generatedUserCount, durationMs);
+
+        return ResponseEntity.ok(Map.of(
+                "status", "completed",
+                "generatedUserCount", generatedUserCount,
+                "durationMs", durationMs
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestSeeder.java
@@ -25,7 +25,7 @@ import java.util.List;
  */
 @Slf4j
 @Component
-@Profile("loadtest")
+@Profile("loadtest & !loadtest-admin")
 @DependsOn("chatListLoadTestSeeder")
 @RequiredArgsConstructor
 public class RecommendationLoadTestSeeder implements ApplicationRunner {
@@ -51,7 +51,7 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
 
         long startedAt = System.nanoTime();
 
-        Long userId = findUserId(LOGIN_EMAIL);
+        Long userId = findOrCreateLoginUser();
         Long categoryId = seedCategory();
         List<Long> problemSetIds = seedProblemSets(userId, categoryId);
         seedRecommendations(userId, problemSetIds);
@@ -66,8 +66,28 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
                 (System.nanoTime() - startedAt) / 1_000_000);
     }
 
-    private Long findUserId(String email) {
-        return jdbc.queryForObject("select user_id from users where email = ?", Long.class, email);
+    private Long findOrCreateLoginUser() {
+        List<Long> userIds = jdbc.queryForList(
+                "select user_id from users where email = ?",
+                Long.class,
+                LOGIN_EMAIL
+        );
+        if (!userIds.isEmpty()) {
+            return userIds.get(0);
+        }
+
+        jdbc.update("""
+                insert into users
+                  (role, email, password, name, nickname, provider, email_verified, is_locked, created_at, updated_at)
+                values
+                  ('STUDENT', ?, ?, '추천 부하 사용자', 'recommendation-loadtest-user', 'LOCAL', true, false, now(6), now(6))
+                """, LOGIN_EMAIL, passwordEncoder.encode(LOADTEST_PASSWORD));
+
+        return jdbc.queryForObject(
+                "select user_id from users where email = ?",
+                Long.class,
+                LOGIN_EMAIL
+        );
     }
 
     private Long seedCategory() {

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestSeeder.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.env.Environment;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -32,14 +33,15 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
 
     private static final String LOGIN_EMAIL = "u01@test.com";
     private static final String LOADTEST_PASSWORD = "Test1234!";
-    private static final int RECOMMENDATION_SETS = 200;
-    private static final int COMPLETED_EVERY = 10;
-    private static final int BATCH_USERS = 120;
-    private static final int BATCH_COMPLETED_PER_USER = 12;
-    private static final int BATCH_EXISTING_RECOMMENDATIONS_PER_USER = 3;
+    private static final int DEFAULT_RECOMMENDATION_SETS = 200;
+    private static final int DEFAULT_COMPLETED_EVERY = 10;
+    private static final int DEFAULT_BATCH_USERS = 120;
+    private static final int DEFAULT_BATCH_COMPLETED_PER_USER = 12;
+    private static final int DEFAULT_BATCH_EXISTING_RECOMMENDATIONS_PER_USER = 3;
 
     private final JdbcTemplate jdbc;
     private final PasswordEncoder passwordEncoder;
+    private final Environment environment;
 
     @Override
     public void run(ApplicationArguments args) {
@@ -50,19 +52,21 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
         }
 
         long startedAt = System.nanoTime();
+        LoadTestRecommendationSeedProperties seedProperties = LoadTestRecommendationSeedProperties.from(environment);
 
         Long userId = findOrCreateLoginUser();
         Long categoryId = seedCategory();
-        List<Long> problemSetIds = seedProblemSets(userId, categoryId);
+        List<Long> problemSetIds = seedProblemSets(userId, categoryId, seedProperties.recommendationSets());
         seedRecommendations(userId, problemSetIds);
-        seedCompletedProgress(userId, problemSetIds);
-        List<Long> batchUserIds = seedBatchUsers();
-        seedBatchCompletedProgress(batchUserIds, problemSetIds);
-        seedBatchExistingRecommendations(batchUserIds, problemSetIds);
+        seedCompletedProgress(userId, problemSetIds, seedProperties.completedEvery());
+        List<Long> batchUserIds = seedBatchUsers(seedProperties.batchUsers());
+        seedBatchCompletedProgress(batchUserIds, problemSetIds, seedProperties.batchCompletedPerUser());
+        seedBatchExistingRecommendations(batchUserIds, problemSetIds, seedProperties.batchExistingRecommendationsPerUser());
 
-        log.info("event=loadtest_recommendation_seed_completed userId={} batchUsers={} problemSets={} recommendations={} durationMs={}",
-                userId, batchUserIds.size(), problemSetIds.size(),
-                RECOMMENDATION_SETS + batchUserIds.size() * BATCH_EXISTING_RECOMMENDATIONS_PER_USER,
+        log.info("event=loadtest_recommendation_seed_completed userId={} batchUsers={} problemSets={} completedPerUser={} existingRecommendationsPerUser={} recommendations={} durationMs={}",
+                userId, batchUserIds.size(), problemSetIds.size(), seedProperties.batchCompletedPerUser(),
+                seedProperties.batchExistingRecommendationsPerUser(),
+                problemSetIds.size() + batchUserIds.size() * seedProperties.batchExistingRecommendationsPerUser(),
                 (System.nanoTime() - startedAt) / 1_000_000);
     }
 
@@ -102,7 +106,7 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
                 """, Long.class);
     }
 
-    private List<Long> seedProblemSets(Long userId, Long categoryId) {
+    private List<Long> seedProblemSets(Long userId, Long categoryId, int recommendationSets) {
         jdbc.batchUpdate("""
                 insert into problem_set
                   (category_id, title, description, difficulty, status,
@@ -119,7 +123,7 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
 
             @Override
             public int getBatchSize() {
-                return RECOMMENDATION_SETS;
+                return recommendationSets;
             }
         });
 
@@ -154,9 +158,9 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
         });
     }
 
-    private void seedCompletedProgress(Long userId, List<Long> problemSetIds) {
+    private void seedCompletedProgress(Long userId, List<Long> problemSetIds, int completedEvery) {
         List<Long> completedProblemSetIds = problemSetIds.stream()
-                .filter(problemSetId -> problemSetIds.indexOf(problemSetId) % COMPLETED_EVERY == COMPLETED_EVERY - 1)
+                .filter(problemSetId -> problemSetIds.indexOf(problemSetId) % completedEvery == completedEvery - 1)
                 .toList();
 
         jdbc.batchUpdate("""
@@ -177,7 +181,7 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
         });
     }
 
-    private List<Long> seedBatchUsers() {
+    private List<Long> seedBatchUsers(int batchUsers) {
         jdbc.batchUpdate("""
                 insert into users
                   (role, email, password, name, nickname, provider, email_verified, is_locked, created_at, updated_at)
@@ -196,7 +200,7 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
 
             @Override
             public int getBatchSize() {
-                return BATCH_USERS;
+                return batchUsers;
             }
         });
 
@@ -208,8 +212,8 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
                 """, Long.class);
     }
 
-    private void seedBatchCompletedProgress(List<Long> batchUserIds, List<Long> problemSetIds) {
-        int progressCount = batchUserIds.size() * BATCH_COMPLETED_PER_USER;
+    private void seedBatchCompletedProgress(List<Long> batchUserIds, List<Long> problemSetIds, int batchCompletedPerUser) {
+        int progressCount = batchUserIds.size() * batchCompletedPerUser;
         jdbc.batchUpdate("""
                 insert into problem_progress
                   (user_id, problem_set_id, current_problem_number, is_completed, completed_at, updated_at)
@@ -217,7 +221,7 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
                 """, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
-                int userIndex = i / BATCH_COMPLETED_PER_USER;
+                int userIndex = i / batchCompletedPerUser;
                 int setIndex = (userIndex * 7 + i) % problemSetIds.size();
                 ps.setLong(1, batchUserIds.get(userIndex));
                 ps.setLong(2, problemSetIds.get(setIndex));
@@ -231,8 +235,8 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
         });
     }
 
-    private void seedBatchExistingRecommendations(List<Long> batchUserIds, List<Long> problemSetIds) {
-        int recommendationCount = batchUserIds.size() * BATCH_EXISTING_RECOMMENDATIONS_PER_USER;
+    private void seedBatchExistingRecommendations(List<Long> batchUserIds, List<Long> problemSetIds, int batchExistingRecommendationsPerUser) {
+        int recommendationCount = batchUserIds.size() * batchExistingRecommendationsPerUser;
         jdbc.batchUpdate("""
                 insert into problem_recommendation
                   (user_id, problem_set_id, support, confidence, lift, rank_no, status, algorithm, created_at, updated_at)
@@ -240,8 +244,8 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
                 """, new BatchPreparedStatementSetter() {
             @Override
             public void setValues(PreparedStatement ps, int i) throws SQLException {
-                int userIndex = i / BATCH_EXISTING_RECOMMENDATIONS_PER_USER;
-                int rankNo = i % BATCH_EXISTING_RECOMMENDATIONS_PER_USER + 1;
+                int userIndex = i / batchExistingRecommendationsPerUser;
+                int rankNo = i % batchExistingRecommendationsPerUser + 1;
                 int setIndex = (userIndex * 11 + rankNo) % problemSetIds.size();
 
                 ps.setLong(1, batchUserIds.get(userIndex));
@@ -257,5 +261,32 @@ public class RecommendationLoadTestSeeder implements ApplicationRunner {
                 return recommendationCount;
             }
         });
+    }
+
+    private record LoadTestRecommendationSeedProperties(
+            int recommendationSets,
+            int completedEvery,
+            int batchUsers,
+            int batchCompletedPerUser,
+            int batchExistingRecommendationsPerUser
+    ) {
+
+        private static LoadTestRecommendationSeedProperties from(Environment environment) {
+            return new LoadTestRecommendationSeedProperties(
+                    readInt(environment, "LOADTEST_RECOMMENDATION_SETS", DEFAULT_RECOMMENDATION_SETS),
+                    readInt(environment, "LOADTEST_RECOMMENDATION_COMPLETED_EVERY", DEFAULT_COMPLETED_EVERY),
+                    readInt(environment, "LOADTEST_RECOMMENDATION_BATCH_USERS", DEFAULT_BATCH_USERS),
+                    readInt(environment, "LOADTEST_RECOMMENDATION_COMPLETED_PER_USER", DEFAULT_BATCH_COMPLETED_PER_USER),
+                    readInt(environment, "LOADTEST_RECOMMENDATION_EXISTING_RECOMMENDATIONS_PER_USER", DEFAULT_BATCH_EXISTING_RECOMMENDATIONS_PER_USER)
+            );
+        }
+
+        private static int readInt(Environment environment, String key, int defaultValue) {
+            String value = environment.getProperty(key);
+            if (value == null || value.isBlank()) {
+                return defaultValue;
+            }
+            return Integer.parseInt(value);
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/loadtest/RecommendationLoadTestSeeder.java
@@ -1,0 +1,241 @@
+package com.wanted.codebombalms.recommendation.infrastructure.loadtest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Recommendation 목록 조회 baseline 용 부하테스트 시드.
+ *
+ * <p>{@code loadtest} 프로파일에서만 실행한다. 추천 목록 query 는 로그인 사용자 기준
+ * {@code problem_recommendation -> problem_set -> problem_category -> problem_progress} 를 조인하므로,
+ * 빈 loadtest DB 에서도 같은 query 경로를 타도록 추천 후보와 완료 progress 일부를 만든다.
+ */
+@Slf4j
+@Component
+@Profile("loadtest")
+@DependsOn("chatListLoadTestSeeder")
+@RequiredArgsConstructor
+public class RecommendationLoadTestSeeder implements ApplicationRunner {
+
+    private static final String LOGIN_EMAIL = "u01@test.com";
+    private static final String LOADTEST_PASSWORD = "Test1234!";
+    private static final int RECOMMENDATION_SETS = 200;
+    private static final int COMPLETED_EVERY = 10;
+    private static final int BATCH_USERS = 120;
+    private static final int BATCH_COMPLETED_PER_USER = 12;
+    private static final int BATCH_EXISTING_RECOMMENDATIONS_PER_USER = 3;
+
+    private final JdbcTemplate jdbc;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Long already = jdbc.queryForObject("select count(*) from problem_recommendation", Long.class);
+        if (already != null && already > 0) {
+            log.info("event=loadtest_recommendation_seed_skipped reason=already_seeded recommendations={}", already);
+            return;
+        }
+
+        long startedAt = System.nanoTime();
+
+        Long userId = findUserId(LOGIN_EMAIL);
+        Long categoryId = seedCategory();
+        List<Long> problemSetIds = seedProblemSets(userId, categoryId);
+        seedRecommendations(userId, problemSetIds);
+        seedCompletedProgress(userId, problemSetIds);
+        List<Long> batchUserIds = seedBatchUsers();
+        seedBatchCompletedProgress(batchUserIds, problemSetIds);
+        seedBatchExistingRecommendations(batchUserIds, problemSetIds);
+
+        log.info("event=loadtest_recommendation_seed_completed userId={} batchUsers={} problemSets={} recommendations={} durationMs={}",
+                userId, batchUserIds.size(), problemSetIds.size(),
+                RECOMMENDATION_SETS + batchUserIds.size() * BATCH_EXISTING_RECOMMENDATIONS_PER_USER,
+                (System.nanoTime() - startedAt) / 1_000_000);
+    }
+
+    private Long findUserId(String email) {
+        return jdbc.queryForObject("select user_id from users where email = ?", Long.class, email);
+    }
+
+    private Long seedCategory() {
+        jdbc.update("""
+                insert into problem_category (category_name, description, status)
+                values ('추천 부하 카테고리', 'loadtest recommendation category', 'ACTIVE')
+                """);
+        return jdbc.queryForObject("""
+                select category_id
+                from problem_category
+                where category_name = '추천 부하 카테고리'
+                """, Long.class);
+    }
+
+    private List<Long> seedProblemSets(Long userId, Long categoryId) {
+        jdbc.batchUpdate("""
+                insert into problem_set
+                  (category_id, title, description, difficulty, status,
+                   total_problem_count, completed_user_count, started_user_count, created_by, created_at)
+                values (?, ?, ?, 'MEDIUM', 'ACTIVE', 1, 0, 0, ?, now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, categoryId);
+                ps.setString(2, "추천 부하 문제세트 " + (i + 1));
+                ps.setString(3, "recommendation loadtest problem set " + (i + 1));
+                ps.setLong(4, userId);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return RECOMMENDATION_SETS;
+            }
+        });
+
+        return jdbc.queryForList("""
+                select problem_set_id
+                from problem_set
+                where title like '추천 부하 문제세트 %'
+                order by problem_set_id
+                """, Long.class);
+    }
+
+    private void seedRecommendations(Long userId, List<Long> problemSetIds) {
+        jdbc.batchUpdate("""
+                insert into problem_recommendation
+                  (user_id, problem_set_id, support, confidence, lift, rank_no, status, algorithm, created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, 'ACTIVE', 'APRIORI', now(6), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, userId);
+                ps.setLong(2, problemSetIds.get(i));
+                ps.setBigDecimal(3, BigDecimal.valueOf(0.010000 + (i % 10) * 0.001000));
+                ps.setBigDecimal(4, BigDecimal.valueOf(0.500000 + (i % 20) * 0.010000));
+                ps.setBigDecimal(5, BigDecimal.valueOf(1.000000 + (i % 30) * 0.010000));
+                ps.setInt(6, i + 1);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return problemSetIds.size();
+            }
+        });
+    }
+
+    private void seedCompletedProgress(Long userId, List<Long> problemSetIds) {
+        List<Long> completedProblemSetIds = problemSetIds.stream()
+                .filter(problemSetId -> problemSetIds.indexOf(problemSetId) % COMPLETED_EVERY == COMPLETED_EVERY - 1)
+                .toList();
+
+        jdbc.batchUpdate("""
+                insert into problem_progress
+                  (user_id, problem_set_id, current_problem_number, is_completed, completed_at, updated_at)
+                values (?, ?, 1, true, now(6), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, userId);
+                ps.setLong(2, completedProblemSetIds.get(i));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return completedProblemSetIds.size();
+            }
+        });
+    }
+
+    private List<Long> seedBatchUsers() {
+        jdbc.batchUpdate("""
+                insert into users
+                  (role, email, password, name, nickname, provider, email_verified, is_locked, created_at, updated_at)
+                values
+                  ('STUDENT', ?, ?, ?, ?, 'LOCAL', true, false, date_sub(now(6), interval ? day), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                int no = i + 1;
+                ps.setString(1, "recommendation-batch-" + no + "@test.com");
+                ps.setString(2, passwordEncoder.encode(LOADTEST_PASSWORD));
+                ps.setString(3, "추천배치대상 " + no);
+                ps.setString(4, "recommendation-batch-" + no);
+                ps.setInt(5, 10 + (i % 30));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return BATCH_USERS;
+            }
+        });
+
+        return jdbc.queryForList("""
+                select user_id
+                from users
+                where email like 'recommendation-batch-%@test.com'
+                order by user_id
+                """, Long.class);
+    }
+
+    private void seedBatchCompletedProgress(List<Long> batchUserIds, List<Long> problemSetIds) {
+        int progressCount = batchUserIds.size() * BATCH_COMPLETED_PER_USER;
+        jdbc.batchUpdate("""
+                insert into problem_progress
+                  (user_id, problem_set_id, current_problem_number, is_completed, completed_at, updated_at)
+                values (?, ?, 1, true, date_sub(now(6), interval ? day), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                int userIndex = i / BATCH_COMPLETED_PER_USER;
+                int setIndex = (userIndex * 7 + i) % problemSetIds.size();
+                ps.setLong(1, batchUserIds.get(userIndex));
+                ps.setLong(2, problemSetIds.get(setIndex));
+                ps.setInt(3, 1 + (i % 20));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return progressCount;
+            }
+        });
+    }
+
+    private void seedBatchExistingRecommendations(List<Long> batchUserIds, List<Long> problemSetIds) {
+        int recommendationCount = batchUserIds.size() * BATCH_EXISTING_RECOMMENDATIONS_PER_USER;
+        jdbc.batchUpdate("""
+                insert into problem_recommendation
+                  (user_id, problem_set_id, support, confidence, lift, rank_no, status, algorithm, created_at, updated_at)
+                values (?, ?, ?, ?, ?, ?, 'ACTIVE', 'APRIORI', date_sub(now(6), interval 1 day), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                int userIndex = i / BATCH_EXISTING_RECOMMENDATIONS_PER_USER;
+                int rankNo = i % BATCH_EXISTING_RECOMMENDATIONS_PER_USER + 1;
+                int setIndex = (userIndex * 11 + rankNo) % problemSetIds.size();
+
+                ps.setLong(1, batchUserIds.get(userIndex));
+                ps.setLong(2, problemSetIds.get(setIndex));
+                ps.setBigDecimal(3, BigDecimal.valueOf(0.020000 + rankNo * 0.001000));
+                ps.setBigDecimal(4, BigDecimal.valueOf(0.600000 + rankNo * 0.010000));
+                ps.setBigDecimal(5, BigDecimal.valueOf(1.200000 + rankNo * 0.010000));
+                ps.setInt(6, rankNo);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return recommendationCount;
+            }
+        });
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java
@@ -1,0 +1,137 @@
+package com.wanted.codebombalms.recommendation.infrastructure.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+/** Recommendation 도메인 커스텀 메트릭을 기록합니다. */
+@Component
+public class RecommendationMetrics {
+
+    private final MeterRegistry registry;
+    private final Timer problemSetListTimer;
+    private final Timer hideLookupTimer;
+    private final Timer problemSetListQueryTimer;
+    private final Timer generationBatchTimer;
+    private final Timer generationExternalTimer;
+    private final Counter generationUserCounter;
+    private final Counter exposedCounter;
+    private final DistributionSummary confidenceSummary;
+    private final DistributionSummary liftSummary;
+    private final DistributionSummary supportSummary;
+
+    // recommendation 도메인의 Time/Counter/DistributionSummary 등록
+    public RecommendationMetrics(MeterRegistry registry) {
+        this.registry = registry;
+
+        // 추천 목록 조회 전체 시간 기록
+        this.problemSetListTimer = Timer.builder("recommendation_problem_set_list_duration")
+                .description("추천 목록 조회 전체 시간")
+                .register(registry);
+
+        // 추천 숨김 상태 조회 시간 기록
+        this.hideLookupTimer = Timer.builder("recommendation_hide_lookup_duration")
+                .description("추천 숨김 상태 조회 시간")
+                .register(registry);
+
+        // ACTIVE 추천 목록 native query 시간 기록
+        this.problemSetListQueryTimer = Timer.builder("recommendation_problem_set_list_query_duration")
+                .description("ACTIVE 추천 목록 native query 시간")
+                .register(registry);
+
+        // 추천 생성 배치 전체 시간 기록
+        this.generationBatchTimer = Timer.builder("recommendation_generation_batch_duration")
+                .description("추천 생성 배치 전체 시간")
+                .register(registry);
+
+        // Java -> Python FastAPI 호출 왕복 시간 기록
+        this.generationExternalTimer = Timer.builder("recommendation_generation_external_duration")
+                .description("Java에서 Python FastAPI를 호출하는 왕복 시간")
+                .register(registry);
+
+        // 사용자별 추천 저장 시간을 success/failed 상태별로 기록
+        this.generationUserCounter = Counter.builder("recommendation_generation_user_total")
+                .description("추천이 생성된 사용자 수 누적")
+                .register(registry);
+
+        // 추천 생성 대상 사용자 수 누적
+        this.exposedCounter = Counter.builder("recommendation_problem_set_exposed_total")
+                .description("추천 목록에서 사용자에게 노출된 추천 카드 수")
+                .register(registry);
+
+        // 추천 생성 실패 수를 reason 별로 기록
+        this.confidenceSummary = DistributionSummary.builder("recommendation_score_confidence")
+                .description("생성된 추천 confidence 분포")
+                .register(registry);
+
+        // 추천 카드 노출 수 누적
+        this.liftSummary = DistributionSummary.builder("recommendation_score_lift")
+                .description("생성된 추천 lift 분포")
+                .register(registry);
+        this.supportSummary = DistributionSummary.builder("recommendation_score_support")
+                .description("생성된 추천 support 분포")
+                .register(registry);
+    }
+
+    public void recordProblemSetList(long elapsedNanos) {
+        problemSetListTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordHideLookup(long elapsedNanos) {
+        hideLookupTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordProblemSetListQuery(long elapsedNanos) {
+        problemSetListQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGenerationBatch(long elapsedNanos) {
+        generationBatchTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGenerationExternal(long elapsedNanos) {
+        generationExternalTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordGenerationSave(String status, long elapsedNanos) {
+        registry.timer("recommendation_generation_save_duration", "status", status)
+                .record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void incrementGenerationUsers(int userCount) {
+        if (userCount > 0) {
+            generationUserCounter.increment(userCount);
+        }
+    }
+
+    public void incrementGenerationFailed(String reason) {
+        Counter.builder("recommendation_generation_failed_total")
+                .description("추천 생성 실패 수")
+                .tag("reason", reason)
+                .register(registry)
+                .increment();
+    }
+
+    public void incrementExposed(int exposedCount) {
+        if (exposedCount > 0) {
+            exposedCounter.increment(exposedCount);
+        }
+    }
+
+    // 추천 score인 confidence/lift/support 분포 기록
+    public void recordScores(BigDecimal confidence, BigDecimal lift, BigDecimal support) {
+        recordIfPresent(confidenceSummary, confidence);
+        recordIfPresent(liftSummary, lift);
+        recordIfPresent(supportSummary, support);
+    }
+
+    private void recordIfPresent(DistributionSummary summary, BigDecimal value) {
+        if (value != null) {
+            summary.record(value.doubleValue());
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java
@@ -3,12 +3,15 @@ package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationCommandPort;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationStatus;
+import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /** 추천 생성 결과 저장 port를 JPA repository로 구현하는 persistence adapter입니다. */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProblemRecommendationCommandAdapter implements ProblemRecommendationCommandPort {
@@ -16,26 +19,43 @@ public class ProblemRecommendationCommandAdapter implements ProblemRecommendatio
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     private final SpringDataProblemRecommendationRepository problemRecommendationRepository;
+    private final RecommendationMetrics recommendationMetrics;
 
     /** 기존 ACTIVE 추천을 INACTIVE 처리한 뒤 Python 서버가 반환한 3개 추천을 ACTIVE로 저장합니다. */
     @Override
     public void replaceActiveRecommendations(GeneratedUserProblemSetRecommendations recommendations) {
+        long startedAt = System.nanoTime();
         LocalDateTime now = LocalDateTime.now(SEOUL_ZONE);
 
-        problemRecommendationRepository.lockByUserIdAndStatus(recommendations.userId(), RecommendationStatus.ACTIVE);
-        problemRecommendationRepository.deactivateActiveByUserId(recommendations.userId(), now);
-        problemRecommendationRepository.saveAll(recommendations.problemSets()
-                .stream()
-                .map(problemSet -> ProblemRecommendationJpaEntity.active(
-                        recommendations.userId(),
-                        problemSet.problemSetId(),
-                        problemSet.support(),
-                        problemSet.confidence(),
-                        problemSet.lift(),
-                        problemSet.rankNo(),
-                        problemSet.algorithm(),
-                        now
-                ))
-                .toList());
+        try {
+            problemRecommendationRepository.lockByUserIdAndStatus(recommendations.userId(), RecommendationStatus.ACTIVE);
+            problemRecommendationRepository.deactivateActiveByUserId(recommendations.userId(), now);
+            problemRecommendationRepository.saveAll(recommendations.problemSets()
+                    .stream()
+                    .peek(problemSet -> recommendationMetrics.recordScores(
+                            problemSet.confidence(),
+                            problemSet.lift(),
+                            problemSet.support()
+                    ))
+                    .map(problemSet -> ProblemRecommendationJpaEntity.active(
+                            recommendations.userId(),
+                            problemSet.problemSetId(),
+                            problemSet.support(),
+                            problemSet.confidence(),
+                            problemSet.lift(),
+                            problemSet.rankNo(),
+                            problemSet.algorithm(),
+                            now
+                    ))
+                    .toList());
+
+            long elapsedNanos = System.nanoTime() - startedAt;
+            recommendationMetrics.recordGenerationSave("success", elapsedNanos);
+            log.info("event=recommendation_generation_saved userId={} itemCount={} durationMs={}",
+                    recommendations.userId(), recommendations.problemSets().size(), elapsedNanos / 1_000_000);
+        } catch (RuntimeException exception) {
+            recommendationMetrics.recordGenerationSave("failed", System.nanoTime() - startedAt);
+            throw exception;
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationQueryAdapter.java
@@ -2,21 +2,26 @@ package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationQueryPort;
 import com.wanted.codebombalms.recommendation.domain.model.ProblemSetRecommendation;
+import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /** 추천 조회 port를 DB 조회로 구현하는 persistence adapter입니다. */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProblemRecommendationQueryAdapter implements ProblemRecommendationQueryPort {
 
     private final SpringDataProblemRecommendationRepository problemRecommendationRepository;
+    private final RecommendationMetrics recommendationMetrics;
 
     /** repository projection을 추천 도메인 모델 목록으로 변환합니다. */
     @Override
     public List<ProblemSetRecommendation> findActiveProblemSetRecommendations(Long userId, int limit) {
-        return problemRecommendationRepository.findActiveProblemSetRecommendations(userId, limit)
+        long startedAt = System.nanoTime();
+        List<ProblemSetRecommendation> result = problemRecommendationRepository.findActiveProblemSetRecommendations(userId, limit)
                 .stream()
                 .map(row -> new ProblemSetRecommendation(
                         row.getRecommendationId(),
@@ -30,5 +35,12 @@ public class ProblemRecommendationQueryAdapter implements ProblemRecommendationQ
                         row.getCategoryName()
                 ))
                 .toList();
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        recommendationMetrics.recordProblemSetListQuery(elapsedNanos);
+        log.info("event=recommendation_problem_set_list_query_completed resultCount={} durationMs={}",
+                result.size(), elapsedNanos / 1_000_000);
+
+        return result;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/RecommendationHidePersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/RecommendationHidePersistenceAdapter.java
@@ -3,23 +3,35 @@ package com.wanted.codebombalms.recommendation.infrastructure.persistence;
 import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /** 추천 숨김 port를 recommendation_hide 테이블 저장/조회로 구현합니다. */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RecommendationHidePersistenceAdapter implements RecommendationHidePort {
 
     private final SpringDataRecommendationHideRepository recommendationHideRepository;
+    private final RecommendationMetrics recommendationMetrics;
 
     /** 사용자와 숨김 유형 기준의 전체 숨김 설정을 조회합니다. */
     @Override
     public Optional<RecommendationHide> findHide(Long userId, RecommendationHideType hideType) {
-        return recommendationHideRepository.findByUserIdAndHideTypeAndTargetIdIsNull(userId, hideType)
+        long startedAt = System.nanoTime();
+        Optional<RecommendationHide> result = recommendationHideRepository.findByUserIdAndHideTypeAndTargetIdIsNull(userId, hideType)
                 .map(RecommendationHideJpaEntity::toDomain);
+        long elapsedNanos = System.nanoTime() - startedAt;
+
+        recommendationMetrics.recordHideLookup(elapsedNanos);
+        log.info("event=recommendation_hide_lookup_completed hidden={} durationMs={}",
+                result.isPresent(), elapsedNanos / 1_000_000);
+
+        return result;
     }
 
     /** 기존 숨김 row가 있으면 갱신하고 없으면 새로 생성합니다. */

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/loadtest/RankingBadgeLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/loadtest/RankingBadgeLoadTestSeeder.java
@@ -16,7 +16,7 @@ import java.sql.SQLException;
 
 @Slf4j
 @Component
-@Profile("loadtest")
+@Profile("loadtest & !loadtest-admin")
 @RequiredArgsConstructor
 public class RankingBadgeLoadTestSeeder implements ApplicationRunner {
 

--- a/src/test/java/com/wanted/codebombalms/admin/permission/infrastructure/web/AdminPermissionInterceptorTest.java
+++ b/src/test/java/com/wanted/codebombalms/admin/permission/infrastructure/web/AdminPermissionInterceptorTest.java
@@ -52,8 +52,8 @@ class AdminPermissionInterceptorTest {
         // given
         authenticate(1L, "ROLE_MASTER");
         MockHttpServletRequest request = new MockHttpServletRequest(
-                "GET",
-                "/api/v1/admin/operation-alerts"
+                "PATCH",
+                "/api/v1/admin/operation-alerts/10/status"
         );
 
         // when
@@ -109,12 +109,48 @@ class AdminPermissionInterceptorTest {
     }
 
     @Test
-    @DisplayName("USER_MANAGEMENT만 있는 ADMIN이 운영 규칙 API에 접근하면 MASTER 문의 메시지와 함께 403 예외를 반환한다.")
-    void user_management_admin_cannot_access_rule_management_api() {
+    @DisplayName("ADMIN은 RULE_MANAGEMENT 없이도 운영 규칙 조회 API를 통과한다.")
+    void admin_rule_query_api_does_not_require_rule_management_permission() {
         // given
         authenticate(2L, "ROLE_ADMIN");
         MockHttpServletRequest request = new MockHttpServletRequest(
                 "GET",
+                "/api/v1/admin/automation-rules"
+        );
+
+        // when
+        boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        // then
+        assertTrue(result);
+        verifyNoInteractions(adminPermissionCheckService);
+    }
+
+    @Test
+    @DisplayName("ADMIN은 RULE_MANAGEMENT 없이도 운영 알림 조회 API를 통과한다.")
+    void admin_operation_alert_query_api_does_not_require_rule_management_permission() {
+        // given
+        authenticate(2L, "ROLE_ADMIN");
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "GET",
+                "/api/v1/admin/operation-alerts/10"
+        );
+
+        // when
+        boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+        // then
+        assertTrue(result);
+        verifyNoInteractions(adminPermissionCheckService);
+    }
+
+    @Test
+    @DisplayName("USER_MANAGEMENT만 있는 ADMIN이 운영 규칙 수정 API에 접근하면 MASTER 문의 메시지와 함께 403 예외를 반환한다.")
+    void user_management_admin_cannot_access_rule_management_api() {
+        // given
+        authenticate(2L, "ROLE_ADMIN");
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "PATCH",
                 "/api/v1/admin/automation-rules"
         );
 
@@ -139,7 +175,7 @@ class AdminPermissionInterceptorTest {
         // given
         authenticate("admin@test.com", "ROLE_ADMIN");
         MockHttpServletRequest request = new MockHttpServletRequest(
-                "GET",
+                "PATCH",
                 "/api/v1/admin/automation-rules"
         );
 


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #확인필요

---

## 🛠️ 기능 관련 작업 내용
- `ADMIN`이면 `RULE_MANAGEMENT` 없이 운영 규칙 목록 조회가 가능하도록 권한 정책을 변경했습니다.
- 운영 알림 목록/상세 조회도 세부 permission 없이 `ADMIN`이면 접근 가능하도록 정리했습니다.
- 운영 규칙 수정, 활성화 변경, 운영 알림 메모/상태 수정 및 삭제는 기존처럼 `RULE_MANAGEMENT` 권한 검증을 유지했습니다.
- 권한 인터셉터 단위 테스트에 조회 허용 케이스와 수정 차단 케이스를 반영했습니다.

---

## ♻️ 패키지 변경 사항
- `project/admin/permission/infrastructure/web`: Admin permission interceptor의 조회 API 권한 매핑 수정
- `project/admin/permission/infrastructure/web/test`: 운영 규칙/알림 조회 허용 및 수정 권한 검증 테스트 보강
- `project/admin`: Admin API 권한 정책 README 문서 갱신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

- **권한/접근 제어**
  - 운영 알림 및 자동화 규칙 엔드포인트의 권한 요구사항이 세분화되었습니다. 조회와 메모/상태 변경·삭제, 규칙 수정/활성화 관련 정책 적용이 엔드포인트별로 달라졌습니다.
- **운영 모니터링**
  - 알림 조회/상세, 규칙 실행, 알림 업서트 및 추천 생성 전반에 대한 소요 시간·성공/실패 지표 수집이 강화되었습니다.
- **부하 테스트(내부)**
  - 부하 테스트 실행용 내부 엔드포인트 및 시딩 로직이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->