### PR TITLE
[Fix] 메일 설정 제거(url 제거)

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
@@ -49,13 +49,13 @@ public class JavaMailEmailSender implements EmailSender {
         message.setFrom(fromAddress);
         message.setTo(to);
         message.setSubject("[Code-Bomba LMS] 새로운 기기 로그인 — 추가 인증 코드");
-        message.setText(buildStepUpBody(code, lockUrl));
+        message.setText(buildStepUpBody(code));
 
         mailSender.send(message);
         log.info("[EmailSender] step-up 코드 발송 완료 - to: {}", maskEmail(to));
     }
 
-    private String buildStepUpBody(String code, String lockUrl) {
+    private String buildStepUpBody(String code) {
         return """
                 평소와 다른 기기 또는 위치에서 로그인이 시도되었습니다.
 
@@ -63,9 +63,8 @@ public class JavaMailEmailSender implements EmailSender {
                 인증 코드: %s
                 (이 코드는 5분간 유효합니다.)
 
-                본인이 시도한 로그인이 아니라면, 아래 링크를 눌러 계정을 즉시 잠그세요.
-                %s
-                """.formatted(code, lockUrl);
+                본인이 시도한 로그인이 아니라면, 계정 보호를 위해 즉시 비밀번호를 변경해주세요.
+                """.formatted(code);
     }
 
     /** 로그에 이메일 평문(PII) 노출 방지 — 앞 1글자 + *** + 도메인만 남긴다. (예: j***@gmail.com) */

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,9 @@ spring:
             enable: true
             required: true
 
+server:
+  forward-headers-strategy: framework
+
 jwt:
   secret: ${JWT_SECRET}
 


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #확인 필요

---

## 🛠️ 기능 관련 작업 내용
- 의심 로그인(step-up) 알림 메일에서 `localhost` 잠금 링크 제거
- "본인이 아니라면 즉시 비밀번호를 변경해주세요" 안내 문구로 교체
- 메일 내 외부 클릭 링크 제거로 메일 프리페치 자동잠금 위험 해소
- 계정 잠금 페이지/엔드포인트는 다음 모듈로 이월 (관련 코드 무해 잔존)

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/infrastructure/mail`: `JavaMailEmailSender.buildStepUpBody` 시그니처에서 `lockUrl` 제거, 본문 교체
- `resources/application.yml`: `server.forward-headers-strategy: framework` 유지 (http→https 사전 준비)

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 추가 인증 메일 안내 문구가 변경되어, 계정 잠금 링크 대신 비밀번호를 즉시 변경하도록 안내합니다.
* **개선**
  * 프록시/로드밸런서 환경에서 전달되는 헤더 처리 방식이 조정되어, 배포 환경에서의 요청 처리 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->