### PR TITLE
[Feat] 문제 세트 목록 조회 페이징 추가

### DIFF
--- a/monitoring-local/k6/results/problem-set-entry-before-optimization-summary.json
+++ b/monitoring-local/k6/results/problem-set-entry-before-optimization-summary.json
@@ -1,0 +1,223 @@
+{
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 3518.25502
+  },
+  "metrics": {
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 3510.266466,
+        "med": 3510.266466,
+        "p(90)": 3510.266466,
+        "p(95)": 3510.266466,
+        "p(99)": 3510.266466,
+        "max": 3510.266466
+      }
+    },
+    "problem_set_entry_valid_rate": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 0
+      },
+      "thresholds": {
+        "rate>0.99": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 3511.940044,
+        "max": 3511.940044,
+        "avg": 3511.940044,
+        "med": 3511.940044,
+        "p(90)": 3511.940044,
+        "p(95)": 3511.940044
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 3511.940044,
+        "p(90)": 3511.940044,
+        "p(95)": 3511.940044,
+        "p(99)": 3511.940044,
+        "max": 3511.940044,
+        "avg": 3511.940044
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.086751,
+        "med": 0.086751,
+        "p(90)": 0.086751,
+        "p(95)": 0.086751,
+        "p(99)": 0.086751,
+        "max": 0.086751
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 234,
+        "rate": 66.51024404706172
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 3517.78613,
+        "med": 3517.78613,
+        "p(90)": 3517.78613,
+        "p(95)": 3517.78613,
+        "p(99)": 3517.78613,
+        "max": 3517.78613
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 50,
+        "min": 50,
+        "max": 50
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 903,
+        "rate": 256.66132638673815
+      }
+    },
+    "http_req_duration{type:problem_set_entry}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 0,
+        "max": 0,
+        "avg": 0,
+        "med": 0,
+        "p(90)": 0
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1,
+        "rate": 0.28423181216693044
+      }
+    },
+    "http_req_receiving": {
+      "contains": "time",
+      "values": {
+        "p(90)": 1.586827,
+        "p(95)": 1.586827,
+        "p(99)": 1.586827,
+        "max": 1.586827,
+        "avg": 1.586827,
+        "med": 1.586827
+      },
+      "type": "trend"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 3.341811,
+        "p(90)": 3.341811,
+        "p(95)": 3.341811,
+        "p(99)": 3.341811,
+        "max": 3.341811,
+        "avg": 3.341811
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 0,
+        "min": 0,
+        "max": 0
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 4.966198,
+        "med": 4.966198,
+        "p(90)": 4.966198,
+        "p(95)": 4.966198,
+        "p(99)": 4.966198,
+        "max": 4.966198
+      }
+    }
+  },
+  "root_group": {
+    "checks": [],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTimeUnit": "",
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ]
+  }
+}

--- a/monitoring-local/k6/results/problem-set-entry-before-optimization-summary.md
+++ b/monitoring-local/k6/results/problem-set-entry-before-optimization-summary.md
@@ -1,0 +1,50 @@
+# k6 Result - problem-set-entry-before-optimization
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 1 |
+| iterations |  |
+| checks success rate |  |
+| http_req_failed | 0.00% |
+| data_received bytes | 903 |
+| data_sent bytes | 234 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 3511.94 |  | 3511.94 | 3511.94 | 3511.94 | 3511.94 | 3511.94 |
+| http_req_waiting | 3510.27 |  | 3510.27 | 3510.27 | 3510.27 | 3510.27 | 3510.27 |
+| http_req_blocked | 4.97 |  | 4.97 | 4.97 | 4.97 | 4.97 | 4.97 |
+| http_req_connecting | 3.34 |  | 3.34 | 3.34 | 3.34 | 3.34 | 3.34 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| check details | Check console output or JSON summary. |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-local/k6/scripts/problems/03-problem-set-entry-baseline.js
+++ b/monitoring-local/k6/scripts/problems/03-problem-set-entry-baseline.js
@@ -1,0 +1,82 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+import { BASE_URL } from '../../lib/config.js';
+import { authCookies, login } from '../../lib/auth.js';
+import { createSummaryHandler } from '../../lib/summary.js';
+
+const PROBLEM_SET_ID = __ENV.PROBLEM_SET_ID || '830001';
+const USER_ID_START = Number(__ENV.USER_ID_START || '830001');
+const USER_COUNT = Number(__ENV.USER_COUNT || '300');
+const PASSWORD = __ENV.PASSWORD || 'Test1234!';
+
+const entryDuration = new Trend('problem_set_entry_duration', true);
+const validRate = new Rate('problem_set_entry_valid_rate');
+
+export const options = {
+    scenarios: {
+        problem_set_entry: {
+            executor: 'shared-iterations',
+            vus: Number(__ENV.VUS || '50'),
+            iterations: Number(__ENV.ITERATIONS || '300'),
+            maxDuration: __ENV.MAX_DURATION || '2m',
+        },
+    },
+    thresholds: {
+        'http_req_failed': ['rate<0.01'],
+        'problem_set_entry_valid_rate': ['rate>0.99'],
+        'http_req_duration{type:problem_set_entry}': ['p(95)<800'],
+    },
+    summaryTrendStats: ['avg', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+};
+
+export function setup() {
+    const tokens = [];
+
+    for (let i = 0; i < USER_COUNT; i += 1) {
+        const userId = USER_ID_START + i;
+        const email = `problem-entry-loadtest-${userId}@test.com`;
+
+        tokens.push(login(email, PASSWORD));
+    }
+
+    return { tokens };
+}
+
+export default function (data) {
+    const token = data.tokens[__ITER % data.tokens.length];
+
+    const params = authCookies(token);
+    params.headers = { Accept: 'application/json' };
+    params.tags = { type: 'problem_set_entry' };
+
+    const res = http.get(`${BASE_URL}/api/v1/problem-sets/${PROBLEM_SET_ID}`, params);
+
+    entryDuration.add(res.timings.duration, { type: 'problem_set_entry' });
+
+    let body = null;
+    try {
+        body = res.json();
+    } catch (e) {
+        body = null;
+    }
+
+    const hasData = body !== null && body.data !== null && body.data !== undefined;
+    const problems = hasData && Array.isArray(body.data.problems)
+        ? body.data.problems
+        : [];
+
+    const valid = check(res, {
+        'status is 200': (r) => r.status === 200,
+        'has data': () => hasData,
+        'problem count is 20': () => hasData && body.data.totalProblemCount === 20,
+        'problems length is 20': () => problems.length === 20,
+        'start code exists': () => problems.every((problem) => problem.startCode !== null),
+    });
+
+    validRate.add(valid);
+
+    sleep(0.1);
+}
+
+export const handleSummary = createSummaryHandler('problem-set-entry-baseline');

--- a/python-runner/app.py
+++ b/python-runner/app.py
@@ -1,4 +1,4 @@
-import os
+zimport os
 import subprocess
 import sys
 import tempfile

--- a/src/main/java/com/wanted/codebombalms/badge/infrastructure/storage/GcsBadgeImageStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/badge/infrastructure/storage/GcsBadgeImageStorageAdapter.java
@@ -1,28 +1,24 @@
 package com.wanted.codebombalms.badge.infrastructure.storage;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 import com.wanted.codebombalms.badge.application.port.BadgeImageStoragePort;
 import com.wanted.codebombalms.badge.exception.BadgeErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.cache.CacheNames;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
+@Slf4j
 @Component
 public class GcsBadgeImageStorageAdapter implements BadgeImageStoragePort {
 
@@ -36,16 +32,16 @@ public class GcsBadgeImageStorageAdapter implements BadgeImageStoragePort {
     );
 
     private final GcpStorageProperties properties;
-    private final ResourceLoader resourceLoader;
+    private final GcpStorageClientFactory storageClientFactory;
 
     private volatile Storage storage;
 
     public GcsBadgeImageStorageAdapter(
             GcpStorageProperties properties,
-            ResourceLoader resourceLoader
+            GcpStorageClientFactory storageClientFactory
     ) {
         this.properties = properties;
-        this.resourceLoader = resourceLoader;
+        this.storageClientFactory = storageClientFactory;
     }
 
     @Override
@@ -85,7 +81,18 @@ public class GcsBadgeImageStorageAdapter implements BadgeImageStoragePort {
                     contentType,
                     fileSize
             );
+        } catch (ExternalServiceException e) {
+            throw e;
         } catch (Exception e) {
+            log.error(
+                    "GCS badge image upload failed. bucket={}, objectName={}, contentType={}, fileSize={}",
+                    properties.getStorage().getBucket(),
+                    objectName,
+                    contentType,
+                    fileSize,
+                    e
+            );
+
             throw new ExternalServiceException(
                     BadgeErrorCode.BADGE_IMAGE_UPLOAD_FAILED,
                     e
@@ -211,7 +218,7 @@ public class GcsBadgeImageStorageAdapter implements BadgeImageStoragePort {
                 .replace("/", "_");
     }
 
-    private Storage getStorage() {
+    private Storage getStorage(){
         if (storage == null) {
             synchronized (this) {
                 if (storage == null) {
@@ -225,26 +232,12 @@ public class GcsBadgeImageStorageAdapter implements BadgeImageStoragePort {
 
     private Storage createStorage() {
         try {
-            return StorageOptions.newBuilder()
-                    .setProjectId(properties.getProjectId())
-                    .setCredentials(loadCredentials())
-                    .build()
-                    .getService();
+            return storageClientFactory.create();
         } catch (Exception e) {
             throw new ExternalServiceException(
                     BadgeErrorCode.BADGE_IMAGE_ACCESS_URL_FAILED,
                     e
             );
-        }
-    }
-
-    private GoogleCredentials loadCredentials() throws IOException {
-        Resource resource = resourceLoader.getResource(
-                properties.getCredentials().getLocation()
-        );
-
-        try (InputStream inputStream = resource.getInputStream()) {
-            return GoogleCredentials.fromStream(inputStream);
         }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
@@ -1,23 +1,18 @@
 package com.wanted.codebombalms.course.infrastructure.storage;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 import com.wanted.codebombalms.course.application.port.CourseThumbnailStoragePort;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.UUID;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -32,16 +27,16 @@ public class GcsCourseThumbnailStorageAdapter implements CourseThumbnailStorageP
     );
 
     private final GcpStorageProperties properties;
-    private final ResourceLoader resourceLoader;
+    private final GcpStorageClientFactory storageClientFactory;
 
     private volatile Storage storage;
 
     public GcsCourseThumbnailStorageAdapter(
             GcpStorageProperties properties,
-            ResourceLoader resourceLoader
+            GcpStorageClientFactory storageClientFactory
     ) {
         this.properties = properties;
-        this.resourceLoader = resourceLoader;
+        this.storageClientFactory = storageClientFactory;
     }
 
     @Override
@@ -230,11 +225,7 @@ public class GcsCourseThumbnailStorageAdapter implements CourseThumbnailStorageP
 
     private Storage createStorage() {
         try {
-            return StorageOptions.newBuilder()
-                    .setProjectId(properties.getProjectId())
-                    .setCredentials(loadCredentials())
-                    .build()
-                    .getService();
+            return storageClientFactory.create();
         } catch (Exception e) {
             throw new ExternalServiceException(
                     CourseErrorCode.COURSE_THUMBNAIL_UPLOAD_FAILED,
@@ -243,13 +234,4 @@ public class GcsCourseThumbnailStorageAdapter implements CourseThumbnailStorageP
         }
     }
 
-    private GoogleCredentials loadCredentials() throws IOException {
-        Resource resource = resourceLoader.getResource(
-                properties.getCredentials().getLocation()
-        );
-
-        try (InputStream inputStream = resource.getInputStream()) {
-            return GoogleCredentials.fromStream(inputStream);
-        }
-    }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/storage/GcpStorageClientFactory.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/storage/GcpStorageClientFactory.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.global.infrastructure.storage;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class GcpStorageClientFactory {
+
+    private final GcpStorageProperties properties;
+
+    public Storage create() throws IOException {
+        return StorageOptions.newBuilder()
+                .setProjectId(properties.getProjectId())
+                .setCredentials(GoogleCredentials.getApplicationDefault())
+                .build()
+                .getService();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/storage/GcpStorageProperties.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/storage/GcpStorageProperties.java
@@ -7,7 +7,7 @@ public class GcpStorageProperties {
 
     private String projectId;
     private final Storage storage = new Storage();
-    private final Credentials credentials = new Credentials();
+
 
     public String getProjectId() {
         return projectId;
@@ -21,9 +21,6 @@ public class GcpStorageProperties {
         return storage;
     }
 
-    public Credentials getCredentials() {
-        return credentials;
-    }
 
     public static class Storage {
 
@@ -73,18 +70,5 @@ public class GcpStorageProperties {
             this.lectureMaterialPrefix = lectureMaterialPrefix;
         }
     }
-
-    public static class Credentials {
-        private String location;
-
-        public String getLocation() {
-            return location;
-        }
-
-        public void setLocation(String location) {
-            this.location = location;
-        }
-    }
-
 
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/storage/GcsLectureMaterialStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/storage/GcsLectureMaterialStorageAdapter.java
@@ -1,17 +1,14 @@
 package com.wanted.codebombalms.lecture.infrastructure.storage;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
 import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
@@ -19,8 +16,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.ContentDisposition;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +38,7 @@ public class GcsLectureMaterialStorageAdapter implements LectureMaterialStorageP
     );
 
     private final GcpStorageProperties properties;
-    private final ResourceLoader resourceLoader;
+    private final GcpStorageClientFactory storageClientFactory;
     private volatile Storage storage;
 
     @Override
@@ -192,11 +187,7 @@ public class GcsLectureMaterialStorageAdapter implements LectureMaterialStorageP
 
     private Storage createStorage() {
         try {
-            return StorageOptions.newBuilder()
-                    .setProjectId(properties.getProjectId())
-                    .setCredentials(loadCredentials())
-                    .build()
-                    .getService();
+            return storageClientFactory.create();
         } catch (Exception e) {
             throw new ExternalServiceException(
                     LectureErrorCode.LECTURE_MATERIAL_UPLOAD_FAILED,
@@ -205,10 +196,4 @@ public class GcsLectureMaterialStorageAdapter implements LectureMaterialStorageP
         }
     }
 
-    private GoogleCredentials loadCredentials() throws IOException {
-        Resource resource = resourceLoader.getResource(properties.getCredentials().getLocation());
-        try (InputStream inputStream = resource.getInputStream()) {
-            return GoogleCredentials.fromStream(inputStream);
-        }
-    }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/GcsDatasetAccessUrlAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/GcsDatasetAccessUrlAdapter.java
@@ -1,17 +1,14 @@
 package com.wanted.codebombalms.problems.dataset.infrastructure.persistence;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.problems.dataset.application.port.GenerateDatasetAccessUrlPort;
 import com.wanted.codebombalms.problems.dataset.application.port.GenerateDatasetDownloadUrlPort;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
 import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.ContentDisposition;
 import org.springframework.stereotype.Component;
 
@@ -29,14 +26,15 @@ public class GcsDatasetAccessUrlAdapter implements
     private static final long SIGNED_URL_DURATION_MINUTES = 30;
     private volatile Storage storage;
     private final GcpStorageProperties properties;
-    private final ResourceLoader resourceLoader;
+    private final GcpStorageClientFactory storageClientFactory;
+
 
     public GcsDatasetAccessUrlAdapter(
             GcpStorageProperties properties,
-            ResourceLoader resourceLoader
+            GcpStorageClientFactory storageClientFactory
     ) {
         this.properties = properties;
-        this.resourceLoader = resourceLoader;
+        this.storageClientFactory = storageClientFactory;
     }
 
 
@@ -60,19 +58,7 @@ public class GcsDatasetAccessUrlAdapter implements
     }
 
     private Storage createStorage() throws IOException {
-        return StorageOptions.newBuilder()
-                .setProjectId(properties.getProjectId())
-                .setCredentials(loadCredentials())
-                .build()
-                .getService();
-    }
-
-    private GoogleCredentials loadCredentials() throws IOException {
-        Resource resource = resourceLoader.getResource(properties.getCredentials().getLocation());
-
-        try (InputStream inputStream = resource.getInputStream()) {
-            return GoogleCredentials.fromStream(inputStream);
-        }
+        return storageClientFactory.create();
     }
     // Runner 접근 URL
     @Override

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/GcsDatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/GcsDatasetFileStorage.java
@@ -1,22 +1,18 @@
 package com.wanted.codebombalms.problems.dataset.infrastructure.storage;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
 import com.wanted.codebombalms.problems.dataset.application.command.UploadProblemDatasetCommand;
 import com.wanted.codebombalms.problems.dataset.application.port.StoreDatasetFilePort;
 import com.wanted.codebombalms.problems.dataset.domain.model.StoredDatasetFile;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.UUID;
 
 @Primary
@@ -28,14 +24,14 @@ public class GcsDatasetFileStorage implements StoreDatasetFilePort {
     private static final String STORAGE_PUBLIC_URL = "https://storage.googleapis.com";
 
     private final GcpStorageProperties properties;
-    private final ResourceLoader resourceLoader;
+    private final GcpStorageClientFactory storageClientFactory;
 
     public GcsDatasetFileStorage(
             GcpStorageProperties properties,
-            ResourceLoader resourceLoader
+            GcpStorageClientFactory storageClientFactory
     ) {
         this.properties = properties;
-        this.resourceLoader = resourceLoader;
+        this.storageClientFactory = storageClientFactory;
     }
 
     @Override
@@ -61,14 +57,6 @@ public class GcsDatasetFileStorage implements StoreDatasetFilePort {
         );
     }
 
-    private Storage createStorage() throws IOException {
-        return StorageOptions.newBuilder()
-                .setProjectId(properties.getProjectId())
-                .setCredentials(loadCredentials())
-                .build()
-                .getService();
-    }
-
     @Override
     public void delete(String filePath) {
         if (filePath == null || filePath.isBlank()) {
@@ -84,11 +72,8 @@ public class GcsDatasetFileStorage implements StoreDatasetFilePort {
         }
     }
 
-    private GoogleCredentials loadCredentials() throws IOException {
-        Resource resource = resourceLoader.getResource(properties.getCredentials().getLocation());
-        try (InputStream inputStream = resource.getInputStream()) {
-            return GoogleCredentials.fromStream(inputStream);
-        }
+    private Storage createStorage() throws IOException {
+        return storageClientFactory.create();
     }
 
     private String buildObjectName(String storedFileName) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemSetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemSetPort.java
@@ -1,16 +1,15 @@
 package com.wanted.codebombalms.problems.set.application.port;
 
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetBrief;
-import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
+import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummaryPage;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface LoadProblemSetPort {
 
-    List<ProblemSetSummary> loadActiveProblemSetsByCategory(Long categoryId);
+    ProblemSetSummaryPage loadActiveProblemSetsByCategory(Long categoryId, int page, int size);
 
-    List<ProblemSetSummary> loadActiveProblemSets();
+    ProblemSetSummaryPage loadActiveProblemSets(int page, int size);
 
     // 챗봇 adapter용 단건 조회
     Optional<ProblemSetBrief> loadById(Long problemSetId);

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/query/GetProblemSetsQuery.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/query/GetProblemSetsQuery.java
@@ -1,6 +1,8 @@
 package com.wanted.codebombalms.problems.set.application.query;
 
 public record GetProblemSetsQuery(
-        Long categoryId
+        Long categoryId,
+        int page,
+        int size
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.zaxxer.hikari.util.ClockSource.elapsedNanos;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.problems.set.domain.model.ProblemDetail;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetEntry;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetProgressState;
 import com.wanted.codebombalms.problems.set.application.usecase.ValidateProblemSetAccessUseCase;
+import com.wanted.codebombalms.problems.set.infrastructure.metrics.ProblemSetEntryMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
     private final LoadProgressProblemPort loadProgressProblemPort;
     private final IncreaseProblemSetStartedCountPort increaseProblemSetStartedCountPort;
     private final ValidateProblemSetAccessUseCase validateProblemSetAccessUseCase;
+    private final ProblemSetEntryMetrics problemSetEntryMetrics;
 
     @Override
     @Transactional
@@ -37,24 +39,37 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
         long startNanos = System.nanoTime();
 
         try {
+        long accessStartedAt = System.nanoTime();
         validateProblemSetAccessUseCase.validate(
                 query.userId(),
                 query.problemSetId()
         );
+        long accessNanos = elapsedNanos(accessStartedAt);
+        problemSetEntryMetrics.recordAccess(accessNanos);
+
+        long problemSetStartedAt = System.nanoTime();
         ProblemSetEntry problemSet =
                 loadProblemSetEntryPort.loadProblemSetEntry(query.problemSetId());
+        long problemSetNanos = elapsedNanos(problemSetStartedAt);
+        problemSetEntryMetrics.recordProblemSet(problemSetNanos);
 
+        long progressStartedAt = System.nanoTime();
         ProblemSetProgressState progress =
                 findOrCreateProblemSetProgressPort.findOrCreateProgress(query.userId(), query.problemSetId());
         if (Boolean.TRUE.equals(progress.created())) {
             increaseProblemSetStartedCountPort.increaseStartedUserCount(query.problemSetId());
         }
+        long progressNanos = elapsedNanos(progressStartedAt);
+        problemSetEntryMetrics.recordProgress(progressNanos);
 
+        long progressItemsStartedAt = System.nanoTime();
         var progressItems = loadProgressProblemPort.loadProgressProblems(
                 query.userId(),
                 query.problemSetId(),
                 progress.currentProblemNumber()
         );
+        long progressItemsNanos = elapsedNanos(progressItemsStartedAt);
+        problemSetEntryMetrics.recordProgressItems(progressItemsNanos);
 
         Map<Long, ProblemProgressItem> progressItemMap = progressItems.stream()
                 .collect(Collectors.toMap(
@@ -62,10 +77,13 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
                         Function.identity()
                 ));
 
+        long problemDetailsStartedAt = System.nanoTime();
         var problems = loadProblemForEntryPort.loadProblems(query.problemSetId())
                 .stream()
                 .map(problem -> toDetailItemView(problem, progressItemMap.get(problem.getProblemId())))
                 .toList();
+        long problemDetailsNanos = elapsedNanos(problemDetailsStartedAt);
+        problemSetEntryMetrics.recordProblemDetails(problemDetailsNanos);
 
         Long currentProblemId = problems.stream()
                 .filter(problem -> problem.problemNumber().equals(progress.currentProblemNumber()))
@@ -89,13 +107,22 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
                 problems
         );
 
+        long totalNanos = elapsedNanos(startNanos);
+        problemSetEntryMetrics.recordTotal(totalNanos);
+
         log.info(
-                "event=problem_set_entered userId={} problemSetId={} problemCount={} solvedProblemCount={} durationMs={}",
+                "event=problem_set_entered userId={} problemSetId={} problemCount={} solvedProblemCount={} "
+                        + "accessMs={} problemSetMs={} progressMs={} progressItemsMs={} problemDetailsMs={} durationMs={}",
                 query.userId(),
                 query.problemSetId(),
                 problems.size(),
                 solvedProblemCount,
-                elapsedMillis(startNanos)
+                nanosToMillis(accessNanos),
+                nanosToMillis(problemSetNanos),
+                nanosToMillis(progressNanos),
+                nanosToMillis(progressItemsNanos),
+                nanosToMillis(problemDetailsNanos),
+                nanosToMillis(totalNanos)
         );
 
         return view;
@@ -105,15 +132,19 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
                     query.userId(),
                     query.problemSetId(),
                     e.getClass().getSimpleName(),
-                    elapsedMillis(startNanos),
+                    nanosToMillis(elapsedNanos(startNanos)),
                     e
             );
             throw e;
         }
     }
 
-    private long elapsedMillis(long startNanos) {
-        return (System.nanoTime() - startNanos) / 1_000_000;
+    private long elapsedNanos(long startNanos) {
+        return System.nanoTime() - startNanos;
+    }
+
+    private long nanosToMillis(long elapsedNanos) {
+        return elapsedNanos / 1_000_000;
     }
 
     private ProblemDetailItemView toDetailItemView(

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static com.zaxxer.hikari.util.ClockSource.elapsedNanos;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -108,7 +110,6 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
         );
 
         long totalNanos = elapsedNanos(startNanos);
-        problemSetEntryMetrics.recordTotal(totalNanos);
 
         log.info(
                 "event=problem_set_entered userId={} problemSetId={} problemCount={} solvedProblemCount={} "
@@ -136,6 +137,8 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
                     e
             );
             throw e;
+        } finally {
+            problemSetEntryMetrics.recordTotal(elapsedNanos(startNanos));
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
@@ -1,17 +1,17 @@
 package com.wanted.codebombalms.problems.set.application.service;
 
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.problems.set.application.port.CheckProblemSetCategoryPort;
 import com.wanted.codebombalms.problems.set.application.port.LoadProblemSetPort;
 import com.wanted.codebombalms.problems.set.application.query.GetProblemSetsQuery;
 import com.wanted.codebombalms.problems.set.application.usecase.GetProblemSetsUseCase;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
-import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummaryPage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,22 +22,46 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ProblemSetSummaryView> handle(GetProblemSetsQuery query) {
+    public ProblemSetPageView handle(GetProblemSetsQuery query) {
+        validatePageRequest(query.page(), query.size());
+
+        ProblemSetSummaryPage problemSets;
+
         if (query.categoryId() == null) {
-            return loadProblemSetPort.loadActiveProblemSets()
-                    .stream()
-                    .map(this::toView)
-                    .toList();
+            problemSets = loadProblemSetPort.loadActiveProblemSets(query.page(), query.size());
+            return toPageView(problemSets);
         }
 
         if (!checkProblemSetCategoryPort.existsActiveCategory(query.categoryId())) {
             throw new NotFoundException(ProblemErrorCode.CATEGORY_NOT_FOUND);
         }
 
-        return loadProblemSetPort.loadActiveProblemSetsByCategory(query.categoryId())
+        problemSets = loadProblemSetPort.loadActiveProblemSetsByCategory(
+                query.categoryId(),
+                query.page(),
+                query.size()
+        );
+        return toPageView(problemSets);
+    }
+
+    private void validatePageRequest(int page, int size) {
+        if (page < 0 || size < 1 || size > 100) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+    }
+
+    private ProblemSetPageView toPageView(ProblemSetSummaryPage page) {
+        return new ProblemSetPageView(
+                page.content()
                 .stream()
                 .map(this::toView)
-                .toList();
+                .toList(),
+                page.page(),
+                page.size(),
+                page.totalElements(),
+                page.totalPages(),
+                page.hasNext()
+        );
     }
 
     // === 챗봇 adapter용 메서드 ===

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
@@ -44,8 +44,16 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
         return toPageView(problemSets);
     }
 
+    private static final int MAX_PAGE_SIZE = 100;
+    private static final long MAX_PAGE_OFFSET = 100_000L;
+
     private void validatePageRequest(int page, int size) {
-        if (page < 0 || size < 1 || size > 100) {
+        if (page < 0 || size < 1 || size > MAX_PAGE_SIZE) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
+        }
+
+        long offset = (long) page * size;
+        if (offset > MAX_PAGE_OFFSET) {
             throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
         }
     }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/GetProblemSetsUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/GetProblemSetsUseCase.java
@@ -7,7 +7,17 @@ import java.util.List;
 
 public interface GetProblemSetsUseCase {
 
-    List<ProblemSetSummaryView> handle(GetProblemSetsQuery query);
+    ProblemSetPageView handle(GetProblemSetsQuery query);
+
+    record ProblemSetPageView(
+            List<ProblemSetSummaryView> content,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean hasNext
+    ) {
+    }
 
     record ProblemSetSummaryView(
             Long problemSetId,

--- a/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetSummaryPage.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetSummaryPage.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.problems.set.domain.model;
+
+import java.util.List;
+
+public record ProblemSetSummaryPage(
+        List<ProblemSetSummary> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemSetEntryLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemSetEntryLoadTestSeeder.java
@@ -1,0 +1,285 @@
+package com.wanted.codebombalms.problems.set.infrastructure.loadtest;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@Profile("loadtest & !loadtest-admin")
+@RequiredArgsConstructor
+public class ProblemSetEntryLoadTestSeeder implements ApplicationRunner {
+
+    private static final int USER_COUNT = 300;
+    private static final int PROBLEM_COUNT = 20;
+    private static final int SUBMISSIONS_PER_PROBLEM = 2;
+    private static final long USER_ID_START = 830001L;
+    private static final long CATEGORY_ID = 830001L;
+    private static final long PROBLEM_SET_ID = 830001L;
+    private static final long PROBLEM_ID_START = 830001L;
+    private static final long DATASET_ID = 830001L;
+    private static final long AUTHOR_ID = 830000L;
+    private static final String PASSWORD = "Test1234!";
+
+    private final JdbcTemplate jdbc;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        long startNanos = System.nanoTime();
+
+        seedUsers();
+        seedCategory();
+        seedProblemSet();
+        seedDataset();
+        seedProblems();
+        seedProgresses();
+        clearSubmissions();
+        seedSubmissions();
+
+        log.info(
+                "event=problem_set_entry_loadtest_seed_completed users={} problemSetId={} problems={} "
+                        + "submissionsPerProblem={} durationMs={}",
+                USER_COUNT,
+                PROBLEM_SET_ID,
+                PROBLEM_COUNT,
+                SUBMISSIONS_PER_PROBLEM,
+                elapsedMillis(startNanos)
+        );
+    }
+
+    private void seedUsers() {
+        String hash = passwordEncoder.encode(PASSWORD);
+
+        jdbc.update("""
+                insert into users
+                  (user_id, role, email, password, name, nickname, provider,
+                   email_verified, is_locked, created_at, updated_at)
+                values
+                  (?, 'OPERATOR', ?, ?, 'Entry Operator', 'problem-entry-operator',
+                   'LOCAL', true, false, now(6), now(6))
+                on duplicate key update
+                  role = values(role),
+                  password = values(password),
+                  name = values(name),
+                  nickname = values(nickname),
+                  updated_at = now(6),
+                  deleted_at = null
+                """, AUTHOR_ID, "problem-entry-operator@test.com", hash);
+
+        jdbc.batchUpdate("""
+                insert into users
+                  (user_id, role, email, password, name, nickname, provider,
+                   email_verified, is_locked, created_at, updated_at)
+                values
+                  (?, 'STUDENT', ?, ?, ?, ?, 'LOCAL', true, false, now(6), now(6))
+                on duplicate key update
+                  role = values(role),
+                  password = values(password),
+                  name = values(name),
+                  nickname = values(nickname),
+                  updated_at = now(6),
+                  deleted_at = null
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                long userId = USER_ID_START + i;
+
+                ps.setLong(1, userId);
+                ps.setString(2, "problem-entry-loadtest-" + userId + "@test.com");
+                ps.setString(3, hash);
+                ps.setString(4, "EntryUser" + (i + 1));
+                ps.setString(5, "problem-entry-" + userId);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return USER_COUNT;
+            }
+        });
+    }
+
+    private void seedCategory() {
+        jdbc.update("""
+                insert into problem_category
+                  (category_id, category_name, description, status)
+                values
+                  (?, 'Problem Set Entry Loadtest', 'Problem set entry bottleneck loadtest category', 'ACTIVE')
+                on duplicate key update
+                  category_name = values(category_name),
+                  description = values(description),
+                  status = values(status)
+                """, CATEGORY_ID);
+    }
+
+    private void seedProblemSet() {
+        jdbc.update("""
+                insert into problem_set
+                  (problem_set_id, category_id, title, description, difficulty, status,
+                   total_problem_count, completed_user_count, started_user_count, created_by, created_at, deleted_at)
+                values
+                  (?, ?, 'Problem Set Entry Loadtest',
+                   'Problem set entry API bottleneck loadtest set',
+                   'EASY', 'ACTIVE', ?, 0, ?, ?, now(6), null)
+                on duplicate key update
+                  category_id = values(category_id),
+                  title = values(title),
+                  description = values(description),
+                  difficulty = values(difficulty),
+                  status = values(status),
+                  total_problem_count = values(total_problem_count),
+                  started_user_count = values(started_user_count),
+                  created_by = values(created_by),
+                  deleted_at = null
+                """, PROBLEM_SET_ID, CATEGORY_ID, PROBLEM_COUNT, USER_COUNT, AUTHOR_ID);
+    }
+
+    private void seedDataset() {
+        jdbc.update("""
+                insert into problem_dataset
+                  (dataset_id, problem_set_id, original_file_name, stored_file_name, file_url,
+                   file_path, file_size, status, created_at, updated_at)
+                values
+                  (?, ?, 'problem-entry-loadtest.csv', 'problem-entry-loadtest.csv',
+                   'https://example.com/problem-entry-loadtest.csv',
+                   'datasets/problem-entry-loadtest.csv', 1024, 'ACTIVE', now(6), now(6))
+                on duplicate key update
+                  problem_set_id = values(problem_set_id),
+                  original_file_name = values(original_file_name),
+                  stored_file_name = values(stored_file_name),
+                  file_url = values(file_url),
+                  file_path = values(file_path),
+                  file_size = values(file_size),
+                  status = values(status),
+                  updated_at = now(6)
+                """, DATASET_ID, PROBLEM_SET_ID);
+    }
+
+    private void seedProblems() {
+        jdbc.batchUpdate("""
+                insert into problem
+                  (problem_id, problem_set_id, title, content, problem_type, difficulty,
+                   explanation, point, attempt_limit, is_retriable, status, problem_order)
+                values
+                  (?, ?, ?, ?, 'CODE', 'EASY', ?, 10, 3, true, 'ACTIVE', ?)
+                on duplicate key update
+                  problem_set_id = values(problem_set_id),
+                  title = values(title),
+                  content = values(content),
+                  problem_type = values(problem_type),
+                  difficulty = values(difficulty),
+                  explanation = values(explanation),
+                  point = values(point),
+                  attempt_limit = values(attempt_limit),
+                  is_retriable = values(is_retriable),
+                  status = values(status),
+                  problem_order = values(problem_order)
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                int problemNumber = i + 1;
+
+                ps.setLong(1, PROBLEM_ID_START + i);
+                ps.setLong(2, PROBLEM_SET_ID);
+                ps.setString(3, "Problem Entry Loadtest Problem " + problemNumber);
+                ps.setString(4, "Loadtest content for problem " + problemNumber);
+                ps.setString(5, "Loadtest explanation for problem " + problemNumber);
+                ps.setInt(6, problemNumber);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return PROBLEM_COUNT;
+            }
+        });
+    }
+
+    private void seedProgresses() {
+        jdbc.batchUpdate("""
+                insert into problem_progress
+                  (user_id, problem_set_id, current_problem_number, is_completed, completed_at, updated_at)
+                values
+                  (?, ?, ?, false, null, now(6))
+                on duplicate key update
+                  current_problem_number = values(current_problem_number),
+                  is_completed = values(is_completed),
+                  completed_at = null,
+                  updated_at = now(6)
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                ps.setLong(1, USER_ID_START + i);
+                ps.setLong(2, PROBLEM_SET_ID);
+                ps.setInt(3, PROBLEM_COUNT);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return USER_COUNT;
+            }
+        });
+    }
+
+    private void clearSubmissions() {
+        jdbc.update("""
+                delete from submission
+                 where user_id between ? and ?
+                   and problem_id between ? and ?
+                """,
+                USER_ID_START,
+                USER_ID_START + USER_COUNT - 1,
+                PROBLEM_ID_START,
+                PROBLEM_ID_START + PROBLEM_COUNT - 1
+        );
+    }
+
+
+
+    private void seedSubmissions() {
+        jdbc.batchUpdate("""
+                insert into submission
+                  (user_id, problem_id, submitted_code, is_correct, attempt_no,
+                   passed_test_count, total_test_count, execution_status, error_message, submitted_at)
+                values
+                  (?, ?, ?, ?, ?, ?, 10, 'SUCCESS', null, timestampadd(second, ?, now(6)))
+                """, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                int perUser = PROBLEM_COUNT * SUBMISSIONS_PER_PROBLEM;
+                int userIndex = i / perUser;
+                int localIndex = i % perUser;
+                int problemIndex = localIndex / SUBMISSIONS_PER_PROBLEM;
+                int attemptNo = (localIndex % SUBMISSIONS_PER_PROBLEM) + 1;
+                boolean latestAttempt = attemptNo == SUBMISSIONS_PER_PROBLEM;
+                boolean correct = latestAttempt && problemIndex % 3 != 0;
+
+                ps.setLong(1, USER_ID_START + userIndex);
+                ps.setLong(2, PROBLEM_ID_START + problemIndex);
+                ps.setString(3, "print('problem-entry-loadtest')");
+                ps.setBoolean(4, correct);
+                ps.setInt(5, attemptNo);
+                ps.setInt(6, correct ? 10 : 3);
+                ps.setInt(7, -(perUser - localIndex));
+            }
+
+            @Override
+            public int getBatchSize() {
+                return USER_COUNT * PROBLEM_COUNT * SUBMISSIONS_PER_PROBLEM;
+            }
+        });
+    }
+
+    private long elapsedMillis(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemSetEntryLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/loadtest/ProblemSetEntryLoadTestSeeder.java
@@ -138,6 +138,7 @@ public class ProblemSetEntryLoadTestSeeder implements ApplicationRunner {
                   difficulty = values(difficulty),
                   status = values(status),
                   total_problem_count = values(total_problem_count),
+                completed_user_count = values(completed_user_count),
                   started_user_count = values(started_user_count),
                   created_by = values(created_by),
                   deleted_at = null
@@ -232,14 +233,16 @@ public class ProblemSetEntryLoadTestSeeder implements ApplicationRunner {
 
     private void clearSubmissions() {
         jdbc.update("""
-                delete from submission
-                 where user_id between ? and ?
-                   and problem_id between ? and ?
-                """,
+            delete s
+              from submission s
+              join problem p
+                on p.problem_id = s.problem_id
+             where s.user_id between ? and ?
+               and p.problem_set_id = ?
+            """,
                 USER_ID_START,
                 USER_ID_START + USER_COUNT - 1,
-                PROBLEM_ID_START,
-                PROBLEM_ID_START + PROBLEM_COUNT - 1
+                PROBLEM_SET_ID
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/metrics/ProblemSetEntryMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/metrics/ProblemSetEntryMetrics.java
@@ -1,0 +1,62 @@
+package com.wanted.codebombalms.problems.set.infrastructure.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProblemSetEntryMetrics {
+
+    private final Timer totalTimer;
+    private final Timer accessTimer;
+    private final Timer problemSetTimer;
+    private final Timer progressTimer;
+    private final Timer progressItemsTimer;
+    private final Timer problemDetailsTimer;
+
+    public ProblemSetEntryMetrics(MeterRegistry registry) {
+        this.totalTimer = Timer.builder("problem_set_entry_duration")
+                .description("Problem set entry total duration")
+                .register(registry);
+        this.accessTimer = Timer.builder("problem_set_entry_access_duration")
+                .description("Problem set entry access validation duration")
+                .register(registry);
+        this.problemSetTimer = Timer.builder("problem_set_entry_problem_set_duration")
+                .description("Problem set base lookup duration during entry")
+                .register(registry);
+        this.progressTimer = Timer.builder("problem_set_entry_progress_duration")
+                .description("Problem set progress lookup or creation duration during entry")
+                .register(registry);
+        this.progressItemsTimer = Timer.builder("problem_set_entry_progress_items_duration")
+                .description("Problem progress item lookup duration during entry")
+                .register(registry);
+        this.problemDetailsTimer = Timer.builder("problem_set_entry_problem_details_duration")
+                .description("Problem detail lookup and response mapping duration during entry")
+                .register(registry);
+    }
+
+    public void recordTotal(long elapsedNanos) {
+        totalTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordAccess(long elapsedNanos) {
+        accessTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordProblemSet(long elapsedNanos) {
+        problemSetTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordProgress(long elapsedNanos) {
+        progressTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordProgressItems(long elapsedNanos) {
+        progressItemsTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordProblemDetails(long elapsedNanos) {
+        problemDetailsTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetPersistenceAdapter.java
@@ -8,11 +8,13 @@ import com.wanted.codebombalms.problems.set.application.port.IncreaseProblemSetC
 import com.wanted.codebombalms.problems.set.application.port.IncreaseProblemSetStartedCountPort;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetStatus;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
+import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummaryPage;
 import com.wanted.codebombalms.problems.set.application.port.LoadProblemSetPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -27,19 +29,14 @@ public class ProblemSetPersistenceAdapter implements
     private final SpringDataProblemSetRepository problemSetRepository;
 
     @Override
-    public List<ProblemSetSummary> loadActiveProblemSetsByCategory(Long categoryId) {
-        var problemSets =
-                problemSetRepository.findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(
-                        categoryId,
-                        ProblemSetStatus.ACTIVE
-                );
+    public ProblemSetSummaryPage loadActiveProblemSetsByCategory(Long categoryId, int page, int size) {
+        var problemSets = problemSetRepository.findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(
+                categoryId,
+                ProblemSetStatus.ACTIVE,
+                PageRequest.of(page, size)
+        );
 
-        return IntStream.range(0, problemSets.size())
-                .mapToObj(index -> ProblemSetMapper.toSummary(
-                        problemSets.get(index),
-                        index + 1
-                ))
-                .toList();
+        return toSummaryPage(problemSets, page, size);
     }
 
     @Override
@@ -70,17 +67,37 @@ public class ProblemSetPersistenceAdapter implements
     }
 
     @Override
-    public List<ProblemSetSummary> loadActiveProblemSets() {
+    public ProblemSetSummaryPage loadActiveProblemSets(int page, int size) {
         var problemSets = problemSetRepository.findByStatusOrderByProblemSetIdAsc(
-                ProblemSetStatus.ACTIVE
+                ProblemSetStatus.ACTIVE,
+                PageRequest.of(page, size)
         );
 
-        return IntStream.range(0, problemSets.size())
+        return toSummaryPage(problemSets, page, size);
+    }
+
+    private ProblemSetSummaryPage toSummaryPage(
+            Page<ProblemSetJpaEntity> problemSets,
+            int page,
+            int size
+    ) {
+        int startNumber = page * size + 1;
+
+        var content = IntStream.range(0, problemSets.getContent().size())
                 .mapToObj(index -> ProblemSetMapper.toSummary(
-                        problemSets.get(index),
-                        index + 1
+                        problemSets.getContent().get(index),
+                        startNumber + index
                 ))
                 .toList();
+
+        return new ProblemSetSummaryPage(
+                content,
+                page,
+                size,
+                problemSets.getTotalElements(),
+                problemSets.getTotalPages(),
+                problemSets.hasNext()
+        );
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.List;
 
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -18,8 +20,19 @@ public interface SpringDataProblemSetRepository extends JpaRepository<ProblemSet
             ProblemSetStatus status
     );
 
+    Page<ProblemSetJpaEntity> findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(
+            Long categoryId,
+            ProblemSetStatus status,
+            Pageable pageable
+    );
+
     List<ProblemSetJpaEntity> findByStatusOrderByProblemSetIdAsc(
             ProblemSetStatus status
+    );
+
+    Page<ProblemSetJpaEntity> findByStatusOrderByProblemSetIdAsc(
+            ProblemSetStatus status,
+            Pageable pageable
     );
 
     @Transactional

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
@@ -44,33 +44,40 @@ public class ProblemSetController {
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(
-                                    name = "문제 세트 목록",
+                                    name = "문제 세트 페이지 목록",
                                     value = """
                                             {
                                               "timestamp": "2026-05-27T12:00:00",
                                               "status": 200,
                                               "code": "COMMON-SUCCESS",
                                               "message": "요청이 성공적으로 처리되었습니다.",
-                                              "data": [
-                                                {
-                                                  "problemSetId": 3001,
-                                                  "problemNumber": 1,
-                                                  "title": "pandas 기초 분석 문제 세트",
-                                                  "description": "CSV 데이터를 불러와 기본 정보를 확인하는 문제 세트입니다.",
-                                                  "difficulty": "EASY",
-                                                  "accuracyRate": 75.5,
-                                                  "createdAt": "2026-05-27T10:00:00"
-                                                },
-                                                {
-                                                  "problemSetId": 3002,
-                                                  "problemNumber": 2,
-                                                  "title": "DataFrame 필터링 문제 세트",
-                                                  "description": "조건에 맞는 데이터를 필터링하는 문제 세트입니다.",
-                                                  "difficulty": "MEDIUM",
-                                                  "accuracyRate": null,
-                                                  "createdAt": "2026-05-27T11:00:00"
-                                                }
-                                              ]
+                                              "data": {
+                                                "content": [
+                                                  {
+                                                    "problemSetId": 3001,
+                                                    "problemNumber": 1,
+                                                    "title": "pandas 기초 분석 문제 세트",
+                                                    "description": "CSV 데이터를 불러와 기본 정보를 확인하는 문제 세트입니다.",
+                                                    "difficulty": "EASY",
+                                                    "accuracyRate": 75.5,
+                                                    "createdAt": "2026-05-27T10:00:00"
+                                                  },
+                                                  {
+                                                    "problemSetId": 3002,
+                                                    "problemNumber": 2,
+                                                    "title": "DataFrame 필터링 문제 세트",
+                                                    "description": "조건에 맞는 데이터를 필터링하는 문제 세트입니다.",
+                                                    "difficulty": "MEDIUM",
+                                                    "accuracyRate": null,
+                                                    "createdAt": "2026-05-27T11:00:00"
+                                                  }
+                                                ],
+                                                "page": 0,
+                                                "size": 20,
+                                                "totalElements": 2,
+                                                "totalPages": 1,
+                                                "hasNext": false
+                                              }
                                             }
                                             """
                             )
@@ -78,21 +85,35 @@ public class ProblemSetController {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "PRB-CAT-002 - 잘못된 문제 분야",
+                    description = "PRB-CAT-002 - 잘못된 문제 분야 또는 PRB-INP-001 - 잘못된 페이징 요청",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    name = "잘못된 카테고리",
-                                    value = """
-                                            {
-                                              "timestamp": "2026-05-27T12:00:00",
-                                              "status": 400,
-                                              "code": "PRB-CAT-002",
-                                              "message": "잘못된 문제 분야입니다.",
-                                              "path": "/api/v1/problem-sets"
-                                            }
-                                            """
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "잘못된 카테고리",
+                                            value = """
+                                                    {
+                                                      "timestamp": "2026-05-27T12:00:00",
+                                                      "status": 400,
+                                                      "code": "PRB-CAT-002",
+                                                      "message": "잘못된 문제 분야입니다.",
+                                                      "path": "/api/v1/problem-sets"
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "잘못된 페이징 요청",
+                                            value = """
+                                                    {
+                                                      "timestamp": "2026-05-27T12:00:00",
+                                                      "status": 400,
+                                                      "code": "PRB-INP-001",
+                                                      "message": "문제 입력값이 올바르지 않습니다.",
+                                                      "path": "/api/v1/problem-sets"
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
@@ -8,7 +8,7 @@ import com.wanted.codebombalms.problems.set.application.query.GetProblemSetsQuer
 import com.wanted.codebombalms.problems.set.application.usecase.EnterProblemSetUseCase;
 import com.wanted.codebombalms.problems.set.application.usecase.GetProblemSetsUseCase;
 import com.wanted.codebombalms.problems.set.presentation.response.ProblemSetEnterResponse;
-import com.wanted.codebombalms.problems.set.presentation.response.ProblemSetListResponse;
+import com.wanted.codebombalms.problems.set.presentation.response.ProblemSetPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,8 +22,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @Tag(name = "문제 세트", description = "학생이 문제 세트 목록을 조회하고 문제 풀이에 진입하는 API")
 @RestController
@@ -118,15 +116,16 @@ public class ProblemSetController {
             )
     })
     @GetMapping("/api/v1/problem-sets")
-    public ResponseEntity<ApiResponse<List<ProblemSetListResponse>>> findProblemSets(
+    public ResponseEntity<ApiResponse<ProblemSetPageResponse>> findProblemSets(
             @Parameter(description = "조회할 문제 카테고리 ID", example = "3001")
-            @RequestParam(required = false) Long categoryId
+            @RequestParam(required = false) Long categoryId,
+            @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size
     ) {
-        var query = new GetProblemSetsQuery(categoryId);
-        var response = getProblemSetsUseCase.handle(query)
-                .stream()
-                .map(ProblemSetListResponse::new)
-                .toList();
+        var query = new GetProblemSetsQuery(categoryId, page, size);
+        var response = ProblemSetPageResponse.from(getProblemSetsUseCase.handle(query));
 
         return ResponseEntity.ok(ApiResponse.success(
                 ApiResponseCode.SUCCESS,

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetPageResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetPageResponse.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.problems.set.presentation.response;
+
+import com.wanted.codebombalms.problems.set.application.usecase.GetProblemSetsUseCase.ProblemSetPageView;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record ProblemSetPageResponse(
+        @Schema(description = "문제 세트 목록")
+        List<ProblemSetListResponse> content,
+
+        @Schema(description = "현재 페이지 번호(0부터 시작)", example = "0")
+        int page,
+
+        @Schema(description = "페이지 크기", example = "20")
+        int size,
+
+        @Schema(description = "전체 문제 세트 수", example = "125")
+        long totalElements,
+
+        @Schema(description = "전체 페이지 수", example = "7")
+        int totalPages,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
+    public static ProblemSetPageResponse from(ProblemSetPageView page) {
+        return new ProblemSetPageResponse(
+                page.content()
+                        .stream()
+                        .map(ProblemSetListResponse::new)
+                        .toList(),
+                page.page(),
+                page.size(),
+                page.totalElements(),
+                page.totalPages(),
+                page.hasNext()
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,9 +65,6 @@ gcp:
     badge-image-prefix: ${GCP_BADGE_IMAGE_PREFIX:badge_image}
     course-thumbnail-prefix: ${GCP_COURSE_THUMBNAIL_PREFIX:course_thumbnail_images}
     lecture-material-prefix: ${GCP_STORAGE_LECTURE_MATERIAL_PREFIX:lecture_materials}
-  credentials:
-    location: ${GCP_CREDENTIALS_LOCATION:file:./secrets/gcp-storage-key.json}
-
 
 code-runner:
   type: cloud-run

--- a/src/test/java/com/wanted/codebombalms/global/infrastructure/storage/GcsConnectionTest.java
+++ b/src/test/java/com/wanted/codebombalms/global/infrastructure/storage/GcsConnectionTest.java
@@ -6,31 +6,26 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.StorageOptions;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 class GcsConnectionTest {
 
-    private static final String TESTER_NAME = "이강욱";
-    private static final DateTimeFormatter FILE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+    private static final String RUN_TEST_ENV = "RUN_GCS_CONNECTION_TEST";
+    private static final String PROJECT_ID_ENV = "GCS_CONNECTION_TEST_PROJECT_ID";
+    private static final String BUCKET_ENV = "GCS_CONNECTION_TEST_BUCKET";
+    private static final String TEST_OBJECT_PREFIX = "gcs-connection-test/";
 
     @Test
-    @DisplayName("서비스 계정 키로 GCS에 연결하고 테스트 파일을 업로드할 수 있다")
-    @EnabledIfEnvironmentVariable(named = "RUN_GCS_CONNECTION_TEST", matches = "true")
+    @DisplayName("ADC 인증으로 GCS 테스트 버킷에 파일을 업로드하고 삭제할 수 있다")
+    @EnabledIfEnvironmentVariable(named = RUN_TEST_ENV, matches = "true")
     void uploadConnectionTestFile() throws Exception {
         GcsConfig config = loadGcsConfig();
-        String objectName = "gcsConnectionTest/"
-                + TESTER_NAME
-                + "-gcs-connection-"
-                + LocalDateTime.now().format(FILE_TIME_FORMATTER)
+        String objectName = TEST_OBJECT_PREFIX
+                + UUID.randomUUID()
                 + ".txt";
 
         var storage = StorageOptions.newBuilder()
@@ -39,60 +34,38 @@ class GcsConnectionTest {
                 .build()
                 .getService();
 
-        BlobInfo blobInfo = BlobInfo.newBuilder(
-                        BlobId.of(config.bucket(), objectName)
-                )
+        BlobId blobId = BlobId.of(config.bucket(), objectName);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
                 .setContentType("text/plain; charset=utf-8")
                 .build();
 
-        storage.create(
-                blobInfo,
-                ("GCS connection test: " + TESTER_NAME).getBytes(StandardCharsets.UTF_8)
-        );
+        try {
+            storage.create(
+                    blobInfo,
+                    "GCS connection test".getBytes(StandardCharsets.UTF_8)
+            );
 
-        assertThat(storage.get(config.bucket(), objectName)).isNotNull();
-        System.out.println("GCS connection test uploaded: gs://" + config.bucket() + "/" + objectName);
+            assertThat(storage.get(blobId)).isNotNull();
+        } finally {
+            storage.delete(blobId);
+        }
     }
 
-    private GcsConfig loadGcsConfig() throws Exception {
-        List<String> lines = Files.readAllLines(Path.of("src/main/resources/application.yml"));
-
-        String projectId = resolvePlaceholder(findValue(lines, "project-id:"));
-        String bucket = resolvePlaceholder(findValue(lines, "bucket:"));
-
+    private GcsConfig loadGcsConfig() {
         return new GcsConfig(
-                projectId,
-                bucket
+                requiredEnv(PROJECT_ID_ENV),
+                requiredEnv(BUCKET_ENV)
         );
     }
 
-    private String findValue(List<String> lines, String key) {
-        return lines.stream()
-                .map(String::trim)
-                .filter(line -> line.startsWith(key))
-                .map(line -> line.substring(key.length()).trim())
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Missing GCS config: " + key));
-    }
+    private String requiredEnv(String key) {
+        String value = System.getenv(key);
 
-    private String resolvePlaceholder(String value) {
-        if (!value.startsWith("${") || !value.endsWith("}")) {
-            return value;
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Missing environment variable: " + key);
         }
 
-        String expression = value.substring(2, value.length() - 1);
-        String[] parts = expression.split(":", 2);
-        String envValue = System.getenv(parts[0]);
-
-        if (envValue != null && !envValue.isBlank()) {
-            return envValue;
-        }
-
-        if (parts.length == 2) {
-            return parts[1];
-        }
-
-        throw new IllegalStateException("Missing environment variable: " + parts[0]);
+        return value;
     }
 
     private record GcsConfig(

--- a/src/test/java/com/wanted/codebombalms/global/infrastructure/storage/GcsConnectionTest.java
+++ b/src/test/java/com/wanted/codebombalms/global/infrastructure/storage/GcsConnectionTest.java
@@ -33,27 +33,25 @@ class GcsConnectionTest {
                 + LocalDateTime.now().format(FILE_TIME_FORMATTER)
                 + ".txt";
 
-        try (InputStream inputStream = Files.newInputStream(Path.of(config.credentialsPath()))) {
-            var storage = StorageOptions.newBuilder()
-                    .setProjectId(config.projectId())
-                    .setCredentials(GoogleCredentials.fromStream(inputStream))
-                    .build()
-                    .getService();
+        var storage = StorageOptions.newBuilder()
+                .setProjectId(config.projectId())
+                .setCredentials(GoogleCredentials.getApplicationDefault())
+                .build()
+                .getService();
 
-            BlobInfo blobInfo = BlobInfo.newBuilder(
-                            BlobId.of(config.bucket(), objectName)
-                    )
-                    .setContentType("text/plain; charset=utf-8")
-                    .build();
+        BlobInfo blobInfo = BlobInfo.newBuilder(
+                        BlobId.of(config.bucket(), objectName)
+                )
+                .setContentType("text/plain; charset=utf-8")
+                .build();
 
-            storage.create(
-                    blobInfo,
-                    ("GCS connection test: " + TESTER_NAME).getBytes(StandardCharsets.UTF_8)
-            );
+        storage.create(
+                blobInfo,
+                ("GCS connection test: " + TESTER_NAME).getBytes(StandardCharsets.UTF_8)
+        );
 
-            assertThat(storage.get(config.bucket(), objectName)).isNotNull();
-            System.out.println("GCS connection test uploaded: gs://" + config.bucket() + "/" + objectName);
-        }
+        assertThat(storage.get(config.bucket(), objectName)).isNotNull();
+        System.out.println("GCS connection test uploaded: gs://" + config.bucket() + "/" + objectName);
     }
 
     private GcsConfig loadGcsConfig() throws Exception {
@@ -61,12 +59,10 @@ class GcsConnectionTest {
 
         String projectId = resolvePlaceholder(findValue(lines, "project-id:"));
         String bucket = resolvePlaceholder(findValue(lines, "bucket:"));
-        String credentialsLocation = resolvePlaceholder(findValue(lines, "location:"));
 
         return new GcsConfig(
                 projectId,
-                bucket,
-                credentialsLocation.replaceFirst("^file:", "")
+                bucket
         );
     }
 
@@ -101,8 +97,7 @@ class GcsConnectionTest {
 
     private record GcsConfig(
             String projectId,
-            String bucket,
-            String credentialsPath
+            String bucket
     ) {
     }
 }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #이슈번호

---

## 🛠️ 기능 관련 작업 내용
- `GET /api/v1/problem-sets` 목록 조회 API에 `page`, `size` 쿼리 파라미터를 추가했습니다.
- 문제 세트 목록 응답을 단순 배열에서 `content`, `page`, `size`, `totalElements`, `totalPages`, `hasNext`를 포함한 페이지 응답 구조로 변경했습니다.
- Repository 조회를 `PageRequest` 기반으로 변경하여 문제 세트 목록을 DB 단계에서 페이징 조회하도록 개선했습니다.
- `categoryId` 필터 조회에도 동일하게 페이징이 적용되도록 처리했습니다.

---

## ♻️ 패키지 변경 사항
- `project/problems/set/presentation`: 문제 세트 목록 조회 API 요청 파라미터 및 페이지 응답 DTO 추가
- `project/problems/set/application`: 문제 세트 목록 조회 Query, UseCase, Service를 페이징 구조로 변경
- `project/problems/set/domain`: 문제 세트 목록 페이지 도메인 모델 추가
- `project/problems/set/infrastructure`: Spring Data JPA 페이징 조회 메서드 및 Persistence Adapter 페이징 처리 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 문제 세트 목록 조회를 페이지네이션 기반으로 전환해, 요청에 `page`, `size`를 지정하고 응답에는 `content`와 `page/size/totalElements/totalPages/hasNext` 정보를 함께 제공합니다.
* **Bug Fixes**
  * 잘못된 `page` 또는 `size` 입력 시 명확한 검증 오류를 반환하도록 개선했습니다.
* **Chores**
  * 문제 세트 입장 처리의 단계별 소요 시간을 메트릭/로깅에 반영했습니다. GCS/GCP 스토리지 초기화 방식이 정리되고, GCP credentials 위치 설정이 제거되었습니다.
* **Tests**
  * 로드 테스트 시딩을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->