### PR TITLE
[Feat] 보안 이벤트 로그 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/CustomAccessDeniedHandler.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.global.infrastructure.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.codebombalms.global.infrastructure.logging.SecurityEventLogger;
 import com.wanted.codebombalms.global.presentation.api.common.ApiErrorResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,9 +15,14 @@ import java.io.IOException;
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     private final ObjectMapper objectMapper;
+    private final SecurityEventLogger securityEventLogger;
 
-    public CustomAccessDeniedHandler(ObjectMapper objectMapper) {
+    public CustomAccessDeniedHandler(
+            ObjectMapper objectMapper,
+            SecurityEventLogger securityEventLogger
+    ) {
         this.objectMapper = objectMapper;
+        this.securityEventLogger = securityEventLogger;
     }
 
     @Override
@@ -25,6 +31,8 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException e
     ) throws IOException {
+        securityEventLogger.accessDenied(request);
+
         response.setStatus(403);
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().write(

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -64,10 +64,6 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     }
 
     private String resolveClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip != null && !ip.isEmpty()) {
-            return ip.split(",")[0].trim();
-        }
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/SecurityEventLogger.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/SecurityEventLogger.java
@@ -38,10 +38,6 @@ public class SecurityEventLogger {
     }
 
     private String resolveClientIp(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip != null && !ip.isEmpty()) {
-            return ip.split(",")[0].trim();
-        }
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/SecurityEventLogger.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/SecurityEventLogger.java
@@ -1,0 +1,47 @@
+package com.wanted.codebombalms.global.infrastructure.logging;
+
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityEventLogger {
+
+    private static final Logger log = LoggerFactory.getLogger(SecurityEventLogger.class);
+    private static final String ANONYMOUS = "anonymous";
+    private static final String ADMIN_API_PREFIX = "/api/v1/admin/";
+
+    public void accessDenied(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String type = resolveAccessDeniedType(uri);
+
+        log.warn("event=security_event type={} method={} uri={} status=403 userId={} role={} clientIp={}",
+                type,
+                request.getMethod(),
+                uri,
+                resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_USER_ID_ATTRIBUTE),
+                resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_ROLE_ATTRIBUTE),
+                resolveClientIp(request));
+    }
+
+    private String resolveAccessDeniedType(String uri) {
+        return uri != null && uri.startsWith(ADMIN_API_PREFIX)
+                ? "ADMIN_API_ACCESS_DENIED"
+                : "ACCESS_DENIED";
+    }
+
+    private String resolveAttribute(HttpServletRequest request, String name) {
+        Object value = request.getAttribute(name);
+        return value == null ? ANONYMOUS : String.valueOf(value);
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip != null && !ip.isEmpty()) {
+            return ip.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---



---

## 🛠️ 기능 관련 작업 내용
- Spring Security 403 접근 거부 발생 시 `event=security_event` 로그를 남기도록 추가
- 관리자 API 접근 거부는 `ADMIN_API_ACCESS_DENIED`, 일반 접근 거부는 `ACCESS_DENIED`로 구분
- 보안 이벤트 로그에 `userId`, `role`, `method`, `uri`, `status`, `clientIp`를 포함해 Loki 알림에서 사용자 식별 가능하도록 개선

---

## ♻️ 패키지 변경 사항
- `project/global/infrastructure/logging`: `SecurityEventLogger` 추가
- `project/global/infrastructure/config/security`: `CustomAccessDeniedHandler`에서 403 응답 전 보안 이벤트 로그 호출

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 접근 거부(403) 발생 시 관련 요청 정보가 추가로 기록되도록 보강되었습니다.
  * 관리자 API 요청과 일반 요청을 구분해 감사 로그가 남도록 개선되었습니다.

* **Bug Fixes**
  * 클라이언트 IP를 더 정확하게 확인하도록 개선되어, 프록시 환경에서도 실제 요청 स्रोत을 반영할 수 있습니다.
  * 인증 정보가 없는 경우에도 로그가 안정적으로 `"anonymous"`로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->