### PR TITLE
[Feat] 챗봇 SSE 스트리밍 및 토큰 사용량 추적

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/application/port/RecordTokenUsagePort.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/port/RecordTokenUsagePort.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.chatbot.application.port;
+
+import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
+
+/**
+ * AI 응답의 토큰 사용량을 관측 시스템에 기록하는 출력 포트.
+ * application 은 이 인터페이스에만 의존하고, 구현(Micrometer 등)은 infrastructure 에 둔다.
+ */
+public interface RecordTokenUsagePort {
+
+    void recordUsage(AiChatStreamChunk.TokenUsage usage);
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
@@ -4,21 +4,24 @@ import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
 import com.wanted.codebombalms.chatbot.application.model.ChatContext;
 import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
+import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatMessageCommandUseCase;
-import com.wanted.codebombalms.chatbot.infrastructure.metrics.ChatMetrics;
+import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatMessageCommandService implements ChatMessageCommandUseCase {
 
     private final AiChatClient aiChatClient;
     private final ChatMessageTransactionService txService;
-    private final ChatMetrics chatMetrics;
+    private final RecordTokenUsagePort recordTokenUsagePort;
 
     @Override
     public Flux<AiChatStreamChunk> send(SendMessageCommand command) {
@@ -38,14 +41,30 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
                     // 3) Done 수신 = 정상 완료 → 완성된 답만 저장(부분답·취소는 저장 안 됨)
                     if (chunk instanceof AiChatStreamChunk.Done done) {
                         // 메트릭은 저장 성공 여부와 무관하게(=실제 소비된 토큰) 항상 먼저 누적한다.
-                        chatMetrics.recordUsage(done.usage());
+                        recordTokenUsagePort.recordUsage(done.usage());
                         return Mono.fromRunnable(
                                         () -> txService.saveAiAnswer(
                                                 command.roomId(), accumulated.toString(), done.usage()))
                                 .subscribeOn(Schedulers.boundedElastic())
-                                .thenReturn((AiChatStreamChunk) chunk);
+                                .thenReturn((AiChatStreamChunk) chunk)
+                                // 저장 실패해도 답변은 이미 생성·전송됨 → done 으로 정상 종료(손실은 로그/알림으로)
+                                .onErrorResume(e -> {
+                                    log.error("event=chat_save_failed roomId={}", command.roomId(), e);
+                                    return Mono.just((AiChatStreamChunk) chunk);
+                                });
                     }
                     return Mono.just(chunk);
-                });
+                })
+                // 4) 종단 안전망: 어떤 예외든 abort(=ERR_INCOMPLETE_CHUNKED_ENCODING) 대신
+                //    error 프레임으로 변환해 스트림을 정상 complete 시킨다.
+                .onErrorResume(e -> {
+                    log.error("event=chat_stream_aborted roomId={}", command.roomId(), e);
+                    return Flux.just(new AiChatStreamChunk.Error(
+                            ChatErrorCode.AI_RESPONSE_FAILED.getCode(),
+                            ChatErrorCode.AI_RESPONSE_FAILED.getMessage()));
+                })
+                // 다음 재현 시 종단 신호(onComplete/onError/cancel)로 원인 구간을 즉시 가른다.
+                .doFinally(signal ->
+                        log.info("event=chat_stream_end roomId={} signal={}", command.roomId(), signal));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
 import com.wanted.codebombalms.chatbot.application.model.ChatContext;
 import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatMessageCommandUseCase;
+import com.wanted.codebombalms.chatbot.infrastructure.metrics.ChatMetrics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -17,6 +18,7 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
 
     private final AiChatClient aiChatClient;
     private final ChatMessageTransactionService txService;
+    private final ChatMetrics chatMetrics;
 
     @Override
     public Flux<AiChatStreamChunk> send(SendMessageCommand command) {
@@ -34,9 +36,12 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
                 })
                 .concatMap(chunk -> {
                     // 3) Done 수신 = 정상 완료 → 완성된 답만 저장(부분답·취소는 저장 안 됨)
-                    if (chunk instanceof AiChatStreamChunk.Done) {
+                    if (chunk instanceof AiChatStreamChunk.Done done) {
+                        // 메트릭은 저장 성공 여부와 무관하게(=실제 소비된 토큰) 항상 먼저 누적한다.
+                        chatMetrics.recordUsage(done.usage());
                         return Mono.fromRunnable(
-                                        () -> txService.saveAiAnswer(command.roomId(), accumulated.toString()))
+                                        () -> txService.saveAiAnswer(
+                                                command.roomId(), accumulated.toString(), done.usage()))
                                 .subscribeOn(Schedulers.boundedElastic())
                                 .thenReturn((AiChatStreamChunk) chunk);
                     }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageTransactionService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageTransactionService.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.chatbot.application.service;
 
 import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
+import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
 import com.wanted.codebombalms.chatbot.application.model.ChatContext;
 import com.wanted.codebombalms.chatbot.domain.model.ChatMessage;
 import com.wanted.codebombalms.chatbot.domain.model.ChatRoom;
@@ -38,10 +39,16 @@ public class ChatMessageTransactionService {
         return chatContextBuilder.build(command, chatRoom);
     }
 
-    /** 스트림 정상 완료 시에만 호출: AI 답변 저장 + 방 타임스탬프 갱신. */
+    /** 스트림 정상 완료 시에만 호출: AI 답변(토큰 사용량 포함) 저장 + 방 타임스탬프 갱신. */
     @Transactional
-    public void saveAiAnswer(Long roomId, String answer) {
-        chatMessageRepository.save(ChatMessage.createAiMessage(roomId, answer));
+    public void saveAiAnswer(Long roomId, String answer, AiChatStreamChunk.TokenUsage usage) {
+        chatMessageRepository.save(ChatMessage.createAiMessage(
+                roomId,
+                answer,
+                usage.promptTokens(),
+                usage.completionTokens(),
+                usage.totalTokens()
+        ));
 
         ChatRoom chatRoom = chatRoomRepository.getById(roomId);
         chatRoom.updateTimestamp(Instant.now());

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/exception/ChatErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/exception/ChatErrorCode.java
@@ -11,7 +11,8 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_NOT_FOUND("CHT-001", "채팅방을 찾을 수 없습니다."),
     CHAT_ROOM_FORBIDDEN("CHT-002", "채팅방에 접근 권한이 없습니다."),
     AI_RESPONSE_FAILED("CHT-003", "AI 응답 생성에 실패했습니다."),
-    CHAT_ROOM_TITLE_INVALID("CHT-004", "채팅방 제목이 올바르지 않습니다.");
+    CHAT_ROOM_TITLE_INVALID("CHT-004", "채팅방 제목이 올바르지 않습니다."),
+    INVALID_TOKEN_USAGE("CHT-005", "토큰 사용량 값이 올바르지 않습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/model/ChatMessage.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/model/ChatMessage.java
@@ -8,31 +8,71 @@ public class ChatMessage {
     private final Long roomId;
     private final MessageRole role;
     private final String content;
+    // 토큰 사용량: AI 응답 행에만 값이 있고 USER 행은 null 이다.
+    private final Integer promptTokens;
+    private final Integer completionTokens;
+    private final Integer totalTokens;
     private final Instant createdAt;
 
-    private ChatMessage(Long id, Long roomId, MessageRole role, String content, Instant createdAt) {
+    private ChatMessage(
+            Long id,
+            Long roomId,
+            MessageRole role,
+            String content,
+            Integer promptTokens,
+            Integer completionTokens,
+            Integer totalTokens,
+            Instant createdAt
+    ) {
         this.id = id;
         this.roomId = roomId;
         this.role = role;
         this.content = content;
+        this.promptTokens = promptTokens;
+        this.completionTokens = completionTokens;
+        this.totalTokens = totalTokens;
         this.createdAt = createdAt;
     }
 
     public static ChatMessage createUserMessage(Long roomId, String content) {
-        return new ChatMessage(null, roomId, MessageRole.USER, content, null);
+        return new ChatMessage(null, roomId, MessageRole.USER, content, null, null, null, null);
     }
 
-    public static ChatMessage createAiMessage(Long roomId, String content) {
-        return new ChatMessage(null, roomId, MessageRole.AI, content, null);
+    public static ChatMessage createAiMessage(
+            Long roomId,
+            String content,
+            Integer promptTokens,
+            Integer completionTokens,
+            Integer totalTokens
+    ) {
+        return new ChatMessage(
+                null, roomId, MessageRole.AI, content,
+                promptTokens, completionTokens, totalTokens, null
+        );
     }
 
-    public static ChatMessage restore(Long id, Long roomId, MessageRole role, String content, Instant createdAt) {
-        return new ChatMessage(id, roomId, role, content, createdAt);
+    public static ChatMessage restore(
+            Long id,
+            Long roomId,
+            MessageRole role,
+            String content,
+            Integer promptTokens,
+            Integer completionTokens,
+            Integer totalTokens,
+            Instant createdAt
+    ) {
+        return new ChatMessage(
+                id, roomId, role, content,
+                promptTokens, completionTokens, totalTokens, createdAt
+        );
     }
 
     public Long getId() { return id; }
     public Long getRoomId() { return roomId; }
     public MessageRole getRole() { return role; }
     public String getContent() { return content; }
+    public Integer getPromptTokens() { return promptTokens; }
+    public Integer getCompletionTokens() { return completionTokens; }
+    public Integer getTotalTokens() { return totalTokens; }
     public Instant getCreatedAt() { return createdAt; }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/model/ChatMessage.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/model/ChatMessage.java
@@ -1,5 +1,8 @@
 package com.wanted.codebombalms.chatbot.domain.model;
 
+import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+
 import java.time.Instant;
 
 public class ChatMessage {
@@ -45,10 +48,22 @@ public class ChatMessage {
             Integer completionTokens,
             Integer totalTokens
     ) {
+        // AI 메시지의 토큰 사용량은 음수일 수 없다(존재하면 0 이상).
+        // 합계 일치(total = prompt + completion)는 강제하지 않는다 — 외부(LLM) 제공 원값을
+        // 그대로 보존·관측하기로 했고, 불일치로 영속을 막으면 답변만 유실되기 때문.
+        requireNonNegative(promptTokens);
+        requireNonNegative(completionTokens);
+        requireNonNegative(totalTokens);
         return new ChatMessage(
                 null, roomId, MessageRole.AI, content,
                 promptTokens, completionTokens, totalTokens, null
         );
+    }
+
+    private static void requireNonNegative(Integer tokenCount) {
+        if (tokenCount != null && tokenCount < 0) {
+            throw new ValidationException(ChatErrorCode.INVALID_TOKEN_USAGE);
+        }
     }
 
     public static ChatMessage restore(

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/MockAiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/MockAiChatClient.java
@@ -25,8 +25,12 @@ public class MockAiChatClient implements AiChatClient {
                 .delayElements(Duration.ofMillis(50))
                 .map(AiChatStreamChunk.Token::new);
 
+        // 토큰 저장/메트릭을 로컬에서 검증할 수 있도록 0이 아닌 임의 사용량을 방출한다.
+        int completion = answer.split("\\s+").length;
+        int prompt = 20 + completion;
         Flux<AiChatStreamChunk> done = Flux.just(
-                new AiChatStreamChunk.Done(new AiChatStreamChunk.TokenUsage(0, 0, 0))
+                new AiChatStreamChunk.Done(
+                        new AiChatStreamChunk.TokenUsage(prompt, completion, prompt + completion))
         );
 
         return Flux.concat(tokens, done);

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.chatbot.infrastructure.metrics;
 
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
+import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -21,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 @Component
-public class ChatMetrics {
+public class ChatMetrics implements RecordTokenUsagePort {
 
     private final Timer listQueryTimer;
     private final Counter promptTokensCounter;
@@ -33,10 +34,12 @@ public class ChatMetrics {
         this.listQueryTimer = Timer.builder("chat_room_list_query_duration")
                 .description("채팅방 목록 조회 구간 시간(문제 제목 fanout 포함)")
                 .register(registry);
-        this.promptTokensCounter = Counter.builder("chat_prompt_tokens_total")
+        // Prometheus 가 counter 에 _total 을 자동으로 붙이므로 등록명에는 붙이지 않는다
+        // (chat_prompt_tokens → chat_prompt_tokens_total 로 노출됨).
+        this.promptTokensCounter = Counter.builder("chat_prompt_tokens")
                 .description("AI 응답 입력(prompt) 토큰 누적량")
                 .register(registry);
-        this.completionTokensCounter = Counter.builder("chat_completion_tokens_total")
+        this.completionTokensCounter = Counter.builder("chat_completion_tokens")
                 .description("AI 응답 출력(completion) 토큰 누적량")
                 .register(registry);
     }
@@ -50,6 +53,7 @@ public class ChatMetrics {
      * AI 응답 1건의 토큰 사용량을 누적한다. DB 저장 성공 여부와 무관하게,
      * 실제 소비된 토큰(=발생한 비용)을 반영하기 위해 항상 호출된다.
      */
+    @Override
     public void recordUsage(AiChatStreamChunk.TokenUsage usage) {
         if (usage.totalTokens() == 0) {
             log.warn("event=chat_token_usage_empty - FastAPI 가 토큰 사용량을 0 으로 반환함(계약 확인 필요)");

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
@@ -1,7 +1,10 @@
 package com.wanted.codebombalms.chatbot.infrastructure.metrics;
 
+import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
@@ -12,11 +15,17 @@ import java.util.concurrent.TimeUnit;
  * <p>HTTP 메트릭({@code http_server_requests})은 요청 전체(컨트롤러~직렬화) 시간만 안다.
  * 이 Timer 는 "목록 조회 내부 구간"만 분리 측정한다. 부하 중 HTTP p95 ↑ 와 이 timer ↑ 가
  * 함께 움직이면 병목 = 목록 쿼리(N+1) 로 좁힐 수 있다.
+ *
+ * <p>토큰 사용량 Counter 는 입력/출력을 분리 누적한다(단가가 달라 비용 계산 시 분리 필수).
+ * total 은 두 Counter 의 합이라 별도 등록하지 않는다.
  */
+@Slf4j
 @Component
 public class ChatMetrics {
 
     private final Timer listQueryTimer;
+    private final Counter promptTokensCounter;
+    private final Counter completionTokensCounter;
 
     public ChatMetrics(MeterRegistry registry) {
         // 등록명엔 _seconds 를 붙이지 않는다. Timer 라서 Prometheus 가
@@ -24,10 +33,28 @@ public class ChatMetrics {
         this.listQueryTimer = Timer.builder("chat_room_list_query_duration")
                 .description("채팅방 목록 조회 구간 시간(문제 제목 fanout 포함)")
                 .register(registry);
+        this.promptTokensCounter = Counter.builder("chat_prompt_tokens_total")
+                .description("AI 응답 입력(prompt) 토큰 누적량")
+                .register(registry);
+        this.completionTokensCounter = Counter.builder("chat_completion_tokens_total")
+                .description("AI 응답 출력(completion) 토큰 누적량")
+                .register(registry);
     }
 
     /** 채팅방 목록 조회(제목 fanout 포함) 구간 소요 시간 기록. */
     public void recordListQuery(long elapsedNanos) {
         listQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * AI 응답 1건의 토큰 사용량을 누적한다. DB 저장 성공 여부와 무관하게,
+     * 실제 소비된 토큰(=발생한 비용)을 반영하기 위해 항상 호출된다.
+     */
+    public void recordUsage(AiChatStreamChunk.TokenUsage usage) {
+        if (usage.totalTokens() == 0) {
+            log.warn("event=chat_token_usage_empty - FastAPI 가 토큰 사용량을 0 으로 반환함(계약 확인 필요)");
+        }
+        promptTokensCounter.increment(usage.promptTokens());
+        completionTokensCounter.increment(usage.completionTokens());
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatMessageJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatMessageJpaEntity.java
@@ -28,14 +28,35 @@ public class ChatMessageJpaEntity {
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Column(name = "prompt_tokens")
+    private Integer promptTokens;
+
+    @Column(name = "completion_tokens")
+    private Integer completionTokens;
+
+    @Column(name = "total_tokens")
+    private Integer totalTokens;
+
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
-    public ChatMessageJpaEntity(Long id, Long roomId, MessageRole role, String content, Instant createdAt) {
+    public ChatMessageJpaEntity(
+            Long id,
+            Long roomId,
+            MessageRole role,
+            String content,
+            Integer promptTokens,
+            Integer completionTokens,
+            Integer totalTokens,
+            Instant createdAt
+    ) {
         this.id = id;
         this.roomId = roomId;
         this.role = role;
         this.content = content;
+        this.promptTokens = promptTokens;
+        this.completionTokens = completionTokens;
+        this.totalTokens = totalTokens;
         this.createdAt = createdAt;
     }
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatMessageMapper.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatMessageMapper.java
@@ -12,6 +12,9 @@ public class ChatMessageMapper {
                 entity.getRoomId(),
                 entity.getRole(),
                 entity.getContent(),
+                entity.getPromptTokens(),
+                entity.getCompletionTokens(),
+                entity.getTotalTokens(),
                 entity.getCreatedAt()
         );
     }
@@ -22,6 +25,9 @@ public class ChatMessageMapper {
                 domain.getRoomId(),
                 domain.getRole(),
                 domain.getContent(),
+                domain.getPromptTokens(),
+                domain.getCompletionTokens(),
+                domain.getTotalTokens(),
                 domain.getCreatedAt()
         );
     }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.global.infrastructure.config.security;
 
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -49,6 +50,11 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        // SSE(servlet async) 완료 시 Tomcat 이 ASYNC 로 필터체인을 재진입하는데,
+                        // OncePerRequestFilter 인 JwtAuthenticationFilter 는 ASYNC 에서 재실행되지 않아
+                        // SecurityContext 가 비고 → AuthorizationFilter 가 Access Denied → 응답 이미 커밋됨
+                        // → ERR_INCOMPLETE_CHUNKED_ENCODING. 최초 REQUEST 는 이미 인가되므로 ASYNC/ERROR 는 허용한다.
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         // Swagger
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()

--- a/src/test/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandServiceTest.java
@@ -1,0 +1,84 @@
+package com.wanted.codebombalms.chatbot.application.service;
+
+import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
+import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
+import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
+import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+
+/**
+ * SSE 스트림이 ERR_INCOMPLETE_CHUNKED_ENCODING 으로 끊기는 버그의 회귀 테스트.
+ *
+ * <p>HTTP 의 incomplete-chunked == Reactor 시임에서 send() Flux 가 onComplete 가 아니라
+ * onError 로 종료되는 것(컨트롤러가 SSE 로 어댑트 → 종료 청크 못 보냄 → abort).
+ * 따라서 "스트림 중/종단 에러가 나도 종단 프레임을 내고 정상 complete 되는가" 를 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMessageCommandService 스트림 종료 처리")
+class ChatMessageCommandServiceTest {
+
+    @Mock
+    private AiChatClient aiChatClient;
+    @Mock
+    private ChatMessageTransactionService txService;
+    @Mock
+    private RecordTokenUsagePort recordTokenUsagePort;
+    @InjectMocks
+    private ChatMessageCommandService service;
+
+    private final SendMessageCommand command = new SendMessageCommand(1L, 10L, "안녕");
+
+    @Test
+    @DisplayName("AI 답변 저장이 실패해도 스트림은 onError 로 끊기지 않고 done 으로 정상 완료된다")
+    void 저장실패_정상종료() {
+        given(txService.prepare(any())).willReturn(null);
+        given(aiChatClient.stream(any())).willReturn(Flux.just(
+                new AiChatStreamChunk.Token("안"),
+                new AiChatStreamChunk.Token("녕"),
+                new AiChatStreamChunk.Done(new AiChatStreamChunk.TokenUsage(10, 2, 12))
+        ));
+        willThrow(new RuntimeException("DB down"))
+                .given(txService).saveAiAnswer(anyLong(), anyString(), any());
+
+        List<AiChatStreamChunk> chunks = service.send(command)
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        assertThat(chunks).isNotNull();
+        assertThat(chunks).last().isInstanceOf(AiChatStreamChunk.Done.class);
+    }
+
+    @Test
+    @DisplayName("스트림 중간 에러 신호도 error 프레임으로 변환되어 정상 완료된다")
+    void 중간에러_정상종료() {
+        given(txService.prepare(any())).willReturn(null);
+        given(aiChatClient.stream(any())).willReturn(Flux.concat(
+                Flux.just(new AiChatStreamChunk.Token("부분")),
+                Flux.error(new RuntimeException("stream broke"))
+        ));
+
+        List<AiChatStreamChunk> chunks = service.send(command)
+                .collectList()
+                .block(Duration.ofSeconds(5));
+
+        assertThat(chunks).isNotNull();
+        assertThat(chunks).last().isInstanceOf(AiChatStreamChunk.Error.class);
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/chatbot/domain/model/ChatMessageTest.java
+++ b/src/test/java/com/wanted/codebombalms/chatbot/domain/model/ChatMessageTest.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.chatbot.domain.model;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("ChatMessage 도메인")
+class ChatMessageTest {
+
+    @Test
+    @DisplayName("AI 메시지 토큰 사용량이 음수면 생성 시 검증 예외가 발생한다")
+    void AI메시지_음수토큰_거부() {
+        assertThatThrownBy(() -> ChatMessage.createAiMessage(10L, "답변", -1, 0, 0))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    @Test
+    @DisplayName("AI 메시지 토큰 사용량이 0 이상이면 정상 생성된다")
+    void AI메시지_정상토큰_생성() {
+        assertThatCode(() -> ChatMessage.createAiMessage(10L, "답변", 10, 2, 12))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("USER 메시지는 토큰 값이 모두 null 이다")
+    void USER메시지_토큰_null() {
+        ChatMessage userMessage = ChatMessage.createUserMessage(10L, "질문");
+
+        assertThat(userMessage.getPromptTokens()).isNull();
+        assertThat(userMessage.getCompletionTokens()).isNull();
+        assertThat(userMessage.getTotalTokens()).isNull();
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #413 [AFK] FastAPI SSE 스트리밍 응답 전환
- Closes #414 [AFK] Spring 기존 ChatRoom 메시지 스트리밍 중계
- Closes #415 [AFK] 첫 메시지 스트리밍 + ChatRoom 생성 이벤트
- Closes #416 [AFK] Mock 스트리밍 클라이언트 + 죽은 코드/문서 정리

---

## 🛠️ 기능 관련 작업 내용

- FastAPI SSE 스트리밍 응답으로 전환: 토큰 청크 단위 병렬 수신 + Done 청크로 완료 신호 정의
- Spring 기존 ChatRoom 메시지 스트리밍 중계: SSE 토큰 청크를 누적하여 완성된 AI 답변만 저장
- 첫 메시지 스트리밍 + ChatRoom 생성 이벤트: Flux 초기화 시점의 ChatRoom 생성 + 타임스탬프 갱신
- AI 응답 토큰 사용량 저장 및 메트릭: prompt/completion/total_tokens 컬럼 추가 + 메트릭 누적(저장 성공 무관)

---

## ♻️ 패키지 변경 사항

- `chatbot/application/service/ChatMessageCommandService`: 토큰 메트릭 기록 로직 추가
- `chatbot/application/service/ChatMessageTransactionService`: 토큰 사용량을 함께 저장하는 별도 메서드 추가
- `chatbot/domain/model/ChatMessage`: 토큰 필드(prompt/completion/total) 3개 추가 + factory 메서드 확장
- `chatbot/infrastructure/client/MockAiChatClient`: 로컬 검증용 임의 토큰 사용량 방출
- `chatbot/infrastructure/metrics/ChatMetrics`: 토큰 사용량 Counter(입력/출력 분리) + 누적 메서드
- `chatbot/infrastructure/persistence/ChatMessageJpaEntity`: 3개 토큰 컬럼 매핑 + 생성자 확장
- `chatbot/infrastructure/persistence/ChatMessageMapper`: 토큰 필드 매핑 로직 추가

---

## ⚠️ 마이그레이션 주의

마이그레이션 파일 `db/schema/chat_message.sql`(ALTER TABLE로 토큰 3컬럼 추가)은 **이번 PR에 포함되지 않음**(아직 미커밋). 배포 전 각 환경 DB에 ALTER를 먼저 적용해야 합니다(ddl-auto: validate 설정).

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI 채팅 응답의 prompt/completion/total 토큰 사용량을 함께 저장하고, 토큰 사용 지표도 집계하도록 개선했습니다.
  * 채팅 메시지에 토큰 정보가 보존되어 이후 조회 시 확인할 수 있습니다.
* **Bug Fixes**
  * 스트리밍 종료 시 토큰 사용량 및 저장 처리가 누락되지 않도록 수정했습니다.
  * 스트림 저장 실패/중단 상황에서도 흐름이 안정적으로 마무리되도록 보강했습니다.
  * 비동기/SSE 처리 중 보안 예외로 응답이 깨지는 이슈를 완화했습니다.
* **Tests**
  * 스트리밍 종료 회귀 및 토큰 검증 시나리오를 추가로 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->