### PR TITLE
[Update] 보안 모니터링용 사용자 역할 메트릭 및 요청 로그 보강

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -7,8 +7,8 @@ POST http://localhost:8080/api/v1/auth/login
 Content-Type: application/json
 
 {
-  "email": "admin@codebomba.com",
-  "password": "password"
+  "email": "u01@test.com",
+  "password": "Test1234!"
 }
 
 ### 1. 내 정보 조회 — 정상 (0번 직후 실행)

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -20,6 +20,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    public static final String AUTHENTICATED_USER_ID_ATTRIBUTE = "authenticatedUserId";
+    public static final String AUTHENTICATED_ROLE_ATTRIBUTE = "authenticatedRole";
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
@@ -41,6 +44,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Claims claims = jwtTokenProvider.getClaims(token);
                 Long userId = Long.parseLong(claims.getSubject());
                 String role = claims.get("role", String.class);
+                request.setAttribute(AUTHENTICATED_USER_ID_ATTRIBUTE, userId);
+                request.setAttribute(AUTHENTICATED_ROLE_ATTRIBUTE, role);
 
                 // 4. SecurityContextHolder에 저장
                 UsernamePasswordAuthenticationToken auth =

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.global.infrastructure.logging;
 
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,6 +16,7 @@ import java.util.UUID;
 public class MdcLoggingFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(MdcLoggingFilter.class);
+    private static final String ANONYMOUS = "anonymous";
 
     @Override
     protected void doFilterInternal(
@@ -38,14 +40,27 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
         } finally {
             // MDC.clear() 전에 남겨야 완료 로그에도 traceId 가 붙는다.
             long durationMs = (System.nanoTime() - startAt) / 1_000_000;
-            log.info("event=request_completed method={} uri={} status={} durationMs={}",
+            String userId = resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_USER_ID_ATTRIBUTE);
+            String role = resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_ROLE_ATTRIBUTE);
+            MDC.put("userId", userId);
+            MDC.put("role", role);
+
+            log.info("event=request_completed method={} uri={} status={} durationMs={} userId={} role={} clientIp={}",
                     request.getMethod(),
                     request.getRequestURI(),
                     response.getStatus(),
-                    durationMs);
+                    durationMs,
+                    userId,
+                    role,
+                    resolveClientIp(request));
 
             MDC.clear();
         }
+    }
+
+    private String resolveAttribute(HttpServletRequest request, String name) {
+        Object value = request.getAttribute(name);
+        return value == null ? ANONYMOUS : String.valueOf(value);
     }
 
     private String resolveClientIp(HttpServletRequest request) {

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/DomainObservationConvention.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/DomainObservationConvention.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.global.infrastructure.metrics;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
 import io.micrometer.common.KeyValues;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Set;
 import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.stereotype.Component;
@@ -27,6 +28,7 @@ public class DomainObservationConvention extends DefaultServerRequestObservation
     private static final String BASE_PACKAGE = "com.wanted.codebombalms.";
     private static final String UNKNOWN = "unknown";
     private static final String ANONYMOUS = "anonymous";
+    private static final Set<String> KNOWN_ROLES = Set.of("STUDENT", "OPERATOR", "ADMIN", "MASTER");
 
     @Override
     public KeyValues getLowCardinalityKeyValues(ServerRequestObservationContext context) {
@@ -42,7 +44,12 @@ public class DomainObservationConvention extends DefaultServerRequestObservation
         }
 
         Object role = request.getAttribute(JwtAuthenticationFilter.AUTHENTICATED_ROLE_ATTRIBUTE);
-        return role == null ? ANONYMOUS : String.valueOf(role);
+        if (role == null) {
+            return ANONYMOUS;
+        }
+
+        String normalizedRole = String.valueOf(role).trim().toUpperCase();
+        return KNOWN_ROLES.contains(normalizedRole) ? normalizedRole : UNKNOWN;
     }
 
     private String resolveDomain(ServerRequestObservationContext context) {

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/DomainObservationConvention.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/DomainObservationConvention.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.global.infrastructure.metrics;
 
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
 import io.micrometer.common.KeyValues;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
@@ -25,11 +26,23 @@ public class DomainObservationConvention extends DefaultServerRequestObservation
 
     private static final String BASE_PACKAGE = "com.wanted.codebombalms.";
     private static final String UNKNOWN = "unknown";
+    private static final String ANONYMOUS = "anonymous";
 
     @Override
     public KeyValues getLowCardinalityKeyValues(ServerRequestObservationContext context) {
         return super.getLowCardinalityKeyValues(context)
-                .and("domain", resolveDomain(context));
+                .and("domain", resolveDomain(context))
+                .and("role", resolveRole(context));
+    }
+
+    private String resolveRole(ServerRequestObservationContext context) {
+        HttpServletRequest request = context.getCarrier();
+        if (request == null) {
+            return ANONYMOUS;
+        }
+
+        Object role = request.getAttribute(JwtAuthenticationFilter.AUTHENTICATED_ROLE_ATTRIBUTE);
+        return role == null ? ANONYMOUS : String.valueOf(role);
     }
 
     private String resolveDomain(ServerRequestObservationContext context) {


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #확인 필요

---

## 🛠️ 기능 관련 작업 내용
- JWT 인증 성공 시 요청 attribute에 `userId`, `role` 정보를 저장하도록 보강
- 요청 완료 로그에 `userId`, `role`, `clientIp`를 포함해 보안 이벤트 추적성 개선
- `http_server_requests_seconds_count` 메트릭에 `role` 태그를 추가해 일반 사용자 기준 401/403 알림 필터링 가능하도록 개선
- Prometheus에서는 `role` 기준 집계만 지원하고, 사용자 식별은 로그의 `userId`로 추적하도록 구성

---

## ♻️ 패키지 변경 사항
- `project/global/infrastructure/jwt`: 인증된 사용자의 `userId`, `role`을 요청 attribute로 전달
- `project/global/infrastructure/logging`: 요청 완료 로그에 사용자/권한/클라이언트 IP 정보 추가
- `project/global/infrastructure/metrics`: HTTP 요청 메트릭에 `role` 태그 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 요청 처리 중 인증된 사용자 ID와 역할을 함께 추적하도록 개선되었습니다.
  * 요청 완료 로그에 사용자 ID와 역할이 함께 표시됩니다.
  * 서버 관측 지표에 역할(role) 태그가 추가되었습니다.
* **Bug Fixes**
  * 인증 정보가 없는 경우에도 사용자 ID/역할이 기본값(`anonymous`)으로 기록되어 누락 없이 집계됩니다.
  * 역할 값이 예상 범위를 벗어나면(`unknown`)으로 정규화해 지표 품질을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->