### PR TITLE
[Fix] 관리자 계정(master, operator, admin) set-up 면제 설정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -20,6 +20,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.Unauthorized
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -71,7 +72,8 @@ public class LoginService implements LoginUseCase {
         // 5. 적응형 판정 — 신뢰 기기 1차 + 위치 보조
         Optional<TrustedDevice> trusted =
                 trustedDeviceRepository.findByUserIdAndDeviceFp(user.getUserId(), deviceFp);
-        boolean stepUpRequired = trusted.isEmpty() || isCountryChanged(trusted.get(), geo);
+        boolean stepUpRequired = user.getRole() == UserRole.STUDENT
+                && (trusted.isEmpty() || isCountryChanged(trusted.get(), geo));
 
         // 6. 로그인 이력 기록 (의심 여부 = step-up 필요 여부)
         loginHistoryRepository.save(LoginHistory.record(

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -72,13 +72,13 @@ public class LoginService implements LoginUseCase {
         // 5. 적응형 판정 — 신뢰 기기 1차 + 위치 보조
         Optional<TrustedDevice> trusted =
                 trustedDeviceRepository.findByUserIdAndDeviceFp(user.getUserId(), deviceFp);
-        boolean stepUpRequired = user.getRole() == UserRole.STUDENT
-                && (trusted.isEmpty() || isCountryChanged(trusted.get(), geo));
+        boolean suspicious = trusted.isEmpty() || isCountryChanged(trusted.get(), geo);
+        boolean stepUpRequired = user.getRole() == UserRole.STUDENT && suspicious;
 
-        // 6. 로그인 이력 기록 (의심 여부 = step-up 필요 여부)
+        // 6. 로그인 이력 기록 (의심 여부 = 신뢰기기/국가 기준, 역할 무관)
         loginHistoryRepository.save(LoginHistory.record(
                 user.getUserId(), ip, request.getHeader("User-Agent"),
-                deviceFp, geo.country(), geo.city(), stepUpRequired));
+                deviceFp, geo.country(), geo.city(), suspicious));
 
         // 7. 미신뢰/위치 급변 → step-up
         if (stepUpRequired) {


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #109

---

## 🛠️ 기능 관련 작업 내용
- 로그인 적응형 인증(step-up) 발동 대상을 `STUDENT` 역할로 한정
- `OPERATOR`/`ADMIN`/`MASTER` 는 신뢰 기기 등록 없이 정상 로그인 (step-up 면제)
- 학생이 미신뢰 기기·위치 급변으로 로그인할 때만 이메일 OTP step-up 유지

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/application/service/LoginService`: step-up 판정에 `user.getRole() == UserRole.STUDENT` 조건 추가 + `UserRole` import
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 로그인 시 보안 단계 추가 인증이 필요한 조건이 조정되었습니다.
  * 이제 학생 계정에 대해서만 신뢰 기기 미사용 또는 국가 변경 시 추가 인증이 요청됩니다.
  * 학생이 아닌 계정은 같은 조건이 발생해도 불필요한 추가 인증이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->