### PR TITLE
[Fix] step-up 메일 중복 발송 차단 + 구글 로그인 이력·신뢰기기 기록

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -4,17 +4,24 @@ import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
 import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
 import com.wanted.codebombalms.auth.application.usecase.GoogleCallbackUseCase;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.OAuthTempData;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import com.wanted.codebombalms.auth.domain.repository.OAuthStateRepository;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TempTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
 import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,9 +40,12 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
     private final RefreshTokenRepository refreshTokenRepository;
     private final TempTokenRepository tempTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final GeoIpResolver geoIpResolver;
+    private final LoginHistoryRepository loginHistoryRepository;
+    private final TrustedDeviceRepository trustedDeviceRepository;
 
     @Override
-    public GoogleCallbackResult handleCallback(String code, String state) {
+    public GoogleCallbackResult handleCallback(String code, String state, HttpServletRequest request, String deviceFp) {
 
         // 1. state 검증 (CSRF 방지, 단일 사용)
         if (!oAuthStateRepository.validateAndDelete(state)) {
@@ -62,7 +72,7 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
             }
 
             // 3-2. 기존 구글 회원 → 토큰 발급 (로그인)
-            return issueTokens(user);
+            return issueTokens(user, request, deviceFp);
         }
 
         // 4. 신규 회원 → TEMP_TOKEN 발급 후 Redis 임시 저장
@@ -71,18 +81,69 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         return GoogleCallbackResult.newUser(tempToken);
     }
 
-    /** 기존 회원 토큰 발급 — 단일 세션 강제 후 AT/RT 생성·저장 (LoginService 동일 패턴) */
-    private GoogleCallbackResult issueTokens(User user) {
-        refreshTokenRepository.deleteByUserId(user.getUserId());
+    /**
+     * 기존 회원 토큰 발급 — 로그인 이력 기록 + 신뢰기기 upsert 후 AT/RT 발급.
+     * step-up(이메일 OTP)은 제외한다 (구글이 이미 인증을 보장).
+     */
+    private GoogleCallbackResult issueTokens(User user, HttpServletRequest request, String deviceFp) {
+        String ip = extractIpAddress(request);
+        GeoLocation geo = geoIpResolver.resolve(ip);
 
-        String accessToken = jwtTokenProvider.generateAccessToken(
+        // 로그인 이력 기록 — 구글 인증 통과이므로 suspicious=false
+        loginHistoryRepository.save(LoginHistory.record(
+                user.getUserId(), ip, request.getHeader("User-Agent"),
+                deviceFp, geo.country(), geo.city(), false));
+
+        // 신뢰기기 upsert — 있으면 갱신, 없으면 등록 (유니크 (user_id, device_fp) 위반 방지)
+        TrustedDevice device = trustedDeviceRepository
+                .findByUserIdAndDeviceFp(user.getUserId(), deviceFp)
+                .map(existing -> {
+                    existing.markUsed(geo.country(), geo.city());
+                    return existing;
+                })
+                .orElseGet(() -> TrustedDevice.register(
+                        user.getUserId(),
+                        deviceFp,
+                        parseDeviceName(request.getHeader("User-Agent")),
+                        geo.country(),
+                        geo.city()
+                ));
+        trustedDeviceRepository.save(device);
+
+        // 단일 세션 강제 후 AT/RT 발급
+        refreshTokenRepository.deleteByUserId(user.getUserId());
+        String token = jwtTokenProvider.generateAccessToken(
                 user.getUserId(), user.getNickname(), user.getRole());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
-
         refreshTokenRepository.save(
                 RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration())
         );
 
-        return GoogleCallbackResult.existingUser(accessToken, refreshToken);
+        return GoogleCallbackResult.existingUser(token, refreshToken);
+    }
+
+    /** User-Agent → "브라우저 · OS" 표시명 (간이 파싱, StepUpVerifyService 와 동일 규칙) */
+    private String parseDeviceName(String userAgent) {
+        if (userAgent == null || userAgent.isBlank()) {
+            return "Unknown device";
+        }
+        String browser = userAgent.contains("Edg") ? "Edge"
+                : userAgent.contains("Chrome") ? "Chrome"
+                  : userAgent.contains("Firefox") ? "Firefox"
+                    : userAgent.contains("Safari") ? "Safari" : "Unknown";
+        String os = userAgent.contains("Windows") ? "Windows"
+                : userAgent.contains("Mac OS") ? "macOS"
+                  : userAgent.contains("Android") ? "Android"
+                    : (userAgent.contains("iPhone") || userAgent.contains("iPad")) ? "iOS"
+                      : userAgent.contains("Linux") ? "Linux" : "Unknown";
+        return browser + " · " + os;
+    }
+
+    private String extractIpAddress(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -89,14 +89,18 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         String ip = extractIpAddress(request);
         GeoLocation geo = geoIpResolver.resolve(ip);
 
-        // 로그인 이력 기록 — 구글 인증 통과이므로 suspicious=false
+        // 신뢰기기 1회 조회로 suspicious 판정 + upsert 모두 처리
+        Optional<TrustedDevice> trusted =
+                trustedDeviceRepository.findByUserIdAndDeviceFp(user.getUserId(), deviceFp);
+        boolean suspicious = trusted.isEmpty() || isCountryChanged(trusted.get(), geo);
+
+        // 로그인 이력 기록 — step-up 은 생략하되, 의심 여부는 실제 계산값으로 남김
         loginHistoryRepository.save(LoginHistory.record(
                 user.getUserId(), ip, request.getHeader("User-Agent"),
-                deviceFp, geo.country(), geo.city(), false));
+                deviceFp, geo.country(), geo.city(), suspicious));
 
         // 신뢰기기 upsert — 있으면 갱신, 없으면 등록 (유니크 (user_id, device_fp) 위반 방지)
-        TrustedDevice device = trustedDeviceRepository
-                .findByUserIdAndDeviceFp(user.getUserId(), deviceFp)
+        TrustedDevice device = trusted
                 .map(existing -> {
                     existing.markUsed(geo.country(), geo.city());
                     return existing;
@@ -120,6 +124,13 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         );
 
         return GoogleCallbackResult.existingUser(token, refreshToken);
+    }
+
+    /** 신뢰기기의 마지막 국가와 현재 국가가 다르면 의심 (LoginService 와 동일 규칙) */
+    private boolean isCountryChanged(TrustedDevice device, GeoLocation geo) {
+        return device.getLastCountry() != null
+                && geo.country() != null
+                && !device.getLastCountry().equals(geo.country());
     }
 
     /** User-Agent → "브라우저 · OS" 표시명 (간이 파싱, StepUpVerifyService 와 동일 규칙) */

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -94,9 +94,17 @@ public class LoginService implements LoginUseCase {
     }
 
     private LoginResult issueStepUp(User user, String deviceFp, GeoLocation geo) {
-        // OTP (step-up) 발급
-        String code = generateCode();
         String stepUpToken = UUID.randomUUID().toString();
+
+        // 멱등성 유지: 같은 기기에 이미 유효한 챌린지가 있으면 재사용 (코드 재발급/메일 재발송 차단)
+        Optional<String> existing =
+                stepUpTokenRepository.reserveDeviceChallenge(user.getUserId(), deviceFp, stepUpToken);
+        if (existing.isPresent()) {
+            return LoginResult.stepUp(existing.get(), maskEmail(user.getEmail()));
+        }
+
+        // 신규 발급 — OTP(step-up) 생성
+        String code = generateCode();
         stepUpTokenRepository.save(stepUpToken,
                 new StepUpChallenge(user.getUserId(), deviceFp, geo.country(), code));
 

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -95,24 +95,23 @@ public class LoginService implements LoginUseCase {
 
     private LoginResult issueStepUp(User user, String deviceFp, GeoLocation geo) {
         String stepUpToken = UUID.randomUUID().toString();
+        String code = generateCode();
 
-        // 멱등성 유지: 같은 기기에 이미 유효한 챌린지가 있으면 재사용 (코드 재발급/메일 재발송 차단)
+        // 챌린지를 먼저 저장 — 예약 키가 가리키는 토큰은 항상 유효 챌린지를 보유 (유령 토큰 방지)
+        stepUpTokenRepository.save(stepUpToken,
+                new StepUpChallenge(user.getUserId(), deviceFp, geo.country(), code));
+
+        // 멱등 예약 — 충돌이면 기존 토큰 재사용 (방금 저장분은 미사용 → TTL 5분 후 자동 만료)
         Optional<String> existing =
                 stepUpTokenRepository.reserveDeviceChallenge(user.getUserId(), deviceFp, stepUpToken);
         if (existing.isPresent()) {
             return LoginResult.stepUp(existing.get(), maskEmail(user.getEmail()));
         }
 
-        // 신규 발급 — OTP(step-up) 생성
-        String code = generateCode();
-        stepUpTokenRepository.save(stepUpToken,
-                new StepUpChallenge(user.getUserId(), deviceFp, geo.country(), code));
-
-        // 계정 잠금 토큰 발급 + 링크 조립
+        // 신규 발급분만 계정 잠금 토큰 + 메일 발송
         String lockToken = UUID.randomUUID().toString();
         lockTokenRepository.save(lockToken, user.getUserId());
         String lockUrl = lockUrlBase + "?token=" + lockToken;
-
         emailSender.sendStepUpCode(user.getEmail(), code, lockUrl);
         return LoginResult.stepUp(stepUpToken, maskEmail(user.getEmail()));
     }

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/GoogleCallbackUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/GoogleCallbackUseCase.java
@@ -1,9 +1,10 @@
 package com.wanted.codebombalms.auth.application.usecase;
 
 import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface GoogleCallbackUseCase {
 
-    /** 구글 콜백 처리 — state 검증 → 토큰 교환 → 기존/신규 분기 */
-    GoogleCallbackResult handleCallback(String code, String state);
+    /** 구글 콜백 처리 — state 검증 → 토큰 교환 → 기존/신규 분기 (이력·신뢰기기 기록 포함) */
+    GoogleCallbackResult handleCallback(String code, String state, HttpServletRequest request, String deviceFp);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/StepUpTokenRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/StepUpTokenRepository.java
@@ -17,4 +17,11 @@ public interface StepUpTokenRepository {
 
     /** OTP 오입력 시 시도 횟수 +1 → 누적값 반환 (토큰 TTL과 동기) */
     int incrementAttempts(String token);
+
+    /**
+     * 같은 기기(userId+deviceFp)의 step-up 발급을 원자적으로 1건으로 제한한다. (TTL 5분)
+     * - 신규 발급권을 선점하면 Optional.empty() 반환 → 호출측이 코드 생성 + 메일 발송 진행
+     * - 이미 유효한 발급이 있으면 그 토큰을 반환 → 호출측은 메일 재발송 없이 재사용
+     */
+    Optional<String> reserveDeviceChallenge(Long userId, String deviceFp, String newToken);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,6 +19,7 @@ public class JavaMailEmailSender implements EmailSender {
     @Value("${spring.mail.username}")
     private String fromAddress;
 
+    @Async("mailTaskExecutor")
     @Override
     public void sendVerificationCode(String to, String code) {
         SimpleMailMessage message = new SimpleMailMessage();
@@ -29,7 +31,7 @@ public class JavaMailEmailSender implements EmailSender {
         mailSender.send(message);
         log.info("[EmailSender] 인증 코드 발송 완료 - to: {}", maskEmail(to));
     }
-
+    @Async("mailTaskExecutor")
     @Override
     public void sendPasswordResetCode(String to, String code) {
         SimpleMailMessage message = new SimpleMailMessage();
@@ -42,7 +44,7 @@ public class JavaMailEmailSender implements EmailSender {
         log.info("[EmailSender] 비밀번호 재설정 코드 발송 완료 - to: {}", maskEmail(to));
     }
 
-    // sendPasswordResetCode 메서드 아래에 추가
+    @Async("mailTaskExecutor")
     @Override
     public void sendStepUpCode(String to, String code, String lockUrl) {
         SimpleMailMessage message = new SimpleMailMessage();

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
@@ -22,6 +22,8 @@ public class RedisStepUpTokenAdapter implements StepUpTokenRepository {
     private static final String KEY_ATTEMPTS  = "stepup:attempts:";  // + {token}
     private static final Duration TTL = Duration.ofMinutes(5);
 
+    private static final String KEY_DEVICE = "stepup:device:"; // + {userId}:{deviceFp}
+
     @Override
     public void save(String token, StepUpChallenge challenge) {
         // 본문 + TTL 단일 SET EX (원자)
@@ -47,6 +49,20 @@ public class RedisStepUpTokenAdapter implements StepUpTokenRepository {
             redisTemplate.expire(key, TTL); // 첫 시도 시 TTL 부여 (토큰과 동기 만료)
         }
         return count == null ? 0 : count.intValue();
+    }
+
+    @Override
+    public Optional<String> reserveDeviceChallenge(Long userId, String deviceFp, String newToken) {
+        String key = KEY_DEVICE + userId + ":" + deviceFp;
+
+        // 원자적 SETNX — 키가 없을 때만 newToken 으로 선점 (TTL 5분)
+        Boolean reserved = redisTemplate.opsForValue().setIfAbsent(key, newToken, TTL);
+        if (Boolean.TRUE.equals(reserved)) {
+            return Optional.empty(); // 선점 성공 → 신규 발급 진행
+        }
+
+        // 이미 발급 진행 중/완료 → 기존 토큰 재사용
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
     }
 
     private String serialize(StepUpChallenge challenge) {

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
@@ -37,6 +37,9 @@ public class RedisStepUpTokenAdapter implements StepUpTokenRepository {
 
     @Override
     public void delete(String token) {
+        // 챌린지에 담긴 userId+deviceFp 로 기기 예약 키(KEY_DEVICE)도 함께 정리 — 생명주기 동기화
+        find(token).ifPresent(challenge ->
+                redisTemplate.delete(KEY_DEVICE + challenge.userId() + ":" + challenge.deviceFp()));
         redisTemplate.delete(KEY_CHALLENGE + token);
         redisTemplate.delete(KEY_ATTEMPTS + token);
     }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/OAuthCallbackController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/OAuthCallbackController.java
@@ -4,11 +4,13 @@ import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
 import com.wanted.codebombalms.auth.application.usecase.GoogleCallbackUseCase;
 import com.wanted.codebombalms.auth.infrastructure.oauth.OAuthProperties;
 import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.auth.presentation.api.support.DeviceFingerprintResolver;
 import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.DomainException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,6 +35,8 @@ public class OAuthCallbackController {
     private final JwtTokenProvider jwtTokenProvider;
     private final OAuthProperties oAuthProperties;
 
+    private final DeviceFingerprintResolver deviceFingerprintResolver;
+
     private static final int TEMP_TOKEN_MAX_AGE = 600; // 10분
 
     @Operation(
@@ -43,10 +47,12 @@ public class OAuthCallbackController {
     public ResponseEntity<Void> googleCallback(
             @RequestParam String code,
             @RequestParam String state,
+            HttpServletRequest httpRequest,
             HttpServletResponse response
     ) {
         try {
-            GoogleCallbackResult result = googleCallbackUseCase.handleCallback(code, state);
+            String deviceFp = deviceFingerprintResolver.resolve(httpRequest, response);
+            GoogleCallbackResult result = googleCallbackUseCase.handleCallback(code, state, httpRequest, deviceFp);
 
             if (result.newUser()) {
                 // 신규 회원 → TEMP_TOKEN 쿠키 + 추가정보 페이지로
@@ -70,16 +76,19 @@ public class OAuthCallbackController {
         }
     }
 
-    /** 성공 흐름 redirect */
+    /**
+     * 성공 흐름 redirect
+     */
     private ResponseEntity<Void> redirect(String uri) {
         return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(uri)).build();
     }
 
-    /** 실패 흐름 redirect — 로그인 페이지에 error code + message 전달(모달 표시용) */
+    /**
+     * 실패 흐름 redirect — 로그인 페이지에 error code 전달(문구는 프론트가 코드로 매핑)
+     */
     private ResponseEntity<Void> redirectError(ErrorCode errorCode) {
         String uri = UriComponentsBuilder.fromUriString(oAuthProperties.getErrorUri())
                 .queryParam("error", errorCode.getCode())
-                .queryParam("message", errorCode.getMessage())
                 .encode(StandardCharsets.UTF_8)
                 .build()
                 .toUriString();

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -24,4 +24,16 @@ public class SchedulingConfig {
         executor.initialize();
         return executor;
     }
+
+    /** 이메일(SMTP) 발송을 로그인 응답 스레드와 분리 — 발송 지연이 응답을 막지 않도록 전용 풀 사용. */
+    @Bean(name = "mailTaskExecutor")
+    public Executor mailTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("mail-async-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -33,6 +33,8 @@ public class SchedulingConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(50);
         executor.setThreadNamePrefix("mail-async-");
+        // 풀+큐 포화 시 호출 스레드에서 직접 실행 — 메일 유실·로그인 실패(TaskRejectedException) 방지
+        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         return executor;
     }

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.auth.application.service;
 
 import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
 import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.model.GeoLocation;
 import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
@@ -12,6 +13,7 @@ import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
 import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
 import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -58,14 +61,15 @@ class GoogleCallbackServiceTest {
 
     @BeforeEach
     void setUp() {
-        given(oAuthStateRepository.validateAndDelete(STATE)).willReturn(true);
-        given(googleOAuthClient.exchangeCodeForAccessToken(CODE)).willReturn("GOOGLE_AT");
-        given(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
-                .willReturn(new OAuthUserInfo(EMAIL, "구글유저", true));
+        // 해피패스 공통 스텁 (실패 테스트에선 일부 미사용 → lenient)
+        lenient().when(oAuthStateRepository.validateAndDelete(STATE)).thenReturn(true);
+        lenient().when(googleOAuthClient.exchangeCodeForAccessToken(CODE)).thenReturn("GOOGLE_AT");
+        lenient().when(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
+                .thenReturn(new OAuthUserInfo(EMAIL, "구글유저", true));
     }
 
     @Test
-    @DisplayName("기존 구글 회원 + 신규 기기 → 로그인 이력 기록 + 신뢰기기 신규 등록 후 토큰 발급")
+    @DisplayName("기존 구글 회원 + 신규 기기 → 의심 이력 기록 + 신뢰기기 신규 등록 후 토큰 발급")
     void 기존회원_신규기기_이력_및_신뢰기기등록() {
         // given
         User user = googleUser(1L);
@@ -79,18 +83,32 @@ class GoogleCallbackServiceTest {
         // when
         GoogleCallbackResult result = service.handleCallback(CODE, STATE, request, DEVICE_FP);
 
-        // then
+        // then — 토큰 발급
         assertFalse(result.newUser());
         assertEquals("AT", result.accessToken());
         assertEquals("RT", result.refreshToken());
-        verify(loginHistoryRepository).save(any(LoginHistory.class));   // 이력 기록
-        verify(trustedDeviceRepository).save(any(TrustedDevice.class)); // 신뢰기기 등록
+
+        // 이력 내용 검증 — 신규 기기이므로 suspicious=true
+        ArgumentCaptor<LoginHistory> historyCaptor = ArgumentCaptor.forClass(LoginHistory.class);
+        verify(loginHistoryRepository).save(historyCaptor.capture());
+        LoginHistory history = historyCaptor.getValue();
+        assertEquals(1L, history.getUserId());
+        assertEquals(DEVICE_FP, history.getDeviceFp());
+        assertTrue(history.isSuspicious());
+
+        // 신뢰기기 내용 검증 — 신규 등록
+        ArgumentCaptor<TrustedDevice> deviceCaptor = ArgumentCaptor.forClass(TrustedDevice.class);
+        verify(trustedDeviceRepository).save(deviceCaptor.capture());
+        TrustedDevice saved = deviceCaptor.getValue();
+        assertEquals(1L, saved.getUserId());
+        assertEquals(DEVICE_FP, saved.getDeviceFp());
+
         verify(refreshTokenRepository).deleteByUserId(1L);
         verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
 
     @Test
-    @DisplayName("기존 구글 회원 + 기존 신뢰기기 → 신규 등록 없이 markUsed 갱신만 한다")
+    @DisplayName("기존 구글 회원 + 기존 신뢰기기(국가 동일) → 정상 이력 + markUsed 갱신만 한다")
     void 기존회원_기존기기_markUsed_갱신() {
         // given
         User user = googleUser(1L);
@@ -105,15 +123,71 @@ class GoogleCallbackServiceTest {
         // when
         service.handleCallback(CODE, STATE, request, DEVICE_FP);
 
-        // then
-        verify(existing).markUsed(any(), any());                       // 기존 기기 갱신
+        // then — 기존 기기 + 국가 동일 → suspicious=false
+        ArgumentCaptor<LoginHistory> historyCaptor = ArgumentCaptor.forClass(LoginHistory.class);
+        verify(loginHistoryRepository).save(historyCaptor.capture());
+        assertFalse(historyCaptor.getValue().isSuspicious());
+
+        verify(existing).markUsed(any(), any());          // 기존 기기 갱신
         verify(trustedDeviceRepository).save(existing);
-        verify(loginHistoryRepository).save(any(LoginHistory.class));
+    }
+
+    @Test
+    @DisplayName("state 검증 실패 → ValidationException(OAUTH_STATE_INVALID), 이력·신뢰기기·토큰 모두 미발생")
+    void state_검증실패() {
+        // given
+        given(oAuthStateRepository.validateAndDelete(STATE)).willReturn(false);
+
+        // when & then
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> service.handleCallback(CODE, STATE, request, DEVICE_FP));
+        assertEquals(AuthErrorCode.OAUTH_STATE_INVALID, ex.getErrorCode());
+        verify(loginHistoryRepository, never()).save(any());
+        verify(trustedDeviceRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("구글 미인증 이메일 → ValidationException(OAUTH_EMAIL_NOT_VERIFIED), 기록 미발생")
+    void 미인증_이메일_거부() {
+        // given
+        given(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
+                .willReturn(new OAuthUserInfo(EMAIL, "구글유저", false));
+
+        // when & then
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> service.handleCallback(CODE, STATE, request, DEVICE_FP));
+        assertEquals(AuthErrorCode.OAUTH_EMAIL_NOT_VERIFIED, ex.getErrorCode());
+        verify(loginHistoryRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("동일 이메일 LOCAL 계정 존재 → ValidationException(OAUTH_EMAIL_ALREADY_LOCAL), 기록 미발생")
+    void 이메일충돌_LOCAL계정() {
+        // given
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(localUser(1L)));
+
+        // when & then
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> service.handleCallback(CODE, STATE, request, DEVICE_FP));
+        assertEquals(AuthErrorCode.OAUTH_EMAIL_ALREADY_LOCAL, ex.getErrorCode());
+        verify(loginHistoryRepository, never()).save(any());
+        verify(trustedDeviceRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).save(any());
     }
 
     // ===== 테스트 헬퍼 =====
 
     private User googleUser(Long userId) {
+        return userWith(userId, AuthProvider.GOOGLE);
+    }
+
+    private User localUser(Long userId) {
+        return userWith(userId, AuthProvider.LOCAL);
+    }
+
+    private User userWith(Long userId, AuthProvider provider) {
         return User.restore(
                 userId,
                 UserRole.STUDENT,
@@ -122,7 +196,7 @@ class GoogleCallbackServiceTest {
                 "홍길동",
                 "길동이",
                 "010-1234-5678",
-                AuthProvider.GOOGLE,
+                provider,
                 null,
                 true,
                 false,

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
@@ -1,0 +1,136 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
+import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
+import com.wanted.codebombalms.auth.domain.repository.OAuthStateRepository;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
+import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GoogleCallbackService 단위 테스트")
+class GoogleCallbackServiceTest {
+
+    private static final String CODE = "AUTH_CODE";
+    private static final String STATE = "STATE";
+    private static final String DEVICE_FP = "DEVICE_FP";
+    private static final String EMAIL = "google@example.com";
+
+    @Mock private OAuthStateRepository oAuthStateRepository;
+    @Mock private GoogleOAuthClient googleOAuthClient;
+    @Mock private UserRepository userRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private GeoIpResolver geoIpResolver;
+    @Mock private LoginHistoryRepository loginHistoryRepository;
+    @Mock private TrustedDeviceRepository trustedDeviceRepository;
+    @Mock private HttpServletRequest request;
+
+    @InjectMocks
+    private GoogleCallbackService service;
+
+    @BeforeEach
+    void setUp() {
+        given(oAuthStateRepository.validateAndDelete(STATE)).willReturn(true);
+        given(googleOAuthClient.exchangeCodeForAccessToken(CODE)).willReturn("GOOGLE_AT");
+        given(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
+                .willReturn(new OAuthUserInfo(EMAIL, "구글유저", true));
+    }
+
+    @Test
+    @DisplayName("기존 구글 회원 + 신규 기기 → 로그인 이력 기록 + 신뢰기기 신규 등록 후 토큰 발급")
+    void 기존회원_신규기기_이력_및_신뢰기기등록() {
+        // given
+        User user = googleUser(1L);
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.empty());
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("AT");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("RT");
+        given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
+
+        // when
+        GoogleCallbackResult result = service.handleCallback(CODE, STATE, request, DEVICE_FP);
+
+        // then
+        assertFalse(result.newUser());
+        assertEquals("AT", result.accessToken());
+        assertEquals("RT", result.refreshToken());
+        verify(loginHistoryRepository).save(any(LoginHistory.class));   // 이력 기록
+        verify(trustedDeviceRepository).save(any(TrustedDevice.class)); // 신뢰기기 등록
+        verify(refreshTokenRepository).deleteByUserId(1L);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("기존 구글 회원 + 기존 신뢰기기 → 신규 등록 없이 markUsed 갱신만 한다")
+    void 기존회원_기존기기_markUsed_갱신() {
+        // given
+        User user = googleUser(1L);
+        TrustedDevice existing = spy(TrustedDevice.register(1L, DEVICE_FP, "Chrome · macOS", null, null));
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.of(existing));
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("AT");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("RT");
+        given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
+
+        // when
+        service.handleCallback(CODE, STATE, request, DEVICE_FP);
+
+        // then
+        verify(existing).markUsed(any(), any());                       // 기존 기기 갱신
+        verify(trustedDeviceRepository).save(existing);
+        verify(loginHistoryRepository).save(any(LoginHistory.class));
+    }
+
+    // ===== 테스트 헬퍼 =====
+
+    private User googleUser(Long userId) {
+        return User.restore(
+                userId,
+                UserRole.STUDENT,
+                EMAIL,
+                "ENCODED_PW",
+                "홍길동",
+                "길동이",
+                "010-1234-5678",
+                AuthProvider.GOOGLE,
+                null,
+                true,
+                false,
+                null,
+                null,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -211,12 +211,13 @@ class LoginServiceTest {
         LoginResult first = loginService.login(command, httpRequest, DEVICE_FP);
         LoginResult second = loginService.login(command, httpRequest, DEVICE_FP);
 
-        // then — 메일/챌린지 저장은 1회만, 2번째는 같은 토큰 재사용
+        // then — 메일·잠금토큰은 신규 발급분 1회만, 2번째는 같은 토큰 재사용
         assertTrue(first.stepUpRequired());
         assertTrue(second.stepUpRequired());
         assertEquals("EXISTING_TOKEN", second.stepUpToken());
         verify(emailSender, times(1)).sendStepUpCode(eq("test@example.com"), anyString(), anyString());
-        verify(stepUpTokenRepository, times(1)).save(anyString(), any());
+        verify(lockTokenRepository, times(1)).save(anyString(), anyLong());  // 잠금 토큰도 1회만 (#10)
+        verify(stepUpTokenRepository, times(2)).save(anyString(), any());    // 챌린지는 예약 전 저장 → 호출 2회(2번째 미사용)
     }
 
     // ===== 테스트 헬퍼 =====

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -194,6 +194,31 @@ class LoginServiceTest {
         inOrder.verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
 
+    @Test
+    @DisplayName("미신뢰 기기에서 동일 요청이 중복 유입돼도 step-up 메일은 1회만 발송한다. (멱등)")
+    void 미신뢰기기_중복요청_메일_1회만() {
+        // given — 같은 userId+deviceFp 로 두 번째 요청은 이미 발급된 토큰을 재사용
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.empty());
+        given(stepUpTokenRepository.reserveDeviceChallenge(eq(1L), eq(DEVICE_FP), anyString()))
+                .willReturn(Optional.empty())               // 1번째 요청 → 발급권 선점
+                .willReturn(Optional.of("EXISTING_TOKEN"));  // 2번째 요청 → 기존 토큰 재사용
+
+        // when — 동일 로그인 2회(재시도 시뮬레이션)
+        LoginResult first = loginService.login(command, httpRequest, DEVICE_FP);
+        LoginResult second = loginService.login(command, httpRequest, DEVICE_FP);
+
+        // then — 메일/챌린지 저장은 1회만, 2번째는 같은 토큰 재사용
+        assertTrue(first.stepUpRequired());
+        assertTrue(second.stepUpRequired());
+        assertEquals("EXISTING_TOKEN", second.stepUpToken());
+        verify(emailSender, times(1)).sendStepUpCode(eq("test@example.com"), anyString(), anyString());
+        verify(stepUpTokenRepository, times(1)).save(anyString(), any());
+    }
+
     // ===== 테스트 헬퍼 =====
 
     private User createUser(Long userId, String email, String encodedPassword, boolean isLocked) {


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #N

---

## 🛠️ 기능 관련 작업 내용
- step-up 이메일 OTP가 동일 로그인에 2통 발송되던 문제 수정 — SMTP 동기 호출로 인한 로그인 응답 지연(1~2초)이 프론트 타임아웃 재시도를 유발한 것이 원인. 메일 발송을 `@Async`로 전환해 응답을 즉시 반환하도록 변경
- Redis `setIfAbsent`(SETNX) 기반 멱등 처리 추가 — 같은 `userId+deviceFp` 중복 요청 시 기존 토큰을 재사용하고 메일은 1통만 발송
- 구글 OAuth 로그인 시 로그인 이력 기록 + 신뢰기기 upsert 추가 — 마이페이지 보안 탭(로그인 이력/신뢰기기 관리)에 구글 로그인도 반영. step-up(OTP)은 구글 인증 신뢰로 제외
- LoginService(중복 1회 발송) / GoogleCallbackService(이력·신뢰기기) 단위 테스트 추가

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/infrastructure/mail`: JavaMailEmailSender 발송 메서드 `@Async` 전환
- `codebombalms/global/infrastructure/config`: 메일 전용 Executor(`mailTaskExecutor`) 빈 추가
- `codebombalms/auth/domain/repository` + `infrastructure/persistence`: `reserveDeviceChallenge`(SETNX 멱등) 추가
- `codebombalms/auth/application/service`: LoginService 멱등 적용 / GoogleCallbackService 이력·신뢰기기 기록
- `codebombalms/auth/presentation/api` + `application/usecase`: OAuthCallbackController·GoogleCallbackUseCase 에 request·deviceFp 배선

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 구글 로그인 콜백에서 기기 정보와 접속 환경을 반영해 로그인 이력과 신뢰 기기 등록이 이루어지도록 개선되었습니다.
  * 동일 기기에서 짧은 시간 내 중복된 추가 인증 요청이 들어오면 기존 발급값을 재사용해 불필요한 재전송을 줄입니다.
  * 이메일 발송이 비동기로 처리되어 로그인 관련 알림 응답이 더 빨라졌습니다.

* **Bug Fixes**
  * 추가 인증 메일이 중복 발송되던 상황을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->