### PR TITLE
[Ref] 수강 신청 기반 학습 콘텐츠 접근 정책 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicy.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.learning.application.policy;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.learning.application.port.LearningEnrollmentPort;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LearningAccessPolicy {
+
+    private final LearningEnrollmentPort learningEnrollmentPort;
+
+    public void validateLectureProblemSetAccess(Long userId, LearningLectureProblemSet lectureProblemSet) {
+        if (userId == null || !learningEnrollmentPort.isActiveStudentOfCourse(
+                lectureProblemSet.courseId(),
+                userId
+        )) {
+            throw new ForbiddenException(LearningErrorCode.LECTURE_PROGRESS_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningLectureProblemSet.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningLectureProblemSet.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.learning.application.port;
 
 public record LearningLectureProblemSet(
         Long lectureProblemSetId,
+        Long courseId,
         Long lectureId,
         Long problemSetId
 ) {

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemProgressService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemProgressService.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.learning.application.service;
 
 import com.wanted.codebombalms.learning.application.command.RecordLectureProblemProgressCommand;
+import com.wanted.codebombalms.learning.application.policy.LearningAccessPolicy;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
 import com.wanted.codebombalms.learning.application.usecase.LectureProblemProgressCommandUseCase;
 import com.wanted.codebombalms.learning.application.usecase.LectureProgressCommandUseCase;
@@ -17,10 +18,14 @@ public class LectureProblemProgressService implements LectureProblemProgressComm
     private final LectureProblemProgressRepository lectureProblemProgressRepository;
     private final LearningLectureProblemSetPort learningLectureProblemSetPort;
     private final LectureProgressCommandUseCase lectureProgressCommandUseCase;
+    private final LearningAccessPolicy learningAccessPolicy;
 
     @Override
     @Transactional
     public LectureProblemProgress recordProgress(RecordLectureProblemProgressCommand command) {
+        var lectureProblemSet = learningLectureProblemSetPort.findLectureProblemSet(command.lectureProblemSetId());
+        learningAccessPolicy.validateLectureProblemSetAccess(command.userId(), lectureProblemSet);
+
         LectureProblemProgress progress = lectureProblemProgressRepository
                 .findByUserIdAndLectureProblemSetId(command.userId(), command.lectureProblemSetId())
                 .orElseGet(() -> LectureProblemProgress.create(command.userId(), command.lectureProblemSetId()));
@@ -29,7 +34,6 @@ public class LectureProblemProgressService implements LectureProblemProgressComm
         LectureProblemProgress savedProgress = lectureProblemProgressRepository.save(progress);
 
         if (command.completed()) {
-            var lectureProblemSet = learningLectureProblemSetPort.findLectureProblemSet(command.lectureProblemSetId());
             lectureProgressCommandUseCase.completeProgress(
                     command.userId(),
                     lectureProblemSet.lectureId()

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ConflictExce
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.learning.application.command.RecordLectureProblemProgressCommand;
+import com.wanted.codebombalms.learning.application.policy.LearningAccessPolicy;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
 import com.wanted.codebombalms.learning.application.port.LearningProblemGradingPort;
@@ -36,12 +37,14 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
     private final LectureProblemProgressCommandUseCase lectureProblemProgressCommandUseCase;
     private final LectureProblemProgressRepository lectureProblemProgressRepository;
     private final LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
+    private final LearningAccessPolicy learningAccessPolicy;
 
     @Override
     @Transactional
     public LectureProblemSetEntryView enterLectureProblemSet(Long userId, Long lectureProblemSetId) {
         LearningLectureProblemSet lectureProblemSet =
                 learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId);
+        learningAccessPolicy.validateLectureProblemSetAccess(userId, lectureProblemSet);
         var problemSet = learningProblemPort.loadProblemSet(lectureProblemSet.problemSetId());
         LectureProblemProgress progress = findOrCreateProgress(userId, lectureProblemSetId);
         Map<Long, LectureProblemSubmission> latestSubmissions =
@@ -80,6 +83,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
     public LectureProblemSetProgressView findLectureProblemSetProgress(Long userId, Long lectureProblemSetId) {
         LearningLectureProblemSet lectureProblemSet =
                 learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId);
+        learningAccessPolicy.validateLectureProblemSetAccess(userId, lectureProblemSet);
         var problemSet = learningProblemPort.loadProblemSet(lectureProblemSet.problemSetId());
         LectureProblemProgress progress = lectureProblemProgressRepository
                 .findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId)
@@ -115,6 +119,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
     public SubmissionView submit(Long lectureProblemSetId, Long problemId, SubmitCodeCommand command) {
         LearningLectureProblemSet lectureProblemSet =
                 learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId);
+        learningAccessPolicy.validateLectureProblemSetAccess(command.userId(), lectureProblemSet);
 
         if (!learningProblemPort.existsProblem(problemId)) {
             throw new NotFoundException(LearningErrorCode.PROBLEM_NOT_FOUND);

--- a/src/main/java/com/wanted/codebombalms/learning/domain/exception/LearningErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/learning/domain/exception/LearningErrorCode.java
@@ -18,7 +18,7 @@ public enum LearningErrorCode implements ErrorCode {
     LECTURE_PROBLEM_NOT_UNLOCKED("LRN-008", "Lecture problem is not unlocked."),
     LECTURE_PROBLEM_SET_ALREADY_COMPLETED("LRN-009", "Lecture problem set is already completed."),
     INVALID_LECTURE_PROGRESS("LRN-010", "Lecture progress value is invalid."),
-    LECTURE_PROGRESS_ACCESS_DENIED("LRN-011", "Only enrolled students can access lecture progress.");
+    LECTURE_PROGRESS_ACCESS_DENIED("LRN-011", "Only enrolled students can access lecture learning content.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningLectureProblemSetAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningLectureProblemSetAdapter.java
@@ -28,6 +28,7 @@ public class LearningLectureProblemSetAdapter implements LearningLectureProblemS
 
         return new LearningLectureProblemSet(
                 lectureProblemSet.getLectureProblemSetId(),
+                lectureProblemSet.getCourseId(),
                 lectureProblemSet.getLectureId(),
                 lectureProblemSet.getProblemSetId()
         );

--- a/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms.lecture.application.policy;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LectureAccessPolicy {
+
+    private final LectureEnrollmentPort lectureEnrollmentPort;
+
+    public void validateLearningContentAccess(Lecture lecture, Long userId, boolean operator) {
+        if (operator) {
+            return;
+        }
+        if (userId == null || !lectureEnrollmentPort.isActiveStudentOfCourse(
+                lecture.getCourse().getCourseId(),
+                userId
+        )) {
+            throw new ForbiddenException(LectureErrorCode.LECTURE_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureQueryService.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
+import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
 import com.wanted.codebombalms.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
@@ -23,6 +24,7 @@ public class LectureQueryService implements LectureQueryUseCase {
 
     private final LectureRepository lectureRepository;
     private final CourseCatalogPort courseCatalogPort;
+    private final LectureAccessPolicy lectureAccessPolicy;
 
     @Override
     public List<Lecture> findLecturesByCourseId(Long courseId) {
@@ -39,9 +41,21 @@ public class LectureQueryService implements LectureQueryUseCase {
     public Lecture findLectureById(Long lectureId) {
         log.info("[LectureQueryService] find lecture - lectureId: {}", lectureId);
 
-        Lecture lecture = lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
-                .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_NOT_FOUND));
+        return findExistingLecture(lectureId);
+    }
+
+    @Override
+    public Lecture findLectureByIdForLearning(Long lectureId, Long userId, boolean operator) {
+        log.info("[LectureQueryService] find lecture for learning - lectureId: {}, userId: {}", lectureId, userId);
+
+        Lecture lecture = findExistingLecture(lectureId);
+        lectureAccessPolicy.validateLearningContentAccess(lecture, userId, operator);
 
         return lecture;
+    }
+
+    private Lecture findExistingLecture(Long lectureId) {
+        return lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
+                .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureQueryUseCase.java
@@ -9,4 +9,6 @@ public interface LectureQueryUseCase {
     List<Lecture> findLecturesByCourseId(Long courseId);
 
     Lecture findLectureById(Long lectureId);
+
+    Lecture findLectureByIdForLearning(Long lectureId, Long userId, boolean operator);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
@@ -17,7 +17,8 @@ public enum LectureErrorCode implements ErrorCode {
     LECTURE_MATERIAL_UPLOAD_FAILED("LCT-007", "Lecture material upload failed."),
     LECTURE_MATERIAL_DOWNLOAD_URL_FAILED("LCT-008", "Lecture material download URL generation failed."),
     LECTURE_MATERIAL_ACCESS_DENIED("LCT-009", "Lecture material access is denied."),
-    LECTURE_MATERIAL_DELETE_FAILED("LCT-010", "Lecture material delete failed.");
+    LECTURE_MATERIAL_DELETE_FAILED("LCT-010", "Lecture material delete failed."),
+    LECTURE_ACCESS_DENIED("LCT-011", "Only enrolled students can access lecture content.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
@@ -60,13 +60,22 @@ public class LectureController {
 
     @GetMapping("/lectures/{lectureId}")
     @Operation(summary = "강의 단건 조회")
-    public ResponseEntity<ApiResponse<?>> findLectureById(@PathVariable Long lectureId) {
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<?>> findLectureById(
+            @PathVariable Long lectureId,
+            @AuthenticationPrincipal Long userId,
+            Authentication authentication
+    ) {
         log.info("[LectureController] find lecture - lectureId: {}", lectureId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 LectureResponseCode.RETRIEVED,
                 LectureResponseMessage.RETRIEVED,
-                LectureDetailResponse.from(lectureQueryUseCase.findLectureById(lectureId))
+                LectureDetailResponse.from(lectureQueryUseCase.findLectureByIdForLearning(
+                        lectureId,
+                        userId,
+                        isOperator(authentication)
+                ))
         ));
     }
 

--- a/src/test/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicyTest.java
@@ -10,9 +10,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class LearningAccessPolicyTest {
@@ -22,6 +25,32 @@ class LearningAccessPolicyTest {
 
     @InjectMocks
     private LearningAccessPolicy learningAccessPolicy;
+
+    @Test
+    void validateLectureProblemSetAccess_allowsStudent_whenStudentIsEnrolled() {
+        Long userId = 10L;
+        LearningLectureProblemSet lectureProblemSet = new LearningLectureProblemSet(6001L, 1L, 101L, 2001L);
+        given(learningEnrollmentPort.isActiveStudentOfCourse(1L, userId)).willReturn(true);
+
+        assertDoesNotThrow(
+                () -> learningAccessPolicy.validateLectureProblemSetAccess(userId, lectureProblemSet)
+        );
+
+        verify(learningEnrollmentPort).isActiveStudentOfCourse(1L, userId);
+    }
+
+    @Test
+    void validateLectureProblemSetAccess_throwsForbidden_whenUserIdIsNull() {
+        LearningLectureProblemSet lectureProblemSet = new LearningLectureProblemSet(6001L, 1L, 101L, 2001L);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> learningAccessPolicy.validateLectureProblemSetAccess(null, lectureProblemSet)
+        );
+
+        assertEquals(LearningErrorCode.LECTURE_PROGRESS_ACCESS_DENIED, exception.getErrorCode());
+        verify(learningEnrollmentPort, never()).isActiveStudentOfCourse(1L, null);
+    }
 
     @Test
     void validateLectureProblemSetAccess_throwsForbidden_whenStudentIsNotEnrolled() {

--- a/src/test/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicyTest.java
@@ -1,0 +1,39 @@
+package com.wanted.codebombalms.learning.application.policy;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.learning.application.port.LearningEnrollmentPort;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class LearningAccessPolicyTest {
+
+    @Mock
+    private LearningEnrollmentPort learningEnrollmentPort;
+
+    @InjectMocks
+    private LearningAccessPolicy learningAccessPolicy;
+
+    @Test
+    void validateLectureProblemSetAccess_throwsForbidden_whenStudentIsNotEnrolled() {
+        Long userId = 10L;
+        LearningLectureProblemSet lectureProblemSet = new LearningLectureProblemSet(6001L, 1L, 101L, 2001L);
+        given(learningEnrollmentPort.isActiveStudentOfCourse(1L, userId)).willReturn(false);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> learningAccessPolicy.validateLectureProblemSetAccess(userId, lectureProblemSet)
+        );
+
+        assertEquals(LearningErrorCode.LECTURE_PROGRESS_ACCESS_DENIED, exception.getErrorCode());
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.learning.application.service;
 
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
+import com.wanted.codebombalms.learning.application.policy.LearningAccessPolicy;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
 import com.wanted.codebombalms.learning.application.port.LearningProblemGradingPort;
 import com.wanted.codebombalms.learning.application.port.LearningProblemPort;
@@ -49,6 +50,9 @@ class LectureProblemSetServiceTest {
     @Mock
     private LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
 
+    @Mock
+    private LearningAccessPolicy learningAccessPolicy;
+
     @InjectMocks
     private LectureProblemSetService lectureProblemSetService;
 
@@ -61,7 +65,7 @@ class LectureProblemSetServiceTest {
         var latestSubmission = submission(9001L, userId, lectureProblemSetId, 3001L, true, 1);
 
         given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
-                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 101L, problemSetId));
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
         given(learningProblemPort.loadProblemSet(problemSetId)).willReturn(problemSet(problemSetId));
         given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
                 .willReturn(Optional.of(progress));
@@ -87,7 +91,7 @@ class LectureProblemSetServiceTest {
         var currentProgress = progress(userId, lectureProblemSetId, 1, false);
 
         given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
-                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 101L, problemSetId));
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
         given(learningProblemPort.existsProblem(problemId)).willReturn(true);
         given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
         given(learningProblemPort.loadProblem(problemId)).willReturn(
@@ -247,7 +251,7 @@ class LectureProblemSetServiceTest {
             int attemptLimit
     ) {
         given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
-                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 101L, problemSetId));
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
         given(learningProblemPort.existsProblem(problemId)).willReturn(true);
         given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
         given(learningProblemPort.loadProblem(problemId)).willReturn(

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -74,6 +74,10 @@ class LectureProblemSetServiceTest {
 
         var result = lectureProblemSetService.enterLectureProblemSet(userId, lectureProblemSetId);
 
+        verify(learningAccessPolicy).validateLectureProblemSetAccess(
+                userId,
+                new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
+        );
         assertEquals(2, result.currentProblemNumber());
         assertEquals(3002L, result.currentProblemId());
         assertEquals(1, result.solvedProblemCount());
@@ -160,6 +164,10 @@ class LectureProblemSetServiceTest {
         verify(lectureProblemSubmissionRepository).save(submissionCaptor.capture());
         assertEquals(lectureProblemSetId, submissionCaptor.getValue().lectureProblemSetId());
         assertEquals(problemId, submissionCaptor.getValue().problemId());
+        verify(learningAccessPolicy).validateLectureProblemSetAccess(
+                userId,
+                new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
+        );
         verify(lectureProblemProgressCommandUseCase).recordProgress(any());
     }
 
@@ -191,6 +199,10 @@ class LectureProblemSetServiceTest {
         assertFalse(result.correct());
         assertEquals(2, result.remainingAttemptCount());
         assertEquals(null, result.nextProblemId());
+        verify(learningAccessPolicy).validateLectureProblemSetAccess(
+                userId,
+                new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
+        );
         verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
     }
 
@@ -214,6 +226,10 @@ class LectureProblemSetServiceTest {
 
         verify(learningProblemGradingPort, never()).grade(any(), any(), any());
         verify(lectureProblemSubmissionRepository, never()).save(any());
+        verify(learningAccessPolicy).validateLectureProblemSetAccess(
+                userId,
+                new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
+        );
         verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
     }
 
@@ -238,6 +254,10 @@ class LectureProblemSetServiceTest {
         );
 
         verify(lectureProblemSubmissionRepository, never()).save(any());
+        verify(learningAccessPolicy).validateLectureProblemSetAccess(
+                userId,
+                new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
+        );
         verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
     }
 

--- a/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
@@ -32,6 +33,32 @@ class LectureAccessPolicyTest {
 
         lectureAccessPolicy.validateLearningContentAccess(lecture, null, true);
 
+        verify(lectureEnrollmentPort, never()).isActiveStudentOfCourse(1L, null);
+    }
+
+    @Test
+    void validateLearningContentAccess_allowsStudent_whenStudentIsEnrolled() {
+        Long userId = 10L;
+        Lecture lecture = lecture(1L);
+        given(lectureEnrollmentPort.isActiveStudentOfCourse(1L, userId)).willReturn(true);
+
+        assertDoesNotThrow(
+                () -> lectureAccessPolicy.validateLearningContentAccess(lecture, userId, false)
+        );
+
+        verify(lectureEnrollmentPort).isActiveStudentOfCourse(1L, userId);
+    }
+
+    @Test
+    void validateLearningContentAccess_throwsForbidden_whenUserIdIsNull() {
+        Lecture lecture = lecture(1L);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureAccessPolicy.validateLearningContentAccess(lecture, null, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
         verify(lectureEnrollmentPort, never()).isActiveStudentOfCourse(1L, null);
     }
 

--- a/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
@@ -1,0 +1,59 @@
+package com.wanted.codebombalms.lecture.application.policy;
+
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LectureAccessPolicyTest {
+
+    @Mock
+    private LectureEnrollmentPort lectureEnrollmentPort;
+
+    @InjectMocks
+    private LectureAccessPolicy lectureAccessPolicy;
+
+    @Test
+    void validateLearningContentAccess_allowsOperatorWithoutEnrollmentCheck() {
+        Lecture lecture = lecture(1L);
+
+        lectureAccessPolicy.validateLearningContentAccess(lecture, null, true);
+
+        verify(lectureEnrollmentPort, never()).isActiveStudentOfCourse(1L, null);
+    }
+
+    @Test
+    void validateLearningContentAccess_throwsForbidden_whenStudentIsNotEnrolled() {
+        Long userId = 10L;
+        Lecture lecture = lecture(1L);
+        given(lectureEnrollmentPort.isActiveStudentOfCourse(1L, userId)).willReturn(false);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureAccessPolicy.validateLearningContentAccess(lecture, userId, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    private Lecture lecture(Long courseId) {
+        Course course = new Course();
+        course.setCourseId(courseId);
+        Lecture lecture = new Lecture();
+        lecture.setCourse(course);
+        return lecture;
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
 import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
+import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
 import com.wanted.codebombalms.lecture.application.service.LectureCommandService;
 import com.wanted.codebombalms.lecture.application.service.LectureQueryService;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
@@ -42,6 +43,9 @@ class LectureServiceTest {
 
     @Mock
     private LectureCreationPolicy lectureCreationPolicy;
+
+    @Mock
+    private LectureAccessPolicy lectureAccessPolicy;
 
     @InjectMocks
     private LectureCommandService lectureCommandService;

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
@@ -85,7 +85,8 @@ class LectureControllerTest {
     @Test
     void findLectureById_returnsApiResponse() throws Exception {
         Long lectureId = 1L;
-        given(lectureQueryUseCase.findLectureById(lectureId)).willReturn(createDetailResult(lectureId, "Java 1"));
+        given(lectureQueryUseCase.findLectureByIdForLearning(eq(lectureId), isNull(), eq(false)))
+                .willReturn(createDetailResult(lectureId, "Java 1"));
 
         mockMvc.perform(get("/api/v1/lectures/{lectureId}", lectureId)
                         .contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #457

---

## 🛠️ 기능 관련 작업 내용

- 강의 상세 조회 시 수강 중인 학생 또는 운영자만 접근 가능하도록 정책을 추가했습니다.
- 강의 문제세트 입장, 진행률 저장, 문제 제출 API에 수강 여부 검증을 적용했습니다.
- `lecture_problem_set` 학습 포트에 `courseId`를 포함해 수강 검증 기준을 명확히 했습니다.
- 접근 정책 단위 테스트와 기존 서비스/컨트롤러 테스트를 보완했습니다.

---

## ♻️ 패키지 변경 사항

- `project/lecture`: 강의 콘텐츠 접근 정책 및 강의 상세 조회 검증 추가
- `project/learning`: 문제세트 학습 접근 정책 및 수강 검증 추가
- `project/test`: 접근 정책 단위 테스트와 관련 테스트 수정

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 강의 및 문제집에 대한 접근 권한 검증 정책 추가
  * 강의 단건 조회 시 사용자 인증 기반으로 학습용 조회 기능 제공
* **Bug Fixes**
  * 수강 중인 사용자만 강의 학습 콘텐츠/진행 정보/문제집에 접근 가능하도록 보안 강화
  * 접근 거부 오류 메시지 및 오류 코드 정의 반영
* **Tests**
  * 접근 권한 검증 정책 단위 테스트 추가
  * 접근 검증 흐름 변경에 따른 기존 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->