### PR TITLE
[Feat] adaptive auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+
+
+    // 적응형 인증 - GeoIP (MaxMind GeoLite2 로컬 DB)
+    implementation 'com.maxmind.geoip2:geoip2:4.2.0'
 }
 
 //성공한 테스트에서도 System.out이 보이도록 showStandardStreams = true 추가

--- a/src/main/java/com/wanted/codebombalms/auth/application/command/StepUpVerifyCommand.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/command/StepUpVerifyCommand.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.auth.application.command;
+
+public record StepUpVerifyCommand(
+        String stepUpToken,
+        String code,
+        boolean trustDevice
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/dto/LoginResult.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/dto/LoginResult.java
@@ -3,9 +3,19 @@ package com.wanted.codebombalms.auth.application.dto;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 
 public record LoginResult(
+        boolean stepUpRequired,
         String accessToken,
         String refreshToken,
         String nickname,
-        UserRole role
+        UserRole role,
+        String stepUpToken,
+        String maskedEmail
 ) {
+    public static LoginResult success(String accessToken, String refreshToken, String nickname, UserRole role) {
+        return new LoginResult(false, accessToken, refreshToken, nickname, role, null, null);
+    }
+
+    public static LoginResult stepUp(String stepUpToken, String maskedEmail) {
+        return new LoginResult(true, null, null, null, null, stepUpToken, maskedEmail);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LockAccountService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LockAccountService.java
@@ -1,0 +1,41 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.usecase.LockAccountUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.repository.LockTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LockAccountService implements LockAccountUseCase {
+
+    private final LockTokenRepository lockTokenRepository;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void lock(String token) {
+        // 1. 토큰 검증 (GETDEL — 단일 사용)
+        if (token == null || token.isBlank()) {
+            throw new ValidationException(AuthErrorCode.AUTH_LOCK_TOKEN_INVALID);
+        }
+        Long userId = lockTokenRepository.findUserIdAndDelete(token)
+                .orElseThrow(() -> new ValidationException(AuthErrorCode.AUTH_LOCK_TOKEN_INVALID));
+
+        // 2. 계정 잠금
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new ValidationException(AuthErrorCode.AUTH_LOCK_TOKEN_INVALID));
+        user.lock();
+        userRepository.save(user);
+
+        // 3. 강제 로그아웃 (RT 전체 삭제)
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -4,10 +4,17 @@ import com.wanted.codebombalms.auth.application.command.LoginCommand;
 import com.wanted.codebombalms.auth.application.dto.LoginResult;
 import com.wanted.codebombalms.auth.application.usecase.LoginUseCase;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
 import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.model.StepUpChallenge;
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
 import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.auth.domain.service.EmailSender;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
@@ -20,68 +27,124 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.auth.domain.repository.LockTokenRepository;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.security.SecureRandom;
+import java.util.Optional;
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class LoginService implements LoginUseCase {
 
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final LoginHistoryRepository loginHistoryRepository;
+    private final TrustedDeviceRepository trustedDeviceRepository;
+    private final StepUpTokenRepository stepUpTokenRepository;
+    private final GeoIpResolver geoIpResolver;
+    private final EmailSender emailSender;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public LoginResult login(LoginCommand command, HttpServletRequest request) {
+    public LoginResult login(LoginCommand command, HttpServletRequest request, String deviceFp) {
 
-        // 1. 이메일로 회원 조회
+        // 1~3. 인증 (이메일 / 비밀번호 / 계정 잠금)
         User user = userRepository.findByEmail(command.email())
                 .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
-
-        // 2. 비밀번호 검증
         if (!passwordEncoder.matches(command.rawpassword(), user.getPassword())) {
             throw new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL);
         }
-
-        // 3. 계정 잠금 확인
         if (user.isLocked()) {
             throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
         }
 
-        // 4. 단일 세션 강제
-        refreshTokenRepository.deleteByUserId(user.getUserId());
+        // 4. 기기 지문 + 지역(GeoIP)
+        String ip = extractIpAddress(request);
+        GeoLocation geo = geoIpResolver.resolve(ip);
 
-        // 5. 토큰 발급
+        // 5. 적응형 판정 — 신뢰 기기 1차 + 위치 보조
+        Optional<TrustedDevice> trusted =
+                trustedDeviceRepository.findByUserIdAndDeviceFp(user.getUserId(), deviceFp);
+        boolean stepUpRequired = trusted.isEmpty() || isCountryChanged(trusted.get(), geo);
+
+        // 6. 로그인 이력 기록 (의심 여부 = step-up 필요 여부)
+        loginHistoryRepository.save(LoginHistory.record(
+                user.getUserId(), ip, request.getHeader("User-Agent"),
+                deviceFp, geo.country(), geo.city(), stepUpRequired));
+
+        // 7. 미신뢰/위치 급변 → step-up
+        if (stepUpRequired) {
+            return issueStepUp(user, deviceFp, geo);
+        }
+
+        // 8. 신뢰 기기 → 정식 로그인 (마지막 사용 갱신)
+        trusted.ifPresent(device -> {
+            device.markUsed(geo.country(), geo.city());
+            trustedDeviceRepository.save(device);
+        });
+        return issueTokens(user);
+    }
+
+    private LoginResult issueStepUp(User user, String deviceFp, GeoLocation geo) {
+        // OTP (step-up) 발급
+        String code = generateCode();
+        String stepUpToken = UUID.randomUUID().toString();
+        stepUpTokenRepository.save(stepUpToken,
+                new StepUpChallenge(user.getUserId(), deviceFp, geo.country(), code));
+
+        // 계정 잠금 토큰 발급 + 링크 조립
+        String lockToken = UUID.randomUUID().toString();
+        lockTokenRepository.save(lockToken, user.getUserId());
+        String lockUrl = lockUrlBase + "?token=" + lockToken;
+
+        emailSender.sendStepUpCode(user.getEmail(), code, lockUrl);
+        return LoginResult.stepUp(stepUpToken, maskEmail(user.getEmail()));
+    }
+
+    private LoginResult issueTokens(User user) {
+        refreshTokenRepository.deleteByUserId(user.getUserId());
         String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getNickname(), user.getRole());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
-
-        // 6. RT 저장
         refreshTokenRepository.save(
-                RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration())
-        );
+                RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration()));
+        return LoginResult.success(accessToken, refreshToken, user.getNickname(), user.getRole());
+    }
 
-        // 7. 로그인 이력 기록
-        loginHistoryRepository.save(
-                LoginHistory.record(
-                        user.getUserId(),
-                        extractIpAddress(request),
-                        request.getHeader("User-Agent"),
-                        null,
-                        null,
-                        null,
-                        false
-                )
-        );
+    private boolean isCountryChanged(TrustedDevice device, GeoLocation geo) {
+        return device.getLastCountry() != null
+                && geo.country() != null
+                && !device.getLastCountry().equals(geo.country());
+    }
 
-        return new LoginResult(accessToken, refreshToken, user.getNickname(), user.getRole());
+    private String generateCode() {
+        return String.format("%06d", RANDOM.nextInt(1_000_000));
+    }
+
+    private String maskEmail(String email) {
+        int at = email.indexOf('@');
+        if (at <= 0) {
+            return "***";
+        }
+        return email.charAt(0) + "***" + email.substring(at);
     }
 
     /** 프록시 환경(X-Forwarded-For) 고려한 클라이언트 IP 추출 */
     private String extractIpAddress(HttpServletRequest request) {
         String forwarded = request.getHeader("X-Forwarded-For");
         if (forwarded != null && !forwarded.isBlank()) {
-            return forwarded.split(",")[0].trim();   // 첫 번째 IP가 원본 클라이언트
+            return forwarded.split(",")[0].trim();
         }
         return request.getRemoteAddr();
     }
+
+    private final LockTokenRepository lockTokenRepository;
+
+    @Value("${app.lock-url:http://localhost:8080/api/v1/auth/lock}")
+    private String lockUrlBase;
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpResendService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpResendService.java
@@ -1,0 +1,64 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.usecase.StepUpResendUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.StepUpChallenge;
+import com.wanted.codebombalms.auth.domain.repository.LockTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
+import com.wanted.codebombalms.auth.domain.service.EmailSender;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StepUpResendService implements StepUpResendUseCase {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final StepUpTokenRepository stepUpTokenRepository;
+    private final LockTokenRepository lockTokenRepository;
+    private final UserRepository userRepository;
+    private final EmailSender emailSender;
+
+    @Value("${app.lock-url:http://localhost:8080/api/v1/auth/lock}")
+    private String lockUrlBase;
+
+    @Override
+    public void resend(String stepUpToken) {
+        // 1. 챌린지 토큰 검증
+        if (stepUpToken == null || stepUpToken.isBlank()) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_STEP_UP_TOKEN_INVALID);
+        }
+        StepUpChallenge challenge = stepUpTokenRepository.find(stepUpToken)
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_STEP_UP_TOKEN_INVALID));
+
+        User user = userRepository.findByUserId(challenge.userId())
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_STEP_UP_TOKEN_INVALID));
+
+        // 2. 새 OTP 생성 → 덮어쓰기(TTL 5분 갱신)
+        String newCode = generateCode();
+        stepUpTokenRepository.save(stepUpToken,
+                new StepUpChallenge(challenge.userId(), challenge.deviceFp(), challenge.country(), newCode));
+
+        // 3. 새 잠금 토큰 발급 + 링크 조립 (의심 로그인 알림과 동일하게)
+        String lockToken = UUID.randomUUID().toString();
+        lockTokenRepository.save(lockToken, user.getUserId());
+        String lockUrl = lockUrlBase + "?token=" + lockToken;
+
+        // 4. 재발송 (OTP + 잠금 링크)
+        emailSender.sendStepUpCode(user.getEmail(), newCode, lockUrl);
+    }
+
+    private String generateCode() {
+        return String.format("%06d", RANDOM.nextInt(1_000_000));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
@@ -64,16 +64,23 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
         User user = userRepository.findByUserId(challenge.userId())
                 .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
 
-        // 4. 신뢰 기기 등록 (옵션)
+        // 4. 신뢰 기기 등록 (옵션) — 이미 있으면 갱신, 없으면 신규 (유니크 (user_id, device_fp) 위반 방지)
         if (command.trustDevice()) {
             GeoLocation geo = geoIpResolver.resolve(extractIpAddress(request));
-            trustedDeviceRepository.save(TrustedDevice.register(
-                    user.getUserId(),
-                    challenge.deviceFp(),
-                    parseDeviceName(request.getHeader("User-Agent")),
-                    geo.country(),
-                    geo.city()
-            ));
+            TrustedDevice device = trustedDeviceRepository
+                    .findByUserIdAndDeviceFp(user.getUserId(), challenge.deviceFp())
+                    .map(existing -> {
+                        existing.markUsed(geo.country(), geo.city());
+                        return existing;
+                    })
+                    .orElseGet(() -> TrustedDevice.register(
+                            user.getUserId(),
+                            challenge.deviceFp(),
+                            parseDeviceName(request.getHeader("User-Agent")),
+                            geo.country(),
+                            geo.city()
+                    ));
+            trustedDeviceRepository.save(device);
         }
 
         // 5. 정식 토큰 발급 (단일 세션 강제)

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
@@ -1,0 +1,112 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.command.StepUpVerifyCommand;
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
+import com.wanted.codebombalms.auth.application.usecase.StepUpVerifyUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.model.StepUpChallenge;
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
+import com.wanted.codebombalms.global.domain.common.error.exception.TooManyRequestsException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StepUpVerifyService implements StepUpVerifyUseCase {
+
+    private static final int MAX_ATTEMPTS = 5;
+
+    private final StepUpTokenRepository stepUpTokenRepository;
+    private final UserRepository userRepository;
+    private final TrustedDeviceRepository trustedDeviceRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final GeoIpResolver geoIpResolver;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public LoginResult verify(StepUpVerifyCommand command, HttpServletRequest request) {
+
+        // 1. 챌린지 토큰 검증
+        String token = command.stepUpToken();
+        if (token == null || token.isBlank()) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_STEP_UP_TOKEN_INVALID);
+        }
+        StepUpChallenge challenge = stepUpTokenRepository.find(token)
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_STEP_UP_TOKEN_INVALID));
+
+        // 2. OTP 검증 (실패 시 시도 카운트 → 초과면 429)
+        if (!challenge.code().equals(command.code())) {
+            int attempts = stepUpTokenRepository.incrementAttempts(token);
+            if (attempts >= MAX_ATTEMPTS) {
+                stepUpTokenRepository.delete(token);
+                throw new TooManyRequestsException(AuthErrorCode.AUTH_STEP_UP_TOO_MANY);
+            }
+            throw new ValidationException(AuthErrorCode.AUTH_CODE_INVALID);
+        }
+
+        // 3. 성공 — 토큰 단일 사용 소비
+        stepUpTokenRepository.delete(token);
+
+        User user = userRepository.findByUserId(challenge.userId())
+                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
+
+        // 4. 신뢰 기기 등록 (옵션)
+        if (command.trustDevice()) {
+            GeoLocation geo = geoIpResolver.resolve(extractIpAddress(request));
+            trustedDeviceRepository.save(TrustedDevice.register(
+                    user.getUserId(),
+                    challenge.deviceFp(),
+                    parseDeviceName(request.getHeader("User-Agent")),
+                    geo.country(),
+                    geo.city()
+            ));
+        }
+
+        // 5. 정식 토큰 발급 (단일 세션 강제)
+        refreshTokenRepository.deleteByUserId(user.getUserId());
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getNickname(), user.getRole());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
+        refreshTokenRepository.save(
+                RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration()));
+        return LoginResult.success(accessToken, refreshToken, user.getNickname(), user.getRole());
+    }
+
+    /** User-Agent → "브라우저 · OS" 표시명 (간이 파싱) */
+    private String parseDeviceName(String userAgent) {
+        if (userAgent == null || userAgent.isBlank()) {
+            return "Unknown device";
+        }
+        String browser = userAgent.contains("Edg") ? "Edge"
+                : userAgent.contains("Chrome") ? "Chrome"
+                  : userAgent.contains("Firefox") ? "Firefox"
+                    : userAgent.contains("Safari") ? "Safari" : "Unknown";
+        String os = userAgent.contains("Windows") ? "Windows"
+                : userAgent.contains("Mac OS") ? "macOS"
+                  : userAgent.contains("Android") ? "Android"
+                    : (userAgent.contains("iPhone") || userAgent.contains("iPad")) ? "iOS"
+                      : userAgent.contains("Linux") ? "Linux" : "Unknown";
+        return browser + " · " + os;
+    }
+
+    private String extractIpAddress(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/LockAccountUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/LockAccountUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+public interface LockAccountUseCase {
+
+    void lock(String token);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/LoginUseCase.java
@@ -6,5 +6,5 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public interface LoginUseCase {
 
-    LoginResult login(LoginCommand command, HttpServletRequest request);
+    LoginResult login(LoginCommand command, HttpServletRequest request, String deviceFp);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/StepUpResendUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/StepUpResendUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+public interface StepUpResendUseCase {
+
+    void resend(String stepUpToken);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/StepUpVerifyUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/StepUpVerifyUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+import com.wanted.codebombalms.auth.application.command.StepUpVerifyCommand;
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface StepUpVerifyUseCase {
+
+    LoginResult verify(StepUpVerifyCommand command, HttpServletRequest request);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/exception/AuthErrorCode.java
@@ -45,7 +45,11 @@ public enum AuthErrorCode implements ErrorCode {
 
     OAUTH_STATE_INVALID("AUT-021", "유효하지 않은 인증 요청입니다. 다시 시도해주세요."),
     OAUTH_EMAIL_ALREADY_LOCAL("AUT-022", "이미 일반 가입된 이메일입니다. 일반 로그인을 이용해주세요."),
-    OAUTH_EMAIL_NOT_VERIFIED("AUT-023", "구글에서 인증되지 않은 이메일입니다.");
+    OAUTH_EMAIL_NOT_VERIFIED("AUT-023", "구글에서 인증되지 않은 이메일입니다."),
+
+    // 적응형 인증 (step-up)
+    AUTH_STEP_UP_TOKEN_INVALID("AUT-024", "추가 인증 세션이 유효하지 않거나 만료되었습니다."),
+    AUTH_STEP_UP_TOO_MANY("AUT-025", "추가 인증 시도 횟수를 초과했습니다. 다시 로그인해주세요.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/auth/domain/model/GeoLocation.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/model/GeoLocation.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.auth.domain.model;
+
+public record GeoLocation(String country, String city) {
+
+    private static final GeoLocation UNKNOWN = new GeoLocation(null, null);
+
+    /** GeoIP 조회 실패(사설 IP·미등록 등) 시 사용 */
+    public static GeoLocation unknown() {
+        return UNKNOWN;
+    }
+
+    public boolean isUnknown() {
+        return country == null && city == null;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/model/StepUpChallenge.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/model/StepUpChallenge.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.auth.domain.model;
+
+/** 미신뢰 기기 로그인 시 추가 인증(step-up) 대기 정보 (Redis 임시토큰으로 조회) */
+public record StepUpChallenge(
+        Long userId,
+        String deviceFp,
+        String country,
+        String code
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/model/TrustedDevice.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/model/TrustedDevice.java
@@ -1,0 +1,78 @@
+package com.wanted.codebombalms.auth.domain.model;
+
+import java.time.LocalDateTime;
+
+public class TrustedDevice {
+
+    private Long trustedDeviceId;
+    private Long userId;
+    private String deviceFp;
+    private String deviceName;
+    private String lastCountry;
+    private String lastCity;
+    private LocalDateTime lastUsedAt;
+    private LocalDateTime createdAt;
+
+    private TrustedDevice() {}
+
+    // ===== Getter =====
+    public Long getTrustedDeviceId() { return trustedDeviceId; }
+    public Long getUserId()          { return userId; }
+    public String getDeviceFp()      { return deviceFp; }
+    public String getDeviceName()    { return deviceName; }
+    public String getLastCountry()   { return lastCountry; }
+    public String getLastCity()      { return lastCity; }
+    public LocalDateTime getLastUsedAt() { return lastUsedAt; }
+    public LocalDateTime getCreatedAt()  { return createdAt; }
+
+    // ===== 정적 팩토리 — 신규 신뢰 등록 =====
+
+    public static TrustedDevice register(
+            Long userId,
+            String deviceFp,
+            String deviceName,
+            String lastCountry,
+            String lastCity
+    ) {
+        TrustedDevice device = new TrustedDevice();
+        device.userId      = userId;
+        device.deviceFp    = deviceFp;
+        device.deviceName  = deviceName;
+        device.lastCountry = lastCountry;
+        device.lastCity    = lastCity;
+        device.lastUsedAt  = LocalDateTime.now();
+        return device;
+    }
+
+    // ===== 신뢰 기기 재사용 시 최신화 =====
+
+    public void markUsed(String lastCountry, String lastCity) {
+        this.lastCountry = lastCountry;
+        this.lastCity    = lastCity;
+        this.lastUsedAt  = LocalDateTime.now();
+    }
+
+    // ===== 영속성 복원 — Adapter 전용 =====
+
+    public static TrustedDevice restore(
+            Long trustedDeviceId,
+            Long userId,
+            String deviceFp,
+            String deviceName,
+            String lastCountry,
+            String lastCity,
+            LocalDateTime lastUsedAt,
+            LocalDateTime createdAt
+    ) {
+        TrustedDevice device = new TrustedDevice();
+        device.trustedDeviceId = trustedDeviceId;
+        device.userId          = userId;
+        device.deviceFp        = deviceFp;
+        device.deviceName      = deviceName;
+        device.lastCountry     = lastCountry;
+        device.lastCity        = lastCity;
+        device.lastUsedAt      = lastUsedAt;
+        device.createdAt       = createdAt;
+        return device;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/LockTokenRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/LockTokenRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.auth.domain.repository;
+
+import java.util.Optional;
+
+public interface LockTokenRepository {
+
+    /** 계정 잠금 토큰 저장 (token → userId, TTL 24시간) */
+    void save(String token, Long userId);
+
+    /** 잠금 링크 클릭 시 — 조회+삭제 단일 원자 연산(GETDEL, 단일 사용) → userId */
+    Optional<Long> findUserIdAndDelete(String token);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/LoginHistoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/LoginHistoryRepository.java
@@ -11,4 +11,6 @@ public interface LoginHistoryRepository {
     LoginHistory save(LoginHistory loginHistory);
 
     Map<Long, LocalDateTime> findLatestLoginAtByUserIds(List<Long> userIds);
+
+    List<LoginHistory> findByUserId(Long userId, int page, int size);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/StepUpTokenRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/StepUpTokenRepository.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.auth.domain.repository;
+
+import com.wanted.codebombalms.auth.domain.model.StepUpChallenge;
+
+import java.util.Optional;
+
+public interface StepUpTokenRepository {
+
+    /** 챌린지 토큰으로 step-up 정보 저장 (TTL 5분). 재발송 시 덮어쓰기 */
+    void save(String token, StepUpChallenge challenge);
+
+    /** 검증/재발송 시 조회 (비파괴 — 성공 시 별도 delete) */
+    Optional<StepUpChallenge> find(String token);
+
+    /** 검증 성공/세션 종료 시 토큰 + 시도 카운터 삭제 */
+    void delete(String token);
+
+    /** OTP 오입력 시 시도 횟수 +1 → 누적값 반환 (토큰 TTL과 동기) */
+    int incrementAttempts(String token);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/TrustedDeviceRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/TrustedDeviceRepository.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.auth.domain.repository;
+
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TrustedDeviceRepository {
+
+    TrustedDevice save(TrustedDevice device);
+
+    /** 로그인 판정 — 이 기기가 신뢰 목록에 있나 */
+    Optional<TrustedDevice> findByUserIdAndDeviceFp(Long userId, String deviceFp);
+
+    /** 마이페이지 — 신뢰 기기 목록 */
+    List<TrustedDevice> findAllByUserId(Long userId);
+
+    /** 신뢰 해제 — 소유권 검증용 (없으면 USR-012) */
+    Optional<TrustedDevice> findByTrustedDeviceIdAndUserId(Long trustedDeviceId, Long userId);
+
+    void deleteById(Long trustedDeviceId);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/service/EmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/service/EmailSender.java
@@ -5,4 +5,5 @@ public interface EmailSender {
     void sendVerificationCode(String to, String code);
     
     void sendPasswordResetCode(String to, String code);
-}
+
+    void sendStepUpCode(String to, String code, String lockUrl);}

--- a/src/main/java/com/wanted/codebombalms/auth/domain/service/GeoIpResolver.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/service/GeoIpResolver.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.auth.domain.service;
+
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
+
+public interface GeoIpResolver {
+
+    /**
+     * IP 주소로 국가/도시를 조회한다.
+     * 조회 불가(사설 IP·미등록·오류) 시 {@link GeoLocation#unknown()} 반환 (예외 던지지 않음).
+     */
+    GeoLocation resolve(String ipAddress);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/geoip/GeoLite2CityAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/geoip/GeoLite2CityAdapter.java
@@ -1,0 +1,55 @@
+package com.wanted.codebombalms.auth.infrastructure.geoip;
+
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.util.List;
+
+@Slf4j
+@Component
+public class GeoLite2CityAdapter implements GeoIpResolver {
+
+    private static final String DB_PATH = "geoip/GeoLite2-City.mmdb";
+
+    private final DatabaseReader reader;
+
+    public GeoLite2CityAdapter() {
+        try (InputStream is = new ClassPathResource(DB_PATH).getInputStream()) {
+            this.reader = new DatabaseReader.Builder(is)
+                    .locales(List.of("en"))
+                    .build();
+            log.info("GeoLite2 City DB 로드 완료: {}", DB_PATH);
+        } catch (IOException e) {
+            throw new IllegalStateException("GeoLite2 City DB 로드 실패: " + DB_PATH, e);
+        }
+    }
+
+    @Override
+    public GeoLocation resolve(String ipAddress) {
+        if (ipAddress == null || ipAddress.isBlank()) {
+            return GeoLocation.unknown();
+        }
+        try {
+            InetAddress address = InetAddress.getByName(ipAddress);
+            CityResponse response = reader.city(address);
+            String country = response.getCountry().getName();
+            String city = response.getCity().getName();
+            if (country == null && city == null) {
+                return GeoLocation.unknown();
+            }
+            return new GeoLocation(country, city);
+        } catch (IOException | GeoIp2Exception e) {
+            // 사설 IP·미등록·조회 오류 → 로그인 막지 않고 unknown
+            return GeoLocation.unknown();
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/geoip/GeoLite2CityAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/geoip/GeoLite2CityAdapter.java
@@ -13,12 +13,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component
 public class GeoLite2CityAdapter implements GeoIpResolver {
 
     private static final String DB_PATH = "geoip/GeoLite2-City.mmdb";
+
+    /** IP 리터럴(IPv4 점표기 / IPv6 콜론포함)만 허용 — 호스트명 입력 시 DNS 조회·블로킹 차단 */
+    private static final Pattern IP_LITERAL = Pattern.compile("^\\d{1,3}(\\.\\d{1,3}){3}$|^[0-9a-fA-F:]*:[0-9a-fA-F:]*$");
 
     private final DatabaseReader reader;
 
@@ -35,11 +39,11 @@ public class GeoLite2CityAdapter implements GeoIpResolver {
 
     @Override
     public GeoLocation resolve(String ipAddress) {
-        if (ipAddress == null || ipAddress.isBlank()) {
-            return GeoLocation.unknown();
+        if (ipAddress == null || ipAddress.isBlank() || !IP_LITERAL.matcher(ipAddress).matches()) {
+            return GeoLocation.unknown(); // 호스트명 등 비-IP 입력은 DNS 조회 없이 unknown
         }
         try {
-            InetAddress address = InetAddress.getByName(ipAddress);
+            InetAddress address = InetAddress.getByName(ipAddress); // 리터럴만 도달 → DNS 미발생
             CityResponse response = reader.city(address);
             String country = response.getCountry().getName();
             String city = response.getCity().getName();

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
@@ -42,6 +42,32 @@ public class JavaMailEmailSender implements EmailSender {
         log.info("[EmailSender] 비밀번호 재설정 코드 발송 완료 - to: {}", maskEmail(to));
     }
 
+    // sendPasswordResetCode 메서드 아래에 추가
+    @Override
+    public void sendStepUpCode(String to, String code, String lockUrl) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
+        message.setTo(to);
+        message.setSubject("[Code-Bomba LMS] 새로운 기기 로그인 — 추가 인증 코드");
+        message.setText(buildStepUpBody(code, lockUrl));
+
+        mailSender.send(message);
+        log.info("[EmailSender] step-up 코드 발송 완료 - to: {}", maskEmail(to));
+    }
+
+    private String buildStepUpBody(String code, String lockUrl) {
+        return """
+                평소와 다른 기기 또는 위치에서 로그인이 시도되었습니다.
+
+                본인이 맞다면 아래 인증 코드를 입력해주세요.
+                인증 코드: %s
+                (이 코드는 5분간 유효합니다.)
+
+                본인이 시도한 로그인이 아니라면, 아래 링크를 눌러 계정을 즉시 잠그세요.
+                %s
+                """.formatted(code, lockUrl);
+    }
+
     /** 로그에 이메일 평문(PII) 노출 방지 — 앞 1글자 + *** + 도메인만 남긴다. (예: j***@gmail.com) */
     private String maskEmail(String email) {
         if (email == null) {

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryRepositoryAdapter.java
@@ -41,7 +41,7 @@ public class LoginHistoryRepositoryAdapter implements LoginHistoryRepository {
     @Override
     public List<LoginHistory> findByUserId(Long userId, int page, int size) {
         return springDataLoginHistoryRepository
-                .findByUserIdOrderByCreatedAtDesc(userId, PageRequest.of(page, size))
+                .findByUserIdOrderByCreatedAtDescLoginHistoryIdDesc(userId, PageRequest.of(page, size))
                 .stream()
                 .map(LoginHistoryJpaEntity::toDomain)
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/LoginHistoryRepositoryAdapter.java
@@ -5,10 +5,13 @@ import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import org.springframework.data.domain.Pageable;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.PageRequest;
 
 @Component
 @RequiredArgsConstructor
@@ -33,5 +36,14 @@ public class LoginHistoryRepositoryAdapter implements LoginHistoryRepository {
                         SpringDataLoginHistoryRepository.LatestLoginAtProjection::getUserId,
                         SpringDataLoginHistoryRepository.LatestLoginAtProjection::getLatestLoginAt
                 ));
+    }
+
+    @Override
+    public List<LoginHistory> findByUserId(Long userId, int page, int size) {
+        return springDataLoginHistoryRepository
+                .findByUserIdOrderByCreatedAtDesc(userId, PageRequest.of(page, size))
+                .stream()
+                .map(LoginHistoryJpaEntity::toDomain)
+                .toList();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisLockTokenAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisLockTokenAdapter.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.repository.LockTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RedisLockTokenAdapter implements LockTokenRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_LOCK = "account:lock:"; // + {token}
+    private static final Duration TTL_LOCK = Duration.ofHours(24);
+
+    @Override
+    public void save(String token, Long userId) {
+        redisTemplate.opsForValue().set(KEY_LOCK + token, String.valueOf(userId), TTL_LOCK);
+    }
+
+    @Override
+    public Optional<Long> findUserIdAndDelete(String token) {
+        String value = redisTemplate.opsForValue().getAndDelete(KEY_LOCK + token);
+        return value == null ? Optional.empty() : Optional.of(Long.valueOf(value));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
@@ -1,0 +1,70 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.codebombalms.auth.domain.model.StepUpChallenge;
+import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RedisStepUpTokenAdapter implements StepUpTokenRepository {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String KEY_CHALLENGE = "stepup:challenge:"; // + {token}
+    private static final String KEY_ATTEMPTS  = "stepup:attempts:";  // + {token}
+    private static final Duration TTL = Duration.ofMinutes(5);
+
+    @Override
+    public void save(String token, StepUpChallenge challenge) {
+        // 본문 + TTL 단일 SET EX (원자)
+        redisTemplate.opsForValue().set(KEY_CHALLENGE + token, serialize(challenge), TTL);
+    }
+
+    @Override
+    public Optional<StepUpChallenge> find(String token) {
+        return deserialize(redisTemplate.opsForValue().get(KEY_CHALLENGE + token));
+    }
+
+    @Override
+    public void delete(String token) {
+        redisTemplate.delete(KEY_CHALLENGE + token);
+        redisTemplate.delete(KEY_ATTEMPTS + token);
+    }
+
+    @Override
+    public int incrementAttempts(String token) {
+        String key = KEY_ATTEMPTS + token;
+        Long count = redisTemplate.opsForValue().increment(key); // 원자 INCR
+        if (count != null && count == 1L) {
+            redisTemplate.expire(key, TTL); // 첫 시도 시 TTL 부여 (토큰과 동기 만료)
+        }
+        return count == null ? 0 : count.intValue();
+    }
+
+    private String serialize(StepUpChallenge challenge) {
+        try {
+            return objectMapper.writeValueAsString(challenge);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("StepUpChallenge 직렬화 실패", e);
+        }
+    }
+
+    private Optional<StepUpChallenge> deserialize(String json) {
+        if (json == null) {
+            return Optional.empty(); // 없거나 만료
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, StepUpChallenge.class));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("StepUpChallenge 역직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.auth.infrastructure.persistence;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,6 +9,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface SpringDataLoginHistoryRepository extends JpaRepository<LoginHistoryJpaEntity, Long> {
+
+    List<LoginHistoryJpaEntity> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     @Query("""
             select lh.userId as userId, max(lh.createdAt) as latestLoginAt

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface SpringDataLoginHistoryRepository extends JpaRepository<LoginHistoryJpaEntity, Long> {
 
-    List<LoginHistoryJpaEntity> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    List<LoginHistoryJpaEntity> findByUserIdOrderByCreatedAtDescLoginHistoryIdDesc(Long userId, Pageable pageable);
 
     @Query("""
             select lh.userId as userId, max(lh.createdAt) as latestLoginAt

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataTrustedDeviceRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataTrustedDeviceRepository.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringDataTrustedDeviceRepository extends JpaRepository<TrustedDeviceJpaEntity, Long> {
+
+    Optional<TrustedDeviceJpaEntity> findByUserIdAndDeviceFp(Long userId, String deviceFp);
+
+    List<TrustedDeviceJpaEntity> findAllByUserId(Long userId);
+
+    Optional<TrustedDeviceJpaEntity> findByTrustedDeviceIdAndUserId(Long trustedDeviceId, Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/TrustedDeviceJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/TrustedDeviceJpaEntity.java
@@ -58,6 +58,7 @@ public class TrustedDeviceJpaEntity {
     }
 
 
+
     public TrustedDevice toDomain() {
         return TrustedDevice.restore(
                 trustedDeviceId,

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/TrustedDeviceJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/TrustedDeviceJpaEntity.java
@@ -1,0 +1,73 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trusted_devices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class TrustedDeviceJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trusted_device_id")
+    private Long trustedDeviceId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "device_fp", nullable = false, length = 64)
+    private String deviceFp;
+
+    @Column(name = "device_name", length = 255)
+    private String deviceName;
+
+    @Column(name = "last_country", length = 50)
+    private String lastCountry;
+
+    @Column(name = "last_city", length = 50)
+    private String lastCity;
+
+    @Column(name = "last_used_at", nullable = false)
+    private LocalDateTime lastUsedAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+
+    public static TrustedDeviceJpaEntity from(TrustedDevice device) {
+        TrustedDeviceJpaEntity e = new TrustedDeviceJpaEntity();
+        e.trustedDeviceId = device.getTrustedDeviceId();
+        e.userId          = device.getUserId();
+        e.deviceFp        = device.getDeviceFp();
+        e.deviceName      = device.getDeviceName();
+        e.lastCountry     = device.getLastCountry();
+        e.lastCity        = device.getLastCity();
+        e.lastUsedAt      = device.getLastUsedAt();
+        return e;
+    }
+
+
+    public TrustedDevice toDomain() {
+        return TrustedDevice.restore(
+                trustedDeviceId,
+                userId,
+                deviceFp,
+                deviceName,
+                lastCountry,
+                lastCity,
+                lastUsedAt,
+                createdAt
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/TrustedDeviceRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/TrustedDeviceRepositoryAdapter.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class TrustedDeviceRepositoryAdapter implements TrustedDeviceRepository {
+
+    private final SpringDataTrustedDeviceRepository springDataTrustedDeviceRepository;
+
+    @Override
+    public TrustedDevice save(TrustedDevice device) {
+        TrustedDeviceJpaEntity entity = TrustedDeviceJpaEntity.from(device);
+        return springDataTrustedDeviceRepository.save(entity).toDomain();
+    }
+
+    @Override
+    public Optional<TrustedDevice> findByUserIdAndDeviceFp(Long userId, String deviceFp) {
+        return springDataTrustedDeviceRepository.findByUserIdAndDeviceFp(userId, deviceFp)
+                .map(TrustedDeviceJpaEntity::toDomain);
+    }
+
+    @Override
+    public List<TrustedDevice> findAllByUserId(Long userId) {
+        return springDataTrustedDeviceRepository.findAllByUserId(userId).stream()
+                .map(TrustedDeviceJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<TrustedDevice> findByTrustedDeviceIdAndUserId(Long trustedDeviceId, Long userId) {
+        return springDataTrustedDeviceRepository.findByTrustedDeviceIdAndUserId(trustedDeviceId, userId)
+                .map(TrustedDeviceJpaEntity::toDomain);
+    }
+
+    @Override
+    public void deleteById(Long trustedDeviceId) {
+        springDataTrustedDeviceRepository.deleteById(trustedDeviceId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
@@ -19,4 +19,9 @@ public class AuthResponseCode {
     public static final String OAUTH_AUTH_URL_ISSUED = "AUTH-OAUTH-AUTH-URL-ISSUED";
     public static final String OAUTH_SIGNUP_COMPLETED = "AUTH-OAUTH-SIGNUP-COMPLETED";
     public static final String OAUTH_TEMP_INFO_RETRIEVED = "AUTH-OAUTH-TEMP-INFO-RETRIEVED";
+
+    public static final String STEP_UP_REQUIRED = "AUTH-STEP-UP-REQUIRED";
+    public static final String STEP_UP_VERIFIED = "AUTH-STEP-UP-VERIFIED";
+    public static final String STEP_UP_CODE_RESENT = "AUTH-STEP-UP-CODE-RESENT";
+    public static final String ACCOUNT_LOCKED = "AUTH-ACCOUNT-LOCKED";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
@@ -19,4 +19,9 @@ public class AuthResponseMessage {
     public static final String OAUTH_AUTH_URL_ISSUED = "구글 인증 URL 발급 성공";
     public static final String OAUTH_SIGNUP_COMPLETED = "소셜 가입 완료";
     public static final String OAUTH_TEMP_INFO_RETRIEVED = "소셜 임시정보 조회 성공";
+
+    public static final String STEP_UP_REQUIRED = "추가 인증이 필요합니다.";
+    public static final String STEP_UP_VERIFIED = "추가 인증이 완료되었습니다.";
+    public static final String STEP_UP_CODE_RESENT = "인증 코드를 재발송했습니다.";
+    public static final String ACCOUNT_LOCKED = "계정이 잠겼습니다. 비밀번호 재설정 후 이용해주세요.";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/LockController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/LockController.java
@@ -1,0 +1,35 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.usecase.LockAccountUseCase;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth - 인증", description = "회원가입 / 로그인 / 토큰 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class LockController {
+
+    private final LockAccountUseCase lockAccountUseCase;
+
+    @Operation(summary = "계정 잠금", description = "의심 로그인 알림 이메일의 링크 클릭 시 계정을 잠그고 모든 세션을 종료한다. (비회원 접근 — 토큰으로 식별)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "잠금 처리 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "AUT-007 유효하지 않은(또는 만료된) 잠금 토큰")
+    @GetMapping("/lock")
+    public ResponseEntity<ApiResponse<Void>> lock(@RequestParam String token) {
+        lockAccountUseCase.lock(token);
+
+        return ResponseEntity.ok(ApiResponse.<Void>success(
+                AuthResponseCode.ACCOUNT_LOCKED,
+                AuthResponseMessage.ACCOUNT_LOCKED,
+                null
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/LoginController.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.auth.application.usecase.LoginUseCase;
 import com.wanted.codebombalms.auth.presentation.api.dto.request.LoginRequest;
 import com.wanted.codebombalms.auth.presentation.api.dto.response.LoginResponse;
 import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.auth.presentation.api.support.DeviceFingerprintResolver;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,15 +26,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class LoginController {
 
+    private static final int STEP_UP_COOKIE_MAX_AGE = 300; // 5분 (step-up TTL과 동일)
+
     private final LoginUseCase loginUseCase;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthCookieFactory authCookieFactory;
+    private final DeviceFingerprintResolver deviceFingerprintResolver;
 
     @Operation(
             summary = "로그인",
-            description = "이메일/비밀번호 검증 후 accessToken/refreshToken 쿠키 2개 발급. 단일 세션 강제 + 로그인 이력 저장. 응답 body 의 data.nickname 으로 닉네임 노출."
+            description = "이메일/비밀번호 검증 후 적응형 인증. 신뢰 기기면 토큰 2개 발급, 미신뢰/위치급변이면 stepupToken 발급 후 이메일 OTP 추가 인증 필요(data.stepUpRequired=true)."
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공 — 쿠키 2개 발급 + body 에 nickname 포함")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공 또는 추가 인증 필요 (data.stepUpRequired 로 분기)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-001 이메일 또는 비밀번호 불일치")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "USR-007 계정 잠금 상태")
     @PostMapping("/login")
@@ -42,20 +46,24 @@ public class LoginController {
             HttpServletRequest httpRequest,
             HttpServletResponse response
     ) {
-        LoginResult result = loginUseCase.login(request.toCommand(), httpRequest);
+        String deviceFp = deviceFingerprintResolver.resolve(httpRequest, response);
+        LoginResult result = loginUseCase.login(request.toCommand(), httpRequest, deviceFp);
 
-        // 쿠키 2개 설정 (토큰은 body 노출 X — HttpOnly 쿠키로만)
-        response.addCookie(authCookieFactory.create(
-                "accessToken",
-                result.accessToken(),
-                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
-        ));
-        response.addCookie(authCookieFactory.create(
-                "refreshToken",
-                result.refreshToken(),
-                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
-        ));
+        // 미신뢰 기기 → stepupToken 쿠키만 발급 (정식 토큰 보류)
+        if (result.stepUpRequired()) {
+            response.addCookie(authCookieFactory.create("stepupToken", result.stepUpToken(), STEP_UP_COOKIE_MAX_AGE));
+            return ResponseEntity.ok(ApiResponse.success(
+                    AuthResponseCode.STEP_UP_REQUIRED,
+                    AuthResponseMessage.STEP_UP_REQUIRED,
+                    LoginResponse.from(result)
+            ));
+        }
 
+        // 신뢰 기기 → 정식 토큰 쿠키 2개
+        response.addCookie(authCookieFactory.create(
+                "accessToken", result.accessToken(), (int) (jwtTokenProvider.getAccessExpiration() / 1000)));
+        response.addCookie(authCookieFactory.create(
+                "refreshToken", result.refreshToken(), (int) (jwtTokenProvider.getRefreshExpiration() / 1000)));
         return ResponseEntity.ok(ApiResponse.success(
                 AuthResponseCode.LOGIN_COMPLETED,
                 AuthResponseMessage.LOGIN_COMPLETED,

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/StepUpResendController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/StepUpResendController.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.usecase.StepUpResendUseCase;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth - 인증", description = "회원가입 / 로그인 / 토큰 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class StepUpResendController {
+
+    private final StepUpResendUseCase stepUpResendUseCase;
+
+    @Operation(summary = "추가 인증 코드 재발송", description = "stepupToken 으로 새 OTP 를 생성해 이메일로 재발송한다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재발송 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-024 step-up 임시토큰 무효/만료")
+    @PostMapping("/step-up/resend")
+    public ResponseEntity<ApiResponse<Void>> resend(
+            @CookieValue(name = "stepupToken", required = false) String stepUpToken
+    ) {
+        stepUpResendUseCase.resend(stepUpToken);
+
+        return ResponseEntity.ok(ApiResponse.<Void>success(
+                AuthResponseCode.STEP_UP_CODE_RESENT,
+                AuthResponseMessage.STEP_UP_CODE_RESENT,
+                null
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/StepUpVerifyController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/StepUpVerifyController.java
@@ -1,0 +1,64 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.command.StepUpVerifyCommand;
+import com.wanted.codebombalms.auth.application.dto.LoginResult;
+import com.wanted.codebombalms.auth.application.usecase.StepUpVerifyUseCase;
+import com.wanted.codebombalms.auth.presentation.api.dto.request.StepUpVerifyRequest;
+import com.wanted.codebombalms.auth.presentation.api.dto.response.LoginResponse;
+import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth - 인증", description = "회원가입 / 로그인 / 토큰 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class StepUpVerifyController {
+
+    private final StepUpVerifyUseCase stepUpVerifyUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthCookieFactory authCookieFactory;
+
+    @Operation(summary = "추가 인증 검증", description = "미신뢰 기기 로그인 시 발급된 stepupToken + 이메일 OTP 검증 → 정식 토큰 발급. trustDevice=true 면 신뢰 기기 등록.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인증 성공 — 토큰 2개 발급")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "AUT-009 유효하지 않은 인증 코드")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-024 step-up 임시토큰 무효/만료")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "AUT-025 추가 인증 시도 초과")
+    @PostMapping("/step-up/verify")
+    public ResponseEntity<ApiResponse<LoginResponse>> verify(
+            @CookieValue(name = "stepupToken", required = false) String stepUpToken,
+            @Valid @RequestBody StepUpVerifyRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse response
+    ) {
+        LoginResult result = stepUpVerifyUseCase.verify(
+                new StepUpVerifyCommand(stepUpToken, request.code(), request.trustDevice()),
+                httpRequest
+        );
+
+        // 정식 토큰 발급 + stepupToken 만료
+        response.addCookie(authCookieFactory.create(
+                "accessToken", result.accessToken(), (int) (jwtTokenProvider.getAccessExpiration() / 1000)));
+        response.addCookie(authCookieFactory.create(
+                "refreshToken", result.refreshToken(), (int) (jwtTokenProvider.getRefreshExpiration() / 1000)));
+        response.addCookie(authCookieFactory.expired("stepupToken"));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.STEP_UP_VERIFIED,
+                AuthResponseMessage.STEP_UP_VERIFIED,
+                LoginResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/StepUpVerifyRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/StepUpVerifyRequest.java
@@ -1,10 +1,12 @@
 package com.wanted.codebombalms.auth.presentation.api.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record StepUpVerifyRequest(
 
         @NotBlank(message = "인증 코드는 필수입니다.")
+        @Pattern(regexp = "\\d{6}", message = "인증 코드는 6자리 숫자여야 합니다.")
         String code,
 
         boolean trustDevice

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/StepUpVerifyRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/StepUpVerifyRequest.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StepUpVerifyRequest(
+
+        @NotBlank(message = "인증 코드는 필수입니다.")
+        String code,
+
+        boolean trustDevice
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/LoginResponse.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/LoginResponse.java
@@ -2,9 +2,18 @@ package com.wanted.codebombalms.auth.presentation.api.dto.response;
 
 import com.wanted.codebombalms.auth.application.dto.LoginResult;
 
-public record LoginResponse(String nickname, String role) {
-
+public record LoginResponse(
+        boolean stepUpRequired,
+        String nickname,
+        String role,
+        String maskedEmail
+) {
     public static LoginResponse from(LoginResult result) {
-        return new LoginResponse(result.nickname(), result.role(). name());
+        return new LoginResponse(
+                result.stepUpRequired(),
+                result.nickname(),
+                result.role() == null ? null : result.role().name(),
+                result.maskedEmail()
+        );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/support/DeviceFingerprintResolver.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/support/DeviceFingerprintResolver.java
@@ -1,0 +1,59 @@
+package com.wanted.codebombalms.auth.presentation.api.support;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HexFormat;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class DeviceFingerprintResolver {
+
+    private static final String DEVICE_ID_COOKIE = "deviceId";
+    private static final int DEVICE_ID_MAX_AGE = 60 * 60 * 24 * 365; // 1년 (영속)
+
+    private final AuthCookieFactory authCookieFactory;
+
+    /**
+     * 요청의 deviceId 쿠키로 기기 지문(SHA-256 64자)을 반환한다.
+     * 쿠키가 없으면 새 deviceId 를 발급해 응답 쿠키로 심는다. (식별용 — 인증은 OTP가 담당)
+     */
+    public String resolve(HttpServletRequest request, HttpServletResponse response) {
+        String deviceId = readDeviceId(request);
+        if (deviceId == null) {
+            deviceId = UUID.randomUUID().toString();
+            response.addCookie(authCookieFactory.create(DEVICE_ID_COOKIE, deviceId, DEVICE_ID_MAX_AGE));
+        }
+        return sha256(deviceId);
+    }
+
+    private String readDeviceId(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> DEVICE_ID_COOKIE.equals(c.getName()))
+                .map(Cookie::getValue)
+                .filter(v -> v != null && !v.isBlank())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash); // 소문자 hex 64자 → device_fp VARCHAR(64)
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 알고리즘을 찾을 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetLoginHistoryService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetLoginHistoryService.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
+import com.wanted.codebombalms.user.application.usecase.GetLoginHistoryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetLoginHistoryService implements GetLoginHistoryUseCase {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final LoginHistoryRepository loginHistoryRepository;
+
+    @Override
+    public List<LoginHistory> getLoginHistory(Long userId, int page) {
+        return loginHistoryRepository.findByUserId(userId, page, PAGE_SIZE);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetLoginHistoryService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetLoginHistoryService.java
@@ -20,6 +20,7 @@ public class GetLoginHistoryService implements GetLoginHistoryUseCase {
 
     @Override
     public List<LoginHistory> getLoginHistory(Long userId, int page) {
-        return loginHistoryRepository.findByUserId(userId, page, PAGE_SIZE);
+        int safePage = Math.max(page, 0); // 음수 페이지 → PageRequest 예외(500) 방지
+        return loginHistoryRepository.findByUserId(userId, safePage, PAGE_SIZE);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetTrustedDevicesService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetTrustedDevicesService.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.user.application.usecase.GetTrustedDevicesUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetTrustedDevicesService implements GetTrustedDevicesUseCase {
+
+    private final TrustedDeviceRepository trustedDeviceRepository;
+
+    @Override
+    public List<TrustedDevice> getTrustedDevices(Long userId) {
+        return trustedDeviceRepository.findAllByUserId(userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/RemoveTrustedDeviceService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/RemoveTrustedDeviceService.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.user.application.usecase.RemoveTrustedDeviceUseCase;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RemoveTrustedDeviceService implements RemoveTrustedDeviceUseCase {
+
+    private final TrustedDeviceRepository trustedDeviceRepository;
+
+    @Override
+    public void remove(Long userId, Long trustedDeviceId) {
+        // 본인 소유 확인 — 없으면 404 (USR-012)
+        TrustedDevice device = trustedDeviceRepository
+                .findByTrustedDeviceIdAndUserId(trustedDeviceId, userId)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.TRUSTED_DEVICE_NOT_FOUND));
+
+        trustedDeviceRepository.deleteById(device.getTrustedDeviceId());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/GetLoginHistoryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/GetLoginHistoryUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+
+import java.util.List;
+
+public interface GetLoginHistoryUseCase {
+
+    List<LoginHistory> getLoginHistory(Long userId, int page);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/GetTrustedDevicesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/GetTrustedDevicesUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+
+import java.util.List;
+
+public interface GetTrustedDevicesUseCase {
+
+    List<TrustedDevice> getTrustedDevices(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/RemoveTrustedDeviceUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/RemoveTrustedDeviceUseCase.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+public interface RemoveTrustedDeviceUseCase {
+
+    void remove(Long userId, Long trustedDeviceId);
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
@@ -27,7 +27,9 @@ public enum UserErrorCode implements ErrorCode {
     USER_EMAIL_NOT_VERIFIED("USR-009", "이메일 인증이 완료되지 않았습니다."),
     STUDENT_NOT_FOUND("USR-010", "학생 회원을 찾을 수 없습니다."),
 
-    USER_REVERIFICATION_REQUIRED("USR-011", "비밀번호 재인증이 필요합니다. 다시 인증해주세요.");
+    USER_REVERIFICATION_REQUIRED("USR-011", "비밀번호 재인증이 필요합니다. 다시 인증해주세요."),
+
+    TRUSTED_DEVICE_NOT_FOUND("USR-012", "신뢰 기기를 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/LoginHistoryController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/LoginHistoryController.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.usecase.GetLoginHistoryUseCase;
+import com.wanted.codebombalms.user.presentation.api.response.LoginHistoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "User - 마이페이지", description = "로그인 사용자의 프로필 조회/수정 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class LoginHistoryController {
+
+    private final GetLoginHistoryUseCase getLoginHistoryUseCase;
+
+    @Operation(summary = "로그인 이력 조회", description = "로그인 사용자의 로그인 이력(IP/지역/의심여부) 최신순 조회. 페이지당 20건.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @GetMapping("/me/login-history")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<LoginHistoryResponse>>> getLoginHistory(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        List<LoginHistoryResponse> history = getLoginHistoryUseCase.getLoginHistory(userId, page).stream()
+                .map(LoginHistoryResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.LOGIN_HISTORY_RETRIEVED,
+                UserResponseMessage.LOGIN_HISTORY_RETRIEVED,
+                history
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/TrustedDeviceController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/TrustedDeviceController.java
@@ -1,0 +1,75 @@
+package com.wanted.codebombalms.user.presentation.api;
+
+import com.wanted.codebombalms.auth.presentation.api.support.DeviceFingerprintResolver;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.user.application.usecase.GetTrustedDevicesUseCase;
+import com.wanted.codebombalms.user.application.usecase.RemoveTrustedDeviceUseCase;
+import com.wanted.codebombalms.user.presentation.api.response.TrustedDeviceResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "User - 신뢰 기기", description = "적응형 인증 신뢰 기기 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class TrustedDeviceController {
+
+    private final GetTrustedDevicesUseCase getTrustedDevicesUseCase;
+    private final RemoveTrustedDeviceUseCase removeTrustedDeviceUseCase;
+    private final DeviceFingerprintResolver deviceFingerprintResolver;
+
+    @Operation(summary = "신뢰 기기 목록 조회", description = "로그인 사용자의 신뢰 기기 목록 조회 (현재 기기 표시 포함).")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @GetMapping("/me/trusted-devices")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<TrustedDeviceResponse>>> getTrustedDevices(
+            @AuthenticationPrincipal Long userId,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String currentFp = deviceFingerprintResolver.resolve(request, response);
+
+        List<TrustedDeviceResponse> devices = getTrustedDevicesUseCase.getTrustedDevices(userId).stream()
+                .map(device -> TrustedDeviceResponse.from(device, currentFp))
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                UserResponseCode.TRUSTED_DEVICES_RETRIEVED,
+                UserResponseMessage.TRUSTED_DEVICES_RETRIEVED,
+                devices
+        ));
+    }
+
+    @Operation(summary = "신뢰 기기 해제", description = "신뢰 기기를 해제한다. 해제된 기기는 다음 로그인 시 추가 인증(step-up)을 다시 요구한다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "해제 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "USR-012 신뢰 기기를 찾을 수 없습니다")
+    @DeleteMapping("/me/trusted-devices/{deviceId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<Void>> removeTrustedDevice(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long deviceId
+    ) {
+        removeTrustedDeviceUseCase.remove(userId, deviceId);
+
+        return ResponseEntity.ok(ApiResponse.<Void>success(
+                UserResponseCode.TRUSTED_DEVICE_REMOVED,
+                UserResponseMessage.TRUSTED_DEVICE_REMOVED,
+                null
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseCode.java
@@ -13,4 +13,10 @@ public class UserResponseCode {
     public static final String PROFILE_UPDATED = "USER-ME-PROFILE-UPDATED";
     public static final String PASSWORD_CHANGED = "USER-ME-PASSWORD-CHANGED";
     public static final String EMAIL_FOUND = "USER-EMAIL-FOUND";
+
+    // 적응형 인증 - 신뢰 기기
+    public static final String TRUSTED_DEVICES_RETRIEVED = "USER-TRUSTED-DEVICES-RETRIEVED";
+    public static final String TRUSTED_DEVICE_REMOVED = "USER-TRUSTED-DEVICE-REMOVED";
+
+    public static final String LOGIN_HISTORY_RETRIEVED = "USER-LOGIN-HISTORY-RETRIEVED";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UserResponseMessage.java
@@ -13,4 +13,10 @@ public class UserResponseMessage {
     public static final String PROFILE_UPDATED = "개인정보 수정 성공";
     public static final String PASSWORD_CHANGED = "비밀번호 변경 성공";
     public static final String EMAIL_FOUND = "이메일 찾기 성공";
+
+    // 적응형 인증 - 신뢰 기기
+    public static final String TRUSTED_DEVICES_RETRIEVED = "신뢰 기기 목록 조회 성공";
+    public static final String TRUSTED_DEVICE_REMOVED = "신뢰 기기를 해제했습니다.";
+
+    public static final String LOGIN_HISTORY_RETRIEVED = "로그인 이력 조회 성공";
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/response/LoginHistoryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/response/LoginHistoryResponse.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.user.presentation.api.response;
+
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+
+import java.time.LocalDateTime;
+
+public record LoginHistoryResponse(
+        Long loginHistoryId,
+        String ipAddress,
+        String country,
+        String city,
+        boolean isSuspicious,
+        LocalDateTime createdAt
+) {
+    public static LoginHistoryResponse from(LoginHistory history) {
+        return new LoginHistoryResponse(
+                history.getLoginHistoryId(),
+                history.getIpAddress(),
+                history.getCountry(),
+                history.getCity(),
+                history.isSuspicious(),
+                history.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/response/TrustedDeviceResponse.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/response/TrustedDeviceResponse.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.user.presentation.api.response;
+
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+
+import java.time.LocalDateTime;
+
+public record TrustedDeviceResponse(
+        Long id,
+        String deviceName,
+        String lastCountry,
+        String lastCity,
+        LocalDateTime lastUsedAt,
+        boolean current
+) {
+    public static TrustedDeviceResponse from(TrustedDevice device, String currentDeviceFp) {
+        return new TrustedDeviceResponse(
+                device.getTrustedDeviceId(),
+                device.getDeviceName(),
+                device.getLastCountry(),
+                device.getLastCity(),
+                device.getLastUsedAt(),
+                device.getDeviceFp().equals(currentDeviceFp)
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -3,10 +3,16 @@ package com.wanted.codebombalms.auth.application.service;
 import com.wanted.codebombalms.auth.application.command.LoginCommand;
 import com.wanted.codebombalms.auth.application.dto.LoginResult;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
 import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
 import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.auth.domain.service.EmailSender;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
@@ -29,7 +35,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -37,9 +43,15 @@ import static org.mockito.Mockito.*;
 @DisplayName("LoginService 단위 테스트")
 class LoginServiceTest {
 
+    private static final String DEVICE_FP = "DEVICE_FP";
+
     @Mock private UserRepository userRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
     @Mock private LoginHistoryRepository loginHistoryRepository;
+    @Mock private TrustedDeviceRepository trustedDeviceRepository;
+    @Mock private StepUpTokenRepository stepUpTokenRepository;
+    @Mock private GeoIpResolver geoIpResolver;
+    @Mock private EmailSender emailSender;
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private HttpServletRequest httpRequest;
@@ -55,26 +67,55 @@ class LoginServiceTest {
     }
 
     @Test
-    @DisplayName("정상 로그인 시 LoginResult(토큰 2개 + 닉네임)를 반환하고 새 Refresh Token + LoginHistory를 저장한다.")
-    void 로그인_성공() {
+    @DisplayName("신뢰 기기 로그인 시 LoginResult(토큰 2개 + 닉네임)를 반환하고 새 Refresh Token + LoginHistory를 저장한다.")
+    void 신뢰기기_로그인_성공() {
         // given
         User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP))
+                .willReturn(Optional.of(TrustedDevice.register(1L, DEVICE_FP, "Chrome", null, null)));
         given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
         // when
-        LoginResult result = loginService.login(command, httpRequest);
+        LoginResult result = loginService.login(command, httpRequest, DEVICE_FP);
 
         // then
+        assertFalse(result.stepUpRequired());
         assertEquals("ACCESS_TOKEN", result.accessToken());
         assertEquals("REFRESH_TOKEN", result.refreshToken());
         assertEquals("길동이", result.nickname());
         verify(refreshTokenRepository).deleteByUserId(1L);
         verify(refreshTokenRepository).save(any(RefreshToken.class));
         verify(loginHistoryRepository).save(any(LoginHistory.class));
+    }
+
+    @Test
+    @DisplayName("미신뢰 기기 로그인 시 step-up(이메일 OTP)을 요구하고 정식 토큰은 발급하지 않는다.")
+    void 미신뢰기기_stepup() {
+        // given
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.empty());
+
+        // when
+        LoginResult result = loginService.login(command, httpRequest, DEVICE_FP);
+
+        // then
+        assertTrue(result.stepUpRequired());
+        assertNotNull(result.stepUpToken());
+        assertNotNull(result.maskedEmail());
+        assertNull(result.accessToken());
+        verify(emailSender).sendStepUpCode(eq("test@example.com"), anyString());
+        verify(stepUpTokenRepository).save(anyString(), any());
+        verify(loginHistoryRepository).save(any(LoginHistory.class));
+        verify(jwtTokenProvider, never()).generateAccessToken(anyLong(), anyString(), any());
+        verify(refreshTokenRepository, never()).save(any());
     }
 
     @Test
@@ -86,7 +127,7 @@ class LoginServiceTest {
         // when & then
         UnauthorizedException ex = assertThrows(
                 UnauthorizedException.class,
-                () -> loginService.login(command, httpRequest)
+                () -> loginService.login(command, httpRequest, DEVICE_FP)
         );
         assertEquals(AuthErrorCode.AUTH_LOGIN_FAIL, ex.getErrorCode());
         verify(refreshTokenRepository, never()).save(any());
@@ -104,7 +145,7 @@ class LoginServiceTest {
         // when & then
         UnauthorizedException ex = assertThrows(
                 UnauthorizedException.class,
-                () -> loginService.login(command, httpRequest)
+                () -> loginService.login(command, httpRequest, DEVICE_FP)
         );
         assertEquals(AuthErrorCode.AUTH_LOGIN_FAIL, ex.getErrorCode());
         verify(refreshTokenRepository, never()).save(any());
@@ -122,7 +163,7 @@ class LoginServiceTest {
         // when & then
         ForbiddenException ex = assertThrows(
                 ForbiddenException.class,
-                () -> loginService.login(command, httpRequest)
+                () -> loginService.login(command, httpRequest, DEVICE_FP)
         );
         assertEquals(UserErrorCode.USER_ACCOUNT_LOCKED, ex.getErrorCode());
         verify(refreshTokenRepository, never()).save(any());
@@ -130,18 +171,21 @@ class LoginServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 시 기존 Refresh Token을 전부 삭제하고 새 토큰을 저장한다 (단일 세션 강제).")
+    @DisplayName("신뢰 기기 로그인 시 기존 Refresh Token을 전부 삭제하고 새 토큰을 저장한다 (단일 세션 강제).")
     void 단일_세션_강제() {
         // given
         User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
         given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP))
+                .willReturn(Optional.of(TrustedDevice.register(1L, DEVICE_FP, "Chrome", null, null)));
         given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
         // when
-        loginService.login(command, httpRequest);
+        loginService.login(command, httpRequest, DEVICE_FP);
 
         // then — 삭제 후 저장 순서 검증
         var inOrder = inOrder(refreshTokenRepository);

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -111,8 +111,7 @@ class LoginServiceTest {
         assertNotNull(result.stepUpToken());
         assertNotNull(result.maskedEmail());
         assertNull(result.accessToken());
-        verify(emailSender).sendStepUpCode(eq("test@example.com"), anyString());
-        verify(stepUpTokenRepository).save(anyString(), any());
+        verify(emailSender).sendStepUpCode(eq("test@example.com"), anyString(), anyString());        verify(stepUpTokenRepository).save(anyString(), any());
         verify(loginHistoryRepository).save(any(LoginHistory.class));
         verify(jwtTokenProvider, never()).generateAccessToken(anyLong(), anyString(), any());
         verify(refreshTokenRepository, never()).save(any());

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -7,6 +7,7 @@ import com.wanted.codebombalms.auth.domain.model.GeoLocation;
 import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
 import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.LockTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
@@ -50,6 +51,7 @@ class LoginServiceTest {
     @Mock private LoginHistoryRepository loginHistoryRepository;
     @Mock private TrustedDeviceRepository trustedDeviceRepository;
     @Mock private StepUpTokenRepository stepUpTokenRepository;
+    @Mock private LockTokenRepository lockTokenRepository;
     @Mock private GeoIpResolver geoIpResolver;
     @Mock private EmailSender emailSender;
     @Mock private PasswordEncoder passwordEncoder;


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #109 + Closes #110 + Closes #111 + Closes #116

---

## 🛠️ 기능 관련 작업 내용
- 로그인 시 **기기 지문(서버 deviceId 쿠키→SHA-256) + GeoIP(GeoLite2-City)** 로 위험을 판정해, 미신뢰 기기·평소와 다른 국가면 정식 토큰 발급을 보류하고 **이메일 OTP 추가 인증(step-up)** 을 요구 (verify/resend)
- step-up 통과 시 **신뢰 기기(TrustedDevice) 등록** → 다음부터 바로 통과. 신뢰 기기 목록 조회/해제 제공
- 의심 로그인 시 **OTP + 계정 잠금 링크 포함 알림 메일** 발송, 링크 클릭 시 `GET /auth/lock` 으로 계정 잠금 + 강제 로그아웃
- 로그인 이력 조회(`/users/me/login-history`, IP/국가/도시/의심여부) 추가 (#116)

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth`: 적응형 로그인 분기(`LoginService`), 기기지문(`DeviceFingerprintResolver`), GeoIP(`GeoIpResolver`/`GeoLite2CityAdapter`), `TrustedDevice` 클린아키처 5종, step-up(Redis 임시토큰·verify·resend), 계정 잠금(`LockToken`·`/auth/lock`), 에러코드 `AUT-024`/`AUT-025`, 로그인 이력 페이지 조회
- `codebombalms/user`: 신뢰 기기 목록/해제 + 로그인 이력 조회 엔드포인트(`/users/me/**`, auth 포트 cross-domain), 에러코드 `USR-012`
- `build.gradle` / `resources`: `com.maxmind.geoip2` 의존성 + `GeoLite2-City.mmdb`, `trusted_devices` 테이블 DDL
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 로그인에 추가 인증(step-up) 흐름이 도입되어, 새 기기나 의심스러운 접속 시 이메일 코드 확인 후 로그인할 수 있습니다.
  * 신뢰 기기 목록 조회 및 등록 해제, 로그인 이력 조회 기능이 추가되었습니다.
  * 계정 잠금 링크를 통해 즉시 계정을 잠그는 기능이 추가되었습니다.
* **Bug Fixes**
  * 로그인 응답이 추가 인증 필요 여부와 마스킹된 이메일을 포함하도록 확장되었습니다.
  * 로그인 시 지역 정보 기반으로 더 정확한 인증 판단이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->