### PR TITLE
[Ref] 제출 외부 채점 트랜잭션 분리 및 부하 테스트 안정화

### DIFF
--- a/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/runner/MockCodeRunnerAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/execution/infrastructure/runner/MockCodeRunnerAdapter.java
@@ -14,6 +14,9 @@ public class MockCodeRunnerAdapter implements RunCodePort {
     public MockCodeRunnerAdapter(
             @Value("${code-runner.mock.delay-ms:300}") long mockDelayMs
     ) {
+        if (mockDelayMs < 0) {
+            throw new IllegalArgumentException("code-runner.mock.delay-ms는 0 이상이어야 합니다.");
+        }
         this.mockDelayMs = mockDelayMs;
     }
 

--- a/src/main/java/com/wanted/codebombalms/submission/application/port/RecordSubmissionMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/port/RecordSubmissionMetricsPort.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.submission.application.port;
+
+public interface RecordSubmissionMetricsPort {
+
+    void recordTotal(long nanos);
+
+    void recordPrepare(long nanos);
+
+    void recordGrading(long nanos);
+
+    void recordSave(long nanos);
+}

--- a/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
+++ b/src/main/java/com/wanted/codebombalms/submission/application/service/SubmissionService.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.submission.application.service;
 import com.wanted.codebombalms.problems.dataset.application.port.GenerateDatasetAccessUrlPort;
 import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
 import com.wanted.codebombalms.submission.application.policy.SubmissionCodePolicy;
+import com.wanted.codebombalms.submission.application.port.RecordSubmissionMetricsPort;
 import com.wanted.codebombalms.submission.application.service.CodeGradingService.CodeGradingResult;
 import com.wanted.codebombalms.submission.application.service.SubmissionTransactionService.SubmissionPreparation;
 import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase;
@@ -20,8 +21,7 @@ public class SubmissionService implements SubmissionCommandUseCase {
     private final CodeGradingService codeGradingService;
     private final SubmissionCodePolicy submissionCodePolicy;
     private final GenerateDatasetAccessUrlPort generateDatasetAccessUrlPort;
-    private final SubmissionMetrics submissionMetrics;
-
+    private final RecordSubmissionMetricsPort submissionMetrics;
     @Override
     public SubmissionView handle(
             Long problemId,

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/loadtest/SubmissionExternalCallLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/loadtest/SubmissionExternalCallLoadTestSeeder.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.submission.infrastructure.loadtest;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
@@ -17,7 +18,6 @@ import java.sql.SQLException;
 @Slf4j
 @Component
 @Profile("loadtest-submission")
-@RequiredArgsConstructor
 public class SubmissionExternalCallLoadTestSeeder implements ApplicationRunner {
 
     private static final int USER_COUNT = 300;
@@ -29,10 +29,25 @@ public class SubmissionExternalCallLoadTestSeeder implements ApplicationRunner {
     private static final long PROBLEM_ID = 840001L;
     private static final long TEST_CASE_ID_START = 840001L;
 
-    private static final String PASSWORD = "Test1234!";
 
     private final JdbcTemplate jdbc;
     private final PasswordEncoder passwordEncoder;
+
+    private final String password;
+
+    public SubmissionExternalCallLoadTestSeeder(
+            JdbcTemplate jdbc,
+            PasswordEncoder passwordEncoder,
+            @Value("${loadtest.submission.password:}") String password
+    ) {
+        this.jdbc = jdbc;
+        this.passwordEncoder = passwordEncoder;
+        this.password = password;
+
+        if (password.isBlank()) {
+            throw new IllegalArgumentException("loadtest.submission.password 설정이 필요합니다.");
+        }
+    }
 
     @Override
     @Transactional
@@ -46,6 +61,7 @@ public class SubmissionExternalCallLoadTestSeeder implements ApplicationRunner {
         seedProblem();
 
         clearPreviousSubmissionData();
+        clearProgresses();
         seedTestCases();
         disableDatasets();
         seedProgresses();
@@ -62,7 +78,7 @@ public class SubmissionExternalCallLoadTestSeeder implements ApplicationRunner {
     }
 
     private void seedUsers() {
-        String passwordHash = passwordEncoder.encode(PASSWORD);
+        String passwordHash = passwordEncoder.encode(password);
 
         jdbc.batchUpdate("""
                 insert into users
@@ -280,6 +296,14 @@ public class SubmissionExternalCallLoadTestSeeder implements ApplicationRunner {
                  where problem_set_id = ?
                    and status = 'ACTIVE'
                 """,
+                PROBLEM_SET_ID
+        );
+    }
+    private void clearProgresses() {
+        jdbc.update("""
+            delete from problem_progress
+             where problem_set_id = ?
+            """,
                 PROBLEM_SET_ID
         );
     }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/loadtest/SubmissionExternalCallLoadTestSeeder.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/loadtest/SubmissionExternalCallLoadTestSeeder.java
@@ -301,10 +301,13 @@ public class SubmissionExternalCallLoadTestSeeder implements ApplicationRunner {
     }
     private void clearProgresses() {
         jdbc.update("""
-            delete from problem_progress
-             where problem_set_id = ?
-            """,
-                PROBLEM_SET_ID
+                delete from problem_progress
+                 where problem_set_id = ?
+                   and user_id between ? and ?
+                """,
+                PROBLEM_SET_ID,
+                USER_ID_START,
+                USER_ID_START + USER_COUNT - 1
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/metrics/SubmissionMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/metrics/SubmissionMetrics.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.submission.infrastructure.metrics;
 
+import com.wanted.codebombalms.submission.application.port.RecordSubmissionMetricsPort;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.springframework.stereotype.Component;
@@ -7,7 +8,7 @@ import org.springframework.stereotype.Component;
 import java.util.concurrent.TimeUnit;
 
 @Component
-public class SubmissionMetrics {
+public class SubmissionMetrics implements RecordSubmissionMetricsPort {
 
     private final Timer totalTimer;
     private final Timer prepareTimer;
@@ -31,19 +32,19 @@ public class SubmissionMetrics {
                 .description("Submission and test result save duration")
                 .register(registry);
     }
-
+    @Override
     public void recordTotal(long elapsedNanos) {
         totalTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
-
+    @Override
     public void recordPrepare(long elapsedNanos) {
         prepareTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
-
+    @Override
     public void recordGrading(long elapsedNanos) {
         gradingTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
-
+    @Override
     public void recordSave(long elapsedNanos) {
         saveTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #503

---

## 🛠️ 기능 관련 작업 내용
- 외부 코드 채점 구간과 DB 트랜잭션을 분리해 트랜잭션 점유 시간을 단축
- 제출 처리 단계별 Micrometer 메트릭과 애플리케이션 포트 추가
- 부하 테스트 계정 비밀번호를 설정값으로 주입하고 문제 진행 데이터 재시딩 로직 보완
- k6 부하 테스트 스크립트, Grafana 대시보드 및 전후 비교 결과 추가

---

## ♻️ 패키지 변경 사항
- `project/submission/application`: 제출 트랜잭션 서비스 분리 및 메트릭 기록 포트 추가
- `project/submission/infrastructure`: 메트릭 구현체와 부하 테스트 시더 안정화
- `project/problems/execution/infrastructure`: Mock Runner 지연 설정값 검증 추가
- `project/monitoring-local`: k6 테스트와 Grafana 모니터링 구성 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 제출 처리의 단계별 및 전체 소요 시간을 기록하는 기능이 추가되었습니다.
* **Bug Fixes**
  * 음수 지연 시간이 설정되면 초기화 시점에 바로 오류가 발생하도록 개선되었습니다.
  * 로드 테스트 데이터 생성 시 비어 있는 비밀번호는 허용되지 않도록 검증이 추가되었습니다.
* **Chores**
  * 로드 테스트 초기화 과정에서 기존 진행 데이터도 함께 정리되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->