### PR TITLE
[Feat] 강의자료 파일 업로드 및 다운로드 기능 구현

### DIFF
--- a/http/lecture.http
+++ b/http/lecture.http
@@ -4,6 +4,7 @@
 ### 테스트용 ID
 @courseId = 101
 @lectureId = 102
+@lectureMaterialId = 1
 
 ### 1. 특정 강좌의 강의 목록 조회
 GET {{host}}/api/v1/courses/{{courseId}}/lectures
@@ -53,5 +54,26 @@ GET {{host}}/api/v1/lectures/{{lectureId}}/progress
 ### 7. 강의 삭제 - learning.http 실행 전에는 실행하지 말 것
 # DELETE {{host}}/api/v1/lectures/{{lectureId}}
 
-### 8. 삭제된 강의 상세 조회 확인 - 강의 삭제 후 별도 실행
+### 8. 강의자료 업로드
+### 응답 data.lectureMaterialId 값을 아래 다운로드 URL 발급/삭제 요청에 넣어서 사용합니다.
+POST {{host}}/api/v1/lectures/{{lectureId}}/materials
+Content-Type: multipart/form-data; boundary=lectureMaterialBoundary
+
+--lectureMaterialBoundary
+Content-Disposition: form-data; name="material"; filename="lecture-material.pdf"
+Content-Type: application/pdf
+
+< ./lecture-material.pdf
+--lectureMaterialBoundary--
+
+### 9. 강의자료 목록 조회
+GET {{host}}/api/v1/lectures/{{lectureId}}/materials
+
+### 10. 강의자료 다운로드 URL 발급
+POST {{host}}/api/v1/lecture-materials/{{lectureMaterialId}}/download-url
+
+### 11. 강의자료 삭제
+# DELETE {{host}}/api/v1/lecture-materials/{{lectureMaterialId}}
+
+### 12. 삭제된 강의 상세 조회 확인 - 강의 삭제 후 별도 실행
 # GET {{host}}/api/v1/lectures/{{lectureId}}

--- a/monitoring/k6/results/learning-student-progress-before-summary.json
+++ b/monitoring/k6/results/learning-student-progress-before-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 158,
+          "fails": 0
+        },
+        {
+          "name": "has data array",
+          "path": "::has data array",
+          "id": "4b06394e68b7c0c7ab1b0deed50b335b",
+          "passes": 158,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 75089.539435
+  },
+  "metrics": {
+    "vus": {
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 30
+      },
+      "type": "gauge"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 316,
+        "fails": 0
+      }
+    },
+    "iterations": {
+      "contains": "default",
+      "values": {
+        "count": 158,
+        "rate": 2.1041546024765543
+      },
+      "type": "counter"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 9.1570645,
+        "p(99)": 27.776021539999903,
+        "max": 34.799097,
+        "avg": 4.275569905660376,
+        "min": 0.170445,
+        "med": 3.218297,
+        "p(90)": 7.4167264
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 11326.238939270439,
+        "min": 154.399669,
+        "med": 12031.879392,
+        "p(90)": 14205.3976178,
+        "p(95)": 14691.424429,
+        "p(99)": 15038.17070898,
+        "max": 15643.555317
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 13407.0296325,
+        "p(99)": 13894.098141699998,
+        "max": 13991.954884,
+        "avg": 10118.01582963522,
+        "min": 147.348584,
+        "med": 10663.555001,
+        "p(90)": 13058.8273218
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 10181.121318531646,
+        "min": 4113.950902,
+        "med": 10728.6857555,
+        "p(90)": 13059.4180437,
+        "p(95)": 13408.65646975,
+        "p(99)": 13895.33335205,
+        "max": 13991.954884
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": false
+        }
+      }
+    },
+    "data_sent": {
+      "contains": "data",
+      "values": {
+        "count": 56932,
+        "rate": 758.1881634695899
+      },
+      "type": "counter"
+    },
+    "http_req_failed": {
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 159
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 5525562,
+        "rate": 73586.30831373137
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 13047.7768,
+        "p(95)": 13403.5896404,
+        "p(99)": 13889.33805522,
+        "max": 13988.450206,
+        "avg": 10113.673577943395,
+        "min": 146.976012,
+        "med": 10661.383869
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 30,
+        "min": 30,
+        "max": 30
+      }
+    },
+    "http_req_blocked": {
+      "contains": "time",
+      "values": {
+        "avg": 0.974721308176101,
+        "min": 0.004261,
+        "med": 0.00727,
+        "p(90)": 3.9706916000000017,
+        "p(95)": 5.946981199999998,
+        "p(99)": 9.460434399999958,
+        "max": 16.94426
+      },
+      "type": "trend"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 3.614960200000003,
+        "p(95)": 4.9433683999999944,
+        "p(99)": 9.315971659999958,
+        "max": 16.715583,
+        "avg": 0.916077075471698
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 0.34271,
+        "avg": 0.06668178616352209,
+        "min": 0.017666,
+        "med": 0.050858,
+        "p(90)": 0.13824480000000003,
+        "p(95)": 0.16452079999999997,
+        "p(99)": 0.24058627999999904
+      }
+    },
+    "http_req_duration": {
+      "contains": "time",
+      "values": {
+        "p(95)": 13407.0296325,
+        "p(99)": 13894.098141699998,
+        "max": 13991.954884,
+        "avg": 10118.01582963522,
+        "min": 147.348584,
+        "med": 10663.555001,
+        "p(90)": 13058.8273218
+      },
+      "type": "trend"
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 159,
+        "rate": 2.117472036669444
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTc3MTU5NiwiZXhwIjoxNzgxNzc1MTk2fQ.cDgDWq6Xdx6N-VC4zTHdRWwgR_eN0zcrrQBp_99M6Ac"
+  }
+}

--- a/monitoring/k6/results/learning-student-progress-before-summary.json
+++ b/monitoring/k6/results/learning-student-progress-before-summary.json
@@ -1,25 +1,25 @@
 {
   "root_group": {
+    "checks": [
+      {
+        "name": "status is 200",
+        "path": "::status is 200",
+        "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+        "passes": 223,
+        "fails": 0
+      },
+      {
+        "passes": 223,
+        "fails": 0,
+        "name": "has data array",
+        "path": "::has data array",
+        "id": "4b06394e68b7c0c7ab1b0deed50b335b"
+      }
+    ],
     "name": "",
     "path": "",
     "id": "d41d8cd98f00b204e9800998ecf8427e",
-    "groups": [],
-    "checks": [
-        {
-          "name": "status is 200",
-          "path": "::status is 200",
-          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
-          "passes": 158,
-          "fails": 0
-        },
-        {
-          "name": "has data array",
-          "path": "::has data array",
-          "id": "4b06394e68b7c0c7ab1b0deed50b335b",
-          "passes": 158,
-          "fails": 0
-        }
-      ]
+    "groups": []
   },
   "options": {
     "summaryTrendStats": [
@@ -37,133 +37,190 @@
   "state": {
     "isStdOutTTY": true,
     "isStdErrTTY": true,
-    "testRunDurationMs": 75089.539435
+    "testRunDurationMs": 75392.470049
   },
   "metrics": {
-    "vus": {
-      "contains": "default",
-      "values": {
-        "value": 1,
-        "min": 1,
-        "max": 30
-      },
-      "type": "gauge"
-    },
-    "checks": {
-      "type": "rate",
-      "contains": "default",
-      "values": {
-        "rate": 1,
-        "passes": 316,
-        "fails": 0
-      }
-    },
-    "iterations": {
-      "contains": "default",
-      "values": {
-        "count": 158,
-        "rate": 2.1041546024765543
-      },
-      "type": "counter"
-    },
-    "http_req_receiving": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(95)": 9.1570645,
-        "p(99)": 27.776021539999903,
-        "max": 34.799097,
-        "avg": 4.275569905660376,
-        "min": 0.170445,
-        "med": 3.218297,
-        "p(90)": 7.4167264
-      }
-    },
-    "iteration_duration": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 11326.238939270439,
-        "min": 154.399669,
-        "med": 12031.879392,
-        "p(90)": 14205.3976178,
-        "p(95)": 14691.424429,
-        "p(99)": 15038.17070898,
-        "max": 15643.555317
-      }
-    },
-    "http_req_duration{expected_response:true}": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "p(95)": 13407.0296325,
-        "p(99)": 13894.098141699998,
-        "max": 13991.954884,
-        "avg": 10118.01582963522,
-        "min": 147.348584,
-        "med": 10663.555001,
-        "p(90)": 13058.8273218
-      }
-    },
     "http_req_duration{type:student-progress}": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 10181.121318531646,
-        "min": 4113.950902,
-        "med": 10728.6857555,
-        "p(90)": 13059.4180437,
-        "p(95)": 13408.65646975,
-        "p(99)": 13895.33335205,
-        "max": 13991.954884
-      },
       "thresholds": {
         "p(95)<800": {
           "ok": false
         }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 9384.77616756,
+        "max": 9411.568027,
+        "avg": 6887.7163188430495,
+        "min": 2109.653952,
+        "med": 7873.93276,
+        "p(90)": 8687.395453000001,
+        "p(95)": 8892.98265
       }
     },
-    "data_sent": {
-      "contains": "data",
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
       "values": {
-        "count": 56932,
-        "rate": 758.1881634695899
-      },
-      "type": "counter"
+        "min": 287.368629,
+        "med": 7872.833269,
+        "p(90)": 8687.3713505,
+        "p(95)": 8892.161294000001,
+        "p(99)": 9384.60266904,
+        "max": 9411.568027,
+        "avg": 6858.250480941964
+      }
     },
-    "http_req_failed": {
+    "iterations": {
+      "type": "counter",
       "contains": "default",
       "values": {
-        "rate": 0,
-        "passes": 0,
-        "fails": 159
-      },
-      "thresholds": {
-        "rate<0.01": {
-          "ok": true
-        }
-      },
-      "type": "rate"
-    },
-    "data_received": {
-      "type": "counter",
-      "contains": "data",
-      "values": {
-        "count": 5525562,
-        "rate": 73586.30831373137
+        "count": 223,
+        "rate": 2.9578550729942275
       }
     },
     "http_req_waiting": {
       "type": "trend",
       "contains": "time",
       "values": {
-        "p(90)": 13047.7768,
-        "p(95)": 13403.5896404,
-        "p(99)": 13889.33805522,
-        "max": 13988.450206,
-        "avg": 10113.673577943395,
-        "min": 146.976012,
-        "med": 10661.383869
+        "p(99)": 9378.37638837,
+        "max": 9409.820283,
+        "avg": 6855.696491178571,
+        "min": 286.806034,
+        "med": 7870.412736,
+        "p(90)": 8684.681283,
+        "p(95)": 8889.0087458
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 103435.72766526484,
+        "count": 7798275
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 30
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 8882.4893955,
+        "p(90)": 10097.010195300001,
+        "p(95)": 10419.077564000001,
+        "p(99)": 10649.52101547,
+        "max": 10934.588961,
+        "avg": 8056.203704160716,
+        "min": 290.859784
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.003564,
+        "med": 0.0059885,
+        "p(90)": 2.0963897000000005,
+        "p(95)": 2.5467913999999996,
+        "p(99)": 4.3629834800000085,
+        "max": 8.213462,
+        "avg": 0.39307481696428576
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.04291379017857148,
+        "min": 0.011796,
+        "med": 0.034631999999999996,
+        "p(90)": 0.08184680000000003,
+        "p(95)": 0.09200775,
+        "p(99)": 0.14562605000000012,
+        "max": 0.217773
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 446,
+        "fails": 0
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.37035750892857144,
+        "min": 0,
+        "med": 0,
+        "p(90)": 1.9914503000000003,
+        "p(95)": 2.3927091000000003,
+        "p(99)": 4.2532482100000095,
+        "max": 8.104014
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 2.1233945,
+        "p(90)": 3.797570900000001,
+        "p(95)": 4.59465835,
+        "p(99)": 8.168877640000012,
+        "max": 14.076433,
+        "avg": 2.5110759732142856,
+        "min": 0.459052
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 7872.833269,
+        "p(90)": 8687.3713505,
+        "p(95)": 8892.161294000001,
+        "p(99)": 9384.60266904,
+        "max": 9411.568027,
+        "avg": 6858.250480941964,
+        "min": 287.368629
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 224
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
       }
     },
     "vus_max": {
@@ -175,81 +232,24 @@
         "max": 30
       }
     },
-    "http_req_blocked": {
-      "contains": "time",
-      "values": {
-        "avg": 0.974721308176101,
-        "min": 0.004261,
-        "med": 0.00727,
-        "p(90)": 3.9706916000000017,
-        "p(95)": 5.946981199999998,
-        "p(99)": 9.460434399999958,
-        "max": 16.94426
-      },
-      "type": "trend"
-    },
-    "http_req_tls_handshaking": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "avg": 0,
-        "min": 0,
-        "med": 0,
-        "p(90)": 0,
-        "p(95)": 0,
-        "p(99)": 0,
-        "max": 0
-      }
-    },
-    "http_req_connecting": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "min": 0,
-        "med": 0,
-        "p(90)": 3.614960200000003,
-        "p(95)": 4.9433683999999944,
-        "p(99)": 9.315971659999958,
-        "max": 16.715583,
-        "avg": 0.916077075471698
-      }
-    },
-    "http_req_sending": {
-      "type": "trend",
-      "contains": "time",
-      "values": {
-        "max": 0.34271,
-        "avg": 0.06668178616352209,
-        "min": 0.017666,
-        "med": 0.050858,
-        "p(90)": 0.13824480000000003,
-        "p(95)": 0.16452079999999997,
-        "p(99)": 0.24058627999999904
-      }
-    },
-    "http_req_duration": {
-      "contains": "time",
-      "values": {
-        "p(95)": 13407.0296325,
-        "p(99)": 13894.098141699998,
-        "max": 13991.954884,
-        "avg": 10118.01582963522,
-        "min": 147.348584,
-        "med": 10663.555001,
-        "p(90)": 13058.8273218
-      },
-      "type": "trend"
-    },
     "http_reqs": {
       "type": "counter",
       "contains": "default",
       "values": {
-        "count": 159,
-        "rate": 2.117472036669444
+        "count": 224,
+        "rate": 2.971118997088372
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 80267,
+        "rate": 1064.655395264698
       }
     }
   },
   "setup_data": {
-    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTc3MTU5NiwiZXhwIjoxNzgxNzc1MTk2fQ.cDgDWq6Xdx6N-VC4zTHdRWwgR_eN0zcrrQBp_99M6Ac"
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMDAwMCIsInR5cCI6ImFjY2VzcyIsIm5pY2tuYW1lIjoibG9hZC1hZG1pbiIsInJvbGUiOiJBRE1JTiIsImlhdCI6MTc4MTgzOTE2NywiZXhwIjoxNzgxODQyNzY3fQ.BseBEcKH7ZX9Wa7wNpAPsFHW1Xp6mAE2mavTa0v17ME"
   }
 }

--- a/monitoring/k6/results/learning-student-progress-before-summary.md
+++ b/monitoring/k6/results/learning-student-progress-before-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-before
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 159 |
+| iterations | 158 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 5525562 |
+| data_sent bytes | 56932 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 10118.02 | 147.35 | 10663.56 | 13058.83 | 13407.03 | 13894.10 | 13991.95 |
+| http_req_waiting | 10113.67 | 146.98 | 10661.38 | 13047.78 | 13403.59 | 13889.34 | 13988.45 |
+| http_req_blocked | 0.97 | 0.00 | 0.01 | 3.97 | 5.95 | 9.46 | 16.94 |
+| http_req_connecting | 0.92 | 0 | 0 | 3.61 | 4.94 | 9.32 | 16.72 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 158 pass / 0 fail |
+| has data array | 158 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring/k6/results/learning-student-progress-before-summary.md
+++ b/monitoring/k6/results/learning-student-progress-before-summary.md
@@ -4,21 +4,21 @@
 
 | Metric | Value |
 | --- | ---: |
-| http_reqs | 159 |
-| iterations | 158 |
+| http_reqs | 224 |
+| iterations | 223 |
 | checks success rate | 100.00% |
 | http_req_failed | 0.00% |
-| data_received bytes | 5525562 |
-| data_sent bytes | 56932 |
+| data_received bytes | 7798275 |
+| data_sent bytes | 80267 |
 
 ## Duration Metrics
 
 | Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| http_req_duration | 10118.02 | 147.35 | 10663.56 | 13058.83 | 13407.03 | 13894.10 | 13991.95 |
-| http_req_waiting | 10113.67 | 146.98 | 10661.38 | 13047.78 | 13403.59 | 13889.34 | 13988.45 |
-| http_req_blocked | 0.97 | 0.00 | 0.01 | 3.97 | 5.95 | 9.46 | 16.94 |
-| http_req_connecting | 0.92 | 0 | 0 | 3.61 | 4.94 | 9.32 | 16.72 |
+| http_req_duration | 6858.25 | 287.37 | 7872.83 | 8687.37 | 8892.16 | 9384.60 | 9411.57 |
+| http_req_waiting | 6855.70 | 286.81 | 7870.41 | 8684.68 | 8889.01 | 9378.38 | 9409.82 |
+| http_req_blocked | 0.39 | 0.00 | 0.01 | 2.10 | 2.55 | 4.36 | 8.21 |
+| http_req_connecting | 0.37 | 0 | 0 | 1.99 | 2.39 | 4.25 | 8.10 |
 
 ## Metric Meaning
 
@@ -36,8 +36,8 @@
 
 | Check | Result |
 | --- | --- |
-| status is 200 | 158 pass / 0 fail |
-| has data array | 158 pass / 0 fail |
+| status is 200 | 223 pass / 0 fail |
+| has data array | 223 pass / 0 fail |
 
 ## How To Compare
 

--- a/monitoring/k6/scripts/learning/01-student-progress-baseline.js
+++ b/monitoring/k6/scripts/learning/01-student-progress-baseline.js
@@ -1,0 +1,68 @@
+// Learning 트랙 A — GET /api/v1/courses/{courseId}/users/learning-progress baseline
+//
+// 목적: 강좌별 학생 학습률 목록 조회의 수강생별 반복 조회 비용을 baseline 으로 박는다.
+//   → 학생 수가 늘 때 HTTP p95, custom timer, Loki durationMs 가 같이 증가하는지 확인한다.
+//
+// 전제:
+//   - 앱은 loadtest 프로파일로 실행한다.
+//   - admin/operator 권한 계정으로 로그인해야 한다.
+//   - COURSE_ID 에 해당하는 강좌에 수강생/강의/문제세트/진행률 데이터가 있어야 병목이 드러난다.
+//
+// 실행 (monitoring/ 에서):
+//   docker compose run --rm -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
+//     -e COURSE_ID=2000 -e RESULT_NAME=learning-student-progress-before \
+//     k6 run -o experimental-prometheus-rw /scripts/learning/01-student-progress-baseline.js
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, randomSleep } from "../../lib/config.js";
+import { login, authCookies } from "../../lib/auth.js";
+import { createSummaryHandler } from "../../lib/summary.js";
+
+const COURSE_ID = __ENV.COURSE_ID || "2000";     // 강좌 아이디가 2000번인 부분에서 테스트를 한다.
+
+export const options = {
+    stages: [
+        { duration: "20s", target: 30 },    // VU를 0명에서 30명까지 증가
+        { duration: "40s", target: 30 },    // VU 30명 유지
+        { duration: "10s", target: 0 },
+    ],
+    thresholds: {
+        http_req_failed: ["rate<0.01"],
+        "http_req_duration{type:student-progress}": ["p(95)<800"],
+        // 요청 실패율이 1% 미만이어야 함, student-progress 타입의 요청의 95%가 800ms 미만이어야 함
+        // 이 타입의 요청만 위 threshold, 즉 성공기준을 적용할 수 있음
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+// 부하 시작 전 1회만 로그인한다. 로그인 부하는 본 측정에 섞지 않는다.
+export function setup() {
+    return { token: login() };
+}
+
+// 요청 실행
+export default function (data) {
+    const params = authCookies(data.token);
+    params.tags = {
+        type: "student-progress",
+        api: "GET /courses/{courseId}/users/learning-progress",
+    };
+
+    const res = http.get(
+        `${BASE_URL}/api/v1/courses/${COURSE_ID}/users/learning-progress`,
+        params
+    );
+
+    // 응답 검증
+    check(res, {
+        "status is 200": (r) => r.status === 200,
+        "has data array": (r) => Array.isArray(r.json("data")),
+    });
+
+    // 사용자 대기 시간, 저 randomSleep 는 글로벌 config에 있음
+    sleep(randomSleep());
+}
+
+// 결과 저장, 테스트 결과 자동 저장
+export const handleSummary = createSummaryHandler("learning-student-progress-baseline");

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/storage/GcpStorageProperties.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/storage/GcpStorageProperties.java
@@ -31,6 +31,7 @@ public class GcpStorageProperties {
         private String datasetPrefix = "problem_dataset";
         private String badgeImagePrefix = "badge_image";
         private String courseThumbnailPrefix = "course_thumbnail_images";
+        private String lectureMaterialPrefix = "lecture_materials";
 
         public String getBucket() {
             return bucket;
@@ -62,6 +63,14 @@ public class GcpStorageProperties {
 
         public void setCourseThumbnailPrefix(String courseThumbnailPrefix) {
             this.courseThumbnailPrefix = courseThumbnailPrefix;
+        }
+
+        public String getLectureMaterialPrefix() {
+            return lectureMaterialPrefix;
+        }
+
+        public void setLectureMaterialPrefix(String lectureMaterialPrefix) {
+            this.lectureMaterialPrefix = lectureMaterialPrefix;
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/AdminLearningProgressQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/AdminLearningProgressQueryService.java
@@ -16,10 +16,14 @@ import com.wanted.codebombalms.learning.domain.model.StudentLearningProgress;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemProgressRepository;
 import com.wanted.codebombalms.learning.domain.repository.LectureProgressRepository;
 import java.util.List;
+
+import com.wanted.codebombalms.learning.infrastructure.metrics.LearningMetrics;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminLearningProgressQueryService implements AdminLearningProgressQueryUseCase {
@@ -31,6 +35,7 @@ public class AdminLearningProgressQueryService implements AdminLearningProgressQ
     private final LearningUserPort learningUserPort;
     private final LectureProgressRepository lectureProgressRepository;
     private final LectureProblemProgressRepository lectureProblemProgressRepository;
+    private final LearningMetrics learningMetrics;
 
     @Override
     @Transactional(readOnly = true)
@@ -50,10 +55,30 @@ public class AdminLearningProgressQueryService implements AdminLearningProgressQ
     @Override
     @Transactional(readOnly = true)
     public List<StudentLearningProgress> findStudentProgresses(Long courseId) {
+        long totalStartedAt = System.nanoTime();
+
+        long studentIdsStartedAt = System.nanoTime();
         List<Long> studentIds = learningEnrollmentPort.findActiveStudentIdsByCourse(courseId);
-        return studentIds.stream()
+        long studentIdsElapsedNanos = System.nanoTime() - studentIdsStartedAt;
+
+        log.info("event=learning_student_ids_queried courseId={} studentCount={} durationMs={}",
+                courseId, studentIds.size(), studentIdsElapsedNanos / 1_000_000);
+
+        long progressBuildStartedAt = System.nanoTime();
+        List<StudentLearningProgress> progresses = studentIds.stream()
                 .map(studentId -> buildStudentProgress(courseId, studentId))
                 .toList();
+        long progressBuildElapsedNanos = System.nanoTime() - progressBuildStartedAt;
+
+        log.info("event=learning_student_progress_built courseId={} studentCount={} durationMs={}",
+                courseId, studentIds.size(), progressBuildElapsedNanos / 1_000_000);
+
+        long totalElapsedNanos = System.nanoTime() - totalStartedAt;
+        learningMetrics.recordStudentProgressQuery(totalElapsedNanos);
+        log.info("event=learning_student_progress_queried courseId={} studentCount={} durationMs={}",
+                courseId, studentIds.size(), totalElapsedNanos / 1_000_000);
+
+        return progresses;
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/loadtest/LearningProgressLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/loadtest/LearningProgressLoadTestSeeder.java
@@ -1,0 +1,295 @@
+package com.wanted.codebombalms.learning.infrastructure.loadtest;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("loadtest")
+@RequiredArgsConstructor
+public class LearningProgressLoadTestSeeder implements ApplicationRunner {
+
+    // === 튜닝 파라미터 ===
+    // /users/learning-progress 1회는 학생마다 buildStudentProgress() 를 반복한다.
+    // 학생 수가 핵심 병목 배율이고, 강의/문제세트 수는 학생별 count 쿼리의 IN 크기를 키운다.
+    // 문서의 100~300명 범위 안에서 baseline 첫 측정용으로 200명을 사용한다.
+    private static final long COURSE_CATEGORY_ID = 1000L;
+    private static final long COURSE_ID = 2000L;
+    private static final long ADMIN_USER_ID = 20000L;
+    private static final long INSTRUCTOR_USER_ID = 20001L;
+    private static final long STUDENT_ID_START = 20100L;
+    private static final long LECTURE_ID_START = 21000L;
+    private static final long PROBLEM_SET_ID_START = 22000L;
+    private static final long LECTURE_PROBLEM_SET_ID_START = 23000L;
+
+    private static final String ADMIN_EMAIL = "admin@test.com";
+    private static final String OPERATOR_EMAIL = "op@test.com";
+    private static final int STUDENTS = 200;
+    private static final int LECTURES = 12;
+    private static final int PROBLEM_SETS = 12;
+    private static final String LOGIN_PASSWORD = "Test1234!";
+
+    private final JdbcTemplate jdbc;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        Long enrollmentCount = jdbc.queryForObject(
+                "select count(*) from enrollment where course_id = ?",
+                Long.class,
+                COURSE_ID
+        );
+        if (enrollmentCount != null && enrollmentCount >= STUDENTS) {
+            log.info("event=learning_loadtest_seed_skipped courseId={} studentCount={}", COURSE_ID, enrollmentCount);
+            return;
+        }
+
+        long startedAt = System.nanoTime();
+
+        seedUsers();
+        seedCourse();
+        seedLectures();
+        seedProblemSets();
+        seedLectureProblemSets();
+        seedEnrollments();
+        seedLectureProgresses();
+        seedLectureProblemProgresses();
+
+        log.info("event=learning_loadtest_seed_completed courseId={} students={} lectures={} problemSets={} durationMs={}",
+                COURSE_ID, STUDENTS, LECTURES, PROBLEM_SETS, (System.nanoTime() - startedAt) / 1_000_000);
+    }
+
+    private void seedUsers() {
+        String hash = passwordEncoder.encode(LOGIN_PASSWORD);
+
+        jdbc.update("""
+                insert into users
+                  (user_id, role, email, password, name, nickname, provider, email_verified, is_locked,
+                   created_at, updated_at)
+                values
+                  (?, 'ADMIN', ?, ?, '부하관리자', 'load-admin', 'LOCAL', true, false, now(6), now(6))
+                on duplicate key update
+                  role = values(role), password = values(password), updated_at = now(6), deleted_at = null
+                """, ADMIN_USER_ID, ADMIN_EMAIL, hash);
+
+        jdbc.update("""
+                insert into users
+                  (user_id, role, email, password, name, nickname, provider, email_verified, is_locked,
+                   created_at, updated_at)
+                values
+                  (?, 'OPERATOR', ?, ?, '부하운영자', 'load-operator', 'LOCAL', true, false, now(6), now(6))
+                on duplicate key update
+                  role = values(role), password = values(password), updated_at = now(6), deleted_at = null
+                """, INSTRUCTOR_USER_ID, OPERATOR_EMAIL, hash);
+
+        jdbc.batchUpdate("""
+                insert into users
+                  (user_id, role, email, password, name, nickname, provider, email_verified, is_locked,
+                   created_at, updated_at)
+                values
+                  (?, 'STUDENT', ?, ?, ?, ?, 'LOCAL', true, false, now(6), now(6))
+                on duplicate key update
+                  role = values(role), password = values(password), name = values(name),
+                  nickname = values(nickname), updated_at = now(6), deleted_at = null
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                long userId = STUDENT_ID_START + i;
+                ps.setLong(1, userId);
+                ps.setString(2, "learning_student_%03d@test.com".formatted(i + 1));
+                ps.setString(3, hash);
+                ps.setString(4, "러닝학생%03d".formatted(i + 1));
+                ps.setString(5, "learning-student-%03d".formatted(i + 1));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return STUDENTS;
+            }
+        });
+    }
+
+    private void seedCourse() {
+        jdbc.update("""
+                insert into course_category
+                  (course_category_id, name, status, display_order, created_at)
+                values
+                  (?, 'Learning Loadtest', 'ACTIVE', 999, now(6))
+                on duplicate key update
+                  status = values(status)
+                """, COURSE_CATEGORY_ID);
+
+        jdbc.update("""
+                insert into course
+                  (course_id, instructor_id, course_category_id, title, description, thumbnail_url,
+                   status, created_at, updated_at, deleted_at)
+                values
+                  (?, ?, ?, 'Learning Progress Loadtest Course',
+                   '학습률 조회 병목 검증용 강좌입니다.',
+                   'https://placehold.co/640x360?text=Learning+Loadtest',
+                   'ACTIVE', now(6), now(6), null)
+                on duplicate key update
+                  instructor_id = values(instructor_id), status = values(status), updated_at = now(6), deleted_at = null
+                """, COURSE_ID, INSTRUCTOR_USER_ID, COURSE_CATEGORY_ID);
+    }
+
+    private void seedLectures() {
+        jdbc.batchUpdate("""
+                insert into lecture
+                  (lecture_id, course_id, title, description, video_url, thumbnail_url, status,
+                   lecture_order, created_at, updated_at, deleted_at)
+                values
+                  (?, ?, ?, '학습률 부하테스트용 강의입니다.', 'https://example.com/video.mp4',
+                   'https://placehold.co/320x180', 'ACTIVE', ?, now(6), now(6), null)
+                on duplicate key update
+                  title = values(title), status = values(status), updated_at = now(6), deleted_at = null
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, LECTURE_ID_START + i);
+                ps.setLong(2, COURSE_ID);
+                ps.setString(3, "러닝 부하 강의 " + (i + 1));
+                ps.setInt(4, i + 1);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return LECTURES;
+            }
+        });
+    }
+
+    private void seedProblemSets() {
+        jdbc.batchUpdate("""
+                insert into problem_set
+                  (problem_set_id, title, description, difficulty, status, total_problem_count,
+                   completed_user_count, started_user_count, created_by, created_at, deleted_at)
+                values
+                  (?, ?, '학습률 부하테스트용 문제세트입니다.', 'EASY', 'ACTIVE', 5, 0, 0, ?, now(6), null)
+                on duplicate key update
+                  title = values(title), status = values(status), deleted_at = null
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, PROBLEM_SET_ID_START + i);
+                ps.setString(2, "러닝 부하 문제세트 " + (i + 1));
+                ps.setLong(3, INSTRUCTOR_USER_ID);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return PROBLEM_SETS;
+            }
+        });
+    }
+
+    private void seedLectureProblemSets() {
+        jdbc.batchUpdate("""
+                insert into lecture_problem_set
+                  (lecture_problem_set_id, course_id, lecture_id, problem_set_id, role, display_order)
+                values
+                  (?, ?, ?, ?, 'MAIN', ?)
+                on duplicate key update
+                  role = values(role), display_order = values(display_order)
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, LECTURE_PROBLEM_SET_ID_START + i);
+                ps.setLong(2, COURSE_ID);
+                ps.setLong(3, LECTURE_ID_START + (i % LECTURES));
+                ps.setLong(4, PROBLEM_SET_ID_START + i);
+                ps.setInt(5, i + 1);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return PROBLEM_SETS;
+            }
+        });
+    }
+
+    private void seedEnrollments() {
+        jdbc.batchUpdate("""
+                insert into enrollment
+                  (user_id, course_id, status, enrolled_at, canceled_at)
+                values
+                  (?, ?, 'ACTIVE', now(6), null)
+                on duplicate key update
+                  status = values(status), canceled_at = null
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, STUDENT_ID_START + i);
+                ps.setLong(2, COURSE_ID);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return STUDENTS;
+            }
+        });
+    }
+
+    private void seedLectureProgresses() {
+        jdbc.batchUpdate("""
+                insert into lecture_progress
+                  (user_id, lecture_id, is_completed, completed_at, last_position_sec,
+                   duration_sec, watched_sec, created_at, updated_at)
+                values
+                  (?, ?, ?, if(?, now(6), null), 0, 600, 600, now(6), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                long studentId = STUDENT_ID_START + (i / LECTURES);
+                long lectureId = LECTURE_ID_START + (i % LECTURES);
+                boolean completed = i % 3 != 0;
+
+                ps.setLong(1, studentId);
+                ps.setLong(2, lectureId);
+                ps.setBoolean(3, completed);
+                ps.setBoolean(4, completed);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return STUDENTS * LECTURES;
+            }
+        });
+    }
+
+    private void seedLectureProblemProgresses() {
+        jdbc.batchUpdate("""
+                insert into lecture_problem_progress
+                  (user_id, lecture_problem_set_id, current_problem_number, is_completed,
+                   completed_at, created_at, updated_at)
+                values
+                  (?, ?, 5, ?, if(?, now(6), null), now(6), now(6))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                long studentId = STUDENT_ID_START + (i / PROBLEM_SETS);
+                long lectureProblemSetId = LECTURE_PROBLEM_SET_ID_START + (i % PROBLEM_SETS);
+                boolean completed = i % 4 != 0;
+
+                ps.setLong(1, studentId);
+                ps.setLong(2, lectureProblemSetId);
+                ps.setBoolean(3, completed);
+                ps.setBoolean(4, completed);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return STUDENTS * PROBLEM_SETS;
+            }
+        });
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/metrics/LearningMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/metrics/LearningMetrics.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.learning.infrastructure.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LearningMetrics {
+
+    private final Timer studentProgressQueryTimer;
+
+    public LearningMetrics(MeterRegistry registry) {
+        this.studentProgressQueryTimer = Timer.builder("learning_student_progress_query_duration")
+                .description("강좌별 학생 학습률 목록 조회 구간 시간")
+                .register(registry);
+    }
+
+    public void recordStudentProgressQuery(long elapsedNanos) {
+        studentProgressQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+}
+
+// 쿼리 서비스가 시간 재면 여기서 시간을 매트릭으로 저장

--- a/src/main/java/com/wanted/codebombalms/lecture/application/command/UploadLectureMaterialCommand.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/command/UploadLectureMaterialCommand.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.lecture.application.command;
+
+public record UploadLectureMaterialCommand(
+        Long lectureId,
+        String originalFileName,
+        String contentType,
+        long fileSize,
+        byte[] content
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/application/port/LectureEnrollmentPort.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/port/LectureEnrollmentPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.lecture.application.port;
+
+public interface LectureEnrollmentPort {
+
+    boolean isActiveStudentOfCourse(Long courseId, Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/application/port/LectureMaterialStoragePort.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/port/LectureMaterialStoragePort.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.lecture.application.port;
+
+public interface LectureMaterialStoragePort {
+
+    StoredLectureMaterial upload(
+            String originalFileName,
+            String contentType,
+            long fileSize,
+            byte[] content
+    );
+
+    void delete(String filePath);
+
+    String generateDownloadUrl(String filePath, String originalFileName);
+
+    record StoredLectureMaterial(
+            String originalFileName,
+            String storedFileName,
+            String filePath,
+            String contentType,
+            long fileSize
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialService.java
@@ -13,12 +13,14 @@ import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialReposito
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class LectureMaterialService implements LectureMaterialUseCase {
 
     private final LectureMaterialRepository lectureMaterialRepository;
@@ -46,7 +48,12 @@ public class LectureMaterialService implements LectureMaterialUseCase {
                 storedMaterial.fileSize()
         );
 
-        return lectureMaterialRepository.save(material);
+        try {
+            return lectureMaterialRepository.save(material);
+        } catch (RuntimeException e) {
+            deleteUploadedMaterialQuietly(storedMaterial.filePath(), e);
+            throw e;
+        }
     }
 
     @Override
@@ -95,5 +102,14 @@ public class LectureMaterialService implements LectureMaterialUseCase {
     private LectureMaterial findMaterial(Long lectureMaterialId) {
         return lectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId)
                 .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_MATERIAL_NOT_FOUND));
+    }
+
+    private void deleteUploadedMaterialQuietly(String filePath, RuntimeException originalException) {
+        try {
+            lectureMaterialStoragePort.delete(filePath);
+        } catch (RuntimeException deleteException) {
+            originalException.addSuppressed(deleteException);
+            log.warn("Failed to delete uploaded lecture material after DB save failure. filePath={}", filePath, deleteException);
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialService.java
@@ -1,0 +1,99 @@
+package com.wanted.codebombalms.lecture.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
+import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.application.usecase.LectureMaterialUseCase;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
+import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LectureMaterialService implements LectureMaterialUseCase {
+
+    private final LectureMaterialRepository lectureMaterialRepository;
+    private final LectureRepository lectureRepository;
+    private final LectureMaterialStoragePort lectureMaterialStoragePort;
+    private final LectureEnrollmentPort lectureEnrollmentPort;
+
+    @Override
+    public LectureMaterial uploadMaterial(UploadLectureMaterialCommand command) {
+        validateLecture(command.lectureId());
+
+        var storedMaterial = lectureMaterialStoragePort.upload(
+                command.originalFileName(),
+                command.contentType(),
+                command.fileSize(),
+                command.content()
+        );
+
+        LectureMaterial material = LectureMaterial.create(
+                command.lectureId(),
+                storedMaterial.originalFileName(),
+                storedMaterial.storedFileName(),
+                storedMaterial.filePath(),
+                storedMaterial.contentType(),
+                storedMaterial.fileSize()
+        );
+
+        return lectureMaterialRepository.save(material);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LectureMaterial> findMaterials(Long lectureId) {
+        validateLecture(lectureId);
+        return lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String issueDownloadUrl(Long lectureMaterialId, Long userId, boolean operator) {
+        LectureMaterial material = findMaterial(lectureMaterialId);
+
+        if (!operator) {
+            if (userId == null) {
+                throw new ForbiddenException(LectureErrorCode.LECTURE_MATERIAL_ACCESS_DENIED);
+            }
+
+            Lecture lecture = validateLecture(material.getLectureId());
+            Long courseId = lecture.getCourse().getCourseId();
+            if (!lectureEnrollmentPort.isActiveStudentOfCourse(courseId, userId)) {
+                throw new ForbiddenException(LectureErrorCode.LECTURE_MATERIAL_ACCESS_DENIED);
+            }
+        }
+
+        return lectureMaterialStoragePort.generateDownloadUrl(
+                material.getFilePath(),
+                material.getOriginalFileName()
+        );
+    }
+
+    @Override
+    public void deleteMaterial(Long lectureMaterialId) {
+        LectureMaterial material = findMaterial(lectureMaterialId);
+        material.delete();
+        lectureMaterialRepository.save(material);
+        lectureMaterialStoragePort.delete(material.getFilePath());
+    }
+
+    private Lecture validateLecture(Long lectureId) {
+        return lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
+                .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_NOT_FOUND));
+    }
+
+    private LectureMaterial findMaterial(Long lectureMaterialId) {
+        return lectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId)
+                .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_MATERIAL_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureMaterialUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureMaterialUseCase.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.lecture.application.usecase;
+
+import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import java.util.List;
+
+public interface LectureMaterialUseCase {
+
+    LectureMaterial uploadMaterial(UploadLectureMaterialCommand command);
+
+    List<LectureMaterial> findMaterials(Long lectureId);
+
+    String issueDownloadUrl(Long lectureMaterialId, Long userId, boolean operator);
+
+    void deleteMaterial(Long lectureMaterialId);
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
@@ -16,7 +16,8 @@ public enum LectureErrorCode implements ErrorCode {
     LECTURE_MATERIAL_INVALID_FILE("LCT-006", "Lecture material file is invalid."),
     LECTURE_MATERIAL_UPLOAD_FAILED("LCT-007", "Lecture material upload failed."),
     LECTURE_MATERIAL_DOWNLOAD_URL_FAILED("LCT-008", "Lecture material download URL generation failed."),
-    LECTURE_MATERIAL_ACCESS_DENIED("LCT-009", "Lecture material access is denied.");
+    LECTURE_MATERIAL_ACCESS_DENIED("LCT-009", "Lecture material access is denied."),
+    LECTURE_MATERIAL_DELETE_FAILED("LCT-010", "Lecture material delete failed.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
@@ -11,7 +11,12 @@ public enum LectureErrorCode implements ErrorCode {
     LECTURE_NOT_FOUND("LCT-001", "Lecture was not found."),
     LECTURE_DELETE_STATUS_REQUIRES_DELETE("LCT-002", "Use the delete API to delete a lecture."),
     LECTURE_ORDER_DUPLICATED("LCT-003", "A lecture with the same order already exists."),
-    INVALID_YOUTUBE_VIDEO_URL("LCT-004", "Lecture video URL must be a YouTube URL.");
+    INVALID_YOUTUBE_VIDEO_URL("LCT-004", "Lecture video URL must be a YouTube URL."),
+    LECTURE_MATERIAL_NOT_FOUND("LCT-005", "Lecture material was not found."),
+    LECTURE_MATERIAL_INVALID_FILE("LCT-006", "Lecture material file is invalid."),
+    LECTURE_MATERIAL_UPLOAD_FAILED("LCT-007", "Lecture material upload failed."),
+    LECTURE_MATERIAL_DOWNLOAD_URL_FAILED("LCT-008", "Lecture material download URL generation failed."),
+    LECTURE_MATERIAL_ACCESS_DENIED("LCT-009", "Lecture material access is denied.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/model/LectureMaterial.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/model/LectureMaterial.java
@@ -1,0 +1,70 @@
+package com.wanted.codebombalms.lecture.domain.model;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class LectureMaterial {
+
+    private Long lectureMaterialId;
+    private Long lectureId;
+    private String originalFileName;
+    private String storedFileName;
+    private String filePath;
+    private String contentType;
+    private Long fileSize;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+
+    public static LectureMaterial create(
+            Long lectureId,
+            String originalFileName,
+            String storedFileName,
+            String filePath,
+            String contentType,
+            Long fileSize
+    ) {
+        LectureMaterial material = new LectureMaterial();
+        material.setLectureId(lectureId);
+        material.setOriginalFileName(originalFileName);
+        material.setStoredFileName(storedFileName);
+        material.setFilePath(filePath);
+        material.setContentType(contentType);
+        material.setFileSize(fileSize);
+        return material;
+    }
+
+    public static LectureMaterial restore(
+            Long lectureMaterialId,
+            Long lectureId,
+            String originalFileName,
+            String storedFileName,
+            String filePath,
+            String contentType,
+            Long fileSize,
+            LocalDateTime createdAt,
+            LocalDateTime deletedAt
+    ) {
+        return new LectureMaterial(
+                lectureMaterialId,
+                lectureId,
+                originalFileName,
+                storedFileName,
+                filePath,
+                contentType,
+                fileSize,
+                createdAt,
+                deletedAt
+        );
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/model/LectureMaterial.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/model/LectureMaterial.java
@@ -1,15 +1,11 @@
 package com.wanted.codebombalms.lecture.domain.model;
 
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
-@Setter
 public class LectureMaterial {
 
     private Long lectureMaterialId;
@@ -22,6 +18,28 @@ public class LectureMaterial {
     private LocalDateTime createdAt;
     private LocalDateTime deletedAt;
 
+    private LectureMaterial(
+            Long lectureMaterialId,
+            Long lectureId,
+            String originalFileName,
+            String storedFileName,
+            String filePath,
+            String contentType,
+            Long fileSize,
+            LocalDateTime createdAt,
+            LocalDateTime deletedAt
+    ) {
+        this.lectureMaterialId = lectureMaterialId;
+        this.lectureId = lectureId;
+        this.originalFileName = originalFileName;
+        this.storedFileName = storedFileName;
+        this.filePath = filePath;
+        this.contentType = contentType;
+        this.fileSize = fileSize;
+        this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
+    }
+
     public static LectureMaterial create(
             Long lectureId,
             String originalFileName,
@@ -30,14 +48,17 @@ public class LectureMaterial {
             String contentType,
             Long fileSize
     ) {
-        LectureMaterial material = new LectureMaterial();
-        material.setLectureId(lectureId);
-        material.setOriginalFileName(originalFileName);
-        material.setStoredFileName(storedFileName);
-        material.setFilePath(filePath);
-        material.setContentType(contentType);
-        material.setFileSize(fileSize);
-        return material;
+        return new LectureMaterial(
+                null,
+                lectureId,
+                originalFileName,
+                storedFileName,
+                filePath,
+                contentType,
+                fileSize,
+                null,
+                null
+        );
     }
 
     public static LectureMaterial restore(

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureMaterialRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureMaterialRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.lecture.domain.repository;
+
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import java.util.List;
+import java.util.Optional;
+
+public interface LectureMaterialRepository {
+
+    LectureMaterial save(LectureMaterial material);
+
+    List<LectureMaterial> findByLectureIdAndDeletedAtIsNull(Long lectureId);
+
+    Optional<LectureMaterial> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId);
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/enrollment/LectureEnrollmentAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/enrollment/LectureEnrollmentAdapter.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.lecture.infrastructure.enrollment;
+
+import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
+import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LectureEnrollmentAdapter implements LectureEnrollmentPort {
+
+    private final EnrollmentQueryUseCase enrollmentQueryUseCase;
+
+    @Override
+    public boolean isActiveStudentOfCourse(Long courseId, Long userId) {
+        return enrollmentQueryUseCase.isActiveStudentOfCourse(courseId, userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialJpaEntity.java
@@ -1,0 +1,96 @@
+package com.wanted.codebombalms.lecture.infrastructure.persistence;
+
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(
+        name = "lecture_material",
+        indexes = @Index(name = "idx_lecture_material_lecture_id", columnList = "lecture_id")
+)
+public class LectureMaterialJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lecture_material_id")
+    private Long lectureMaterialId;
+
+    @Column(name = "lecture_id", nullable = false)
+    private Long lectureId;
+
+    @Column(name = "original_file_name", nullable = false, length = 255)
+    private String originalFileName;
+
+    @Column(name = "stored_file_name", nullable = false, length = 255)
+    private String storedFileName;
+
+    @Column(name = "file_path", nullable = false, length = 500)
+    private String filePath;
+
+    @Column(name = "content_type", nullable = false, length = 100)
+    private String contentType;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public static LectureMaterialJpaEntity from(LectureMaterial material) {
+        LectureMaterialJpaEntity entity = new LectureMaterialJpaEntity();
+        entity.lectureMaterialId = material.getLectureMaterialId();
+        entity.lectureId = material.getLectureId();
+        entity.originalFileName = material.getOriginalFileName();
+        entity.storedFileName = material.getStoredFileName();
+        entity.filePath = material.getFilePath();
+        entity.contentType = material.getContentType();
+        entity.fileSize = material.getFileSize();
+        entity.createdAt = material.getCreatedAt();
+        entity.deletedAt = material.getDeletedAt();
+        return entity;
+    }
+
+    public void apply(LectureMaterial material) {
+        this.lectureId = material.getLectureId();
+        this.originalFileName = material.getOriginalFileName();
+        this.storedFileName = material.getStoredFileName();
+        this.filePath = material.getFilePath();
+        this.contentType = material.getContentType();
+        this.fileSize = material.getFileSize();
+        this.deletedAt = material.getDeletedAt();
+    }
+
+    public LectureMaterial toDomain() {
+        return LectureMaterial.restore(
+                lectureMaterialId,
+                lectureId,
+                originalFileName,
+                storedFileName,
+                filePath,
+                contentType,
+                fileSize,
+                createdAt,
+                deletedAt
+        );
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.wanted.codebombalms.lecture.infrastructure.persistence;
 
 import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +24,7 @@ public class LectureMaterialRepositoryAdapter implements LectureMaterialReposito
                     found.apply(material);
                     return found;
                 })
-                .orElseGet(() -> LectureMaterialJpaEntity.from(material));
+                .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_MATERIAL_NOT_FOUND));
 
         return springDataLectureMaterialRepository.save(entity).toDomain();
     }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
@@ -1,0 +1,44 @@
+package com.wanted.codebombalms.lecture.infrastructure.persistence;
+
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureMaterialRepositoryAdapter implements LectureMaterialRepository {
+
+    private final SpringDataLectureMaterialRepository springDataLectureMaterialRepository;
+
+    @Override
+    public LectureMaterial save(LectureMaterial material) {
+        LectureMaterialJpaEntity entity = material.getLectureMaterialId() == null
+                ? LectureMaterialJpaEntity.from(material)
+                : springDataLectureMaterialRepository.findById(material.getLectureMaterialId())
+                .map(found -> {
+                    found.apply(material);
+                    return found;
+                })
+                .orElseGet(() -> LectureMaterialJpaEntity.from(material));
+
+        return springDataLectureMaterialRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public List<LectureMaterial> findByLectureIdAndDeletedAtIsNull(Long lectureId) {
+        return springDataLectureMaterialRepository
+                .findByLectureIdAndDeletedAtIsNullOrderByCreatedAtDesc(lectureId)
+                .stream()
+                .map(LectureMaterialJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<LectureMaterial> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId) {
+        return springDataLectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId)
+                .map(LectureMaterialJpaEntity::toDomain);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureMaterialRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureMaterialRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.lecture.infrastructure.persistence;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataLectureMaterialRepository extends JpaRepository<LectureMaterialJpaEntity, Long> {
+
+    List<LectureMaterialJpaEntity> findByLectureIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long lectureId);
+
+    Optional<LectureMaterialJpaEntity> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId);
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -39,6 +39,7 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
 
         deleteLectureProblemSetsByLectureIds(lectureIds);
         deleteLectureProgressesByLectureIds(lectureIds);
+        deleteLectureMaterialsByLectureIds(lectureIds);
         return deleteLecturesByIds(lectureIds);
     }
 
@@ -88,6 +89,13 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
             where p.lectureId in :lectureIds
             """)
     int deleteLectureProgressesByLectureIds(@Param("lectureIds") List<Long> lectureIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureMaterialJpaEntity m
+            where m.lectureId in :lectureIds
+            """)
+    int deleteLectureMaterialsByLectureIds(@Param("lectureIds") List<Long> lectureIds);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/storage/GcsLectureMaterialStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/storage/GcsLectureMaterialStorageAdapter.java
@@ -91,7 +91,10 @@ public class GcsLectureMaterialStorageAdapter implements LectureMaterialStorageP
         try {
             getStorage().delete(BlobId.of(properties.getStorage().getBucket(), filePath));
         } catch (Exception e) {
-            log.warn("Failed to delete lecture material from GCS. filePath={}", filePath, e);
+            throw new ExternalServiceException(
+                    LectureErrorCode.LECTURE_MATERIAL_DELETE_FAILED,
+                    e
+            );
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/storage/GcsLectureMaterialStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/storage/GcsLectureMaterialStorageAdapter.java
@@ -1,0 +1,211 @@
+package com.wanted.codebombalms.lecture.infrastructure.storage;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.http.ContentDisposition;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GcsLectureMaterialStorageAdapter implements LectureMaterialStoragePort {
+
+    private static final long MAX_FILE_SIZE = 20 * 1024 * 1024;
+    private static final long DOWNLOAD_URL_DURATION_MINUTES = 1;
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "application/pdf",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "text/plain",
+            "text/csv",
+            "application/zip"
+    );
+
+    private final GcpStorageProperties properties;
+    private final ResourceLoader resourceLoader;
+    private volatile Storage storage;
+
+    @Override
+    public StoredLectureMaterial upload(
+            String originalFileName,
+            String contentType,
+            long fileSize,
+            byte[] content
+    ) {
+        validateFile(originalFileName, contentType, fileSize, content);
+
+        String sanitizedFileName = sanitizeFileName(originalFileName);
+        String storedFileName = UUID.randomUUID() + "_" + sanitizedFileName;
+        String objectName = buildObjectName(storedFileName);
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(
+                        BlobId.of(properties.getStorage().getBucket(), objectName)
+                )
+                .setContentType(contentType)
+                .build();
+
+        try {
+            getStorage().create(blobInfo, content);
+            return new StoredLectureMaterial(
+                    sanitizedFileName,
+                    storedFileName,
+                    objectName,
+                    contentType,
+                    fileSize
+            );
+        } catch (Exception e) {
+            throw new ExternalServiceException(
+                    LectureErrorCode.LECTURE_MATERIAL_UPLOAD_FAILED,
+                    e
+            );
+        }
+    }
+
+    @Override
+    public void delete(String filePath) {
+        if (filePath == null || filePath.isBlank()) {
+            return;
+        }
+
+        try {
+            getStorage().delete(BlobId.of(properties.getStorage().getBucket(), filePath));
+        } catch (Exception e) {
+            log.warn("Failed to delete lecture material from GCS. filePath={}", filePath, e);
+        }
+    }
+
+    @Override
+    public String generateDownloadUrl(String filePath, String originalFileName) {
+        if (filePath == null || filePath.isBlank()
+                || originalFileName == null || originalFileName.isBlank()) {
+            throw new ValidationException(LectureErrorCode.LECTURE_MATERIAL_INVALID_FILE);
+        }
+
+        String contentDisposition = ContentDisposition.attachment()
+                .filename(originalFileName, StandardCharsets.UTF_8)
+                .build()
+                .toString();
+
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(
+                    properties.getStorage().getBucket(),
+                    filePath
+            ).build();
+
+            return getStorage()
+                    .signUrl(
+                            blobInfo,
+                            DOWNLOAD_URL_DURATION_MINUTES,
+                            TimeUnit.MINUTES,
+                            Storage.SignUrlOption.withV4Signature(),
+                            Storage.SignUrlOption.withQueryParams(Map.of(
+                                    "response-content-disposition",
+                                    contentDisposition
+                            ))
+                    )
+                    .toString();
+        } catch (Exception e) {
+            throw new ExternalServiceException(
+                    LectureErrorCode.LECTURE_MATERIAL_DOWNLOAD_URL_FAILED,
+                    e
+            );
+        }
+    }
+
+    private void validateFile(
+            String originalFileName,
+            String contentType,
+            long fileSize,
+            byte[] content
+    ) {
+        boolean invalidFile = originalFileName == null
+                || originalFileName.isBlank()
+                || contentType == null
+                || !ALLOWED_CONTENT_TYPES.contains(contentType)
+                || fileSize <= 0
+                || fileSize > MAX_FILE_SIZE
+                || content == null
+                || content.length == 0
+                || fileSize != content.length;
+
+        if (invalidFile) {
+            throw new ValidationException(LectureErrorCode.LECTURE_MATERIAL_INVALID_FILE);
+        }
+    }
+
+    private String buildObjectName(String storedFileName) {
+        String prefix = normalizePrefix(properties.getStorage().getLectureMaterialPrefix());
+        if (prefix.isBlank()) {
+            return storedFileName;
+        }
+        return prefix + "/" + storedFileName;
+    }
+
+    private String normalizePrefix(String prefix) {
+        if (prefix == null) {
+            return "";
+        }
+        return prefix.replaceAll("^/+", "").replaceAll("/+$", "");
+    }
+
+    private String sanitizeFileName(String originalFileName) {
+        return originalFileName
+                .replace("\\", "_")
+                .replace("/", "_")
+                .replaceAll("[^a-zA-Z0-9._-]", "_");
+    }
+
+    private Storage getStorage() {
+        if (storage == null) {
+            synchronized (this) {
+                if (storage == null) {
+                    storage = createStorage();
+                }
+            }
+        }
+        return storage;
+    }
+
+    private Storage createStorage() {
+        try {
+            return StorageOptions.newBuilder()
+                    .setProjectId(properties.getProjectId())
+                    .setCredentials(loadCredentials())
+                    .build()
+                    .getService();
+        } catch (Exception e) {
+            throw new ExternalServiceException(
+                    LectureErrorCode.LECTURE_MATERIAL_UPLOAD_FAILED,
+                    e
+            );
+        }
+    }
+
+    private GoogleCredentials loadCredentials() throws IOException {
+        Resource resource = resourceLoader.getResource(properties.getCredentials().getLocation());
+        try (InputStream inputStream = resource.getInputStream()) {
+            return GoogleCredentials.fromStream(inputStream);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
@@ -2,23 +2,34 @@ package com.wanted.codebombalms.lecture.presentation.api;
 
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
+import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
 import com.wanted.codebombalms.lecture.application.usecase.LectureCommandUseCase;
+import com.wanted.codebombalms.lecture.application.usecase.LectureMaterialUseCase;
 import com.wanted.codebombalms.lecture.application.usecase.LectureQueryUseCase;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureCreateRequest;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureUpdateRequest;
 import com.wanted.codebombalms.lecture.presentation.api.response.LectureDetailResponse;
+import com.wanted.codebombalms.lecture.presentation.api.response.LectureMaterialDownloadUrlResponse;
+import com.wanted.codebombalms.lecture.presentation.api.response.LectureMaterialResponse;
 import com.wanted.codebombalms.lecture.presentation.api.response.LectureResponse;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -30,6 +41,7 @@ public class LectureController {
 
     private final LectureCommandUseCase lectureCommandUseCase;
     private final LectureQueryUseCase lectureQueryUseCase;
+    private final LectureMaterialUseCase lectureMaterialUseCase;
 
     @GetMapping("/courses/{courseId}/lectures")
     @Operation(summary = "강좌별 강의 목록 조회")
@@ -116,5 +128,87 @@ public class LectureController {
         lectureCommandUseCase.deleteLecture(lectureId);
 
         return ResponseEntity.noContent().build();
+    }
+    @PostMapping(value = "/lectures/{lectureId}/materials", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "강의자료 업로드")
+    @PreAuthorize("hasRole('OPERATOR')")
+    public ResponseEntity<ApiResponse<?>> uploadMaterial(
+            @PathVariable Long lectureId,
+            @RequestParam("material") MultipartFile material
+    ) {
+        byte[] materialBytes = readMaterialBytes(material);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(
+                        LectureResponseCode.MATERIAL_UPLOADED,
+                        LectureResponseMessage.MATERIAL_UPLOADED,
+                        LectureMaterialResponse.from(lectureMaterialUseCase.uploadMaterial(
+                                new UploadLectureMaterialCommand(
+                                        lectureId,
+                                        material.getOriginalFilename(),
+                                        material.getContentType(),
+                                        material.getSize(),
+                                        materialBytes
+                                )
+                        ))
+                ));
+    }
+
+    @GetMapping("/lectures/{lectureId}/materials")
+    @Operation(summary = "강의자료 목록 조회")
+    public ResponseEntity<ApiResponse<?>> findMaterials(@PathVariable Long lectureId) {
+        return ResponseEntity.ok(ApiResponse.success(
+                LectureResponseCode.RETRIEVED,
+                LectureResponseMessage.RETRIEVED,
+                lectureMaterialUseCase.findMaterials(lectureId)
+                        .stream()
+                        .map(LectureMaterialResponse::from)
+                        .toList()
+        ));
+    }
+
+    @PostMapping("/lecture-materials/{lectureMaterialId}/download-url")
+    @Operation(summary = "강의자료 다운로드 URL 발급")
+    public ResponseEntity<ApiResponse<?>> issueMaterialDownloadUrl(
+            @PathVariable Long lectureMaterialId,
+            @AuthenticationPrincipal Long userId,
+            Authentication authentication
+    ) {
+        String downloadUrl = lectureMaterialUseCase.issueDownloadUrl(
+                lectureMaterialId,
+                userId,
+                isOperator(authentication)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                LectureResponseCode.MATERIAL_DOWNLOAD_URL_ISSUED,
+                LectureResponseMessage.MATERIAL_DOWNLOAD_URL_ISSUED,
+                new LectureMaterialDownloadUrlResponse(downloadUrl)
+        ));
+    }
+
+    @DeleteMapping("/lecture-materials/{lectureMaterialId}")
+    @Operation(summary = "강의자료 삭제")
+    @PreAuthorize("hasRole('OPERATOR')")
+    public ResponseEntity<Void> deleteMaterial(@PathVariable Long lectureMaterialId) {
+        lectureMaterialUseCase.deleteMaterial(lectureMaterialId);
+        return ResponseEntity.noContent().build();
+    }
+
+    private byte[] readMaterialBytes(MultipartFile material) {
+        try {
+            return material.getBytes();
+        } catch (IOException e) {
+            throw new ExternalServiceException(
+                    LectureErrorCode.LECTURE_MATERIAL_UPLOAD_FAILED,
+                    e
+            );
+        }
+    }
+
+    private boolean isOperator(Authentication authentication) {
+        return authentication != null
+                && authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_OPERATOR".equals(authority.getAuthority()));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
@@ -169,6 +169,7 @@ public class LectureController {
 
     @PostMapping("/lecture-materials/{lectureMaterialId}/download-url")
     @Operation(summary = "강의자료 다운로드 URL 발급")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<?>> issueMaterialDownloadUrl(
             @PathVariable Long lectureMaterialId,
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureResponseCode.java
@@ -8,4 +8,6 @@ public class LectureResponseCode {
     public static final String CREATED = "LECTURE-CREATED";
     public static final String UPDATED = "LECTURE-UPDATED";
     public static final String DELETED = "LECTURE-DELETED";
+    public static final String MATERIAL_UPLOADED = "LECTURE-MATERIAL-UPLOADED";
+    public static final String MATERIAL_DOWNLOAD_URL_ISSUED = "LECTURE-MATERIAL-DOWNLOAD-URL-ISSUED";
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureResponseMessage.java
@@ -8,4 +8,6 @@ public class LectureResponseMessage {
     public static final String CREATED = "강의가 생성되었습니다.";
     public static final String UPDATED = "강의가 수정되었습니다.";
     public static final String DELETED = "강의가 삭제되었습니다.";
+    public static final String MATERIAL_UPLOADED = "Lecture material has been uploaded.";
+    public static final String MATERIAL_DOWNLOAD_URL_ISSUED = "Lecture material download URL has been issued.";
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureResponseMessage.java
@@ -8,6 +8,6 @@ public class LectureResponseMessage {
     public static final String CREATED = "강의가 생성되었습니다.";
     public static final String UPDATED = "강의가 수정되었습니다.";
     public static final String DELETED = "강의가 삭제되었습니다.";
-    public static final String MATERIAL_UPLOADED = "Lecture material has been uploaded.";
-    public static final String MATERIAL_DOWNLOAD_URL_ISSUED = "Lecture material download URL has been issued.";
+    public static final String MATERIAL_UPLOADED = "강의자료가 업로드되었습니다.";
+    public static final String MATERIAL_DOWNLOAD_URL_ISSUED = "강의자료 다운로드 URL이 발급되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/LectureMaterialDownloadUrlResponse.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/LectureMaterialDownloadUrlResponse.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.lecture.presentation.api.response;
+
+public record LectureMaterialDownloadUrlResponse(
+        String downloadUrl
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/LectureMaterialResponse.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/LectureMaterialResponse.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.lecture.presentation.api.response;
+
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import java.time.LocalDateTime;
+
+public record LectureMaterialResponse(
+        Long lectureMaterialId,
+        Long lectureId,
+        String originalFileName,
+        String contentType,
+        Long fileSize,
+        LocalDateTime createdAt
+) {
+
+    public static LectureMaterialResponse from(LectureMaterial material) {
+        return new LectureMaterialResponse(
+                material.getLectureMaterialId(),
+                material.getLectureId(),
+                material.getOriginalFileName(),
+                material.getContentType(),
+                material.getFileSize(),
+                material.getCreatedAt()
+        );
+    }
+}

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -4,6 +4,12 @@ spring:
     username: lms_loadtest
     password: loadtest
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 3
+      idle-timeout: 30000
+      max-lifetime: 1800000
+      connection-timeout: 3000
 
   mail:
     username: loadtest@example.com
@@ -11,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: false

--- a/src/main/resources/application-loadtest.yml
+++ b/src/main/resources/application-loadtest.yml
@@ -5,9 +5,18 @@ spring:
     password: loadtest
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  mail:
+    username: loadtest@example.com
+    password: loadtest
+
   jpa:
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         format_sql: false
+
+jwt:
+  secret: g4SoLqa33ggACZrbDM3X8MDqzNEDOhw+dKb5cr9CQbw=
+  access-expiration: 3600000
+  refresh-expiration: 1209600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,7 @@ gcp:
     dataset-prefix: ${GCP_STORAGE_DATASET_PREFIX:problem_dataset}
     badge-image-prefix: ${GCP_BADGE_IMAGE_PREFIX:badge_image}
     course-thumbnail-prefix: ${GCP_COURSE_THUMBNAIL_PREFIX:course_thumbnail_images}
+    lecture-material-prefix: ${GCP_STORAGE_LECTURE_MATERIAL_PREFIX:lecture_materials}
   credentials:
     location: ${GCP_CREDENTIALS_LOCATION:file:./secrets/gcp-storage-key.json}
 

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
@@ -477,6 +477,7 @@ class LearningServiceTest {
         assertEquals(50, result.lectureProgressRate());
         assertEquals(2L, result.completedProblemCount());
         assertEquals(3L, result.totalProblemCount());
+        verify(learningMetrics).recordStudentProgressQuery(anyLong());
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
@@ -20,6 +20,7 @@ import com.wanted.codebombalms.learning.domain.model.LectureProgress;
 import com.wanted.codebombalms.learning.domain.model.StudentLearningProgress;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemProgressRepository;
 import com.wanted.codebombalms.learning.domain.repository.LectureProgressRepository;
+import com.wanted.codebombalms.learning.infrastructure.metrics.LearningMetrics;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -66,6 +67,9 @@ class LearningServiceTest {
 
     @Mock
     private LearningUserPort learningUserPort;
+
+    @Mock
+    private LearningMetrics learningMetrics;
 
     @InjectMocks
     private LectureProgressService lectureProgressService;

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
@@ -1,0 +1,142 @@
+package com.wanted.codebombalms.lecture.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
+import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
+import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LectureMaterialService unit test")
+class LectureMaterialServiceTest {
+
+    @Mock
+    private LectureMaterialRepository lectureMaterialRepository;
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @Mock
+    private LectureMaterialStoragePort lectureMaterialStoragePort;
+
+    @Mock
+    private LectureEnrollmentPort lectureEnrollmentPort;
+
+    @InjectMocks
+    private LectureMaterialService lectureMaterialService;
+
+    @Test
+    void uploadMaterial_savesStoredMaterial() {
+        Long lectureId = 1L;
+        LectureMaterial saved = createMaterial(10L, lectureId);
+
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(Optional.of(createLecture(lectureId, 100L)));
+        given(lectureMaterialStoragePort.upload("guide.pdf", "application/pdf", 3L, "pdf".getBytes()))
+                .willReturn(new LectureMaterialStoragePort.StoredLectureMaterial(
+                        "guide.pdf",
+                        "stored-guide.pdf",
+                        "lecture_materials/stored-guide.pdf",
+                        "application/pdf",
+                        3L
+                ));
+        given(lectureMaterialRepository.save(any(LectureMaterial.class))).willReturn(saved);
+
+        LectureMaterial result = lectureMaterialService.uploadMaterial(
+                new UploadLectureMaterialCommand(
+                        lectureId,
+                        "guide.pdf",
+                        "application/pdf",
+                        3L,
+                        "pdf".getBytes()
+                )
+        );
+
+        assertEquals(10L, result.getLectureMaterialId());
+        assertEquals("guide.pdf", result.getOriginalFileName());
+        verify(lectureMaterialRepository).save(any(LectureMaterial.class));
+    }
+
+    @Test
+    void issueDownloadUrl_returnsUrl_whenStudentEnrolled() {
+        Long lectureMaterialId = 10L;
+        Long lectureId = 1L;
+        Long userId = 20L;
+        Long courseId = 100L;
+
+        given(lectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId))
+                .willReturn(Optional.of(createMaterial(lectureMaterialId, lectureId)));
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(Optional.of(createLecture(lectureId, courseId)));
+        given(lectureEnrollmentPort.isActiveStudentOfCourse(courseId, userId)).willReturn(true);
+        given(lectureMaterialStoragePort.generateDownloadUrl(
+                "lecture_materials/stored-guide.pdf",
+                "guide.pdf"
+        )).willReturn("https://download-url");
+
+        String result = lectureMaterialService.issueDownloadUrl(lectureMaterialId, userId, false);
+
+        assertEquals("https://download-url", result);
+    }
+
+    @Test
+    void issueDownloadUrl_throwsForbidden_whenStudentNotEnrolled() {
+        Long lectureMaterialId = 10L;
+        Long lectureId = 1L;
+        Long userId = 20L;
+        Long courseId = 100L;
+
+        given(lectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId))
+                .willReturn(Optional.of(createMaterial(lectureMaterialId, lectureId)));
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(Optional.of(createLecture(lectureId, courseId)));
+        given(lectureEnrollmentPort.isActiveStudentOfCourse(courseId, userId)).willReturn(false);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureMaterialService.issueDownloadUrl(lectureMaterialId, userId, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_MATERIAL_ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    private Lecture createLecture(Long lectureId, Long courseId) {
+        Course course = new Course();
+        course.setCourseId(courseId);
+
+        Lecture lecture = new Lecture();
+        lecture.setLectureId(lectureId);
+        lecture.setCourse(course);
+        return lecture;
+    }
+
+    private LectureMaterial createMaterial(Long lectureMaterialId, Long lectureId) {
+        LectureMaterial material = new LectureMaterial();
+        material.setLectureMaterialId(lectureMaterialId);
+        material.setLectureId(lectureId);
+        material.setOriginalFileName("guide.pdf");
+        material.setStoredFileName("stored-guide.pdf");
+        material.setFilePath("lecture_materials/stored-guide.pdf");
+        material.setContentType("application/pdf");
+        material.setFileSize(3L);
+        return material;
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
@@ -98,6 +100,23 @@ class LectureMaterialServiceTest {
     }
 
     @Test
+    void issueDownloadUrl_returnsUrl_whenOperator() {
+        Long lectureMaterialId = 10L;
+
+        given(lectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId))
+                .willReturn(Optional.of(createMaterial(lectureMaterialId, 1L)));
+        given(lectureMaterialStoragePort.generateDownloadUrl(
+                "lecture_materials/stored-guide.pdf",
+                "guide.pdf"
+        )).willReturn("https://download-url");
+
+        String result = lectureMaterialService.issueDownloadUrl(lectureMaterialId, null, true);
+
+        assertEquals("https://download-url", result);
+        verify(lectureEnrollmentPort, never()).isActiveStudentOfCourse(any(), any());
+    }
+
+    @Test
     void issueDownloadUrl_throwsForbidden_whenStudentNotEnrolled() {
         Long lectureMaterialId = 10L;
         Long lectureId = 1L;
@@ -118,6 +137,76 @@ class LectureMaterialServiceTest {
         assertEquals(LectureErrorCode.LECTURE_MATERIAL_ACCESS_DENIED, exception.getErrorCode());
     }
 
+    @Test
+    void issueDownloadUrl_throwsForbidden_whenUserIdIsNull() {
+        Long lectureMaterialId = 10L;
+
+        given(lectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId))
+                .willReturn(Optional.of(createMaterial(lectureMaterialId, 1L)));
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureMaterialService.issueDownloadUrl(lectureMaterialId, null, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_MATERIAL_ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    @Test
+    void findMaterials_returnsMaterials() {
+        Long lectureId = 1L;
+
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(Optional.of(createLecture(lectureId, 100L)));
+        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(java.util.List.of(createMaterial(10L, lectureId)));
+
+        var result = lectureMaterialService.findMaterials(lectureId);
+
+        assertEquals(1, result.size());
+        assertEquals(10L, result.get(0).getLectureMaterialId());
+    }
+
+    @Test
+    void findMaterials_throwsNotFound_whenLectureMissing() {
+        Long lectureId = 999L;
+
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)).willReturn(Optional.empty());
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> lectureMaterialService.findMaterials(lectureId)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void deleteMaterial_softDeletesAndDeletesStorageObject() {
+        Long lectureMaterialId = 10L;
+        LectureMaterial material = createMaterial(lectureMaterialId, 1L);
+        LectureMaterial deleted = LectureMaterial.restore(
+                lectureMaterialId,
+                1L,
+                "guide.pdf",
+                "stored-guide.pdf",
+                "lecture_materials/stored-guide.pdf",
+                "application/pdf",
+                3L,
+                null,
+                java.time.LocalDateTime.now()
+        );
+
+        given(lectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId))
+                .willReturn(Optional.of(material));
+        given(lectureMaterialRepository.save(any(LectureMaterial.class))).willReturn(deleted);
+
+        lectureMaterialService.deleteMaterial(lectureMaterialId);
+
+        verify(lectureMaterialRepository).save(any(LectureMaterial.class));
+        verify(lectureMaterialStoragePort).delete("lecture_materials/stored-guide.pdf");
+    }
+
     private Lecture createLecture(Long lectureId, Long courseId) {
         Course course = new Course();
         course.setCourseId(courseId);
@@ -129,14 +218,16 @@ class LectureMaterialServiceTest {
     }
 
     private LectureMaterial createMaterial(Long lectureMaterialId, Long lectureId) {
-        LectureMaterial material = new LectureMaterial();
-        material.setLectureMaterialId(lectureMaterialId);
-        material.setLectureId(lectureId);
-        material.setOriginalFileName("guide.pdf");
-        material.setStoredFileName("stored-guide.pdf");
-        material.setFilePath("lecture_materials/stored-guide.pdf");
-        material.setContentType("application/pdf");
-        material.setFileSize(3L);
-        return material;
+        return LectureMaterial.restore(
+                lectureMaterialId,
+                lectureId,
+                "guide.pdf",
+                "stored-guide.pdf",
+                "lecture_materials/stored-guide.pdf",
+                "application/pdf",
+                3L,
+                null,
+                null
+        );
     }
 }

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
@@ -34,6 +34,8 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -200,6 +202,8 @@ class LectureControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(LectureResponseCode.MATERIAL_DOWNLOAD_URL_ISSUED))
                 .andExpect(jsonPath("$.data.downloadUrl").value("https://storage.googleapis.com/codebombalms/lecture_materials/guide.pdf?signature=test"));
+
+        verify(lectureMaterialUseCase).issueDownloadUrl(eq(lectureMaterialId), isNull(), eq(false));
     }
 
     private Lecture createDetailResult(Long lectureId, String title) {
@@ -234,16 +238,17 @@ class LectureControllerTest {
     }
 
     private LectureMaterial createMaterial(Long lectureMaterialId, Long lectureId) {
-        LectureMaterial material = new LectureMaterial();
-        material.setLectureMaterialId(lectureMaterialId);
-        material.setLectureId(lectureId);
-        material.setOriginalFileName("guide.pdf");
-        material.setStoredFileName("stored-guide.pdf");
-        material.setFilePath("lecture_materials/stored-guide.pdf");
-        material.setContentType("application/pdf");
-        material.setFileSize(3L);
-        material.setCreatedAt(LocalDateTime.now());
-        return material;
+        return LectureMaterial.restore(
+                lectureMaterialId,
+                lectureId,
+                "guide.pdf",
+                "stored-guide.pdf",
+                "lecture_materials/stored-guide.pdf",
+                "application/pdf",
+                3L,
+                LocalDateTime.now(),
+                null
+        );
     }
 
     private Authentication operatorUser(Long userId) {

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
@@ -4,16 +4,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wanted.codebombalms.admin.permission.application.service.AdminPermissionCheckService;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
+import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
 import com.wanted.codebombalms.lecture.application.usecase.LectureCommandUseCase;
+import com.wanted.codebombalms.lecture.application.usecase.LectureMaterialUseCase;
 import com.wanted.codebombalms.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.lecture.presentation.api.LectureController;
 import com.wanted.codebombalms.lecture.presentation.api.LectureResponseCode;
 import com.wanted.codebombalms.lecture.presentation.api.LectureResponseMessage;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureCreateRequest;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureUpdateRequest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +33,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -52,6 +57,9 @@ class LectureControllerTest {
 
     @MockitoBean
     private LectureQueryUseCase lectureQueryUseCase;
+
+    @MockitoBean
+    private LectureMaterialUseCase lectureMaterialUseCase;
 
     @MockitoBean
     private AdminPermissionCheckService adminPermissionCheckService;
@@ -147,6 +155,53 @@ class LectureControllerTest {
         verify(lectureCommandUseCase).deleteLecture(lectureId);
     }
 
+    @Test
+    void uploadMaterial_returnsApiResponse() throws Exception {
+        Long lectureId = 1L;
+        MockMultipartFile material = new MockMultipartFile(
+                "material",
+                "guide.pdf",
+                "application/pdf",
+                "pdf".getBytes()
+        );
+
+        given(lectureMaterialUseCase.uploadMaterial(any(UploadLectureMaterialCommand.class)))
+                .willReturn(createMaterial(10L, lectureId));
+
+        mockMvc.perform(multipart("/api/v1/lectures/{lectureId}/materials", lectureId)
+                        .file(material)
+                        .with(authentication(operatorUser(10L))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value(LectureResponseCode.MATERIAL_UPLOADED))
+                .andExpect(jsonPath("$.message").value(LectureResponseMessage.MATERIAL_UPLOADED))
+                .andExpect(jsonPath("$.data.originalFileName").value("guide.pdf"));
+    }
+
+    @Test
+    void findMaterials_returnsApiResponse() throws Exception {
+        Long lectureId = 1L;
+        given(lectureMaterialUseCase.findMaterials(lectureId))
+                .willReturn(List.of(createMaterial(10L, lectureId)));
+
+        mockMvc.perform(get("/api/v1/lectures/{lectureId}/materials", lectureId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(LectureResponseCode.RETRIEVED))
+                .andExpect(jsonPath("$.data[0].lectureMaterialId").value(10L));
+    }
+
+    @Test
+    void issueMaterialDownloadUrl_returnsApiResponse() throws Exception {
+        Long lectureMaterialId = 10L;
+        given(lectureMaterialUseCase.issueDownloadUrl(any(), any(), anyBoolean()))
+                .willReturn("https://storage.googleapis.com/codebombalms/lecture_materials/guide.pdf?signature=test");
+
+        mockMvc.perform(post("/api/v1/lecture-materials/{lectureMaterialId}/download-url", lectureMaterialId)
+                        .with(authentication(studentUser(20L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(LectureResponseCode.MATERIAL_DOWNLOAD_URL_ISSUED))
+                .andExpect(jsonPath("$.data.downloadUrl").value("https://storage.googleapis.com/codebombalms/lecture_materials/guide.pdf?signature=test"));
+    }
+
     private Lecture createDetailResult(Long lectureId, String title) {
         return createLecture(lectureId, createCourse(1L), title);
     }
@@ -178,8 +233,27 @@ class LectureControllerTest {
         return lecture;
     }
 
+    private LectureMaterial createMaterial(Long lectureMaterialId, Long lectureId) {
+        LectureMaterial material = new LectureMaterial();
+        material.setLectureMaterialId(lectureMaterialId);
+        material.setLectureId(lectureId);
+        material.setOriginalFileName("guide.pdf");
+        material.setStoredFileName("stored-guide.pdf");
+        material.setFilePath("lecture_materials/stored-guide.pdf");
+        material.setContentType("application/pdf");
+        material.setFileSize(3L);
+        material.setCreatedAt(LocalDateTime.now());
+        return material;
+    }
+
     private Authentication operatorUser(Long userId) {
         TestingAuthenticationToken authentication = new TestingAuthenticationToken(userId, null, "ROLE_OPERATOR");
+        authentication.setAuthenticated(true);
+        return authentication;
+    }
+
+    private Authentication studentUser(Long userId) {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(userId, null, "ROLE_STUDENT");
         authentication.setAuthenticated(true);
         return authentication;
     }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #429
- Closes #447 

---

## 🛠️ 기능 관련 작업 내용

- 강의별 강의자료 업로드, 목록 조회, 다운로드 URL 발급, 삭제 API를 추가했습니다.
- 강의자료 파일을 GCS `lecture_materials/` prefix에 저장하고, DB에는 파일 메타데이터와 `filePath`를 저장하도록 구현했습니다.
- 다운로드 URL 발급 시 수강 중인 학생 또는 운영자만 접근할 수 있도록 수강 여부 검증을 연동했습니다.
- `http/lecture.http`에 강의자료 API 테스트 요청 예시를 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `project/lecture`: 강의자료 도메인, 저장소, 서비스, 컨트롤러, 응답 DTO, GCS 저장 어댑터 추가
- `project/global/infrastructure/storage`: 강의자료 GCS prefix 설정 추가
- `project/resources`: `lecture_materials` GCS prefix 설정 추가
- `project/http`: 강의자료 업로드/조회/다운로드 URL 발급/삭제 테스트 요청 추가
- `project/test`: 강의자료 컨트롤러 및 서비스 테스트 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 강의 자료 업로드/목록 조회/다운로드 URL 발급/삭제 API 제공, 운영자 및 수강 상태에 따른 접근 제어 강화
  * 강의 자료 오류 코드 체계 및 학습 진행 조회 성능 지표 수집 추가
* **테스트**
  * 강의 자료 서비스·컨트롤러 유스케이스 테스트 및 학습 지표 관련 검증 추가
  * 로드 테스트 시딩 추가
* **설정**
  * GCS 강의 자료 경로 프리픽스 설정 추가(기본값 포함)
* **버그 수정**
  * 강의 하드 삭제 시 강의 자료가 함께 정리되도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->