### PR TITLE
[Ref] 제출 결과 상세 조회 N+1 쿼리 개선

### DIFF
--- a/monitoring-local/docs/domains/problems/domain-dashboards.md
+++ b/monitoring-local/docs/domains/problems/domain-dashboards.md
@@ -1,0 +1,86 @@
+# Problem / Submission / Ranking / Badge / Reward 대시보드
+
+## 1. DDD 기준 분리
+
+| 바운디드 컨텍스트 | 대시보드 | 핵심 관측 대상 |
+| --- | --- | --- |
+| Problem | `[LMS][도메인 상세] 문제` | 문제세트 진입 단계, 진행도 조회, 코드 실행기 실패 |
+| Submission | `[LMS][도메인 상세] 제출` | 제출 준비, 채점, 저장, 실패 로그 |
+| Ranking | `[LMS][도메인 상세] 랭킹` | 내 랭킹 없음, 랭킹 정합성, 대표 뱃지 URL 후보 |
+| Badge | `[LMS][도메인 상세] 뱃지` | 뱃지 동기화 단계, 신규 획득 로그, 이미지 저장소 오류 |
+| Reward | `[LMS][도메인 상세] 보상 포인트` | 포인트 지급 작업, 재시도, 영구 실패, 복구 스케줄러 |
+
+전용 대시보드는 `monitoring-local/grafana/provisioning/dashboards/`에 있다.
+
+## 2. 모든 코드에 커스텀 메트릭과 로그가 필요한가
+
+필요하지 않다. 관측은 아래 3개 계층으로 나눈다.
+
+| 계층 | 현재 상태 | 답하는 질문 |
+| --- | --- | --- |
+| 요청 메트릭 + `domain` 태그 | 공통 자동 수집 | 어느 컨텍스트와 API가 느리거나 실패하는가 |
+| 공통 요청 로그 + `traceId` | 공통 자동 수집 | 실패하거나 느린 요청 하나가 무엇인가 |
+| 커스텀 Timer/Counter/Gauge + 이벤트 로그 | 핵심 흐름에만 추가 | 내부의 어느 구간과 이유가 문제인가 |
+
+공용 대시보드는 요청량, 오류율, URI별 평균 응답 시간, 리소스 상태를 보여주는 1차 탐지 화면이다. 도메인 상세 대시보드는 이 공용 지표를 반복하지 않고, 내부 처리 단계와 비즈니스 이벤트 로그만 보여준다.
+
+Reward는 요청 컨트롤러가 없는 비동기 컨텍스트이므로 공용 요청 지표가 생성되지 않는다. 지급 작업의 적체와 실패를 보려면 커스텀 메트릭과 구조화 로그가 필수다.
+
+## 3. 현재 계측 상태
+
+| 컨텍스트 | 자동 HTTP | 커스텀 메트릭 | 구조화 이벤트 로그 | 판단 |
+| --- | --- | --- | --- | --- |
+| Problem | 공용 대시보드에서 확인 | 문제세트 진입 단계별 Timer 있음 | 진입/실패, 코드 실행기 완료/실패 있음 | 상세 대시보드에서 원인 분해 가능 |
+| Submission | 공용 대시보드에서 확인 | prepare/grading/save/total Timer 있음 | 완료/실패 있음 | 상세 대시보드에서 원인 분해 가능 |
+| Ranking | 공용 대시보드에서 확인 | 없음 | 공통 요청 로그만 있음 | 상세 대시보드는 정합성/오류 로그 중심 |
+| Badge | 공용 대시보드에서 확인 | 동기화 단계별 Timer 있음 | 동기화 완료 로그 있음 | 상세 대시보드에서 원인 분해 가능 |
+| Reward | 없음 | pending/scheduled/processed/duration 있음 | 작업 생성·완료·재시도·실패 로그 있음 | 비동기 처리 전용 대시보드 사용 가능 |
+
+## 4. Reward 메트릭 계약
+
+Reward 대시보드는 아래 이름을 사용한다.
+
+| 메트릭 | 종류 | 의미 |
+| --- | --- | --- |
+| `reward_point_task_pending` | Gauge | 현재 PENDING 지급 작업 수 |
+| `reward_point_task_scheduled_total` | Counter | 생성된 지급 작업 누적 수 |
+| `reward_point_task_processed_total{result}` | Counter | `completed`, `retry`, `failed` 결과별 처리 수 |
+| `reward_point_task_process_duration` | Timer | 지급 작업 한 건의 처리 시간 |
+
+`reward_point_task_pending`은 Prometheus 스크레이프마다 DB를 조회하지 않는다. 별도 스케줄러가 기본 30초마다 `PENDING` 건수를 조회해 Gauge를 갱신한다. 이 방식은 DB 부하와 수집기 결합을 줄이는 대신 대기 건수가 최대 30초 늦게 반영될 수 있다.
+
+권장 이벤트 로그는 다음과 같다.
+
+```text
+event=reward_point_task_scheduled submissionId=... point=...
+event=reward_point_task_completed submissionId=... retryCount=... durationMs=...
+event=reward_point_task_retry_scheduled submissionId=... retryCount=... reason=...
+event=reward_point_task_failed submissionId=... retryCount=... reason=...
+event=reward_point_recovery_completed processedCount=... durationMs=...
+```
+
+`userId`, `problemId`, `submissionId`, 예외 메시지는 메트릭 태그로 사용하지 않고 로그 본문에만 기록한다. 메트릭의 `result`와 `reason`은 미리 정한 낮은 카디널리티 값만 사용한다.
+
+## 5. 선택적 추가 계측
+
+| 컨텍스트 | 추가 시점 | 후보 |
+| --- | --- | --- |
+| Ranking | API 평균·최대 지연이 상승하고 DB 집계와 URL 생성 중 원인을 구분해야 할 때 | `ranking_query_duration`, `ranking_badge_url_duration` |
+| Badge | 실패 원인과 신규 획득량을 시계열로 집계해야 할 때 | `badge_sync_processed_total{result}`, `badge_sync_newly_earned` |
+| Submission | HTTP 상태와 별개로 채점 결과/실패 이유가 필요할 때 | `submission_processed_total{result}`, `submission_failed_total{reason}` |
+
+## 6. 공용/상세 대시보드 역할 분리
+
+운영 흐름은 다음 순서로 본다.
+
+1. `[LMS 공용 도메인 대시보드]`에서 도메인별 요청량, 오류율, URI별 평균 응답 시간, 리소스 상태를 확인한다.
+2. 이상이 발생한 도메인의 `[LMS][도메인 상세] ...` 대시보드로 이동한다.
+3. 상세 대시보드에서 내부 처리 단계, 비즈니스 이벤트 로그, 실패 로그로 원인을 좁힌다.
+
+이 분리는 공용 대시보드와 상세 대시보드가 같은 패널을 반복하지 않기 위한 결정이다. 공용은 "어디가 이상한가"를 답하고, 상세는 "왜 이상한가"를 답한다.
+
+## 7. Import
+
+로컬 구성은 datasource UID를 `prometheus`, `loki`로 고정한다. Grafana의 `Dashboards > New > Import`에서 JSON 파일을 업로드하거나, `monitoring-local`을 다시 시작하면 provisioning으로 자동 로드된다.
+
+다른 Grafana 환경에 Import할 때는 Prometheus와 Loki datasource UID가 다르면 JSON의 datasource UID를 해당 환경에 맞게 변경한다.

--- a/monitoring-local/docs/domains/submission/operating-baseline.md
+++ b/monitoring-local/docs/domains/submission/operating-baseline.md
@@ -1,0 +1,51 @@
+# Submission 운영 기준선
+
+## 목적
+
+Submission 대시보드는 단순히 응답 시간이 느린지 보는 화면이 아니라, 운영 중 이상 징후가 생겼을 때 원인 후보를 빠르게 좁히기 위한 화면이다.
+
+이 기준은 이전 제출 API 부하 테스트 결과를 기준으로 잡았다.
+
+| 구간 | 실패율 | 유효 요청률 | k6 p95 | k6 p99 | Hikari pending |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 트랜잭션 분리 전 | 28.33% | 43.3% | 3.66s | 4.56s | 약 40 |
+| 트랜잭션 분리 후 | 0% | 100% | 1.88~1.95s | 1.99~2.00s | 0 |
+
+따라서 현재 운영 대시보드에서는 개선 후 상태를 정상 기준선으로 둔다.
+
+## 운영 기준
+
+| 지표 | 정상 | 경고 | 위험 | 해석 |
+| --- | --- | --- | --- | --- |
+| Submit 평균 응답 시간 | 2s 미만 | 2s 이상 | 3s 이상 | 사용자가 제출 후 기다리는 시간 |
+| 5xx Error Rate | 1% 미만 | 1% 이상 | 5% 이상 | 서버 장애 또는 런타임 실패 |
+| Hikari Pending | 0 | 1 이상 지속 | 5 이상 | DB 커넥션 대기 발생 |
+| DB Pool Saturation | 70% 미만 | 70% 이상 | 90% 이상 | DB 커넥션 풀이 꽉 차는 중인지 |
+| Prepare Avg | 100ms 미만 | 100ms 이상 | 300ms 이상 | 문제, 테스트케이스, 데이터셋 조회 지연 |
+| Grading Avg | 1.8s 미만 | 1.8s 이상 | 2.5s 이상 | 외부 채점 실행 지연 |
+| Save Avg | 100ms 미만 | 100ms 이상 | 300ms 이상 | 제출/테스트 결과 저장 지연 |
+
+## 이상 상황별 판단
+
+| 관찰 | 가장 의심할 원인 | 먼저 볼 곳 |
+| --- | --- | --- |
+| 응답 시간 증가 + Hikari pending 증가 | DB 커넥션 부족, 긴 트랜잭션, 락 경합 | Hikari Pool Pressure, Failure Logs |
+| 응답 시간 증가 + Grading Avg만 증가 | 외부 runner 지연, 테스트케이스 수 증가, runner timeout | Grading Avg, Runner Failure Logs |
+| Prepare Avg 증가 | 문제/테스트케이스/데이터셋 조회 쿼리 문제 | Prepare Avg, Slow Request Logs |
+| Save Avg 증가 | submission 저장, test result 저장, DB lock 문제 | Save Avg, Hikari Pending |
+| 5xx 증가 | 애플리케이션 예외 또는 외부 runner 실패 | Submission Failures, traceId |
+| 4xx 증가 + 5xx 정상 | 클라이언트 요청, 인증, 테스트 데이터 문제 | Request body, user/problem state |
+
+## 운영자가 보는 순서
+
+1. `5xx Error Rate`가 빨간색인지 확인한다.
+2. `Hikari Pending`이 0보다 큰 상태로 지속되는지 본다.
+3. `Prepare / Grading / Save` 중 어느 구간이 같이 올라갔는지 본다.
+4. `Slow Submission Requests`에서 `traceId`를 복사한다.
+5. Loki에서 같은 `traceId`로 요청 흐름과 예외 로그를 따라간다.
+
+## 주의점
+
+현재 기준은 로컬 부하 테스트와 mock runner 지연을 기반으로 한 운영 참고선이다. Cloud Run, RDS, 실제 네트워크 환경으로 배포하면 절대 시간은 달라질 수 있다.
+
+다만 실패율, Hikari pending, prepare/grading/save 중 어디가 올라갔는지 보는 방식은 환경이 바뀌어도 유효하다.

--- a/monitoring-local/grafana/provisioning/dashboards/lms-badge-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-badge-domain-dashboard.json
@@ -1,0 +1,618 @@
+{
+  "uid": "lms-badge-domain",
+  "title": "[LMS][도메인 상세] 뱃지",
+  "description": "공용 대시보드에서 뱃지 도메인 이상을 발견한 뒤, 뱃지 동기화 내부 단계와 이미지 저장소/이미지 오류를 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "badge",
+    "ddd",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `badge` 도메인의 지연이나 오류를 먼저 확인합니다.\n- 이 상세 화면에서는 요청량/요청 오류율을 반복하지 않고, 뱃지 동기화 내부 구간을 봅니다.\n- `저장 평균`이 높으면 다건 저장/락, `지급 가능 조회`가 높으면 조건 조회, `이미지 저장소 오류`가 있으면 이미지 저장/URL 생성을 확인합니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "뱃지 동기화 원인 분해",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "동기화 전체 평균",
+      "description": "내 뱃지 동기화 전체 내부 처리 시간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "지급 가능 조회 평균",
+      "description": "현재 포인트로 받을 수 있는 뱃지 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_grantable_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_grantable_lookup_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "보유 뱃지 조회 평균",
+      "description": "이미 획득한 뱃지 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_earned_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_earned_lookup_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "저장 평균",
+      "description": "새로 획득한 뱃지 저장 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_save_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "뱃지 동기화 단계별 평균",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "전체"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_grantable_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_grantable_lookup_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "지급 가능 조회"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_earned_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_earned_lookup_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "보유 뱃지 조회"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_save_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "저장"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "뱃지 도메인 이벤트",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "동기화 완료(5분)",
+      "description": "뱃지 동기화 성공 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 21
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=badge_sync_completed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "뱃지/이미지 저장소 오류(5분)",
+      "description": "뱃지 이미지 저장, 삭제, URL 생성 후보 오류입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 21
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\", level=~\"WARN|ERROR\"} |~ \"badge|Badge|GCS|Signed URL\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "신규 획득 발생 로그(5분)",
+      "description": "신규 획득 뱃지가 1개 이상 발생한 동기화 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=badge_sync_completed\" |~ \"newlyEarnedBadgeCount=([1-9][0-9]*)\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "title": "추가 계측 판단",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "id": 12,
+      "options": {
+        "mode": "markdown",
+        "content": "### 현재 로그로 보는 값\n- `newlyEarnedBadgeCount`는 현재 로그 본문에서 확인합니다.\n- 시계열 카드로 정확히 보고 싶으면 `badge_sync_newly_earned` 또는 `badge_sync_processed_total{result}` 같은 전용 지표를 추가합니다.\n- 공용 대시보드의 요청 지표와 이 화면의 동기화 단계 지표를 같이 보면 원인을 좁힐 수 있습니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "뱃지 도메인 로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 13,
+      "collapsed": false
+    },
+    {
+      "type": "logs",
+      "title": "뱃지 동기화 로그",
+      "description": "newlyEarnedBadgeCount, grantableLookupMs, earnedLookupMs, saveMs, durationMs를 같이 봅니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 14,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |= \"event=badge_sync_completed\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "뱃지 / 이미지 저장소 오류 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 15,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\", level=~\"WARN|ERROR\"} |~ \"badge|Badge|GCS|Signed URL\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-domain-dashboard.json
@@ -1,22 +1,38 @@
 {
   "uid": "lms-domain",
-  "title": "LMS 도메인 대시보드",
-  "tags": ["lms", "loadtest"],
+  "title": "LMS 공용 도메인 대시보드",
+  "tags": [
+    "lms",
+    "loadtest"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
   "refresh": "5s",
-  "time": { "from": "now-15m", "to": "now" },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "templating": {
     "list": [
       {
         "name": "domain",
         "label": "도메인",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
         "definition": "label_values(http_server_requests_seconds_count, domain)",
-        "query": { "qryType": 1, "query": "label_values(http_server_requests_seconds_count, domain)", "refId": "A" },
-        "current": { "text": "chatbot", "value": "chatbot" },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_requests_seconds_count, domain)",
+          "refId": "A"
+        },
+        "current": {
+          "text": "chatbot",
+          "value": "chatbot"
+        },
         "includeAll": false,
         "multi": false,
         "refresh": 2,
@@ -25,18 +41,45 @@
     ]
   },
   "panels": [
-    { "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 1, "collapsed": false },
+    {
+      "type": "row",
+      "title": "트래픽",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "collapsed": false
+    },
     {
       "type": "timeseries",
-      "title": "RPS by URI  ($domain)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "title": "URI별 요청량  ($domain)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
       "id": 2,
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m]))",
           "legendFormat": "{{uri}}"
         }
@@ -44,32 +87,76 @@
     },
     {
       "type": "timeseries",
-      "title": "HTTP Error Rate  ($domain)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "title": "요청 오류율  ($domain)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
       "id": 3,
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(rate(http_server_requests_seconds_count{domain=\"$domain\",status=~\"4..|5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
-          "legendFormat": "error rate"
+          "legendFormat": "오류율"
         }
       ]
     },
-    { "type": "row", "title": "Latency", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }, "id": 4, "collapsed": false },
+    {
+      "type": "row",
+      "title": "응답 시간",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "collapsed": false
+    },
     {
       "type": "timeseries",
-      "title": "HTTP Avg Duration by URI  ($domain)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "title": "URI별 평균 응답 시간  ($domain)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
       "id": 5,
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum by (uri) (rate(http_server_requests_seconds_sum{domain=\"$domain\"}[1m])) / clamp_min(sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
           "legendFormat": "{{uri}}"
         }
@@ -77,85 +164,184 @@
     },
     {
       "type": "timeseries",
-      "title": "커스텀: chat 목록 쿼리 구간 avg (N+1 증거)",
-      "description": "domain=chatbot 일 때만 값이 있음. 커스텀 메트릭은 이름 prefix 라 domain 변수와 무관.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "title": "커스텀: 채팅 목록 쿼리 평균 (N+1 증거)",
+      "description": "도메인=chatbot 일 때만 값이 있음. 커스텀 메트릭은 이름 접두어 라 domain 변수와 무관.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
       "id": 6,
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "rate(chat_room_list_query_duration_seconds_sum[1m]) / clamp_min(rate(chat_room_list_query_duration_seconds_count[1m]), 0.0001)",
-          "legendFormat": "chat_room_list_query avg"
+          "legendFormat": "채팅 목록 쿼리 평균"
         }
       ]
     },
-    { "type": "row", "title": "Resource (앱 전체)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }, "id": 7, "collapsed": false },
+    {
+      "type": "row",
+      "title": "리소스 (앱 전체)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "collapsed": false
+    },
     {
       "type": "timeseries",
-      "title": "Hikari Active Connections",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "title": "DB 커넥션 사용 수",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
       "id": 8,
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "hikaricp_connections_active",
-          "legendFormat": "active"
+          "legendFormat": "사용 중"
         }
       ]
     },
     {
       "type": "timeseries",
-      "title": "Process CPU Usage",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "title": "프로세스 CPU 사용률",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
       "id": 9,
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "process_cpu_usage",
-          "legendFormat": "cpu"
+          "legendFormat": "CPU"
         }
       ]
     },
     {
       "type": "timeseries",
-      "title": "JVM Heap Used",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "title": "JVM 힙 메모리 사용량",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
       "id": 10,
-      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
-          "legendFormat": "heap used"
+          "legendFormat": "힙 사용량"
         }
       ]
     },
-    { "type": "row", "title": "Logs (Loki)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }, "id": 11, "collapsed": false },
+    {
+      "type": "row",
+      "title": "로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "collapsed": false
+    },
     {
       "type": "logs",
       "title": "요청 완료 로그 (actuator 제외)",
-      "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 28 },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
       "id": 12,
-      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending"
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "loki" },
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
           "expr": "{job=\"lms\"} |= \"event=request_completed\" != \"actuator\"",
           "queryType": "range"
         }
       ]
     }
-  ]
+  ],
+  "description": "도메인별 요청량, 오류율, 응답 시간, 공통 리소스를 먼저 확인하는 1차 탐지용 대시보드입니다."
 }

--- a/monitoring-local/grafana/provisioning/dashboards/lms-problem-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-problem-domain-dashboard.json
@@ -1,0 +1,807 @@
+{
+  "uid": "lms-problem-domain",
+  "title": "[LMS][도메인 상세] 문제",
+  "description": "공용 대시보드에서 문제 도메인 이상을 발견한 뒤, 문제세트 진입과 코드 실행 코드 실행기의 내부 원인을 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "problem",
+    "ddd",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `problems` 도메인의 응답 지연이나 오류를 먼저 확인합니다.\n- 이 상세 화면에서는 공용 요청 지표를 반복하지 않고, 문제 도메인 내부 원인을 봅니다.\n- 먼저 `문제세트 진입 단계별 평균`에서 느린 구간을 찾고, 그다음 `진입 실패`와 `코드 실행기 실패` 로그를 확인합니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "문제세트 진입 원인 분해",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "진입 전체 평균",
+      "description": "문제세트 진입 전체 내부 처리 시간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "접근 검증 평균",
+      "description": "수강/권한/접근 가능 여부 확인 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_access_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_access_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "문제세트 조회 평균",
+      "description": "문제세트 기본 정보 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_problem_set_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_set_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "진행도 조회 평균",
+      "description": "사용자 진행도 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_progress_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "진행도 항목 평균",
+      "description": "문제별 진행 상태 매핑 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_progress_items_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_items_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "문제 상세 평균",
+      "description": "소문제 상세와 응답 구성 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_problem_details_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_details_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "문제세트 진입 단계별 평균",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "전체"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_access_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_access_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "접근 검증"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_problem_set_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_set_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "문제세트 조회"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_progress_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "진행도 조회"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_progress_items_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_items_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "진행도 항목"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_problem_details_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_details_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "문제 상세"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "문제 도메인 이벤트",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "문제세트 진입 실패(5분)",
+      "description": "문제세트 진입 서비스 실패 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 21
+      },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=problem_set_entry_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "코드 실행기 실패(5분)",
+      "description": "코드 실행 코드 실행기 호출 실패 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 21
+      },
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=code_execution_runner_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "코드 실행기 빈 응답(5분)",
+      "description": "코드 실행기가 응답은 했지만 결과가 비어 있는 경우입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      },
+      "id": 13,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=code_execution_runner_completed\" |= \"reason=empty_response\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "문제세트 진입 완료(5분)",
+      "description": "문제세트 진입 성공 이벤트 수입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "id": 14,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=problem_set_entered\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "문제세트 진입 로그",
+      "description": "problemSetId, problemCount, solvedProblemCount, durationMs를 함께 봅니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 15,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=problem_set_(entered|entry_failed)\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "코드 실행 코드 실행기 로그",
+      "description": "endpoint, success, executionTimeMs, durationMs로 원인을 좁힙니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 16,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=code_execution_runner_(completed|failed)\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json
@@ -1,0 +1,323 @@
+{
+  "uid": "lms-ranking-domain",
+  "title": "[LMS][도메인 상세] 랭킹",
+  "description": "공용 대시보드에서 랭킹 이상을 발견한 뒤, 랭킹 데이터 정합성, 내 랭킹 없음, 대표 뱃지 URL 비용 후보를 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "ranking",
+    "ddd",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `ranking` 도메인의 지연이나 4xx/5xx 증가를 먼저 확인합니다.\n- 현재 랭킹 도메인은 전용 내부 처리 시간 지표가 없으므로, 이 화면은 요청 로그와 정합성 후보를 중심으로 봅니다.\n- 내 랭킹 404가 늘면 포인트 이력/랭킹 조회 모델/시드 데이터 정합성을 먼저 확인합니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "랭킹 정합성 / 오류 이벤트",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "랭킹 오류 로그(5분)",
+      "description": "랭킹 요청 중 실패 상태 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"/api/v1/rankings/\" |~ \"status=4..|status=5..\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "내 랭킹 없음(5분)",
+      "description": "내 랭킹 404는 데이터 정합성 문제일 수 있습니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"/api/v1/rankings/points/me\" |= \"status=404\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "대표 뱃지 후보 오류(5분)",
+      "description": "랭킹 응답에 대표 뱃지 URL이 포함될 때의 후보 오류입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\", level=~\"WARN|ERROR\"} |~ \"ranking|Ranking|badge|Badge|Signed URL\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "title": "추가 계측 판단",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "mode": "markdown",
+        "content": "### 아직 공용 지표만으로 부족할 때\n- 전체/주간/내 랭킹 중 어느 조회가 느린지는 공용 대시보드의 URI별 지연에서 확인합니다.\n- 그 다음 원인이 DB 집계인지 대표 뱃지 URL 생성인지 구분이 필요해질 때만 `ranking_query_duration`, `ranking_badge_url_duration`을 추가합니다.\n- 사용자 ID를 메트릭 태그로 넣으면 시계열이 폭증하므로 로그에서만 봅니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "랭킹 도메인 로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "collapsed": false
+    },
+    {
+      "type": "logs",
+      "title": "랭킹 요청 / 오류 로그",
+      "description": "status, durationMs, traceId로 공용 대시보드의 이상 구간과 연결합니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 8,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |= \"/api/v1/rankings/\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "랭킹 관련 경고 / 오류 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 9,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\", level=~\"WARN|ERROR\"} |~ \"ranking|Ranking|rankings|badge|Badge\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-reward-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-reward-domain-dashboard.json
@@ -1,0 +1,563 @@
+{
+  "uid": "lms-reward-domain",
+  "title": "[LMS][도메인 상세] 보상 포인트",
+  "description": "공용 요청 대시보드에 잡히지 않는 보상 포인트 비동기 작업의 대기, 완료, 재시도, 실패를 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "reward",
+    "ddd",
+    "async",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 보상 포인트는 요청 컨트롤러가 아니라 비동기 작업 중심이라 공용 요청 대시보드에 잘 드러나지 않습니다.\n- 이 상세 화면에서 대기 작업, 예약, 완료, 재시도, 영구 실패를 직접 봅니다.\n- 재시도는 일시 문제, 영구 실패는 수동 확인이 필요한 문제로 봅니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "보상 작업 상태",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "대기 작업",
+      "description": "현재 PENDING 상태의 포인트 지급 작업 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 20
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(reward_point_task_pending) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "예약(5분)",
+      "description": "제출 성공 후 포인트 지급 작업이 예약된 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_scheduled_total[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "완료(5분)",
+      "description": "정상 지급 완료 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 8,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_processed_total{result=\"completed\"}[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "재시도(5분)",
+      "description": "재시도 예약 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_processed_total{result=\"retry\"}[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "영구 실패(5분)",
+      "description": "1 이상이면 원인 확인이 필요합니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_processed_total{result=\"failed\"}[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "처리 평균 시간",
+      "description": "작업 1건 로드/지급/상태 업데이트 평균입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum(rate(reward_point_task_process_duration_seconds_sum[$__rate_interval])) / clamp_min(sum(rate(reward_point_task_process_duration_seconds_count[$__rate_interval])), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "보상 작업 결과 추이",
+      "description": "완료/재시도/실패 흐름을 한 화면에서 봅니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_scheduled_total[$__rate_interval]))",
+          "legendFormat": "예약"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_processed_total{result=\"completed\"}[$__rate_interval]))",
+          "legendFormat": "완료"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_processed_total{result=\"retry\"}[$__rate_interval]))",
+          "legendFormat": "재시도"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_processed_total{result=\"failed\"}[$__rate_interval]))",
+          "legendFormat": "영구 실패"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "보상 작업 처리 평균",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum(rate(reward_point_task_process_duration_seconds_sum[$__rate_interval])) / clamp_min(sum(rate(reward_point_task_process_duration_seconds_count[$__rate_interval])), 0.0001)) or vector(0)",
+          "legendFormat": "처리 평균"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "보상 포인트 로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 11,
+      "collapsed": false
+    },
+    {
+      "type": "logs",
+      "title": "보상 작업 전체 로그",
+      "description": "submissionId, retryCount, exceptionType으로 원인을 좁힙니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 16,
+        "x": 0,
+        "y": 22
+      },
+      "id": 12,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=reward_point_task_(scheduled|completed|retry_scheduled|failed|not_found|skipped|processing_failed)\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "보상 경고 / 오류 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "id": 13,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\", level=~\"WARN|ERROR\"} |~ \"reward_point|Reward|PointReward\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-submission-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-submission-domain-dashboard.json
@@ -1,13 +1,13 @@
 {
-  "uid": "lms-user-domain",
-  "title": "[LMS][도메인 상세] 사용자/인증",
-  "description": "공용 대시보드에서 사용자/인증 이상을 발견한 뒤, 로그인 실패, 추가 인증 실패, 계정 잠금, 조회 쿼리 지연을 확인합니다.",
+  "uid": "lms-submission-domain",
+  "title": "[LMS][도메인 상세] 제출",
+  "description": "공용 대시보드에서 제출 지연이나 오류를 발견한 뒤, 제출 준비, 채점, 저장 중 어느 구간이 원인인지 확인합니다.",
   "tags": [
     "lms",
     "domain-detail",
-    "user",
-    "auth",
+    "submission",
     "ddd",
+    "operations",
     "korean"
   ],
   "timezone": "browser",
@@ -31,12 +31,12 @@
       "id": 1,
       "options": {
         "mode": "markdown",
-        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `auth` 또는 `user` 계열 API 오류와 지연을 먼저 확인합니다.\n- 이 상세 화면에서는 로그인 실패, 추가 인증 검증 실패, 계정 잠금 변경, 학생 목록/로그인 이력 조회 구간을 봅니다.\n- 의심 로그인과 추가 인증 잠금은 현재 DB 값/정책 결과라 전용 지표를 추가해야 자동 집계됩니다."
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `submission` 도메인의 지연, 오류율, Hikari 상태를 먼저 확인합니다.\n- 이 상세 화면에서는 요청량을 반복하지 않고 `준비`, `채점`, `저장` 구간을 분리해서 봅니다.\n- 채점 평균만 높으면 코드 실행기 또는 테스트케이스 비용, 저장 평균이 높으면 DB 쓰기/락, 준비 평균이 높으면 조회 쿼리를 먼저 의심합니다."
       }
     },
     {
       "type": "row",
-      "title": "인증 보안 이벤트",
+      "title": "제출 처리 구간 분해",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -48,356 +48,8 @@
     },
     {
       "type": "stat",
-      "title": "로그인 실패(5분)",
-      "description": "로그인 API의 실패 상태 응답입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 0,
-        "y": 6
-      },
-      "id": 3,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 5
-              },
-              {
-                "color": "red",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/auth/login\",status=~\"4..|5..\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "추가 인증 검증 실패(5분)",
-      "description": "추가 인증 코드 검증 실패/오류입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 4,
-        "y": 6
-      },
-      "id": 4,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 3
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/auth/step-up/verify\",status=~\"4..|5..\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "계정 잠금 변경(5분)",
-      "description": "관리자 계정 잠금/해제 요청 수입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 8,
-        "y": 6
-      },
-      "id": 5,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/users/{userId}/lock\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "신뢰기기 삭제(5분)",
-      "description": "사용자 신뢰기기 삭제 요청 수입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 12,
-        "y": 6
-      },
-      "id": 6,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/users/me/trusted-devices/{deviceId}\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "의심 로그인(전용 지표 필요)",
-      "description": "현재는 login_history.is_suspicious DB 값입니다. 자동 집계가 필요하면 전용 지표나 이벤트 로그를 추가해야 합니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
-        "y": 6
-      },
-      "id": 7,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(auth_suspicious_login_total[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "추가 인증 잠금(전용 지표 필요)",
-      "description": "추가 인증 시도 초과/잠금 정책을 운영 지표로 보고 싶을 때 추가할 후보입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 6
-      },
-      "id": 8,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(auth_stepup_locked_total[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "row",
-      "title": "사용자 조회 원인 분해",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 12
-      },
-      "id": 9,
-      "collapsed": false
-    },
-    {
-      "type": "stat",
-      "title": "학생 목록 쿼리 평균",
-      "description": "학생 목록 list + count 쿼리 구간입니다.",
+      "title": "준비 평균",
+      "description": "문제/테스트케이스 조회와 제출 준비 구간입니다.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -406,9 +58,9 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 13
+        "y": 6
       },
-      "id": 10,
+      "id": 3,
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -422,11 +74,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.2
+                "value": 0.1
               },
               {
                 "color": "red",
-                "value": 0.5
+                "value": 0.3
               }
             ]
           }
@@ -452,15 +104,15 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(rate(user_student_list_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(user_student_list_query_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "expr": "(rate(submission_prepare_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_prepare_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
           "legendFormat": ""
         }
       ]
     },
     {
       "type": "stat",
-      "title": "로그인 이력 쿼리 평균",
-      "description": "내 로그인 이력 페이지 조회 쿼리 구간입니다.",
+      "title": "채점 평균",
+      "description": "Mock 기준 300ms x 5개면 약 1.5초가 자연스럽습니다.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -469,9 +121,9 @@
         "h": 5,
         "w": 6,
         "x": 6,
-        "y": 13
+        "y": 6
       },
-      "id": 11,
+      "id": 4,
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -485,11 +137,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.2
+                "value": 1.8
               },
               {
                 "color": "red",
-                "value": 0.5
+                "value": 2.5
               }
             ]
           }
@@ -515,41 +167,152 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(rate(auth_login_history_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(auth_login_history_query_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "expr": "(rate(submission_grading_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_grading_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
           "legendFormat": ""
         }
       ]
     },
     {
-      "type": "text",
-      "title": "추가 계측 판단",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 13
+      "type": "stat",
+      "title": "저장 평균",
+      "description": "제출과 테스트 결과 저장 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
       },
-      "id": 12,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "options": {
-        "mode": "markdown",
-        "content": "### 지금 없는 상세 지표\n- 의심 로그인 건수: `auth_suspicious_login_total` 또는 `event=suspicious_login_detected` 추가 후보입니다.\n- 추가 인증 잠금 건수: `auth_stepup_locked_total` 추가 후보입니다.\n- 지금은 로그인 실패/추가 인증 실패는 요청 상태와 요청 로그로 확인합니다."
-      }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(submission_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_save_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "전체 처리 평균",
+      "description": "SubmissionService 내부 전체 처리 시간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(submission_total_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_total_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
     },
     {
       "type": "timeseries",
-      "title": "사용자 조회 내부 구간 평균",
+      "title": "제출 처리 단계별 평균",
       "description": "",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 9,
+        "w": 24,
         "x": 0,
-        "y": 18
+        "y": 11
       },
-      "id": 13,
+      "id": 7,
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -564,8 +327,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(user_student_list_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(user_student_list_query_duration_seconds_count[$__rate_interval]), 0.0001)",
-          "legendFormat": "학생 목록"
+          "expr": "rate(submission_total_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_total_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "전체"
         },
         {
           "refId": "B",
@@ -573,36 +336,347 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(auth_login_history_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(auth_login_history_query_duration_seconds_count[$__rate_interval]), 0.0001)",
-          "legendFormat": "로그인 이력"
+          "expr": "rate(submission_prepare_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_prepare_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "준비"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(submission_grading_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_grading_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "채점"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(submission_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_save_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "저장"
         }
       ]
     },
     {
       "type": "row",
-      "title": "보안/사용자 로그",
+      "title": "제출 도메인 이벤트",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 20
       },
-      "id": 14,
+      "id": 8,
       "collapsed": false
     },
     {
+      "type": "stat",
+      "title": "제출 완료(5분)",
+      "description": "정상 완료된 제출 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 21
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=submission_completed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "제출 실패(5분)",
+      "description": "SubmissionService 실패 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 21
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=submission_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "코드 실행기 실패(5분)",
+      "description": "외부 채점 호출 실패입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=code_execution_runner_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "느린 제출 로그(5분)",
+      "description": "2초 이상 걸린 제출 요청 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=request_completed\" |= \"/api/v1/problems/\" |= \"/submissions\" |~ \"durationMs=([2-9][0-9]{3}|[1-9][0-9]{4,})\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
       "type": "logs",
-      "title": "로그인 / 추가 인증 실패 요청",
-      "description": "비정상 로그인 증가, 추가 인증 검증 실패를 빠르게 확인합니다.",
+      "title": "제출 완료 로그",
+      "description": "prepareMs, gradingMs, saveMs, durationMs를 함께 봅니다.",
       "datasource": {
         "type": "loki",
         "uid": "loki"
       },
       "gridPos": {
         "h": 10,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 27
+        "y": 26
+      },
+      "id": 13,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |= \"event=submission_completed\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "제출 실패 / 코드 실행기 실패 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "id": 14,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=submission_failed|event=code_execution_runner_failed|Connection is not available\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "느린 제출 요청 로그",
+      "description": "traceId로 제출 처리 로그와 연결해서 봅니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 26
       },
       "id": 15,
       "options": {
@@ -618,119 +692,10 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "{job=\"lms\"} |= \"event=request_completed\" |~ \"/api/v1/auth/(login|step-up/verify)\" |~ \"status=4..|status=5..\"",
-          "queryType": "range"
-        }
-      ]
-    },
-    {
-      "type": "logs",
-      "title": "학생 목록 / 로그인 이력 조회 로그",
-      "description": "durationMs, resultCount, page/size를 같이 봅니다.",
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 12,
-        "y": 27
-      },
-      "id": 16,
-      "options": {
-        "showTime": true,
-        "wrapLogMessage": true,
-        "sortOrder": "Descending",
-        "enableLogDetails": true
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "expr": "{job=\"lms\"} |~ \"event=user_student_list_queried|event=auth_login_history_queried\"",
-          "queryType": "range"
-        }
-      ]
-    },
-    {
-      "type": "logs",
-      "title": "계정 잠금 / 신뢰기기 요청 로그",
-      "description": "",
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 37
-      },
-      "id": 17,
-      "options": {
-        "showTime": true,
-        "wrapLogMessage": true,
-        "sortOrder": "Descending",
-        "enableLogDetails": true
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "expr": "{job=\"lms\"} |= \"event=request_completed\" |~ \"/api/v1/users/.*/lock|/api/v1/users/me/trusted-devices\"",
+          "expr": "{job=\"lms\"} |= \"event=request_completed\" |= \"/api/v1/problems/\" |= \"/submissions\" |~ \"durationMs=([2-9][0-9]{3}|[1-9][0-9]{4,})\"",
           "queryType": "range"
         }
       ]
     }
-  ],
-  "templating": {
-    "list": [
-      {
-        "name": "category",
-        "label": "카테고리",
-        "type": "custom",
-        "query": "전체,로그인,추가 인증,학생조회,계정잠금",
-        "current": {
-          "text": "전체",
-          "value": "전체"
-        },
-        "includeAll": false,
-        "multi": false,
-        "options": [
-          {
-            "text": "전체",
-            "value": "전체",
-            "selected": true
-          },
-          {
-            "text": "로그인",
-            "value": "로그인",
-            "selected": false
-          },
-          {
-            "text": "추가 인증",
-            "value": "추가 인증",
-            "selected": false
-          },
-          {
-            "text": "학생조회",
-            "value": "학생조회",
-            "selected": false
-          },
-          {
-            "text": "계정잠금",
-            "value": "계정잠금",
-            "selected": false
-          }
-        ]
-      }
-    ]
-  }
+  ]
 }

--- a/python-runner/app.py
+++ b/python-runner/app.py
@@ -1,4 +1,4 @@
-zimport os
+import os
 import subprocess
 import sys
 import tempfile

--- a/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.reward.point.application.port;
+
+public interface RecordRewardMetricsPort {
+
+    void recordScheduled();
+
+    void recordProcessed(ProcessResult result);
+
+    void recordProcess(long elapsedNanos);
+
+    void updatePending(long pendingCount);
+
+    enum ProcessResult {
+        COMPLETED("completed"),
+        RETRY("retry"),
+        FAILED("failed"),
+        SKIPPED("skipped"),
+        NOT_FOUND("not_found"),
+        ERROR("error");
+
+        private final String tagValue;
+
+        ProcessResult(String tagValue) {
+            this.tagValue = tagValue;
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
@@ -2,6 +2,8 @@ package com.wanted.codebombalms.reward.point.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.DomainException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort.ProcessResult;
 import com.wanted.codebombalms.reward.point.application.usecase.GrantProblemPointUseCase;
 import com.wanted.codebombalms.reward.point.application.usecase.ProcessPointRewardTaskUseCase;
 import com.wanted.codebombalms.reward.point.application.usecase.SchedulePointRewardTaskUseCase;
@@ -10,13 +12,16 @@ import com.wanted.codebombalms.reward.point.domain.model.PointRewardTask;
 import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
 import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PointRewardTaskService
@@ -26,6 +31,7 @@ public class PointRewardTaskService
 
     private final PointRewardTaskRepository pointRewardTaskRepository;
     private final GrantProblemPointUseCase grantProblemPointUseCase;
+    private final RecordRewardMetricsPort rewardMetrics;
     private final Clock clock;
     private static final long MAX_RETRY_DELAY_MINUTES = 16L;
 
@@ -49,16 +55,57 @@ public class PointRewardTaskService
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void process(Long submissionId) {
-        PointRewardTask task = pointRewardTaskRepository
-                .findBySubmissionIdForUpdate(submissionId)
-                .orElseThrow(() -> new NotFoundException(
-                        RewardErrorCode.REWARD_POINT_TASK_NOT_FOUND
-                ));
+        long startedAtNanos = System.nanoTime();
+        ProcessResult result = null;
+        try {
+            PointRewardTask task = pointRewardTaskRepository
+                    .findBySubmissionIdForUpdate(submissionId)
+                    .orElseThrow(() -> new NotFoundException(
+                            RewardErrorCode.REWARD_POINT_TASK_NOT_FOUND
+                    ));
 
-        if (task.status() != PointRewardTaskStatus.PENDING) {
-            return;
+            if (task.status() != PointRewardTaskStatus.PENDING) {
+                result = ProcessResult.SKIPPED;
+                log.info(
+                        "event=reward_point_task_skipped submissionId={} status={} durationMs={}",
+                        submissionId,
+                        task.status(),
+                        elapsedMillis(startedAtNanos)
+                );
+                return;
+            }
+
+            result = processPendingTask(task, startedAtNanos);
+        } catch (NotFoundException e) {
+            result = ProcessResult.NOT_FOUND;
+            log.warn(
+                    "event=reward_point_task_not_found submissionId={} durationMs={}",
+                    submissionId,
+                    elapsedMillis(startedAtNanos)
+            );
+            throw e;
+        } catch (Exception e) {
+            result = ProcessResult.ERROR;
+            log.error(
+                    "event=reward_point_task_processing_failed submissionId={} exceptionType={} durationMs={}",
+                    submissionId,
+                    e.getClass().getSimpleName(),
+                    elapsedMillis(startedAtNanos),
+                    e
+            );
+            throw e;
+        } finally {
+            if (result != null) {
+                rewardMetrics.recordProcessed(result);
+            }
+            rewardMetrics.recordProcess(System.nanoTime() - startedAtNanos);
         }
+    }
 
+    private ProcessResult processPendingTask(
+            PointRewardTask task,
+            long startedAtNanos
+    ) {
         try {
             grantProblemPointUseCase.grant(
                     task.userId(),
@@ -68,31 +115,65 @@ public class PointRewardTaskService
             );
 
             pointRewardTaskRepository.save(task.complete());
+            log.info(
+                    "event=reward_point_task_completed userId={} problemId={} submissionId={} point={} retryCount={} durationMs={}",
+                    task.userId(),
+                    task.problemId(),
+                    task.submissionId(),
+                    task.point(),
+                    task.retryCount(),
+                    elapsedMillis(startedAtNanos)
+            );
+            return ProcessResult.COMPLETED;
         } catch (DomainException e) {
-            handleDomainFailure(task, e);
+            return handleDomainFailure(task, e, startedAtNanos);
         } catch (Exception e) {
-            handleFailure(task, e);
+            return handleFailure(task, e, startedAtNanos);
         }
     }
 
-    private void handleDomainFailure(
+    private ProcessResult handleDomainFailure(
             PointRewardTask task,
-            DomainException exception
+            DomainException exception,
+            long startedAtNanos
     ) {
         if (isAlreadyGranted(exception)) {
             pointRewardTaskRepository.save(task.complete());
-            return;
+            log.info(
+                    "event=reward_point_task_completed userId={} problemId={} submissionId={} point={} retryCount={} reason=already_granted durationMs={}",
+                    task.userId(),
+                    task.problemId(),
+                    task.submissionId(),
+                    task.point(),
+                    task.retryCount(),
+                    elapsedMillis(startedAtNanos)
+            );
+            return ProcessResult.COMPLETED;
         }
 
         pointRewardTaskRepository.save(
                 task.failPermanently(exception.getMessage())
         );
+        log.warn(
+                "event=reward_point_task_failed userId={} problemId={} submissionId={} retryCount={} reason=domain_failure exceptionType={} durationMs={}",
+                task.userId(),
+                task.problemId(),
+                task.submissionId(),
+                task.retryCount(),
+                exception.getClass().getSimpleName(),
+                elapsedMillis(startedAtNanos)
+        );
+        return ProcessResult.FAILED;
     }
 
-    private void handleFailure(PointRewardTask task, Exception exception) {
+    private ProcessResult handleFailure(
+            PointRewardTask task,
+            Exception exception,
+            long startedAtNanos
+    ) {
         if (isAlreadyGranted(exception)) {
             pointRewardTaskRepository.save(task.complete());
-            return;
+            return ProcessResult.COMPLETED;
         }
 
         long retryDelayMinutes = Math.min(
@@ -100,11 +181,38 @@ public class PointRewardTaskService
                 1L << task.retryCount()
         );
 
-        pointRewardTaskRepository.save(task.retry(
+        PointRewardTask updatedTask = task.retry(
                 exception.getMessage(),
                 now().plusMinutes(retryDelayMinutes),
                 MAX_RETRY_COUNT
-        ));
+        );
+        pointRewardTaskRepository.save(updatedTask);
+
+        if (updatedTask.status() == PointRewardTaskStatus.FAILED) {
+            log.error(
+                    "event=reward_point_task_failed userId={} problemId={} submissionId={} retryCount={} reason=max_retry_exceeded exceptionType={} durationMs={}",
+                    task.userId(),
+                    task.problemId(),
+                    task.submissionId(),
+                    updatedTask.retryCount(),
+                    exception.getClass().getSimpleName(),
+                    elapsedMillis(startedAtNanos),
+                    exception
+            );
+            return ProcessResult.FAILED;
+        }
+
+        log.warn(
+                "event=reward_point_task_retry_scheduled userId={} problemId={} submissionId={} retryCount={} exceptionType={} nextRetryAt={} durationMs={}",
+                task.userId(),
+                task.problemId(),
+                task.submissionId(),
+                updatedTask.retryCount(),
+                exception.getClass().getSimpleName(),
+                updatedTask.nextRetryAt(),
+                elapsedMillis(startedAtNanos)
+        );
+        return ProcessResult.RETRY;
     }
 
     private boolean isAlreadyGranted(Exception exception) {
@@ -115,5 +223,11 @@ public class PointRewardTaskService
 
     private LocalDateTime now() {
         return LocalDateTime.now(clock);
+    }
+
+    private long elapsedMillis(long startedAtNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(
+                System.nanoTime() - startedAtNanos
+        );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/reward/point/domain/repository/PointRewardTaskRepository.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/domain/repository/PointRewardTaskRepository.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.reward.point.domain.repository;
 
 import com.wanted.codebombalms.reward.point.domain.model.PointRewardTask;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,4 +17,6 @@ public interface PointRewardTaskRepository {
             LocalDateTime now,
             int limit
     );
+
+    long countByStatus(PointRewardTaskStatus status);
 }

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandler.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandler.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.reward.point.infrastructure.event;
 
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
 import com.wanted.codebombalms.reward.point.application.usecase.ProcessPointRewardTaskUseCase;
 import com.wanted.codebombalms.reward.point.application.usecase.SchedulePointRewardTaskUseCase;
 import com.wanted.codebombalms.submission.domain.event.ProblemSolvedEvent;
@@ -16,6 +17,7 @@ public class PointRewardEventHandler {
 
     private final SchedulePointRewardTaskUseCase schedulePointRewardTaskUseCase;
     private final ProcessPointRewardTaskUseCase processPointRewardTaskUseCase;
+    private final RecordRewardMetricsPort rewardMetrics;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void schedule(ProblemSolvedEvent event) {
@@ -29,6 +31,15 @@ public class PointRewardEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void process(ProblemSolvedEvent event) {
+        rewardMetrics.recordScheduled();
+        log.info(
+                "event=reward_point_task_scheduled userId={} problemId={} submissionId={} point={}",
+                event.userId(),
+                event.problemId(),
+                event.submissionId(),
+                event.point()
+        );
+
         try {
             processPointRewardTaskUseCase.process(event.submissionId());
         } catch (Exception e) {

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
@@ -1,0 +1,71 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class RewardMetrics implements RecordRewardMetricsPort {
+
+    private final Counter scheduledCounter;
+    private final Map<ProcessResult, Counter> processedCounters;
+    private final Timer processTimer;
+    private final AtomicLong pendingTasks = new AtomicLong();
+
+    public RewardMetrics(MeterRegistry registry) {
+        this.scheduledCounter = Counter.builder("reward_point_task_scheduled")
+                .description("Committed point reward tasks")
+                .register(registry);
+
+        this.processedCounters = new EnumMap<>(ProcessResult.class);
+        for (ProcessResult result : ProcessResult.values()) {
+            processedCounters.put(
+                    result,
+                    Counter.builder("reward_point_task_processed")
+                            .description("Point reward task processing outcomes")
+                            .tag("result", result.tagValue())
+                            .register(registry)
+            );
+        }
+
+        this.processTimer = Timer.builder("reward_point_task_process_duration")
+                .description("Point reward task processing duration")
+                .register(registry);
+
+        Gauge.builder(
+                        "reward_point_task_pending",
+                        pendingTasks,
+                        AtomicLong::doubleValue
+                )
+                .description("Current pending point reward task count")
+                .register(registry);
+    }
+
+    @Override
+    public void recordScheduled() {
+        scheduledCounter.increment();
+    }
+
+    @Override
+    public void recordProcessed(ProcessResult result) {
+        processedCounters.get(result).increment();
+    }
+
+    @Override
+    public void recordProcess(long elapsedNanos) {
+        processTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void updatePending(long pendingCount) {
+        pendingTasks.set(Math.max(pendingCount, 0));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsScheduler.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
+import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RewardPendingMetricsScheduler {
+
+    private final PointRewardTaskRepository pointRewardTaskRepository;
+    private final RecordRewardMetricsPort rewardMetrics;
+
+    @Scheduled(
+            fixedDelayString = "${reward.point.metrics.pending-refresh-ms:30000}",
+            initialDelayString = "${reward.point.metrics.pending-initial-delay-ms:0}"
+    )
+    public void refreshPendingCount() {
+        try {
+            long pendingCount = pointRewardTaskRepository.countByStatus(
+                    PointRewardTaskStatus.PENDING
+            );
+            rewardMetrics.updatePending(pendingCount);
+        } catch (Exception e) {
+            log.warn(
+                    "event=reward_point_pending_metric_refresh_failed exceptionType={}",
+                    e.getClass().getSimpleName(),
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/PointRewardTaskPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/PointRewardTaskPersistenceAdapter.java
@@ -44,4 +44,9 @@ public class PointRewardTaskPersistenceAdapter
                 .map(PointRewardTaskJpaEntity::toDomain)
                 .toList();
     }
+
+    @Override
+    public long countByStatus(PointRewardTaskStatus status) {
+        return repository.countByStatus(status);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/SpringDataPointRewardTaskRepository.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/SpringDataPointRewardTaskRepository.java
@@ -31,4 +31,6 @@ public interface SpringDataPointRewardTaskRepository
             LocalDateTime now,
             Pageable pageable
     );
+
+    long countByStatus(PointRewardTaskStatus status);
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
@@ -1,10 +1,31 @@
 package com.wanted.codebombalms.submission.infrastructure.persistence;
 
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionTestCaseResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface SpringDataSubmissionTestResultRepository extends JpaRepository<SubmissionTestResultJpaEntity, Long> {
+public interface SpringDataSubmissionTestResultRepository
+        extends JpaRepository<SubmissionTestResultJpaEntity, Long> {
 
-    List<SubmissionTestResultJpaEntity> findBySubmission_SubmissionIdOrderByTestCase_TestOrderAsc(Long submissionId);
+
+    @Query("""
+            select new com.wanted.codebombalms.submission.domain.model.CodeSubmissionTestCaseResult(
+                testCase.testCaseId,
+                result.passed,
+                testCase.hidden,
+                result.actualOutput,
+                result.errorMessage,
+                result.executionTimeMs
+            )
+            from SubmissionTestResultJpaEntity result
+            join result.testCase testCase
+            where result.submission.submissionId = :submissionId
+            order by testCase.testOrder asc
+            """)
+    List<CodeSubmissionTestCaseResult> findResultDetailsBySubmissionId(
+            @Param("submissionId") Long submissionId
+    );
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
@@ -23,7 +23,7 @@ public interface SpringDataSubmissionTestResultRepository
             from SubmissionTestResultJpaEntity result
             join result.testCase testCase
             where result.submission.submissionId = :submissionId
-            order by testCase.testOrder asc
+            order by testCase.testOrder asc, testCase.testCaseId asc
             """)
     List<CodeSubmissionTestCaseResult> findResultDetailsBySubmissionId(
             @Param("submissionId") Long submissionId

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionResultQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionResultQueryPersistenceAdapter.java
@@ -28,11 +28,9 @@ public class SubmissionResultQueryPersistenceAdapter implements SubmissionResult
         SubmissionJpaEntity submission = submissionRepository.findBySubmissionIdAndUserId(submissionId, userId)
                 .orElseThrow(() -> new NotFoundException(SubmissionErrorCode.SUBMISSION_NOT_FOUND));
 
-        List<CodeSubmissionTestCaseResult> testCaseResults = submissionTestResultRepository
-                .findBySubmission_SubmissionIdOrderByTestCase_TestOrderAsc(submissionId)
-                .stream()
-                .map(this::toTestCaseResult)
-                .toList();
+        List<CodeSubmissionTestCaseResult> testCaseResults =
+                submissionTestResultRepository
+                        .findResultDetailsBySubmissionId(submissionId);
 
         return new CodeSubmissionResult(
                 submission.getSubmissionId(),
@@ -48,14 +46,4 @@ public class SubmissionResultQueryPersistenceAdapter implements SubmissionResult
         );
     }
 
-    private CodeSubmissionTestCaseResult toTestCaseResult(SubmissionTestResultJpaEntity result) {
-        return new CodeSubmissionTestCaseResult(
-                result.getTestCase().getTestCaseId(),
-                result.getPassed(),
-                result.getTestCase().getHidden(),
-                result.getActualOutput(),
-                result.getErrorMessage(),
-                result.getExecutionTimeMs()
-        );
-    }
 }

--- a/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
@@ -1,0 +1,146 @@
+package com.wanted.codebombalms.reward.point.application.service;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort.ProcessResult;
+import com.wanted.codebombalms.reward.point.application.usecase.GrantProblemPointUseCase;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTask;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
+import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PointRewardTaskServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-06-30T00:00:00Z");
+
+    @Mock
+    private PointRewardTaskRepository pointRewardTaskRepository;
+
+    @Mock
+    private GrantProblemPointUseCase grantProblemPointUseCase;
+
+    @Mock
+    private RecordRewardMetricsPort rewardMetrics;
+
+    private PointRewardTaskService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PointRewardTaskService(
+                pointRewardTaskRepository,
+                grantProblemPointUseCase,
+                rewardMetrics,
+                Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void recordsCompletedResultWhenGrantSucceeds() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        service.process(30L);
+
+        ArgumentCaptor<PointRewardTask> savedTask =
+                ArgumentCaptor.forClass(PointRewardTask.class);
+        verify(pointRewardTaskRepository).save(savedTask.capture());
+        assertThat(savedTask.getValue().status())
+                .isEqualTo(PointRewardTaskStatus.COMPLETED);
+        verify(rewardMetrics).recordProcessed(ProcessResult.COMPLETED);
+        verify(rewardMetrics).recordProcess(anyLong());
+    }
+
+    @Test
+    void recordsRetryResultWhenGrantThrowsTransientError() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+        doThrow(new IllegalStateException("temporary DB failure"))
+                .when(grantProblemPointUseCase)
+                .grant(10L, 20L, 30L, 100);
+
+        service.process(30L);
+
+        ArgumentCaptor<PointRewardTask> savedTask =
+                ArgumentCaptor.forClass(PointRewardTask.class);
+        verify(pointRewardTaskRepository).save(savedTask.capture());
+        assertThat(savedTask.getValue().status())
+                .isEqualTo(PointRewardTaskStatus.PENDING);
+        assertThat(savedTask.getValue().retryCount()).isEqualTo(1);
+        verify(rewardMetrics).recordProcessed(ProcessResult.RETRY);
+    }
+
+    @Test
+    void recordsFailedResultWhenRetryLimitIsReached() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 4);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+        doThrow(new IllegalStateException("persistent DB failure"))
+                .when(grantProblemPointUseCase)
+                .grant(10L, 20L, 30L, 100);
+
+        service.process(30L);
+
+        ArgumentCaptor<PointRewardTask> savedTask =
+                ArgumentCaptor.forClass(PointRewardTask.class);
+        verify(pointRewardTaskRepository).save(savedTask.capture());
+        assertThat(savedTask.getValue().status())
+                .isEqualTo(PointRewardTaskStatus.FAILED);
+        assertThat(savedTask.getValue().retryCount()).isEqualTo(5);
+        verify(rewardMetrics).recordProcessed(ProcessResult.FAILED);
+    }
+
+    @Test
+    void recordsSkippedResultForAlreadyProcessedTask() {
+        PointRewardTask task = task(PointRewardTaskStatus.COMPLETED, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        service.process(30L);
+
+        verify(grantProblemPointUseCase, never())
+                .grant(10L, 20L, 30L, 100);
+        verify(pointRewardTaskRepository, never()).save(any(PointRewardTask.class));
+        verify(rewardMetrics).recordProcessed(ProcessResult.SKIPPED);
+    }
+
+    private PointRewardTask task(
+            PointRewardTaskStatus status,
+            int retryCount
+    ) {
+        LocalDateTime now = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+        return new PointRewardTask(
+                1L,
+                10L,
+                20L,
+                30L,
+                100,
+                status,
+                retryCount,
+                null,
+                now,
+                now,
+                now
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandlerTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandlerTest.java
@@ -1,0 +1,63 @@
+package com.wanted.codebombalms.reward.point.infrastructure.event;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.application.usecase.ProcessPointRewardTaskUseCase;
+import com.wanted.codebombalms.reward.point.application.usecase.SchedulePointRewardTaskUseCase;
+import com.wanted.codebombalms.submission.domain.event.ProblemSolvedEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PointRewardEventHandlerTest {
+
+    @Mock
+    private SchedulePointRewardTaskUseCase schedulePointRewardTaskUseCase;
+
+    @Mock
+    private ProcessPointRewardTaskUseCase processPointRewardTaskUseCase;
+
+    @Mock
+    private RecordRewardMetricsPort rewardMetrics;
+
+    @InjectMocks
+    private PointRewardEventHandler handler;
+
+    @Test
+    void recordsScheduledMetricAfterCommittedEvent() {
+        ProblemSolvedEvent event = new ProblemSolvedEvent(
+                10L,
+                20L,
+                30L,
+                100
+        );
+
+        handler.process(event);
+
+        verify(rewardMetrics).recordScheduled();
+        verify(processPointRewardTaskUseCase).process(30L);
+    }
+
+    @Test
+    void schedulesPersistentTaskBeforeCommit() {
+        ProblemSolvedEvent event = new ProblemSolvedEvent(
+                10L,
+                20L,
+                30L,
+                100
+        );
+
+        handler.schedule(event);
+
+        verify(schedulePointRewardTaskUseCase).schedule(
+                10L,
+                20L,
+                30L,
+                100
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort.ProcessResult;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RewardMetricsTest {
+
+    @Test
+    void rewardMetricsExposeExpectedNamesAndTags() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RewardMetrics metrics = new RewardMetrics(registry);
+
+        metrics.recordScheduled();
+        metrics.recordProcessed(ProcessResult.COMPLETED);
+        metrics.recordProcessed(ProcessResult.RETRY);
+        metrics.recordProcessed(ProcessResult.FAILED);
+        metrics.recordProcess(TimeUnit.MILLISECONDS.toNanos(250));
+        metrics.updatePending(7);
+
+        assertThat(registry.get("reward_point_task_scheduled").counter().count())
+                .isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_processed")
+                .tag("result", "completed")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_processed")
+                .tag("result", "retry")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_processed")
+                .tag("result", "failed")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_process_duration")
+                .timer()
+                .totalTime(TimeUnit.MILLISECONDS)).isEqualTo(250.0);
+        assertThat(registry.get("reward_point_task_pending").gauge().value())
+                .isEqualTo(7.0);
+    }
+
+    @Test
+    void pendingGaugeDoesNotAcceptNegativeValues() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RewardMetrics metrics = new RewardMetrics(registry);
+
+        metrics.updatePending(-1);
+
+        assertThat(registry.get("reward_point_task_pending").gauge().value())
+                .isZero();
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsSchedulerTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsSchedulerTest.java
@@ -1,0 +1,36 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
+import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RewardPendingMetricsSchedulerTest {
+
+    @Mock
+    private PointRewardTaskRepository pointRewardTaskRepository;
+
+    @Mock
+    private RecordRewardMetricsPort rewardMetrics;
+
+    @InjectMocks
+    private RewardPendingMetricsScheduler scheduler;
+
+    @Test
+    void refreshesPendingGaugeFromPersistentTasks() {
+        given(pointRewardTaskRepository.countByStatus(PointRewardTaskStatus.PENDING))
+                .willReturn(12L);
+
+        scheduler.refreshPendingCount();
+
+        verify(rewardMetrics).updatePending(12L);
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #509 

---

## 🛠️ 기능 관련 작업 내용
- 제출 결과와 테스트케이스를 JOIN하는 DTO Projection 쿼리 추가
- 테스트케이스별 LAZY 추가 조회가 발생하던 Entity Mapper 제거
- 필요한 결과 컬럼만 조회해 테스트케이스 수와 관계없이 쿼리 수 고정

---

## ♻️ 패키지 변경 사항
- `project/submission/infrastructure/persistence`: 제출 테스트 결과 Projection 조회 및 Adapter 매핑 구조 개선

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 보상 포인트 처리에 대한 처리 결과별 메트릭(성공/재시도/실패 등)과 처리 시간, 대기 중 작업 수를 계측합니다.
  * 일정 주기로 PENDING 상태 작업 수를 조회해 대기 메트릭을 갱신합니다.
* **Bug Fixes**
  * 제출물 기준 테스트 결과 상세 조회 방식이 개선되어 더 안정적으로 불러옵니다.
  * 테스트 케이스 결과는 기존과 동일하게 실행 순서에 맞춰 정렬됩니다.
* **Tests**
  * 보상 처리/이벤트/메트릭 관련 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->