### PR TITLE
[Feat] 챗봇 운영 모니터링 인프라 구축

### DIFF
--- a/monitoring-local/docs/domains/chat/bottleneck-hypothesis.md
+++ b/monitoring-local/docs/domains/chat/bottleneck-hypothesis.md
@@ -45,5 +45,5 @@ N+1이라 인덱스로 안 풀린다. 해소 수단 후보(전후 비교로 택1
 
 ## 다음 단계
 
-- **2단계**: 커스텀 메트릭 심기 — `chat_list_query_*`(또는 트랙B `chat_active_streams` Gauge), `event=chat_*` 로그. → [`metrics.md`](metrics.md)
+- **2단계** ✅: 커스텀 메트릭 심기 완료 — 트랙A `chat_room_list_query_*`, 트랙B `chat_active_streams` Gauge·`chat_ai_stream_duration`(outcome)·`chat_ai_time_to_first_token`(TTFT)·`chat_stream_terminations`(signal), `event=chat_*` 로그 + BE↔FastAPI traceId 전파. → [`metrics.md`](metrics.md), 운영 대시보드 [`lms-chat-ops-dashboard.json`](../../../grafana/provisioning/dashboards/lms-chat-ops-dashboard.json)
 - **4·5단계**: `monitoring-local/k6/scripts/chat/` 시나리오 + baseline (방 다수 시드 선행, `db/seed/`)

--- a/monitoring-local/docs/domains/chat/metrics.md
+++ b/monitoring-local/docs/domains/chat/metrics.md
@@ -1,13 +1,18 @@
 # 챗봇 도메인 — 심은 메트릭/로그 (7단계 §2단계)
 
 > 프로세스 [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션 [`../../CONVENTION.md`](../../CONVENTION.md)
-> 트랙 A(N+1 최적화 서사)만 대상. 트랙 B(SSE 한계측정)의 `chat_active_streams` Gauge는 후속.
+> 트랙 A(N+1 최적화)·트랙 B(SSE 운영) 모두 대상. 운영 대시보드: [`lms-chat-ops-dashboard.json`](../../../grafana/provisioning/dashboards/lms-chat-ops-dashboard.json).
 
 ## 커스텀 메트릭 (Layer 3)
 
 | Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
 |---|---|---|---|---|
 | `chat_room_list_query_duration_seconds_{count,sum,max}` | Timer | `chat_room_list_query_duration` | 채팅방 목록 조회 구간(제목 fanout 포함) 시간 | [`ChatMetrics`](../../../../src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java), [`ChatRoomQueryService.listRooms`](../../../../src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomQueryService.java#L28) |
+| `chat_prompt_tokens_total` / `chat_completion_tokens_total` | Counter | `chat_prompt_tokens` / `chat_completion_tokens` | AI 입력/출력 토큰 누적(=비용). 단가 달라 분리 | [`ChatMetrics`](../../../../src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java) |
+| `chat_active_streams` | Gauge | `chat_active_streams` | 현재 동시 SSE 스트림 수 | [`ChatMetrics`](../../../../src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java), [`ChatMessageCommandService.send`](../../../../src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java) |
+| `chat_ai_stream_duration_seconds_*` (tag `outcome`) | Timer(histogram) | `chat_ai_stream_duration` | AI 스트림 전체 소요(+실패율: `outcome=error`) | 〃 |
+| `chat_ai_time_to_first_token_seconds_*` | Timer(histogram) | `chat_ai_time_to_first_token` | 구독~첫 토큰(TTFT, 체감 지연) | 〃 |
+| `chat_stream_terminations_total` (tag `signal`) | Counter | `chat_stream_terminations` | 종료 신호 분포(`onComplete` vs `cancel`/`onError`=중도이탈) | 〃 |
 
 PromQL(평균):
 ```promql
@@ -29,6 +34,25 @@ event=chat_room_list_queried resultCount=<n> durationMs=<n>   (+ MDC traceId 자
   | regexp "durationMs=(?P<durationMs>[0-9]+)" | unwrap durationMs
 ```
 - 보조 증거: loadtest 프로파일은 `org.hibernate.SQL DEBUG`라 **느린 요청 traceId로 1+2N개 SQL이 로그에 직접 보인다**(N+1 육안 확인).
+
+### 스트림 에러/추적 로그 ([`ChatMessageCommandService.send`](../../../../src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java))
+
+SSE 콜백은 별도 reactor 스레드라 MDC가 전파 안 된다 → 식별자(`userId`/`roomId`/`traceId`)를 `command`에서 꺼내 **명시적으로** 박는다. 유저 입력 원문은 로깅 안 함(`userMessageLength`만).
+
+```text
+event=chat_ai_error_chunk  userId=.. roomId=.. code=.. traceId=..      # FastAPI가 error 프레임
+event=chat_save_failed     userId=.. roomId=.. traceId=..              # 답변 저장 실패
+event=chat_stream_aborted  userId=.. roomId=.. exceptionType=.. traceId=..
+event=chat_stream_end      userId=.. roomId=.. signal=.. outcome=.. durationMs=.. userMessageLength=.. traceId=..  # 정상 포함 추적 기준선
+```
+
+### traceId 전파 (BE ↔ FastAPI)
+
+`MdcLoggingFilter` 생성 traceId → 컨트롤러에서 캡처해 command → 스트림 로그 + `FastApiChatClient`가 **`X-Trace-Id` 헤더로 FastAPI에 전파**. FastAPI(`tsarbombaChatBot`)는 헤더를 받아 `trace_id=`로 로깅 → 두 서비스 로그가 같은 값으로 엮인다.
+
+```logql
+{job=~".+"} |= "a1b2c3d4"   # 값으로 매칭 → BE(traceId=)·FastAPI(trace_id=) 양쪽 다 잡힘
+```
 
 ## 공용 메트릭 (Layer 1·2, 추가 작업 없음)
 

--- a/monitoring-local/grafana/provisioning/dashboards/lms-chat-ops-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-chat-ops-dashboard.json
@@ -1,0 +1,170 @@
+{
+  "uid": "lms-chat-ops",
+  "title": "LMS Chatbot - Ops",
+  "tags": ["lms", "ops", "chat"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "type": "textbox",
+        "name": "traceId",
+        "label": "traceId",
+        "description": "에러 로그에서 본 traceId를 입력하면 Row6에서 BE+FastAPI 로그가 함께 뜬다",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      }
+    ]
+  },
+  "panels": [
+    { "id": 100, "type": "row", "title": "1. 비용 (Tokens)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 } },
+    {
+      "id": 1, "type": "stat", "title": "누적 입력(prompt) 토큰",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 0, "y": 1 },
+      "targets": [ { "refId": "A", "expr": "chat_prompt_tokens_total", "legendFormat": "prompt" } ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 2, "type": "stat", "title": "누적 출력(completion) 토큰",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 6, "y": 1 },
+      "targets": [ { "refId": "A", "expr": "chat_completion_tokens_total", "legendFormat": "completion" } ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "토큰 소비율 (tokens/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 1 },
+      "targets": [
+        { "refId": "A", "expr": "rate(chat_prompt_tokens_total[5m])", "legendFormat": "prompt/s" },
+        { "refId": "B", "expr": "rate(chat_completion_tokens_total[5m])", "legendFormat": "completion/s" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+
+    { "id": 101, "type": "row", "title": "2. 외부 AI 의존 (FastAPI/Gemini)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 } },
+    {
+      "id": 4, "type": "stat", "title": "AI 스트림 p95",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 0, "y": 9 },
+      "targets": [ { "refId": "A", "expr": "histogram_quantile(0.95, sum(rate(chat_ai_stream_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p95" } ],
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 2 }, { "color": "red", "value": 5 } ] } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 5, "type": "stat", "title": "AI 실패율 (outcome=error)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 6, "y": 9 },
+      "targets": [ { "refId": "A", "expr": "sum(rate(chat_ai_stream_duration_seconds_count{outcome=\"error\"}[5m])) / clamp_min(sum(rate(chat_ai_stream_duration_seconds_count[5m])), 1e-9)", "legendFormat": "fail rate" } ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 0.01 }, { "color": "red", "value": 0.05 } ] } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "TTFT (첫 토큰까지) 평균 / p95",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 9 },
+      "targets": [
+        { "refId": "A", "expr": "rate(chat_ai_time_to_first_token_seconds_sum[5m]) / clamp_min(rate(chat_ai_time_to_first_token_seconds_count[5m]), 1e-9)", "legendFormat": "avg" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum(rate(chat_ai_time_to_first_token_seconds_bucket[5m])) by (le))", "legendFormat": "p95" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+
+    { "id": 102, "type": "row", "title": "3. 스트리밍 건강성 (SSE)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 } },
+    {
+      "id": 7, "type": "timeseries", "title": "활성 스트림 수 (동시 SSE)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 17 },
+      "targets": [ { "refId": "A", "expr": "chat_active_streams", "legendFormat": "active" } ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "스트림 종료 분포 (signal) — cancel/onError=중도이탈",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 17 },
+      "targets": [ { "refId": "A", "expr": "sum by (signal) (rate(chat_stream_terminations_total[5m]))", "legendFormat": "{{signal}}" } ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+
+    { "id": 103, "type": "row", "title": "4. API 성능 (RED)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 } },
+    {
+      "id": 9, "type": "timeseries", "title": "RPS by URI",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 25 },
+      "targets": [ { "refId": "A", "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"chatbot\"}[1m]))", "legendFormat": "{{uri}}" } ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "5xx 에러율",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 25 },
+      "targets": [ { "refId": "A", "expr": "sum(rate(http_server_requests_seconds_count{domain=\"chatbot\",status=~\"5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"chatbot\"}[1m])), 1e-9)", "legendFormat": "5xx rate" } ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 11, "type": "timeseries", "title": "채팅방 목록 조회 평균(내부 구간)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 25 },
+      "targets": [ { "refId": "A", "expr": "rate(chat_room_list_query_duration_seconds_sum[5m]) / clamp_min(rate(chat_room_list_query_duration_seconds_count[5m]), 1e-9)", "legendFormat": "list query avg" } ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+
+    { "id": 104, "type": "row", "title": "5. 인프라 포화", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 } },
+    {
+      "id": 12, "type": "timeseries", "title": "Hikari 커넥션 (active/pending)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 33 },
+      "targets": [
+        { "refId": "A", "expr": "hikaricp_connections_active", "legendFormat": "active" },
+        { "refId": "B", "expr": "hikaricp_connections_pending", "legendFormat": "pending" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "JVM Heap 사용량",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 33 },
+      "targets": [ { "refId": "A", "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})", "legendFormat": "heap used" } ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 14, "type": "stat", "title": "Process CPU",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 33 },
+      "targets": [ { "refId": "A", "expr": "process_cpu_usage", "legendFormat": "cpu" } ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 0.7 }, { "color": "red", "value": 0.9 } ] } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+
+    { "id": 105, "type": "row", "title": "6. 로그 (Loki) — 실패율↑ 보이면 여기서 traceId 확인", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 } },
+    {
+      "id": 15, "type": "logs", "title": "챗봇 에러 로그 (BE)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 41 },
+      "targets": [ { "refId": "A", "expr": "{job=\"lms\", level=\"ERROR\"} |= \"event=chat_\"" } ],
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending", "dedupStrategy": "none" }
+    },
+    {
+      "id": 16, "type": "logs", "title": "traceId 통합 추적 (BE + FastAPI) — 위 traceId 변수 입력",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 49 },
+      "targets": [ { "refId": "A", "expr": "{job=~\".+\"} |= \"$traceId\"" } ],
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Ascending", "dedupStrategy": "none" }
+    }
+  ]
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendFirstMessageCommand.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendFirstMessageCommand.java
@@ -4,5 +4,6 @@ public record SendFirstMessageCommand(
         Long userId,
         String userMessage,
         Long problemSetId,
-        Long problemId
+        Long problemId,
+        String traceId
 ) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendMessageCommand.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendMessageCommand.java
@@ -3,5 +3,6 @@ package com.wanted.codebombalms.chatbot.application.command;
 public record SendMessageCommand(
         Long userId,
         Long roomId,
-        String userMessage
+        String userMessage,
+        String traceId
 ) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/port/AiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/port/AiChatClient.java
@@ -9,6 +9,9 @@ public interface AiChatClient {
     /**
      * ChatContext를 FastAPI에 전송하고 AI 응답을 토큰 단위로 스트리밍한다.
      * Token(N회) → Done(1회) 순서이며, 도중 실패 시 Error로 끝난다.
+     *
+     * @param traceId 분산 추적용 상관 ID. FastAPI로 {@code X-Trace-Id} 헤더로 전파해
+     *                두 서비스 로그를 같은 traceId로 엮는다. null 이면 전파하지 않는다.
      */
-    Flux<AiChatStreamChunk> stream(ChatContext context);
+    Flux<AiChatStreamChunk> stream(ChatContext context, String traceId);
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatStreamMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatStreamMetricsPort.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.chatbot.application.port;
+
+/**
+ * AI 응답 스트림의 생명주기를 관측 시스템에 기록하는 출력 포트.
+ *
+ * <p>토큰 사용량({@link RecordTokenUsagePort})과 책임을 분리한다 — 이쪽은 "스트림이 몇 개 떠 있고,
+ * 얼마나 걸렸고, 어떻게 끝났나"(동시성·지연·중도이탈)다. application 은 이 인터페이스에만 의존하고,
+ * 구현(Micrometer)은 infrastructure 에 둔다.
+ */
+public interface ChatStreamMetricsPort {
+
+    /** 스트림 구독 시작 — 활성 스트림 수 +1. */
+    void onStreamStart();
+
+    /** 첫 토큰 수신까지의 시간(TTFT). 스트림당 1회만 호출. */
+    void onFirstToken(long ttftNanos);
+
+    /**
+     * 스트림 종료 — 활성 스트림 수 -1, 전체 소요시간(outcome 별), 종료 신호 분포를 한 번에 기록.
+     *
+     * @param durationNanos 구독~종료까지 소요(ns)
+     * @param outcome       {@code "success"} | {@code "error"} — AI 응답 정상 완료 여부
+     * @param signal        reactor 종단 신호명({@code onComplete}/{@code cancel}/{@code onError})
+     */
+    void onStreamEnd(long durationNanos, String outcome, String signal);
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
 import com.wanted.codebombalms.chatbot.application.model.ChatContext;
 import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
+import com.wanted.codebombalms.chatbot.application.port.ChatStreamMetricsPort;
 import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatMessageCommandUseCase;
 import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
@@ -14,6 +15,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,19 +26,32 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
     private final AiChatClient aiChatClient;
     private final ChatMessageTransactionService txService;
     private final RecordTokenUsagePort recordTokenUsagePort;
+    private final ChatStreamMetricsPort streamMetricsPort;
 
     @Override
     public Flux<AiChatStreamChunk> send(SendMessageCommand command) {
         // 1) 스트림 전 동기 구간(블로킹 tx) — 호출 스레드에서 먼저 끝낸다
         ChatContext context = txService.prepare(command);
 
-        // 2) 스트리밍: 토큰을 누적하며 그대로 흘린다
+        // 2) per-subscription 상태 — reactive 콜백이 별도 스레드라 MDC 대신 클로저로 들고 다닌다.
         StringBuilder accumulated = new StringBuilder();
+        long startNanos = System.nanoTime();
+        AtomicBoolean firstToken = new AtomicBoolean(false);
+        AtomicReference<String> outcome = new AtomicReference<>("success");
+        streamMetricsPort.onStreamStart();
 
-        return aiChatClient.stream(context)
+        return aiChatClient.stream(context, command.traceId())
                 .doOnNext(chunk -> {
                     if (chunk instanceof AiChatStreamChunk.Token token) {
+                        if (firstToken.compareAndSet(false, true)) {
+                            streamMetricsPort.onFirstToken(System.nanoTime() - startNanos);
+                        }
                         accumulated.append(token.text());
+                    } else if (chunk instanceof AiChatStreamChunk.Error err) {
+                        // FastAPI 가 error 프레임을 보낸 경우(client onErrorResume 포함) — outcome 갈음 + 추적 로그
+                        outcome.set("error");
+                        log.error("event=chat_ai_error_chunk userId={} roomId={} code={} traceId={}",
+                                command.userId(), command.roomId(), err.code(), command.traceId());
                     }
                 })
                 .concatMap(chunk -> {
@@ -49,7 +66,8 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
                                 .thenReturn((AiChatStreamChunk) chunk)
                                 // 저장 실패해도 답변은 이미 생성·전송됨 → done 으로 정상 종료(손실은 로그/알림으로)
                                 .onErrorResume(e -> {
-                                    log.error("event=chat_save_failed roomId={}", command.roomId(), e);
+                                    log.error("event=chat_save_failed userId={} roomId={} traceId={}",
+                                            command.userId(), command.roomId(), command.traceId(), e);
                                     return Mono.just((AiChatStreamChunk) chunk);
                                 });
                     }
@@ -58,13 +76,23 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
                 // 4) 종단 안전망: 어떤 예외든 abort(=ERR_INCOMPLETE_CHUNKED_ENCODING) 대신
                 //    error 프레임으로 변환해 스트림을 정상 complete 시킨다.
                 .onErrorResume(e -> {
-                    log.error("event=chat_stream_aborted roomId={}", command.roomId(), e);
+                    outcome.set("error");
+                    log.error("event=chat_stream_aborted userId={} roomId={} exceptionType={} traceId={}",
+                            command.userId(), command.roomId(), e.getClass().getSimpleName(), command.traceId(), e);
                     return Flux.just(new AiChatStreamChunk.Error(
                             ChatErrorCode.AI_RESPONSE_FAILED.getCode(),
                             ChatErrorCode.AI_RESPONSE_FAILED.getMessage()));
                 })
-                // 다음 재현 시 종단 신호(onComplete/onError/cancel)로 원인 구간을 즉시 가른다.
-                .doFinally(signal ->
-                        log.info("event=chat_stream_end roomId={} signal={}", command.roomId(), signal));
+                // 5) 종단: 활성 스트림 -1, 전체 소요/종료신호 기록 + 추적 기준선 로그(정상도 1줄).
+                //    durationMs 는 async 라 HTTP 메트릭보다 이 값이 정확하다.
+                .doFinally(signal -> {
+                    long elapsedNanos = System.nanoTime() - startNanos;
+                    streamMetricsPort.onStreamEnd(elapsedNanos, outcome.get(), signal.toString());
+                    log.info("event=chat_stream_end userId={} roomId={} signal={} outcome={} durationMs={} userMessageLength={} traceId={}",
+                            command.userId(), command.roomId(), signal, outcome.get(),
+                            elapsedNanos / 1_000_000,
+                            command.userMessage() == null ? 0 : command.userMessage().length(),
+                            command.traceId());
+                });
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
@@ -34,7 +34,7 @@ public class ChatRoomCommandService implements ChatRoomCommandUseCase {
         return Flux.concat(
                 Flux.just(new AiChatStreamChunk.Room(room.getId())),
                 chatMessageCommandUseCase.send(
-                        new SendMessageCommand(command.userId(), room.getId(), command.userMessage()))
+                        new SendMessageCommand(command.userId(), room.getId(), command.userMessage(), command.traceId()))
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatClient.java
@@ -32,17 +32,24 @@ public class FastApiChatClient implements AiChatClient {
     private final ObjectMapper objectMapper;
 
     @Override
-    public Flux<AiChatStreamChunk> stream(ChatContext context) {
+    public Flux<AiChatStreamChunk> stream(ChatContext context, String traceId) {
         FastApiChatRequest request = toRequest(context);
 
         return webClient.post()
                 .uri("/chat")
+                // BE↔FastAPI 로그를 같은 traceId로 엮기 위해 상관 ID를 헤더로 전파한다.
+                .headers(h -> {
+                    if (traceId != null) {
+                        h.set("X-Trace-Id", traceId);
+                    }
+                })
                 .bodyValue(request)
                 .retrieve()
                 .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
                 .map(this::toChunk)
                 .onErrorResume(e -> {
-                    log.error("FastAPI 스트리밍 호출 실패", e);
+                    // raw 예외는 stack trace 만(WARN). "누구/어디" 책임 로그는 application(chat_ai_error_chunk)에서.
+                    log.warn("event=chat_ai_call_failed traceId={} - FastAPI 스트리밍 호출 실패", traceId, e);
                     return Flux.just(new AiChatStreamChunk.Error(
                             ChatErrorCode.AI_RESPONSE_FAILED.getCode(),
                             ChatErrorCode.AI_RESPONSE_FAILED.getMessage()

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/MockAiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/MockAiChatClient.java
@@ -17,7 +17,7 @@ public class MockAiChatClient implements AiChatClient {
     private final AtomicInteger callCount = new AtomicInteger(0);
 
     @Override
-    public Flux<AiChatStreamChunk> stream(ChatContext context) {
+    public Flux<AiChatStreamChunk> stream(ChatContext context, String traceId) {
         int count = callCount.incrementAndGet();
         String answer = "Fastapi 반환 mock입니다." + count + " 토큰 단위로 스트리밍됩니다.";
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
@@ -1,14 +1,17 @@
 package com.wanted.codebombalms.chatbot.infrastructure.metrics;
 
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
+import com.wanted.codebombalms.chatbot.application.port.ChatStreamMetricsPort;
 import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 챗봇 도메인 커스텀 메트릭 (관측 Layer 3).
@@ -19,16 +22,25 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>토큰 사용량 Counter 는 입력/출력을 분리 누적한다(단가가 달라 비용 계산 시 분리 필수).
  * total 은 두 Counter 의 합이라 별도 등록하지 않는다.
+ *
+ * <p>스트림 생명주기 메트릭({@link ChatStreamMetricsPort}) — 운영 대시보드의 "외부 AI 의존"·
+ * "스트리밍 건강성" 행을 채운다. AI Timer 두 개는 외부연동 p95 가 핵심 SLI 라
+ * {@code publishPercentileHistogram()} 으로 히스토그램 버킷을 노출한다(PromQL {@code histogram_quantile}).
+ * outcome/signal 은 동적 태그라 {@link MeterRegistry} 에서 그때그때 빌드한다(같은 name+tag 는 캐시됨).
  */
 @Slf4j
 @Component
-public class ChatMetrics implements RecordTokenUsagePort {
+public class ChatMetrics implements RecordTokenUsagePort, ChatStreamMetricsPort {
 
+    private final MeterRegistry registry;
     private final Timer listQueryTimer;
     private final Counter promptTokensCounter;
     private final Counter completionTokensCounter;
+    private final Timer timeToFirstTokenTimer;
+    private final AtomicInteger activeStreams = new AtomicInteger();
 
     public ChatMetrics(MeterRegistry registry) {
+        this.registry = registry;
         // 등록명엔 _seconds 를 붙이지 않는다. Timer 라서 Prometheus 가
         // chat_room_list_query_duration_seconds_{count,sum,max} 로 자동 변환한다.
         this.listQueryTimer = Timer.builder("chat_room_list_query_duration")
@@ -42,11 +54,45 @@ public class ChatMetrics implements RecordTokenUsagePort {
         this.completionTokensCounter = Counter.builder("chat_completion_tokens")
                 .description("AI 응답 출력(completion) 토큰 누적량")
                 .register(registry);
+        this.timeToFirstTokenTimer = Timer.builder("chat_ai_time_to_first_token")
+                .description("스트림 구독부터 첫 토큰 수신까지(TTFT, 사용자 체감 지연)")
+                .publishPercentileHistogram()
+                .register(registry);
+        // 현재 동시 SSE 스트림 수. 단위 suffix 없이 chat_active_streams 로 노출.
+        Gauge.builder("chat_active_streams", activeStreams, AtomicInteger::get)
+                .description("현재 동시 AI 스트림 수")
+                .register(registry);
     }
 
     /** 채팅방 목록 조회(제목 fanout 포함) 구간 소요 시간 기록. */
     public void recordListQuery(long elapsedNanos) {
         listQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void onStreamStart() {
+        activeStreams.incrementAndGet();
+    }
+
+    @Override
+    public void onFirstToken(long ttftNanos) {
+        timeToFirstTokenTimer.record(ttftNanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void onStreamEnd(long durationNanos, String outcome, String signal) {
+        activeStreams.decrementAndGet();
+        Timer.builder("chat_ai_stream_duration")
+                .description("AI 스트림 전체 소요시간(outcome 별)")
+                .tag("outcome", outcome)
+                .publishPercentileHistogram()
+                .register(registry)
+                .record(durationNanos, TimeUnit.NANOSECONDS);
+        Counter.builder("chat_stream_terminations")
+                .description("스트림 종료 신호 분포(정상완료 vs 중도이탈)")
+                .tag("signal", signal)
+                .register(registry)
+                .increment();
     }
 
     /**

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -59,11 +60,14 @@ public class ChatRoomController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody SendFirstMessageRequest request
     ) {
+        // SSE 스트림 콜백은 별도 reactor 스레드라 MDC(traceId)가 전파되지 않는다.
+        // 호출 스레드인 여기서 캡처해 command 로 넘겨야 스트림 로그에 traceId 가 박힌다.
         SendFirstMessageCommand command = new SendFirstMessageCommand(
                 userId,
                 request.userMessage(),
                 request.problemSetId(),
-                request.problemId()
+                request.problemId(),
+                MDC.get("traceId")
         );
 
         // sendFirst() 호출 시 방 준비(tx)가 동기 실행됨 → 진입부 예외는 여기서 JSON으로 처리됨
@@ -165,7 +169,8 @@ public class ChatRoomController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ChatMessageRequest request
     ) {
-        SendMessageCommand command = new SendMessageCommand(userId, roomId, request.userMessage());
+        SendMessageCommand command = new SendMessageCommand(
+                userId, roomId, request.userMessage(), MDC.get("traceId"));
 
         Flux<ServerSentEvent<Object>> body = chatMessageCommandUseCase.send(command)
                 .map(this::toServerSentEvent);

--- a/src/test/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.chatbot.application.service;
 import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
 import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
+import com.wanted.codebombalms.chatbot.application.port.ChatStreamMetricsPort;
 import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,16 +41,18 @@ class ChatMessageCommandServiceTest {
     private ChatMessageTransactionService txService;
     @Mock
     private RecordTokenUsagePort recordTokenUsagePort;
+    @Mock
+    private ChatStreamMetricsPort streamMetricsPort;
     @InjectMocks
     private ChatMessageCommandService service;
 
-    private final SendMessageCommand command = new SendMessageCommand(1L, 10L, "안녕");
+    private final SendMessageCommand command = new SendMessageCommand(1L, 10L, "안녕", "test-trace");
 
     @Test
     @DisplayName("AI 답변 저장이 실패해도 스트림은 onError 로 끊기지 않고 done 으로 정상 완료된다")
     void 저장실패_정상종료() {
         given(txService.prepare(any())).willReturn(null);
-        given(aiChatClient.stream(any())).willReturn(Flux.just(
+        given(aiChatClient.stream(any(), any())).willReturn(Flux.just(
                 new AiChatStreamChunk.Token("안"),
                 new AiChatStreamChunk.Token("녕"),
                 new AiChatStreamChunk.Done(new AiChatStreamChunk.TokenUsage(10, 2, 12))
@@ -69,7 +72,7 @@ class ChatMessageCommandServiceTest {
     @DisplayName("스트림 중간 에러 신호도 error 프레임으로 변환되어 정상 완료된다")
     void 중간에러_정상종료() {
         given(txService.prepare(any())).willReturn(null);
-        given(aiChatClient.stream(any())).willReturn(Flux.concat(
+        given(aiChatClient.stream(any(), any())).willReturn(Flux.concat(
                 Flux.just(new AiChatStreamChunk.Token("부분")),
                 Flux.error(new RuntimeException("stream broke"))
         ));


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

운영 모니터링 보강(이슈 미지정, 백로그 항목)

---

## 🛠️ 기능 관련 작업 내용

1. **커스텀 메트릭 4종 추가** (ChatMetrics + ChatStreamMetricsPort)
   - `chat_active_streams` — 현재 동시 SSE 스트림 수 (Gauge)
   - `chat_ai_stream_duration` — AI 응답 스트림 전체 소요시간 (Timer+histogram, outcome 태그)
   - `chat_ai_time_to_first_token` — TTFT(사용자 체감 지연) 계측 (Timer+histogram)
   - `chat_stream_terminations` — 스트림 종료 신호 분포 (Counter, signal 태그 → 정상완료 vs 중도이탈)

2. **구조화 에러 로깅** — SSE 콜백은 MDC 전파 불가이므로, command에서 userId/roomId/traceId를 명시적으로 추출·로그에 박음
   - 신규 이벤트: `chat_ai_error_chunk`, `chat_save_failed`, `chat_stream_aborted`, `chat_stream_end`
   - 유저 입력 원문은 비로깅, userMessageLength만 기록

3. **traceId 전파** — MdcLoggingFilter 생성 traceId를 컨트롤러에서 캡처 → SendMessageCommand/SendFirstMessageCommand에 담아 스트림 로그에 기록
   - FastApiChatClient가 `X-Trace-Id` 헤더로 FastAPI에 전파 (BE↔FastAPI 로그 상관)

4. **Grafana 운영 대시보드** (`lms-chat-ops-dashboard.json`)
   - 6행 구성: 비용(토큰)/외부AI의존(stream duration, TTFT)/스트리밍건강성(active streams, terminations)/API(RED)/인프라/Loki로그+traceId 검색

5. **문서 동기화** — metrics.md, bottleneck-hypothesis.md 갱신

---

## ♻️ 패키지 변경 사항

- `chatbot/infrastructure/metrics/ChatMetrics` — 메트릭 포트 구현, Gauge/Timer/Counter 등록
- `chatbot/application/port/ChatStreamMetricsPort` (신규) — 스트림 생명주기 콜백 인터페이스
- `chatbot/application/port/RecordTokenUsagePort` (신규) — 토큰 사용량 기록 포트
- `chatbot/application/service/ChatMessageCommandService` — reactive 체인에 메트릭 계측(doOnNext, onFirstToken, onStreamEnd, doFinally), 구조화 로깅
- `chatbot/application/command/SendMessageCommand`, `SendFirstMessageCommand` — traceId 필드 추가
- `chatbot/infrastructure/client/FastApiChatClient` — X-Trace-Id 헤더 전파
- `chatbot/presentation/api/ChatRoomController` — traceId 캡처·command에 담기
- `monitoring-local/grafana/provisioning/dashboards/lms-chat-ops-dashboard.json` (신규) — 운영 대시보드 정의
- `monitoring-local/docs/domains/chat/metrics.md` — 메트릭 명세 갱신
- `monitoring-local/docs/domains/chat/bottleneck-hypothesis.md` — 병목 분석 갱신
- 테스트: `ChatMessageCommandServiceTest`, `ChatMessageTest` (신규)

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다. (로컬 메시지 전송 시 메트릭 실시간 증가, traceId 로그 정상 기록)
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.

---

**참고:** FastAPI 서버 측 변경(traceId 추가 응답·로그 구조화)은 별도 레포에서 별도 PR로 올라갑니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 채팅 메시지 전송에 요청 추적 정보가 함께 전달되어, 응답 흐름을 더 안정적으로 추적할 수 있게 되었습니다.
  * AI 스트리밍 응답의 시작, 첫 토큰 도달, 종료 시점을 기록해 상태 파악이 강화되었습니다.
  * 스트리밍 요청에 추적 식별자가 포함되어, 문제 분석과 로그 확인이 더 쉬워졌습니다.

* **Bug Fixes**
  * 스트리밍 중 오류 발생 시 종료 상태와 로그 정보가 더 일관되게 남도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->