### PR TITLE
[Release] v1.3.0

### DIFF
--- a/monitoring-local/docs/domains/chat/bottleneck-hypothesis.md
+++ b/monitoring-local/docs/domains/chat/bottleneck-hypothesis.md
@@ -45,5 +45,5 @@ N+1이라 인덱스로 안 풀린다. 해소 수단 후보(전후 비교로 택1
 
 ## 다음 단계
 
-- **2단계**: 커스텀 메트릭 심기 — `chat_list_query_*`(또는 트랙B `chat_active_streams` Gauge), `event=chat_*` 로그. → [`metrics.md`](metrics.md)
+- **2단계** ✅: 커스텀 메트릭 심기 완료 — 트랙A `chat_room_list_query_*`, 트랙B `chat_active_streams` Gauge·`chat_ai_stream_duration`(outcome)·`chat_ai_time_to_first_token`(TTFT)·`chat_stream_terminations`(signal), `event=chat_*` 로그 + BE↔FastAPI traceId 전파. → [`metrics.md`](metrics.md), 운영 대시보드 [`lms-chat-ops-dashboard.json`](../../../grafana/provisioning/dashboards/lms-chat-ops-dashboard.json)
 - **4·5단계**: `monitoring-local/k6/scripts/chat/` 시나리오 + baseline (방 다수 시드 선행, `db/seed/`)

--- a/monitoring-local/docs/domains/chat/metrics.md
+++ b/monitoring-local/docs/domains/chat/metrics.md
@@ -1,13 +1,18 @@
 # 챗봇 도메인 — 심은 메트릭/로그 (7단계 §2단계)
 
 > 프로세스 [`../../PROCESS.md`](../../PROCESS.md) · 컨벤션 [`../../CONVENTION.md`](../../CONVENTION.md)
-> 트랙 A(N+1 최적화 서사)만 대상. 트랙 B(SSE 한계측정)의 `chat_active_streams` Gauge는 후속.
+> 트랙 A(N+1 최적화)·트랙 B(SSE 운영) 모두 대상. 운영 대시보드: [`lms-chat-ops-dashboard.json`](../../../grafana/provisioning/dashboards/lms-chat-ops-dashboard.json).
 
 ## 커스텀 메트릭 (Layer 3)
 
 | Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
 |---|---|---|---|---|
 | `chat_room_list_query_duration_seconds_{count,sum,max}` | Timer | `chat_room_list_query_duration` | 채팅방 목록 조회 구간(제목 fanout 포함) 시간 | [`ChatMetrics`](../../../../src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java), [`ChatRoomQueryService.listRooms`](../../../../src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomQueryService.java#L28) |
+| `chat_prompt_tokens_total` / `chat_completion_tokens_total` | Counter | `chat_prompt_tokens` / `chat_completion_tokens` | AI 입력/출력 토큰 누적(=비용). 단가 달라 분리 | [`ChatMetrics`](../../../../src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java) |
+| `chat_active_streams` | Gauge | `chat_active_streams` | 현재 동시 SSE 스트림 수 | [`ChatMetrics`](../../../../src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java), [`ChatMessageCommandService.send`](../../../../src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java) |
+| `chat_ai_stream_duration_seconds_*` (tag `outcome`) | Timer(histogram) | `chat_ai_stream_duration` | AI 스트림 전체 소요(+실패율: `outcome=error`) | 〃 |
+| `chat_ai_time_to_first_token_seconds_*` | Timer(histogram) | `chat_ai_time_to_first_token` | 구독~첫 토큰(TTFT, 체감 지연) | 〃 |
+| `chat_stream_terminations_total` (tag `signal`) | Counter | `chat_stream_terminations` | 종료 신호 분포(`onComplete` vs `cancel`/`onError`=중도이탈) | 〃 |
 
 PromQL(평균):
 ```promql
@@ -29,6 +34,25 @@ event=chat_room_list_queried resultCount=<n> durationMs=<n>   (+ MDC traceId 자
   | regexp "durationMs=(?P<durationMs>[0-9]+)" | unwrap durationMs
 ```
 - 보조 증거: loadtest 프로파일은 `org.hibernate.SQL DEBUG`라 **느린 요청 traceId로 1+2N개 SQL이 로그에 직접 보인다**(N+1 육안 확인).
+
+### 스트림 에러/추적 로그 ([`ChatMessageCommandService.send`](../../../../src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java))
+
+SSE 콜백은 별도 reactor 스레드라 MDC가 전파 안 된다 → 식별자(`userId`/`roomId`/`traceId`)를 `command`에서 꺼내 **명시적으로** 박는다. 유저 입력 원문은 로깅 안 함(`userMessageLength`만).
+
+```text
+event=chat_ai_error_chunk  userId=.. roomId=.. code=.. traceId=..      # FastAPI가 error 프레임
+event=chat_save_failed     userId=.. roomId=.. traceId=..              # 답변 저장 실패
+event=chat_stream_aborted  userId=.. roomId=.. exceptionType=.. traceId=..
+event=chat_stream_end      userId=.. roomId=.. signal=.. outcome=.. durationMs=.. userMessageLength=.. traceId=..  # 정상 포함 추적 기준선
+```
+
+### traceId 전파 (BE ↔ FastAPI)
+
+`MdcLoggingFilter` 생성 traceId → 컨트롤러에서 캡처해 command → 스트림 로그 + `FastApiChatClient`가 **`X-Trace-Id` 헤더로 FastAPI에 전파**. FastAPI(`tsarbombaChatBot`)는 헤더를 받아 `trace_id=`로 로깅 → 두 서비스 로그가 같은 값으로 엮인다.
+
+```logql
+{job=~".+"} |= "a1b2c3d4"   # 값으로 매칭 → BE(traceId=)·FastAPI(trace_id=) 양쪽 다 잡힘
+```
 
 ## 공용 메트릭 (Layer 1·2, 추가 작업 없음)
 

--- a/monitoring-local/docs/domains/problems/domain-dashboards.md
+++ b/monitoring-local/docs/domains/problems/domain-dashboards.md
@@ -1,0 +1,86 @@
+# Problem / Submission / Ranking / Badge / Reward 대시보드
+
+## 1. DDD 기준 분리
+
+| 바운디드 컨텍스트 | 대시보드 | 핵심 관측 대상 |
+| --- | --- | --- |
+| Problem | `[LMS][도메인 상세] 문제` | 문제세트 진입 단계, 진행도 조회, 코드 실행기 실패 |
+| Submission | `[LMS][도메인 상세] 제출` | 제출 준비, 채점, 저장, 실패 로그 |
+| Ranking | `[LMS][도메인 상세] 랭킹` | 내 랭킹 없음, 랭킹 정합성, 대표 뱃지 URL 후보 |
+| Badge | `[LMS][도메인 상세] 뱃지` | 뱃지 동기화 단계, 신규 획득 로그, 이미지 저장소 오류 |
+| Reward | `[LMS][도메인 상세] 보상 포인트` | 포인트 지급 작업, 재시도, 영구 실패, 복구 스케줄러 |
+
+전용 대시보드는 `monitoring-local/grafana/provisioning/dashboards/`에 있다.
+
+## 2. 모든 코드에 커스텀 메트릭과 로그가 필요한가
+
+필요하지 않다. 관측은 아래 3개 계층으로 나눈다.
+
+| 계층 | 현재 상태 | 답하는 질문 |
+| --- | --- | --- |
+| 요청 메트릭 + `domain` 태그 | 공통 자동 수집 | 어느 컨텍스트와 API가 느리거나 실패하는가 |
+| 공통 요청 로그 + `traceId` | 공통 자동 수집 | 실패하거나 느린 요청 하나가 무엇인가 |
+| 커스텀 Timer/Counter/Gauge + 이벤트 로그 | 핵심 흐름에만 추가 | 내부의 어느 구간과 이유가 문제인가 |
+
+공용 대시보드는 요청량, 오류율, URI별 평균 응답 시간, 리소스 상태를 보여주는 1차 탐지 화면이다. 도메인 상세 대시보드는 이 공용 지표를 반복하지 않고, 내부 처리 단계와 비즈니스 이벤트 로그만 보여준다.
+
+Reward는 요청 컨트롤러가 없는 비동기 컨텍스트이므로 공용 요청 지표가 생성되지 않는다. 지급 작업의 적체와 실패를 보려면 커스텀 메트릭과 구조화 로그가 필수다.
+
+## 3. 현재 계측 상태
+
+| 컨텍스트 | 자동 HTTP | 커스텀 메트릭 | 구조화 이벤트 로그 | 판단 |
+| --- | --- | --- | --- | --- |
+| Problem | 공용 대시보드에서 확인 | 문제세트 진입 단계별 Timer 있음 | 진입/실패, 코드 실행기 완료/실패 있음 | 상세 대시보드에서 원인 분해 가능 |
+| Submission | 공용 대시보드에서 확인 | prepare/grading/save/total Timer 있음 | 완료/실패 있음 | 상세 대시보드에서 원인 분해 가능 |
+| Ranking | 공용 대시보드에서 확인 | 없음 | 공통 요청 로그만 있음 | 상세 대시보드는 정합성/오류 로그 중심 |
+| Badge | 공용 대시보드에서 확인 | 동기화 단계별 Timer 있음 | 동기화 완료 로그 있음 | 상세 대시보드에서 원인 분해 가능 |
+| Reward | 없음 | pending/scheduled/processed/duration 있음 | 작업 생성·완료·재시도·실패 로그 있음 | 비동기 처리 전용 대시보드 사용 가능 |
+
+## 4. Reward 메트릭 계약
+
+Reward 대시보드는 아래 이름을 사용한다.
+
+| 메트릭 | 종류 | 의미 |
+| --- | --- | --- |
+| `reward_point_task_pending` | Gauge | 현재 PENDING 지급 작업 수 |
+| `reward_point_task_scheduled_total` | Counter | 생성된 지급 작업 누적 수 |
+| `reward_point_task_processed_total{result}` | Counter | `completed`, `retry`, `failed` 결과별 처리 수 |
+| `reward_point_task_process_duration` | Timer | 지급 작업 한 건의 처리 시간 |
+
+`reward_point_task_pending`은 Prometheus 스크레이프마다 DB를 조회하지 않는다. 별도 스케줄러가 기본 30초마다 `PENDING` 건수를 조회해 Gauge를 갱신한다. 이 방식은 DB 부하와 수집기 결합을 줄이는 대신 대기 건수가 최대 30초 늦게 반영될 수 있다.
+
+권장 이벤트 로그는 다음과 같다.
+
+```text
+event=reward_point_task_scheduled submissionId=... point=...
+event=reward_point_task_completed submissionId=... retryCount=... durationMs=...
+event=reward_point_task_retry_scheduled submissionId=... retryCount=... reason=...
+event=reward_point_task_failed submissionId=... retryCount=... reason=...
+event=reward_point_recovery_completed processedCount=... durationMs=...
+```
+
+`userId`, `problemId`, `submissionId`, 예외 메시지는 메트릭 태그로 사용하지 않고 로그 본문에만 기록한다. 메트릭의 `result`와 `reason`은 미리 정한 낮은 카디널리티 값만 사용한다.
+
+## 5. 선택적 추가 계측
+
+| 컨텍스트 | 추가 시점 | 후보 |
+| --- | --- | --- |
+| Ranking | API 평균·최대 지연이 상승하고 DB 집계와 URL 생성 중 원인을 구분해야 할 때 | `ranking_query_duration`, `ranking_badge_url_duration` |
+| Badge | 실패 원인과 신규 획득량을 시계열로 집계해야 할 때 | `badge_sync_processed_total{result}`, `badge_sync_newly_earned` |
+| Submission | HTTP 상태와 별개로 채점 결과/실패 이유가 필요할 때 | `submission_processed_total{result}`, `submission_failed_total{reason}` |
+
+## 6. 공용/상세 대시보드 역할 분리
+
+운영 흐름은 다음 순서로 본다.
+
+1. `[LMS 공용 도메인 대시보드]`에서 도메인별 요청량, 오류율, URI별 평균 응답 시간, 리소스 상태를 확인한다.
+2. 이상이 발생한 도메인의 `[LMS][도메인 상세] ...` 대시보드로 이동한다.
+3. 상세 대시보드에서 내부 처리 단계, 비즈니스 이벤트 로그, 실패 로그로 원인을 좁힌다.
+
+이 분리는 공용 대시보드와 상세 대시보드가 같은 패널을 반복하지 않기 위한 결정이다. 공용은 "어디가 이상한가"를 답하고, 상세는 "왜 이상한가"를 답한다.
+
+## 7. Import
+
+로컬 구성은 datasource UID를 `prometheus`, `loki`로 고정한다. Grafana의 `Dashboards > New > Import`에서 JSON 파일을 업로드하거나, `monitoring-local`을 다시 시작하면 provisioning으로 자동 로드된다.
+
+다른 Grafana 환경에 Import할 때는 Prometheus와 Loki datasource UID가 다르면 JSON의 datasource UID를 해당 환경에 맞게 변경한다.

--- a/monitoring-local/docs/domains/submission/operating-baseline.md
+++ b/monitoring-local/docs/domains/submission/operating-baseline.md
@@ -1,0 +1,51 @@
+# Submission 운영 기준선
+
+## 목적
+
+Submission 대시보드는 단순히 응답 시간이 느린지 보는 화면이 아니라, 운영 중 이상 징후가 생겼을 때 원인 후보를 빠르게 좁히기 위한 화면이다.
+
+이 기준은 이전 제출 API 부하 테스트 결과를 기준으로 잡았다.
+
+| 구간 | 실패율 | 유효 요청률 | k6 p95 | k6 p99 | Hikari pending |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 트랜잭션 분리 전 | 28.33% | 43.3% | 3.66s | 4.56s | 약 40 |
+| 트랜잭션 분리 후 | 0% | 100% | 1.88~1.95s | 1.99~2.00s | 0 |
+
+따라서 현재 운영 대시보드에서는 개선 후 상태를 정상 기준선으로 둔다.
+
+## 운영 기준
+
+| 지표 | 정상 | 경고 | 위험 | 해석 |
+| --- | --- | --- | --- | --- |
+| Submit 평균 응답 시간 | 2s 미만 | 2s 이상 | 3s 이상 | 사용자가 제출 후 기다리는 시간 |
+| 5xx Error Rate | 1% 미만 | 1% 이상 | 5% 이상 | 서버 장애 또는 런타임 실패 |
+| Hikari Pending | 0 | 1 이상 지속 | 5 이상 | DB 커넥션 대기 발생 |
+| DB Pool Saturation | 70% 미만 | 70% 이상 | 90% 이상 | DB 커넥션 풀이 꽉 차는 중인지 |
+| Prepare Avg | 100ms 미만 | 100ms 이상 | 300ms 이상 | 문제, 테스트케이스, 데이터셋 조회 지연 |
+| Grading Avg | 1.8s 미만 | 1.8s 이상 | 2.5s 이상 | 외부 채점 실행 지연 |
+| Save Avg | 100ms 미만 | 100ms 이상 | 300ms 이상 | 제출/테스트 결과 저장 지연 |
+
+## 이상 상황별 판단
+
+| 관찰 | 가장 의심할 원인 | 먼저 볼 곳 |
+| --- | --- | --- |
+| 응답 시간 증가 + Hikari pending 증가 | DB 커넥션 부족, 긴 트랜잭션, 락 경합 | Hikari Pool Pressure, Failure Logs |
+| 응답 시간 증가 + Grading Avg만 증가 | 외부 runner 지연, 테스트케이스 수 증가, runner timeout | Grading Avg, Runner Failure Logs |
+| Prepare Avg 증가 | 문제/테스트케이스/데이터셋 조회 쿼리 문제 | Prepare Avg, Slow Request Logs |
+| Save Avg 증가 | submission 저장, test result 저장, DB lock 문제 | Save Avg, Hikari Pending |
+| 5xx 증가 | 애플리케이션 예외 또는 외부 runner 실패 | Submission Failures, traceId |
+| 4xx 증가 + 5xx 정상 | 클라이언트 요청, 인증, 테스트 데이터 문제 | Request body, user/problem state |
+
+## 운영자가 보는 순서
+
+1. `5xx Error Rate`가 빨간색인지 확인한다.
+2. `Hikari Pending`이 0보다 큰 상태로 지속되는지 본다.
+3. `Prepare / Grading / Save` 중 어느 구간이 같이 올라갔는지 본다.
+4. `Slow Submission Requests`에서 `traceId`를 복사한다.
+5. Loki에서 같은 `traceId`로 요청 흐름과 예외 로그를 따라간다.
+
+## 주의점
+
+현재 기준은 로컬 부하 테스트와 mock runner 지연을 기반으로 한 운영 참고선이다. Cloud Run, RDS, 실제 네트워크 환경으로 배포하면 절대 시간은 달라질 수 있다.
+
+다만 실패율, Hikari pending, prepare/grading/save 중 어디가 올라갔는지 보는 방식은 환경이 바뀌어도 유효하다.

--- a/monitoring-local/grafana/provisioning/dashboards/lms-badge-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-badge-domain-dashboard.json
@@ -1,0 +1,618 @@
+{
+  "uid": "lms-badge-domain",
+  "title": "[LMS][도메인 상세] 뱃지",
+  "description": "공용 대시보드에서 뱃지 도메인 이상을 발견한 뒤, 뱃지 동기화 내부 단계와 이미지 저장소/이미지 오류를 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "badge",
+    "ddd",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `badge` 도메인의 지연이나 오류를 먼저 확인합니다.\n- 이 상세 화면에서는 요청량/요청 오류율을 반복하지 않고, 뱃지 동기화 내부 구간을 봅니다.\n- `저장 평균`이 높으면 다건 저장/락, `지급 가능 조회`가 높으면 조건 조회, `이미지 저장소 오류`가 있으면 이미지 저장/URL 생성을 확인합니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "뱃지 동기화 원인 분해",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "동기화 전체 평균",
+      "description": "내 뱃지 동기화 전체 내부 처리 시간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "지급 가능 조회 평균",
+      "description": "현재 포인트로 받을 수 있는 뱃지 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_grantable_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_grantable_lookup_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "보유 뱃지 조회 평균",
+      "description": "이미 획득한 뱃지 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_earned_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_earned_lookup_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "저장 평균",
+      "description": "새로 획득한 뱃지 저장 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(badge_sync_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_save_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "뱃지 동기화 단계별 평균",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "전체"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_grantable_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_grantable_lookup_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "지급 가능 조회"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_earned_lookup_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_earned_lookup_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "보유 뱃지 조회"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(badge_sync_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(badge_sync_save_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "저장"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "뱃지 도메인 이벤트",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "동기화 완료(5분)",
+      "description": "뱃지 동기화 성공 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 21
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=badge_sync_completed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "뱃지/이미지 저장소 오류(5분)",
+      "description": "뱃지 이미지 저장, 삭제, URL 생성 후보 오류입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 21
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\", level=~\"WARN|ERROR\"} |~ \"badge|Badge|GCS|Signed URL\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "신규 획득 발생 로그(5분)",
+      "description": "신규 획득 뱃지가 1개 이상 발생한 동기화 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=badge_sync_completed\" |~ \"newlyEarnedBadgeCount=([1-9][0-9]*)\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "title": "추가 계측 판단",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "id": 12,
+      "options": {
+        "mode": "markdown",
+        "content": "### 현재 로그로 보는 값\n- `newlyEarnedBadgeCount`는 현재 로그 본문에서 확인합니다.\n- 시계열 카드로 정확히 보고 싶으면 `badge_sync_newly_earned` 또는 `badge_sync_processed_total{result}` 같은 전용 지표를 추가합니다.\n- 공용 대시보드의 요청 지표와 이 화면의 동기화 단계 지표를 같이 보면 원인을 좁힐 수 있습니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "뱃지 도메인 로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 13,
+      "collapsed": false
+    },
+    {
+      "type": "logs",
+      "title": "뱃지 동기화 로그",
+      "description": "newlyEarnedBadgeCount, grantableLookupMs, earnedLookupMs, saveMs, durationMs를 같이 봅니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 14,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |= \"event=badge_sync_completed\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "뱃지 / 이미지 저장소 오류 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 15,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\", level=~\"WARN|ERROR\"} |~ \"badge|Badge|GCS|Signed URL\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-chat-ops-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-chat-ops-dashboard.json
@@ -1,0 +1,170 @@
+{
+  "uid": "lms-chat-ops",
+  "title": "LMS Chatbot - Ops",
+  "tags": ["lms", "ops", "chat"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "type": "textbox",
+        "name": "traceId",
+        "label": "traceId",
+        "description": "에러 로그에서 본 traceId를 입력하면 Row6에서 BE+FastAPI 로그가 함께 뜬다",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      }
+    ]
+  },
+  "panels": [
+    { "id": 100, "type": "row", "title": "1. 비용 (Tokens)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 } },
+    {
+      "id": 1, "type": "stat", "title": "누적 입력(prompt) 토큰",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 0, "y": 1 },
+      "targets": [ { "refId": "A", "expr": "chat_prompt_tokens_total", "legendFormat": "prompt" } ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 2, "type": "stat", "title": "누적 출력(completion) 토큰",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 6, "y": 1 },
+      "targets": [ { "refId": "A", "expr": "chat_completion_tokens_total", "legendFormat": "completion" } ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 3, "type": "timeseries", "title": "토큰 소비율 (tokens/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 1 },
+      "targets": [
+        { "refId": "A", "expr": "rate(chat_prompt_tokens_total[5m])", "legendFormat": "prompt/s" },
+        { "refId": "B", "expr": "rate(chat_completion_tokens_total[5m])", "legendFormat": "completion/s" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+
+    { "id": 101, "type": "row", "title": "2. 외부 AI 의존 (FastAPI/Gemini)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 } },
+    {
+      "id": 4, "type": "stat", "title": "AI 스트림 p95",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 0, "y": 9 },
+      "targets": [ { "refId": "A", "expr": "histogram_quantile(0.95, sum(rate(chat_ai_stream_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p95" } ],
+      "fieldConfig": { "defaults": { "unit": "s", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 2 }, { "color": "red", "value": 5 } ] } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 5, "type": "stat", "title": "AI 실패율 (outcome=error)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 6, "x": 6, "y": 9 },
+      "targets": [ { "refId": "A", "expr": "sum(rate(chat_ai_stream_duration_seconds_count{outcome=\"error\"}[5m])) / clamp_min(sum(rate(chat_ai_stream_duration_seconds_count[5m])), 1e-9)", "legendFormat": "fail rate" } ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 0.01 }, { "color": "red", "value": 0.05 } ] } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+    {
+      "id": 6, "type": "timeseries", "title": "TTFT (첫 토큰까지) 평균 / p95",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 9 },
+      "targets": [
+        { "refId": "A", "expr": "rate(chat_ai_time_to_first_token_seconds_sum[5m]) / clamp_min(rate(chat_ai_time_to_first_token_seconds_count[5m]), 1e-9)", "legendFormat": "avg" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum(rate(chat_ai_time_to_first_token_seconds_bucket[5m])) by (le))", "legendFormat": "p95" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+
+    { "id": 102, "type": "row", "title": "3. 스트리밍 건강성 (SSE)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 } },
+    {
+      "id": 7, "type": "timeseries", "title": "활성 스트림 수 (동시 SSE)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 17 },
+      "targets": [ { "refId": "A", "expr": "chat_active_streams", "legendFormat": "active" } ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 8, "type": "timeseries", "title": "스트림 종료 분포 (signal) — cancel/onError=중도이탈",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 17 },
+      "targets": [ { "refId": "A", "expr": "sum by (signal) (rate(chat_stream_terminations_total[5m]))", "legendFormat": "{{signal}}" } ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+
+    { "id": 103, "type": "row", "title": "4. API 성능 (RED)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 } },
+    {
+      "id": 9, "type": "timeseries", "title": "RPS by URI",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 25 },
+      "targets": [ { "refId": "A", "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"chatbot\"}[1m]))", "legendFormat": "{{uri}}" } ],
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 10, "type": "timeseries", "title": "5xx 에러율",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 25 },
+      "targets": [ { "refId": "A", "expr": "sum(rate(http_server_requests_seconds_count{domain=\"chatbot\",status=~\"5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"chatbot\"}[1m])), 1e-9)", "legendFormat": "5xx rate" } ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 11, "type": "timeseries", "title": "채팅방 목록 조회 평균(내부 구간)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 25 },
+      "targets": [ { "refId": "A", "expr": "rate(chat_room_list_query_duration_seconds_sum[5m]) / clamp_min(rate(chat_room_list_query_duration_seconds_count[5m]), 1e-9)", "legendFormat": "list query avg" } ],
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+
+    { "id": 104, "type": "row", "title": "5. 인프라 포화", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 } },
+    {
+      "id": 12, "type": "timeseries", "title": "Hikari 커넥션 (active/pending)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 33 },
+      "targets": [
+        { "refId": "A", "expr": "hikaricp_connections_active", "legendFormat": "active" },
+        { "refId": "B", "expr": "hikaricp_connections_pending", "legendFormat": "pending" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "multi" } }
+    },
+    {
+      "id": 13, "type": "timeseries", "title": "JVM Heap 사용량",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 33 },
+      "targets": [ { "refId": "A", "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})", "legendFormat": "heap used" } ],
+      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } }
+    },
+    {
+      "id": 14, "type": "stat", "title": "Process CPU",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 33 },
+      "targets": [ { "refId": "A", "expr": "process_cpu_usage", "legendFormat": "cpu" } ],
+      "fieldConfig": { "defaults": { "unit": "percentunit", "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 0.7 }, { "color": "red", "value": 0.9 } ] } }, "overrides": [] },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "colorMode": "value", "graphMode": "area", "textMode": "auto" }
+    },
+
+    { "id": 105, "type": "row", "title": "6. 로그 (Loki) — 실패율↑ 보이면 여기서 traceId 확인", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 40 } },
+    {
+      "id": 15, "type": "logs", "title": "챗봇 에러 로그 (BE)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 41 },
+      "targets": [ { "refId": "A", "expr": "{job=\"lms\", level=\"ERROR\"} |= \"event=chat_\"" } ],
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending", "dedupStrategy": "none" }
+    },
+    {
+      "id": 16, "type": "logs", "title": "traceId 통합 추적 (BE + FastAPI) — 위 traceId 변수 입력",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 49 },
+      "targets": [ { "refId": "A", "expr": "{job=~\".+\"} |= \"$traceId\"" } ],
+      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Ascending", "dedupStrategy": "none" }
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-domain-dashboard.json
@@ -1,22 +1,38 @@
 {
   "uid": "lms-domain",
-  "title": "LMS 도메인 대시보드",
-  "tags": ["lms", "loadtest"],
+  "title": "LMS 공용 도메인 대시보드",
+  "tags": [
+    "lms",
+    "loadtest"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
   "refresh": "5s",
-  "time": { "from": "now-15m", "to": "now" },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "templating": {
     "list": [
       {
         "name": "domain",
         "label": "도메인",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
         "definition": "label_values(http_server_requests_seconds_count, domain)",
-        "query": { "qryType": 1, "query": "label_values(http_server_requests_seconds_count, domain)", "refId": "A" },
-        "current": { "text": "chatbot", "value": "chatbot" },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(http_server_requests_seconds_count, domain)",
+          "refId": "A"
+        },
+        "current": {
+          "text": "chatbot",
+          "value": "chatbot"
+        },
         "includeAll": false,
         "multi": false,
         "refresh": 2,
@@ -25,18 +41,45 @@
     ]
   },
   "panels": [
-    { "type": "row", "title": "Traffic", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }, "id": 1, "collapsed": false },
+    {
+      "type": "row",
+      "title": "트래픽",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "collapsed": false
+    },
     {
       "type": "timeseries",
-      "title": "RPS by URI  ($domain)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "title": "URI별 요청량  ($domain)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
       "id": 2,
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m]))",
           "legendFormat": "{{uri}}"
         }
@@ -44,32 +87,76 @@
     },
     {
       "type": "timeseries",
-      "title": "HTTP Error Rate  ($domain)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "title": "요청 오류율  ($domain)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
       "id": 3,
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0 }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(rate(http_server_requests_seconds_count{domain=\"$domain\",status=~\"4..|5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
-          "legendFormat": "error rate"
+          "legendFormat": "오류율"
         }
       ]
     },
-    { "type": "row", "title": "Latency", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 }, "id": 4, "collapsed": false },
+    {
+      "type": "row",
+      "title": "응답 시간",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "collapsed": false
+    },
     {
       "type": "timeseries",
-      "title": "HTTP Avg Duration by URI  ($domain)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "title": "URI별 평균 응답 시간  ($domain)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
       "id": 5,
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum by (uri) (rate(http_server_requests_seconds_sum{domain=\"$domain\"}[1m])) / clamp_min(sum by (uri) (rate(http_server_requests_seconds_count{domain=\"$domain\"}[1m])), 0.0001)",
           "legendFormat": "{{uri}}"
         }
@@ -77,85 +164,184 @@
     },
     {
       "type": "timeseries",
-      "title": "커스텀: chat 목록 쿼리 구간 avg (N+1 증거)",
-      "description": "domain=chatbot 일 때만 값이 있음. 커스텀 메트릭은 이름 prefix 라 domain 변수와 무관.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "title": "커스텀: 채팅 목록 쿼리 평균 (N+1 증거)",
+      "description": "도메인=chatbot 일 때만 값이 있음. 커스텀 메트릭은 이름 접두어 라 domain 변수와 무관.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
       "id": 6,
-      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "rate(chat_room_list_query_duration_seconds_sum[1m]) / clamp_min(rate(chat_room_list_query_duration_seconds_count[1m]), 0.0001)",
-          "legendFormat": "chat_room_list_query avg"
+          "legendFormat": "채팅 목록 쿼리 평균"
         }
       ]
     },
-    { "type": "row", "title": "Resource (앱 전체)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 }, "id": 7, "collapsed": false },
+    {
+      "type": "row",
+      "title": "리소스 (앱 전체)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "collapsed": false
+    },
     {
       "type": "timeseries",
-      "title": "Hikari Active Connections",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "title": "DB 커넥션 사용 수",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
       "id": 8,
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "hikaricp_connections_active",
-          "legendFormat": "active"
+          "legendFormat": "사용 중"
         }
       ]
     },
     {
       "type": "timeseries",
-      "title": "Process CPU Usage",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 19 },
+      "title": "프로세스 CPU 사용률",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
       "id": 9,
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "process_cpu_usage",
-          "legendFormat": "cpu"
+          "legendFormat": "CPU"
         }
       ]
     },
     {
       "type": "timeseries",
-      "title": "JVM Heap Used",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 19 },
+      "title": "JVM 힙 메모리 사용량",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
       "id": 10,
-      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(jvm_memory_used_bytes{area=\"heap\"})",
-          "legendFormat": "heap used"
+          "legendFormat": "힙 사용량"
         }
       ]
     },
-    { "type": "row", "title": "Logs (Loki)", "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 }, "id": 11, "collapsed": false },
+    {
+      "type": "row",
+      "title": "로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "collapsed": false
+    },
     {
       "type": "logs",
       "title": "요청 완료 로그 (actuator 제외)",
-      "datasource": { "type": "loki", "uid": "loki" },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 28 },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
       "id": 12,
-      "options": { "showTime": true, "wrapLogMessage": true, "sortOrder": "Descending" },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending"
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "loki" },
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
           "expr": "{job=\"lms\"} |= \"event=request_completed\" != \"actuator\"",
           "queryType": "range"
         }
       ]
     }
-  ]
+  ],
+  "description": "도메인별 요청량, 오류율, 응답 시간, 공통 리소스를 먼저 확인하는 1차 탐지용 대시보드입니다."
 }

--- a/monitoring-local/grafana/provisioning/dashboards/lms-problem-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-problem-domain-dashboard.json
@@ -1,0 +1,807 @@
+{
+  "uid": "lms-problem-domain",
+  "title": "[LMS][도메인 상세] 문제",
+  "description": "공용 대시보드에서 문제 도메인 이상을 발견한 뒤, 문제세트 진입과 코드 실행 코드 실행기의 내부 원인을 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "problem",
+    "ddd",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `problems` 도메인의 응답 지연이나 오류를 먼저 확인합니다.\n- 이 상세 화면에서는 공용 요청 지표를 반복하지 않고, 문제 도메인 내부 원인을 봅니다.\n- 먼저 `문제세트 진입 단계별 평균`에서 느린 구간을 찾고, 그다음 `진입 실패`와 `코드 실행기 실패` 로그를 확인합니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "문제세트 진입 원인 분해",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "진입 전체 평균",
+      "description": "문제세트 진입 전체 내부 처리 시간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "접근 검증 평균",
+      "description": "수강/권한/접근 가능 여부 확인 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_access_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_access_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "문제세트 조회 평균",
+      "description": "문제세트 기본 정보 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_problem_set_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_set_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "진행도 조회 평균",
+      "description": "사용자 진행도 조회 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_progress_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "진행도 항목 평균",
+      "description": "문제별 진행 상태 매핑 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_progress_items_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_items_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "문제 상세 평균",
+      "description": "소문제 상세와 응답 구성 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(problem_set_entry_problem_details_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_details_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "문제세트 진입 단계별 평균",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "전체"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_access_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_access_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "접근 검증"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_problem_set_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_set_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "문제세트 조회"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_progress_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "진행도 조회"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_progress_items_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_progress_items_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "진행도 항목"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(problem_set_entry_problem_details_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(problem_set_entry_problem_details_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "문제 상세"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "문제 도메인 이벤트",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 10,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "문제세트 진입 실패(5분)",
+      "description": "문제세트 진입 서비스 실패 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 21
+      },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=problem_set_entry_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "코드 실행기 실패(5분)",
+      "description": "코드 실행 코드 실행기 호출 실패 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 21
+      },
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=code_execution_runner_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "코드 실행기 빈 응답(5분)",
+      "description": "코드 실행기가 응답은 했지만 결과가 비어 있는 경우입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      },
+      "id": 13,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=code_execution_runner_completed\" |= \"reason=empty_response\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "문제세트 진입 완료(5분)",
+      "description": "문제세트 진입 성공 이벤트 수입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "id": 14,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=problem_set_entered\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "문제세트 진입 로그",
+      "description": "problemSetId, problemCount, solvedProblemCount, durationMs를 함께 봅니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 15,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=problem_set_(entered|entry_failed)\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "코드 실행 코드 실행기 로그",
+      "description": "endpoint, success, executionTimeMs, durationMs로 원인을 좁힙니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 16,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=code_execution_runner_(completed|failed)\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json
@@ -1,0 +1,323 @@
+{
+  "uid": "lms-ranking-domain",
+  "title": "[LMS][도메인 상세] 랭킹",
+  "description": "공용 대시보드에서 랭킹 이상을 발견한 뒤, 랭킹 데이터 정합성, 내 랭킹 없음, 대표 뱃지 URL 비용 후보를 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "ranking",
+    "ddd",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `ranking` 도메인의 지연이나 4xx/5xx 증가를 먼저 확인합니다.\n- 현재 랭킹 도메인은 전용 내부 처리 시간 지표가 없으므로, 이 화면은 요청 로그와 정합성 후보를 중심으로 봅니다.\n- 내 랭킹 404가 늘면 포인트 이력/랭킹 조회 모델/시드 데이터 정합성을 먼저 확인합니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "랭킹 정합성 / 오류 이벤트",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "랭킹 오류 로그(5분)",
+      "description": "랭킹 요청 중 실패 상태 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"/api/v1/rankings/\" |~ \"status=4..|status=5..\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "내 랭킹 없음(5분)",
+      "description": "내 랭킹 404는 데이터 정합성 문제일 수 있습니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"/api/v1/rankings/points/me\" |= \"status=404\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "대표 뱃지 후보 오류(5분)",
+      "description": "랭킹 응답에 대표 뱃지 URL이 포함될 때의 후보 오류입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\", level=~\"WARN|ERROR\"} |~ \"ranking|Ranking|badge|Badge|Signed URL\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "title": "추가 계측 판단",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "mode": "markdown",
+        "content": "### 아직 공용 지표만으로 부족할 때\n- 전체/주간/내 랭킹 중 어느 조회가 느린지는 공용 대시보드의 URI별 지연에서 확인합니다.\n- 그 다음 원인이 DB 집계인지 대표 뱃지 URL 생성인지 구분이 필요해질 때만 `ranking_query_duration`, `ranking_badge_url_duration`을 추가합니다.\n- 사용자 ID를 메트릭 태그로 넣으면 시계열이 폭증하므로 로그에서만 봅니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "랭킹 도메인 로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "collapsed": false
+    },
+    {
+      "type": "logs",
+      "title": "랭킹 요청 / 오류 로그",
+      "description": "status, durationMs, traceId로 공용 대시보드의 이상 구간과 연결합니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 8,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |= \"/api/v1/rankings/\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "랭킹 관련 경고 / 오류 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 9,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\", level=~\"WARN|ERROR\"} |~ \"ranking|Ranking|rankings|badge|Badge\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-reward-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-reward-domain-dashboard.json
@@ -1,0 +1,563 @@
+{
+  "uid": "lms-reward-domain",
+  "title": "[LMS][도메인 상세] 보상 포인트",
+  "description": "공용 요청 대시보드에 잡히지 않는 보상 포인트 비동기 작업의 대기, 완료, 재시도, 실패를 확인합니다.",
+  "tags": [
+    "lms",
+    "domain-detail",
+    "reward",
+    "ddd",
+    "async",
+    "korean"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 5,
+  "refresh": "10s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "text",
+      "title": "공용 대시보드 다음 확인 순서",
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- 보상 포인트는 요청 컨트롤러가 아니라 비동기 작업 중심이라 공용 요청 대시보드에 잘 드러나지 않습니다.\n- 이 상세 화면에서 대기 작업, 예약, 완료, 재시도, 영구 실패를 직접 봅니다.\n- 재시도는 일시 문제, 영구 실패는 수동 확인이 필요한 문제로 봅니다."
+      }
+    },
+    {
+      "type": "row",
+      "title": "보상 작업 상태",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 2,
+      "collapsed": false
+    },
+    {
+      "type": "stat",
+      "title": "대기 작업",
+      "description": "현재 PENDING 상태의 포인트 지급 작업 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 20
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(reward_point_task_pending) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "예약(5분)",
+      "description": "제출 성공 후 포인트 지급 작업이 예약된 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 6
+      },
+      "id": 4,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_scheduled_total[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "완료(5분)",
+      "description": "정상 지급 완료 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 8,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_processed_total{result=\"completed\"}[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "재시도(5분)",
+      "description": "재시도 예약 수입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_processed_total{result=\"retry\"}[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "영구 실패(5분)",
+      "description": "1 이상이면 원인 확인이 필요합니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "id": 7,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(reward_point_task_processed_total{result=\"failed\"}[5m])) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "처리 평균 시간",
+      "description": "작업 1건 로드/지급/상태 업데이트 평균입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "id": 8,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.2
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum(rate(reward_point_task_process_duration_seconds_sum[$__rate_interval])) / clamp_min(sum(rate(reward_point_task_process_duration_seconds_count[$__rate_interval])), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "보상 작업 결과 추이",
+      "description": "완료/재시도/실패 흐름을 한 화면에서 봅니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_scheduled_total[$__rate_interval]))",
+          "legendFormat": "예약"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_processed_total{result=\"completed\"}[$__rate_interval]))",
+          "legendFormat": "완료"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_processed_total{result=\"retry\"}[$__rate_interval]))",
+          "legendFormat": "재시도"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(reward_point_task_processed_total{result=\"failed\"}[$__rate_interval]))",
+          "legendFormat": "영구 실패"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "보상 작업 처리 평균",
+      "description": "",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum(rate(reward_point_task_process_duration_seconds_sum[$__rate_interval])) / clamp_min(sum(rate(reward_point_task_process_duration_seconds_count[$__rate_interval])), 0.0001)) or vector(0)",
+          "legendFormat": "처리 평균"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "보상 포인트 로그",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 11,
+      "collapsed": false
+    },
+    {
+      "type": "logs",
+      "title": "보상 작업 전체 로그",
+      "description": "submissionId, retryCount, exceptionType으로 원인을 좁힙니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 16,
+        "x": 0,
+        "y": 22
+      },
+      "id": 12,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=reward_point_task_(scheduled|completed|retry_scheduled|failed|not_found|skipped|processing_failed)\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "보상 경고 / 오류 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 8,
+        "x": 16,
+        "y": 22
+      },
+      "id": 13,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\", level=~\"WARN|ERROR\"} |~ \"reward_point|Reward|PointReward\"",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring-local/grafana/provisioning/dashboards/lms-submission-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-submission-domain-dashboard.json
@@ -1,13 +1,13 @@
 {
-  "uid": "lms-user-domain",
-  "title": "[LMS][도메인 상세] 사용자/인증",
-  "description": "공용 대시보드에서 사용자/인증 이상을 발견한 뒤, 로그인 실패, 추가 인증 실패, 계정 잠금, 조회 쿼리 지연을 확인합니다.",
+  "uid": "lms-submission-domain",
+  "title": "[LMS][도메인 상세] 제출",
+  "description": "공용 대시보드에서 제출 지연이나 오류를 발견한 뒤, 제출 준비, 채점, 저장 중 어느 구간이 원인인지 확인합니다.",
   "tags": [
     "lms",
     "domain-detail",
-    "user",
-    "auth",
+    "submission",
     "ddd",
+    "operations",
     "korean"
   ],
   "timezone": "browser",
@@ -31,12 +31,12 @@
       "id": 1,
       "options": {
         "mode": "markdown",
-        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `auth` 또는 `user` 계열 API 오류와 지연을 먼저 확인합니다.\n- 이 상세 화면에서는 로그인 실패, 추가 인증 검증 실패, 계정 잠금 변경, 학생 목록/로그인 이력 조회 구간을 봅니다.\n- 의심 로그인과 추가 인증 잠금은 현재 DB 값/정책 결과라 전용 지표를 추가해야 자동 집계됩니다."
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `submission` 도메인의 지연, 오류율, Hikari 상태를 먼저 확인합니다.\n- 이 상세 화면에서는 요청량을 반복하지 않고 `준비`, `채점`, `저장` 구간을 분리해서 봅니다.\n- 채점 평균만 높으면 코드 실행기 또는 테스트케이스 비용, 저장 평균이 높으면 DB 쓰기/락, 준비 평균이 높으면 조회 쿼리를 먼저 의심합니다."
       }
     },
     {
       "type": "row",
-      "title": "인증 보안 이벤트",
+      "title": "제출 처리 구간 분해",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -48,356 +48,8 @@
     },
     {
       "type": "stat",
-      "title": "로그인 실패(5분)",
-      "description": "로그인 API의 실패 상태 응답입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 0,
-        "y": 6
-      },
-      "id": 3,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 5
-              },
-              {
-                "color": "red",
-                "value": 20
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/auth/login\",status=~\"4..|5..\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "추가 인증 검증 실패(5분)",
-      "description": "추가 인증 코드 검증 실패/오류입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 4,
-        "y": 6
-      },
-      "id": 4,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 3
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/auth/step-up/verify\",status=~\"4..|5..\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "계정 잠금 변경(5분)",
-      "description": "관리자 계정 잠금/해제 요청 수입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 8,
-        "y": 6
-      },
-      "id": 5,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/users/{userId}/lock\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "신뢰기기 삭제(5분)",
-      "description": "사용자 신뢰기기 삭제 요청 수입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 12,
-        "y": 6
-      },
-      "id": 6,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/users/me/trusted-devices/{deviceId}\"}[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "의심 로그인(전용 지표 필요)",
-      "description": "현재는 login_history.is_suspicious DB 값입니다. 자동 집계가 필요하면 전용 지표나 이벤트 로그를 추가해야 합니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 16,
-        "y": 6
-      },
-      "id": 7,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(auth_suspicious_login_total[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "추가 인증 잠금(전용 지표 필요)",
-      "description": "추가 인증 시도 초과/잠금 정책을 운영 지표로 보고 싶을 때 추가할 후보입니다.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 6
-      },
-      "id": 8,
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "area",
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(increase(auth_stepup_locked_total[5m])) or vector(0)",
-          "legendFormat": ""
-        }
-      ]
-    },
-    {
-      "type": "row",
-      "title": "사용자 조회 원인 분해",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 12
-      },
-      "id": 9,
-      "collapsed": false
-    },
-    {
-      "type": "stat",
-      "title": "학생 목록 쿼리 평균",
-      "description": "학생 목록 list + count 쿼리 구간입니다.",
+      "title": "준비 평균",
+      "description": "문제/테스트케이스 조회와 제출 준비 구간입니다.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -406,9 +58,9 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 13
+        "y": 6
       },
-      "id": 10,
+      "id": 3,
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -422,11 +74,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.2
+                "value": 0.1
               },
               {
                 "color": "red",
-                "value": 0.5
+                "value": 0.3
               }
             ]
           }
@@ -452,15 +104,15 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(rate(user_student_list_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(user_student_list_query_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "expr": "(rate(submission_prepare_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_prepare_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
           "legendFormat": ""
         }
       ]
     },
     {
       "type": "stat",
-      "title": "로그인 이력 쿼리 평균",
-      "description": "내 로그인 이력 페이지 조회 쿼리 구간입니다.",
+      "title": "채점 평균",
+      "description": "Mock 기준 300ms x 5개면 약 1.5초가 자연스럽습니다.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -469,9 +121,9 @@
         "h": 5,
         "w": 6,
         "x": 6,
-        "y": 13
+        "y": 6
       },
-      "id": 11,
+      "id": 4,
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -485,11 +137,11 @@
               },
               {
                 "color": "orange",
-                "value": 0.2
+                "value": 1.8
               },
               {
                 "color": "red",
-                "value": 0.5
+                "value": 2.5
               }
             ]
           }
@@ -515,41 +167,152 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(rate(auth_login_history_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(auth_login_history_query_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "expr": "(rate(submission_grading_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_grading_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
           "legendFormat": ""
         }
       ]
     },
     {
-      "type": "text",
-      "title": "추가 계측 판단",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 13
+      "type": "stat",
+      "title": "저장 평균",
+      "description": "제출과 테스트 결과 저장 구간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
       },
-      "id": 12,
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "options": {
-        "mode": "markdown",
-        "content": "### 지금 없는 상세 지표\n- 의심 로그인 건수: `auth_suspicious_login_total` 또는 `event=suspicious_login_detected` 추가 후보입니다.\n- 추가 인증 잠금 건수: `auth_stepup_locked_total` 추가 후보입니다.\n- 지금은 로그인 실패/추가 인증 실패는 요청 상태와 요청 로그로 확인합니다."
-      }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(submission_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_save_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "전체 처리 평균",
+      "description": "SubmissionService 내부 전체 처리 시간입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(rate(submission_total_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_total_duration_seconds_count[$__rate_interval]), 0.0001)) or vector(0)",
+          "legendFormat": ""
+        }
+      ]
     },
     {
       "type": "timeseries",
-      "title": "사용자 조회 내부 구간 평균",
+      "title": "제출 처리 단계별 평균",
       "description": "",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 9,
+        "w": 24,
         "x": 0,
-        "y": 18
+        "y": 11
       },
-      "id": 13,
+      "id": 7,
       "fieldConfig": {
         "defaults": {
           "unit": "s",
@@ -564,8 +327,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(user_student_list_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(user_student_list_query_duration_seconds_count[$__rate_interval]), 0.0001)",
-          "legendFormat": "학생 목록"
+          "expr": "rate(submission_total_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_total_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "전체"
         },
         {
           "refId": "B",
@@ -573,36 +336,347 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(auth_login_history_query_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(auth_login_history_query_duration_seconds_count[$__rate_interval]), 0.0001)",
-          "legendFormat": "로그인 이력"
+          "expr": "rate(submission_prepare_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_prepare_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "준비"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(submission_grading_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_grading_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "채점"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(submission_save_duration_seconds_sum[$__rate_interval]) / clamp_min(rate(submission_save_duration_seconds_count[$__rate_interval]), 0.0001)",
+          "legendFormat": "저장"
         }
       ]
     },
     {
       "type": "row",
-      "title": "보안/사용자 로그",
+      "title": "제출 도메인 이벤트",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 20
       },
-      "id": 14,
+      "id": 8,
       "collapsed": false
     },
     {
+      "type": "stat",
+      "title": "제출 완료(5분)",
+      "description": "정상 완료된 제출 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 21
+      },
+      "id": 9,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=submission_completed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "제출 실패(5분)",
+      "description": "SubmissionService 실패 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 21
+      },
+      "id": 10,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=submission_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "코드 실행기 실패(5분)",
+      "description": "외부 채점 호출 실패입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 21
+      },
+      "id": 11,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=code_execution_runner_failed\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "느린 제출 로그(5분)",
+      "description": "2초 이상 걸린 제출 요청 로그입니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 21
+      },
+      "id": 12,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=request_completed\" |= \"/api/v1/problems/\" |= \"/submissions\" |~ \"durationMs=([2-9][0-9]{3}|[1-9][0-9]{4,})\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
       "type": "logs",
-      "title": "로그인 / 추가 인증 실패 요청",
-      "description": "비정상 로그인 증가, 추가 인증 검증 실패를 빠르게 확인합니다.",
+      "title": "제출 완료 로그",
+      "description": "prepareMs, gradingMs, saveMs, durationMs를 함께 봅니다.",
       "datasource": {
         "type": "loki",
         "uid": "loki"
       },
       "gridPos": {
         "h": 10,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 27
+        "y": 26
+      },
+      "id": 13,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |= \"event=submission_completed\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "제출 실패 / 코드 실행기 실패 로그",
+      "description": "",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "id": 14,
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{job=\"lms\"} |~ \"event=submission_failed|event=code_execution_runner_failed|Connection is not available\"",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "logs",
+      "title": "느린 제출 요청 로그",
+      "description": "traceId로 제출 처리 로그와 연결해서 봅니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 26
       },
       "id": 15,
       "options": {
@@ -618,119 +692,10 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "{job=\"lms\"} |= \"event=request_completed\" |~ \"/api/v1/auth/(login|step-up/verify)\" |~ \"status=4..|status=5..\"",
-          "queryType": "range"
-        }
-      ]
-    },
-    {
-      "type": "logs",
-      "title": "학생 목록 / 로그인 이력 조회 로그",
-      "description": "durationMs, resultCount, page/size를 같이 봅니다.",
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 12,
-        "x": 12,
-        "y": 27
-      },
-      "id": 16,
-      "options": {
-        "showTime": true,
-        "wrapLogMessage": true,
-        "sortOrder": "Descending",
-        "enableLogDetails": true
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "expr": "{job=\"lms\"} |~ \"event=user_student_list_queried|event=auth_login_history_queried\"",
-          "queryType": "range"
-        }
-      ]
-    },
-    {
-      "type": "logs",
-      "title": "계정 잠금 / 신뢰기기 요청 로그",
-      "description": "",
-      "datasource": {
-        "type": "loki",
-        "uid": "loki"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 37
-      },
-      "id": 17,
-      "options": {
-        "showTime": true,
-        "wrapLogMessage": true,
-        "sortOrder": "Descending",
-        "enableLogDetails": true
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "loki",
-            "uid": "loki"
-          },
-          "expr": "{job=\"lms\"} |= \"event=request_completed\" |~ \"/api/v1/users/.*/lock|/api/v1/users/me/trusted-devices\"",
+          "expr": "{job=\"lms\"} |= \"event=request_completed\" |= \"/api/v1/problems/\" |= \"/submissions\" |~ \"durationMs=([2-9][0-9]{3}|[1-9][0-9]{4,})\"",
           "queryType": "range"
         }
       ]
     }
-  ],
-  "templating": {
-    "list": [
-      {
-        "name": "category",
-        "label": "카테고리",
-        "type": "custom",
-        "query": "전체,로그인,추가 인증,학생조회,계정잠금",
-        "current": {
-          "text": "전체",
-          "value": "전체"
-        },
-        "includeAll": false,
-        "multi": false,
-        "options": [
-          {
-            "text": "전체",
-            "value": "전체",
-            "selected": true
-          },
-          {
-            "text": "로그인",
-            "value": "로그인",
-            "selected": false
-          },
-          {
-            "text": "추가 인증",
-            "value": "추가 인증",
-            "selected": false
-          },
-          {
-            "text": "학생조회",
-            "value": "학생조회",
-            "selected": false
-          },
-          {
-            "text": "계정잠금",
-            "value": "계정잠금",
-            "selected": false
-          }
-        ]
-      }
-    ]
-  }
+  ]
 }

--- a/python-runner/app.py
+++ b/python-runner/app.py
@@ -1,4 +1,4 @@
-zimport os
+import os
 import subprocess
 import sys
 import tempfile

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -4,17 +4,24 @@ import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
 import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
 import com.wanted.codebombalms.auth.application.usecase.GoogleCallbackUseCase;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.OAuthTempData;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
 import com.wanted.codebombalms.auth.domain.repository.OAuthStateRepository;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TempTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
 import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,9 +40,12 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
     private final RefreshTokenRepository refreshTokenRepository;
     private final TempTokenRepository tempTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final GeoIpResolver geoIpResolver;
+    private final LoginHistoryRepository loginHistoryRepository;
+    private final TrustedDeviceRepository trustedDeviceRepository;
 
     @Override
-    public GoogleCallbackResult handleCallback(String code, String state) {
+    public GoogleCallbackResult handleCallback(String code, String state, HttpServletRequest request, String deviceFp) {
 
         // 1. state 검증 (CSRF 방지, 단일 사용)
         if (!oAuthStateRepository.validateAndDelete(state)) {
@@ -62,7 +72,7 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
             }
 
             // 3-2. 기존 구글 회원 → 토큰 발급 (로그인)
-            return issueTokens(user);
+            return issueTokens(user, request, deviceFp);
         }
 
         // 4. 신규 회원 → TEMP_TOKEN 발급 후 Redis 임시 저장
@@ -71,18 +81,69 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         return GoogleCallbackResult.newUser(tempToken);
     }
 
-    /** 기존 회원 토큰 발급 — 단일 세션 강제 후 AT/RT 생성·저장 (LoginService 동일 패턴) */
-    private GoogleCallbackResult issueTokens(User user) {
-        refreshTokenRepository.deleteByUserId(user.getUserId());
+    /**
+     * 기존 회원 토큰 발급 — 로그인 이력 기록 + 신뢰기기 upsert 후 AT/RT 발급.
+     * step-up(이메일 OTP)은 제외한다 (구글이 이미 인증을 보장).
+     */
+    private GoogleCallbackResult issueTokens(User user, HttpServletRequest request, String deviceFp) {
+        String ip = extractIpAddress(request);
+        GeoLocation geo = geoIpResolver.resolve(ip);
 
-        String accessToken = jwtTokenProvider.generateAccessToken(
+        // 로그인 이력 기록 — 구글 인증 통과이므로 suspicious=false
+        loginHistoryRepository.save(LoginHistory.record(
+                user.getUserId(), ip, request.getHeader("User-Agent"),
+                deviceFp, geo.country(), geo.city(), false));
+
+        // 신뢰기기 upsert — 있으면 갱신, 없으면 등록 (유니크 (user_id, device_fp) 위반 방지)
+        TrustedDevice device = trustedDeviceRepository
+                .findByUserIdAndDeviceFp(user.getUserId(), deviceFp)
+                .map(existing -> {
+                    existing.markUsed(geo.country(), geo.city());
+                    return existing;
+                })
+                .orElseGet(() -> TrustedDevice.register(
+                        user.getUserId(),
+                        deviceFp,
+                        parseDeviceName(request.getHeader("User-Agent")),
+                        geo.country(),
+                        geo.city()
+                ));
+        trustedDeviceRepository.save(device);
+
+        // 단일 세션 강제 후 AT/RT 발급
+        refreshTokenRepository.deleteByUserId(user.getUserId());
+        String token = jwtTokenProvider.generateAccessToken(
                 user.getUserId(), user.getNickname(), user.getRole());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
-
         refreshTokenRepository.save(
                 RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration())
         );
 
-        return GoogleCallbackResult.existingUser(accessToken, refreshToken);
+        return GoogleCallbackResult.existingUser(token, refreshToken);
+    }
+
+    /** User-Agent → "브라우저 · OS" 표시명 (간이 파싱, StepUpVerifyService 와 동일 규칙) */
+    private String parseDeviceName(String userAgent) {
+        if (userAgent == null || userAgent.isBlank()) {
+            return "Unknown device";
+        }
+        String browser = userAgent.contains("Edg") ? "Edge"
+                : userAgent.contains("Chrome") ? "Chrome"
+                  : userAgent.contains("Firefox") ? "Firefox"
+                    : userAgent.contains("Safari") ? "Safari" : "Unknown";
+        String os = userAgent.contains("Windows") ? "Windows"
+                : userAgent.contains("Mac OS") ? "macOS"
+                  : userAgent.contains("Android") ? "Android"
+                    : (userAgent.contains("iPhone") || userAgent.contains("iPad")) ? "iOS"
+                      : userAgent.contains("Linux") ? "Linux" : "Unknown";
+        return browser + " · " + os;
+    }
+
+    private String extractIpAddress(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -15,6 +15,8 @@ import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TempTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
 import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEvent;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEventRecorder;
 import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
@@ -43,6 +45,7 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
     private final GeoIpResolver geoIpResolver;
     private final LoginHistoryRepository loginHistoryRepository;
     private final TrustedDeviceRepository trustedDeviceRepository;
+    private final AuthSecurityEventRecorder securityEventRecorder;
 
     @Override
     public GoogleCallbackResult handleCallback(String code, String state, HttpServletRequest request, String deviceFp) {
@@ -92,12 +95,21 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         // 신뢰기기 1회 조회로 suspicious 판정 + upsert 모두 처리
         Optional<TrustedDevice> trusted =
                 trustedDeviceRepository.findByUserIdAndDeviceFp(user.getUserId(), deviceFp);
-        boolean suspicious = trusted.isEmpty() || isCountryChanged(trusted.get(), geo);
+        boolean countryChanged = trusted.isPresent() && isCountryChanged(trusted.get(), geo);
+        boolean suspicious = trusted.isEmpty() || countryChanged;
 
         // 로그인 이력 기록 — step-up 은 생략하되, 의심 여부는 실제 계산값으로 남김
         loginHistoryRepository.save(LoginHistory.record(
                 user.getUserId(), ip, request.getHeader("User-Agent"),
                 deviceFp, geo.country(), geo.city(), suspicious));
+
+        // 비정상 행위 기록
+        if (suspicious) {
+            securityEventRecorder.record(AuthSecurityEvent.SUSPICIOUS_LOGIN, user.getUserId());
+        }
+        if (countryChanged) {
+            securityEventRecorder.record(AuthSecurityEvent.COUNTRY_CHANGED, user.getUserId());
+        }
 
         // 신뢰기기 upsert — 있으면 갱신, 없으면 등록 (유니크 (user_id, device_fp) 위반 방지)
         TrustedDevice device = trusted

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -89,14 +89,18 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         String ip = extractIpAddress(request);
         GeoLocation geo = geoIpResolver.resolve(ip);
 
-        // 로그인 이력 기록 — 구글 인증 통과이므로 suspicious=false
+        // 신뢰기기 1회 조회로 suspicious 판정 + upsert 모두 처리
+        Optional<TrustedDevice> trusted =
+                trustedDeviceRepository.findByUserIdAndDeviceFp(user.getUserId(), deviceFp);
+        boolean suspicious = trusted.isEmpty() || isCountryChanged(trusted.get(), geo);
+
+        // 로그인 이력 기록 — step-up 은 생략하되, 의심 여부는 실제 계산값으로 남김
         loginHistoryRepository.save(LoginHistory.record(
                 user.getUserId(), ip, request.getHeader("User-Agent"),
-                deviceFp, geo.country(), geo.city(), false));
+                deviceFp, geo.country(), geo.city(), suspicious));
 
         // 신뢰기기 upsert — 있으면 갱신, 없으면 등록 (유니크 (user_id, device_fp) 위반 방지)
-        TrustedDevice device = trustedDeviceRepository
-                .findByUserIdAndDeviceFp(user.getUserId(), deviceFp)
+        TrustedDevice device = trusted
                 .map(existing -> {
                     existing.markUsed(geo.country(), geo.city());
                     return existing;
@@ -120,6 +124,13 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         );
 
         return GoogleCallbackResult.existingUser(token, refreshToken);
+    }
+
+    /** 신뢰기기의 마지막 국가와 현재 국가가 다르면 의심 (LoginService 와 동일 규칙) */
+    private boolean isCountryChanged(TrustedDevice device, GeoLocation geo) {
+        return device.getLastCountry() != null
+                && geo.country() != null
+                && !device.getLastCountry().equals(geo.country());
     }
 
     /** User-Agent → "브라우저 · OS" 표시명 (간이 파싱, StepUpVerifyService 와 동일 규칙) */

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -94,9 +94,17 @@ public class LoginService implements LoginUseCase {
     }
 
     private LoginResult issueStepUp(User user, String deviceFp, GeoLocation geo) {
-        // OTP (step-up) 발급
-        String code = generateCode();
         String stepUpToken = UUID.randomUUID().toString();
+
+        // 멱등성 유지: 같은 기기에 이미 유효한 챌린지가 있으면 재사용 (코드 재발급/메일 재발송 차단)
+        Optional<String> existing =
+                stepUpTokenRepository.reserveDeviceChallenge(user.getUserId(), deviceFp, stepUpToken);
+        if (existing.isPresent()) {
+            return LoginResult.stepUp(existing.get(), maskEmail(user.getEmail()));
+        }
+
+        // 신규 발급 — OTP(step-up) 생성
+        String code = generateCode();
         stepUpTokenRepository.save(stepUpToken,
                 new StepUpChallenge(user.getUserId(), deviceFp, geo.country(), code));
 

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -15,6 +15,8 @@ import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
 import com.wanted.codebombalms.auth.domain.service.EmailSender;
 import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEvent;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEventRecorder;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
@@ -51,6 +53,7 @@ public class LoginService implements LoginUseCase {
     private final EmailSender emailSender;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthSecurityEventRecorder securityEventRecorder;
 
     @Override
     public LoginResult login(LoginCommand command, HttpServletRequest request, String deviceFp) {
@@ -72,13 +75,22 @@ public class LoginService implements LoginUseCase {
         // 5. 적응형 판정 — 신뢰 기기 1차 + 위치 보조
         Optional<TrustedDevice> trusted =
                 trustedDeviceRepository.findByUserIdAndDeviceFp(user.getUserId(), deviceFp);
-        boolean suspicious = trusted.isEmpty() || isCountryChanged(trusted.get(), geo);
+        boolean countryChanged = trusted.isPresent() && isCountryChanged(trusted.get(), geo);
+        boolean suspicious = trusted.isEmpty() || countryChanged;
         boolean stepUpRequired = user.getRole() == UserRole.STUDENT && suspicious;
 
         // 6. 로그인 이력 기록 (의심 여부 = 신뢰기기/국가 기준, 역할 무관)
         loginHistoryRepository.save(LoginHistory.record(
                 user.getUserId(), ip, request.getHeader("User-Agent"),
                 deviceFp, geo.country(), geo.city(), suspicious));
+
+        // 비정상 행위 기록
+        if (suspicious) {
+            securityEventRecorder.record(AuthSecurityEvent.SUSPICIOUS_LOGIN, user.getUserId());
+        }
+        if (countryChanged) {
+            securityEventRecorder.record(AuthSecurityEvent.COUNTRY_CHANGED, user.getUserId());
+        }
 
         // 7. 미신뢰/위치 급변 → step-up
         if (stepUpRequired) {
@@ -112,6 +124,7 @@ public class LoginService implements LoginUseCase {
         String lockToken = UUID.randomUUID().toString();
         lockTokenRepository.save(lockToken, user.getUserId());
         String lockUrl = lockUrlBase + "?token=" + lockToken;
+        securityEventRecorder.record(AuthSecurityEvent.STEPUP_ISSUED, user.getUserId());
         emailSender.sendStepUpCode(user.getEmail(), code, lockUrl);
         return LoginResult.stepUp(stepUpToken, maskEmail(user.getEmail()));
     }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -124,8 +124,9 @@ public class LoginService implements LoginUseCase {
         String lockToken = UUID.randomUUID().toString();
         lockTokenRepository.save(lockToken, user.getUserId());
         String lockUrl = lockUrlBase + "?token=" + lockToken;
-        securityEventRecorder.record(AuthSecurityEvent.STEPUP_ISSUED, user.getUserId());
         emailSender.sendStepUpCode(user.getEmail(), code, lockUrl);
+        // 메일 발송 성공 후 기록 (발송 실패 시엔 발급 성공으로 집계하지 않음)
+        securityEventRecorder.record(AuthSecurityEvent.STEPUP_ISSUED, user.getUserId());
         return LoginResult.stepUp(stepUpToken, maskEmail(user.getEmail()));
     }
 

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -95,24 +95,23 @@ public class LoginService implements LoginUseCase {
 
     private LoginResult issueStepUp(User user, String deviceFp, GeoLocation geo) {
         String stepUpToken = UUID.randomUUID().toString();
+        String code = generateCode();
 
-        // 멱등성 유지: 같은 기기에 이미 유효한 챌린지가 있으면 재사용 (코드 재발급/메일 재발송 차단)
+        // 챌린지를 먼저 저장 — 예약 키가 가리키는 토큰은 항상 유효 챌린지를 보유 (유령 토큰 방지)
+        stepUpTokenRepository.save(stepUpToken,
+                new StepUpChallenge(user.getUserId(), deviceFp, geo.country(), code));
+
+        // 멱등 예약 — 충돌이면 기존 토큰 재사용 (방금 저장분은 미사용 → TTL 5분 후 자동 만료)
         Optional<String> existing =
                 stepUpTokenRepository.reserveDeviceChallenge(user.getUserId(), deviceFp, stepUpToken);
         if (existing.isPresent()) {
             return LoginResult.stepUp(existing.get(), maskEmail(user.getEmail()));
         }
 
-        // 신규 발급 — OTP(step-up) 생성
-        String code = generateCode();
-        stepUpTokenRepository.save(stepUpToken,
-                new StepUpChallenge(user.getUserId(), deviceFp, geo.country(), code));
-
-        // 계정 잠금 토큰 발급 + 링크 조립
+        // 신규 발급분만 계정 잠금 토큰 + 메일 발송
         String lockToken = UUID.randomUUID().toString();
         lockTokenRepository.save(lockToken, user.getUserId());
         String lockUrl = lockUrlBase + "?token=" + lockToken;
-
         emailSender.sendStepUpCode(user.getEmail(), code, lockUrl);
         return LoginResult.stepUp(stepUpToken, maskEmail(user.getEmail()));
     }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
@@ -12,6 +12,8 @@ import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.StepUpTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
 import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEvent;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEventRecorder;
 import com.wanted.codebombalms.global.domain.common.error.exception.TooManyRequestsException;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -36,6 +38,7 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
     private final RefreshTokenRepository refreshTokenRepository;
     private final GeoIpResolver geoIpResolver;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthSecurityEventRecorder securityEventRecorder;
 
     @Override
     public LoginResult verify(StepUpVerifyCommand command, HttpServletRequest request) {
@@ -53,8 +56,10 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
             int attempts = stepUpTokenRepository.incrementAttempts(token);
             if (attempts >= MAX_ATTEMPTS) {
                 stepUpTokenRepository.delete(token);
+                securityEventRecorder.record(AuthSecurityEvent.STEPUP_LOCKED, challenge.userId());
                 throw new TooManyRequestsException(AuthErrorCode.AUTH_STEP_UP_TOO_MANY);
             }
+            securityEventRecorder.record(AuthSecurityEvent.STEPUP_OTP_FAIL, challenge.userId());
             throw new ValidationException(AuthErrorCode.AUTH_CODE_INVALID);
         }
 

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/GoogleCallbackUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/GoogleCallbackUseCase.java
@@ -1,9 +1,10 @@
 package com.wanted.codebombalms.auth.application.usecase;
 
 import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
+import jakarta.servlet.http.HttpServletRequest;
 
 public interface GoogleCallbackUseCase {
 
-    /** 구글 콜백 처리 — state 검증 → 토큰 교환 → 기존/신규 분기 */
-    GoogleCallbackResult handleCallback(String code, String state);
+    /** 구글 콜백 처리 — state 검증 → 토큰 교환 → 기존/신규 분기 (이력·신뢰기기 기록 포함) */
+    GoogleCallbackResult handleCallback(String code, String state, HttpServletRequest request, String deviceFp);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/StepUpTokenRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/StepUpTokenRepository.java
@@ -17,4 +17,11 @@ public interface StepUpTokenRepository {
 
     /** OTP 오입력 시 시도 횟수 +1 → 누적값 반환 (토큰 TTL과 동기) */
     int incrementAttempts(String token);
+
+    /**
+     * 같은 기기(userId+deviceFp)의 step-up 발급을 원자적으로 1건으로 제한한다. (TTL 5분)
+     * - 신규 발급권을 선점하면 Optional.empty() 반환 → 호출측이 코드 생성 + 메일 발송 진행
+     * - 이미 유효한 발급이 있으면 그 토큰을 반환 → 호출측은 메일 재발송 없이 재사용
+     */
+    Optional<String> reserveDeviceChallenge(Long userId, String deviceFp, String newToken);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/mail/JavaMailEmailSender.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,6 +19,7 @@ public class JavaMailEmailSender implements EmailSender {
     @Value("${spring.mail.username}")
     private String fromAddress;
 
+    @Async("mailTaskExecutor")
     @Override
     public void sendVerificationCode(String to, String code) {
         SimpleMailMessage message = new SimpleMailMessage();
@@ -29,7 +31,7 @@ public class JavaMailEmailSender implements EmailSender {
         mailSender.send(message);
         log.info("[EmailSender] 인증 코드 발송 완료 - to: {}", maskEmail(to));
     }
-
+    @Async("mailTaskExecutor")
     @Override
     public void sendPasswordResetCode(String to, String code) {
         SimpleMailMessage message = new SimpleMailMessage();
@@ -42,7 +44,7 @@ public class JavaMailEmailSender implements EmailSender {
         log.info("[EmailSender] 비밀번호 재설정 코드 발송 완료 - to: {}", maskEmail(to));
     }
 
-    // sendPasswordResetCode 메서드 아래에 추가
+    @Async("mailTaskExecutor")
     @Override
     public void sendStepUpCode(String to, String code, String lockUrl) {
         SimpleMailMessage message = new SimpleMailMessage();

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEvent.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEvent.java
@@ -1,0 +1,43 @@
+package com.wanted.codebombalms.auth.infrastructure.metrics;
+
+import lombok.Getter;
+
+/** Auth/User 도메인 비정상 행위. category = 대시보드 드롭다운 단위, type = 세부 지표. */
+@Getter
+public enum AuthSecurityEvent {
+
+    // 🅰 authn_attack — 인증 무차별 공격
+    LOGIN_FAIL("authn_attack", "login_fail"),
+    STEPUP_OTP_FAIL("authn_attack", "stepup_otp_fail"),
+    STEPUP_LOCKED("authn_attack", "stepup_locked"),
+    EMAIL_SEND_BLOCKED("authn_attack", "email_send_blocked"),
+    PASSWORD_RESET_BLOCKED("authn_attack", "password_reset_blocked"),
+
+    // 🅱 takeover — 계정 탈취/이상 접속
+    SUSPICIOUS_LOGIN("takeover", "suspicious_login"),
+    COUNTRY_CHANGED("takeover", "country_changed"),
+    STEPUP_ISSUED("takeover", "stepup_issued"),
+
+    // 🅲 oauth — 소셜 로그인 이상
+    OAUTH_STATE_INVALID("oauth", "oauth_state_invalid"),
+    OAUTH_TOKEN_EXCHANGE_FAIL("oauth", "oauth_token_exchange_fail"),
+    OAUTH_USERINFO_FAIL("oauth", "oauth_userinfo_fail"),
+    OAUTH_EMAIL_CONFLICT("oauth", "oauth_email_conflict"),
+    OAUTH_EMAIL_NOT_VERIFIED("oauth", "oauth_email_not_verified"),
+
+    // 🅳 token — 토큰/세션 남용
+    REFRESH_TOKEN_INVALID("token", "refresh_token_invalid"),
+    TEMP_TOKEN_INVALID("token", "temp_token_invalid"),
+    LOCK_TOKEN_INVALID("token", "lock_token_invalid"),
+
+    // 🅴 signup — 가입/인증코드 이상
+    EMAIL_CODE_EXPIRED("signup", "email_code_expired");
+
+    private final String category;
+    private final String type;
+
+    AuthSecurityEvent(String category, String type) {
+        this.category = category;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
@@ -1,0 +1,69 @@
+package com.wanted.codebombalms.auth.infrastructure.metrics;
+
+import static com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEvent.*;
+
+import com.wanted.codebombalms.global.infrastructure.metrics.SecurityEventReporter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+/**
+ * 비정상 행위를 Prometheus(집계) + Loki(상세) 이중 기록한다.
+ *
+ * <p>메트릭은 저카디널리티 집계용 {@code auth_security_event_total{category,type}} 하나로 통일.
+ * ip/userId 같은 고카디널리티 정보는 메트릭 라벨이 아니라 로그 본문(logfmt)에만 담는다.
+ */
+@Slf4j
+@Component
+public class AuthSecurityEventRecorder implements SecurityEventReporter {
+
+    // 등록명엔 _total 을 붙이지 않는다. Counter 라서 Prometheus 가 auth_security_event_total 로 변환한다.
+    private static final String METRIC = "auth_security_event";
+
+    // ErrorCode(AUT-*) → 이벤트. 흐름성/모호 코드(AUT-009 등)는 서비스에서 직접 기록한다.
+    private static final Map<String, AuthSecurityEvent> BY_CODE = Map.ofEntries(
+            Map.entry("AUT-001", LOGIN_FAIL),
+            Map.entry("AUT-014", EMAIL_SEND_BLOCKED),
+            Map.entry("AUT-017", PASSWORD_RESET_BLOCKED),
+            Map.entry("AUT-019", OAUTH_TOKEN_EXCHANGE_FAIL),
+            Map.entry("AUT-020", OAUTH_USERINFO_FAIL),
+            Map.entry("AUT-021", OAUTH_STATE_INVALID),
+            Map.entry("AUT-022", OAUTH_EMAIL_CONFLICT),
+            Map.entry("AUT-023", OAUTH_EMAIL_NOT_VERIFIED),
+            Map.entry("AUT-004", REFRESH_TOKEN_INVALID),
+            Map.entry("AUT-005", REFRESH_TOKEN_INVALID),
+            Map.entry("AUT-006", TEMP_TOKEN_INVALID),
+            Map.entry("AUT-007", LOCK_TOKEN_INVALID),
+            Map.entry("AUT-008", LOCK_TOKEN_INVALID),
+            Map.entry("AUT-010", EMAIL_CODE_EXPIRED));
+
+    private final MeterRegistry registry;
+
+    public AuthSecurityEventRecorder(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    /** 흐름 기반 이벤트(의심 로그인 등) 직접 기록. ip/uri 는 MDC(MdcLoggingFilter)에서 가져온다. */
+    public void record(AuthSecurityEvent event, Long userId) {
+        registry.counter(METRIC, "category", event.getCategory(), "type", event.getType()).increment();
+        log.warn("event=security_event category={} type={} userId={} ip={} uri={}",
+                event.getCategory(), event.getType(),
+                userId == null ? "-" : userId, mdc("clientIp"), mdc("requestURI"));
+    }
+
+    /** 예외 기반 이벤트 — GlobalExceptionHandler 가 ErrorCode 로 호출. 매핑 없는 코드는 무시. */
+    @Override
+    public void reportByErrorCode(String errorCode) {
+        AuthSecurityEvent event = BY_CODE.get(errorCode);
+        if (event != null) {
+            record(event, null);
+        }
+    }
+
+    private String mdc(String key) {
+        String value = MDC.get(key);
+        return value == null ? "-" : value;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
@@ -22,6 +22,8 @@ public class RedisStepUpTokenAdapter implements StepUpTokenRepository {
     private static final String KEY_ATTEMPTS  = "stepup:attempts:";  // + {token}
     private static final Duration TTL = Duration.ofMinutes(5);
 
+    private static final String KEY_DEVICE = "stepup:device:"; // + {userId}:{deviceFp}
+
     @Override
     public void save(String token, StepUpChallenge challenge) {
         // 본문 + TTL 단일 SET EX (원자)
@@ -47,6 +49,20 @@ public class RedisStepUpTokenAdapter implements StepUpTokenRepository {
             redisTemplate.expire(key, TTL); // 첫 시도 시 TTL 부여 (토큰과 동기 만료)
         }
         return count == null ? 0 : count.intValue();
+    }
+
+    @Override
+    public Optional<String> reserveDeviceChallenge(Long userId, String deviceFp, String newToken) {
+        String key = KEY_DEVICE + userId + ":" + deviceFp;
+
+        // 원자적 SETNX — 키가 없을 때만 newToken 으로 선점 (TTL 5분)
+        Boolean reserved = redisTemplate.opsForValue().setIfAbsent(key, newToken, TTL);
+        if (Boolean.TRUE.equals(reserved)) {
+            return Optional.empty(); // 선점 성공 → 신규 발급 진행
+        }
+
+        // 이미 발급 진행 중/완료 → 기존 토큰 재사용
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key));
     }
 
     private String serialize(StepUpChallenge challenge) {

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisStepUpTokenAdapter.java
@@ -37,6 +37,9 @@ public class RedisStepUpTokenAdapter implements StepUpTokenRepository {
 
     @Override
     public void delete(String token) {
+        // 챌린지에 담긴 userId+deviceFp 로 기기 예약 키(KEY_DEVICE)도 함께 정리 — 생명주기 동기화
+        find(token).ifPresent(challenge ->
+                redisTemplate.delete(KEY_DEVICE + challenge.userId() + ":" + challenge.deviceFp()));
         redisTemplate.delete(KEY_CHALLENGE + token);
         redisTemplate.delete(KEY_ATTEMPTS + token);
     }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/OAuthCallbackController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/OAuthCallbackController.java
@@ -4,11 +4,13 @@ import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
 import com.wanted.codebombalms.auth.application.usecase.GoogleCallbackUseCase;
 import com.wanted.codebombalms.auth.infrastructure.oauth.OAuthProperties;
 import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.auth.presentation.api.support.DeviceFingerprintResolver;
 import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.DomainException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,6 +35,8 @@ public class OAuthCallbackController {
     private final JwtTokenProvider jwtTokenProvider;
     private final OAuthProperties oAuthProperties;
 
+    private final DeviceFingerprintResolver deviceFingerprintResolver;
+
     private static final int TEMP_TOKEN_MAX_AGE = 600; // 10분
 
     @Operation(
@@ -43,10 +47,12 @@ public class OAuthCallbackController {
     public ResponseEntity<Void> googleCallback(
             @RequestParam String code,
             @RequestParam String state,
+            HttpServletRequest httpRequest,
             HttpServletResponse response
     ) {
         try {
-            GoogleCallbackResult result = googleCallbackUseCase.handleCallback(code, state);
+            String deviceFp = deviceFingerprintResolver.resolve(httpRequest, response);
+            GoogleCallbackResult result = googleCallbackUseCase.handleCallback(code, state, httpRequest, deviceFp);
 
             if (result.newUser()) {
                 // 신규 회원 → TEMP_TOKEN 쿠키 + 추가정보 페이지로
@@ -70,16 +76,19 @@ public class OAuthCallbackController {
         }
     }
 
-    /** 성공 흐름 redirect */
+    /**
+     * 성공 흐름 redirect
+     */
     private ResponseEntity<Void> redirect(String uri) {
         return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(uri)).build();
     }
 
-    /** 실패 흐름 redirect — 로그인 페이지에 error code + message 전달(모달 표시용) */
+    /**
+     * 실패 흐름 redirect — 로그인 페이지에 error code 전달(문구는 프론트가 코드로 매핑)
+     */
     private ResponseEntity<Void> redirectError(ErrorCode errorCode) {
         String uri = UriComponentsBuilder.fromUriString(oAuthProperties.getErrorUri())
                 .queryParam("error", errorCode.getCode())
-                .queryParam("message", errorCode.getMessage())
                 .encode(StandardCharsets.UTF_8)
                 .build()
                 .toUriString();

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendFirstMessageCommand.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendFirstMessageCommand.java
@@ -4,5 +4,6 @@ public record SendFirstMessageCommand(
         Long userId,
         String userMessage,
         Long problemSetId,
-        Long problemId
+        Long problemId,
+        String traceId
 ) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendMessageCommand.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/command/SendMessageCommand.java
@@ -3,5 +3,6 @@ package com.wanted.codebombalms.chatbot.application.command;
 public record SendMessageCommand(
         Long userId,
         Long roomId,
-        String userMessage
+        String userMessage,
+        String traceId
 ) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/port/AiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/port/AiChatClient.java
@@ -9,6 +9,9 @@ public interface AiChatClient {
     /**
      * ChatContext를 FastAPI에 전송하고 AI 응답을 토큰 단위로 스트리밍한다.
      * Token(N회) → Done(1회) 순서이며, 도중 실패 시 Error로 끝난다.
+     *
+     * @param traceId 분산 추적용 상관 ID. FastAPI로 {@code X-Trace-Id} 헤더로 전파해
+     *                두 서비스 로그를 같은 traceId로 엮는다. null 이면 전파하지 않는다.
      */
-    Flux<AiChatStreamChunk> stream(ChatContext context);
+    Flux<AiChatStreamChunk> stream(ChatContext context, String traceId);
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatStreamMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatStreamMetricsPort.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.chatbot.application.port;
+
+/**
+ * AI 응답 스트림의 생명주기를 관측 시스템에 기록하는 출력 포트.
+ *
+ * <p>토큰 사용량({@link RecordTokenUsagePort})과 책임을 분리한다 — 이쪽은 "스트림이 몇 개 떠 있고,
+ * 얼마나 걸렸고, 어떻게 끝났나"(동시성·지연·중도이탈)다. application 은 이 인터페이스에만 의존하고,
+ * 구현(Micrometer)은 infrastructure 에 둔다.
+ */
+public interface ChatStreamMetricsPort {
+
+    /** 스트림 구독 시작 — 활성 스트림 수 +1. */
+    void onStreamStart();
+
+    /** 첫 토큰 수신까지의 시간(TTFT). 스트림당 1회만 호출. */
+    void onFirstToken(long ttftNanos);
+
+    /**
+     * 스트림 종료 — 활성 스트림 수 -1, 전체 소요시간(outcome 별), 종료 신호 분포를 한 번에 기록.
+     *
+     * @param durationNanos 구독~종료까지 소요(ns)
+     * @param outcome       {@code "success"} | {@code "error"} — AI 응답 정상 완료 여부
+     * @param signal        reactor 종단 신호명({@code onComplete}/{@code cancel}/{@code onError})
+     */
+    void onStreamEnd(long durationNanos, String outcome, String signal);
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandService.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
 import com.wanted.codebombalms.chatbot.application.model.ChatContext;
 import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
+import com.wanted.codebombalms.chatbot.application.port.ChatStreamMetricsPort;
 import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatMessageCommandUseCase;
 import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
@@ -14,6 +15,9 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -22,19 +26,32 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
     private final AiChatClient aiChatClient;
     private final ChatMessageTransactionService txService;
     private final RecordTokenUsagePort recordTokenUsagePort;
+    private final ChatStreamMetricsPort streamMetricsPort;
 
     @Override
     public Flux<AiChatStreamChunk> send(SendMessageCommand command) {
         // 1) 스트림 전 동기 구간(블로킹 tx) — 호출 스레드에서 먼저 끝낸다
         ChatContext context = txService.prepare(command);
 
-        // 2) 스트리밍: 토큰을 누적하며 그대로 흘린다
+        // 2) per-subscription 상태 — reactive 콜백이 별도 스레드라 MDC 대신 클로저로 들고 다닌다.
         StringBuilder accumulated = new StringBuilder();
+        long startNanos = System.nanoTime();
+        AtomicBoolean firstToken = new AtomicBoolean(false);
+        AtomicReference<String> outcome = new AtomicReference<>("success");
+        streamMetricsPort.onStreamStart();
 
-        return aiChatClient.stream(context)
+        return aiChatClient.stream(context, command.traceId())
                 .doOnNext(chunk -> {
                     if (chunk instanceof AiChatStreamChunk.Token token) {
+                        if (firstToken.compareAndSet(false, true)) {
+                            streamMetricsPort.onFirstToken(System.nanoTime() - startNanos);
+                        }
                         accumulated.append(token.text());
+                    } else if (chunk instanceof AiChatStreamChunk.Error err) {
+                        // FastAPI 가 error 프레임을 보낸 경우(client onErrorResume 포함) — outcome 갈음 + 추적 로그
+                        outcome.set("error");
+                        log.error("event=chat_ai_error_chunk userId={} roomId={} code={} traceId={}",
+                                command.userId(), command.roomId(), err.code(), command.traceId());
                     }
                 })
                 .concatMap(chunk -> {
@@ -49,7 +66,8 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
                                 .thenReturn((AiChatStreamChunk) chunk)
                                 // 저장 실패해도 답변은 이미 생성·전송됨 → done 으로 정상 종료(손실은 로그/알림으로)
                                 .onErrorResume(e -> {
-                                    log.error("event=chat_save_failed roomId={}", command.roomId(), e);
+                                    log.error("event=chat_save_failed userId={} roomId={} traceId={}",
+                                            command.userId(), command.roomId(), command.traceId(), e);
                                     return Mono.just((AiChatStreamChunk) chunk);
                                 });
                     }
@@ -58,13 +76,23 @@ public class ChatMessageCommandService implements ChatMessageCommandUseCase {
                 // 4) 종단 안전망: 어떤 예외든 abort(=ERR_INCOMPLETE_CHUNKED_ENCODING) 대신
                 //    error 프레임으로 변환해 스트림을 정상 complete 시킨다.
                 .onErrorResume(e -> {
-                    log.error("event=chat_stream_aborted roomId={}", command.roomId(), e);
+                    outcome.set("error");
+                    log.error("event=chat_stream_aborted userId={} roomId={} exceptionType={} traceId={}",
+                            command.userId(), command.roomId(), e.getClass().getSimpleName(), command.traceId(), e);
                     return Flux.just(new AiChatStreamChunk.Error(
                             ChatErrorCode.AI_RESPONSE_FAILED.getCode(),
                             ChatErrorCode.AI_RESPONSE_FAILED.getMessage()));
                 })
-                // 다음 재현 시 종단 신호(onComplete/onError/cancel)로 원인 구간을 즉시 가른다.
-                .doFinally(signal ->
-                        log.info("event=chat_stream_end roomId={} signal={}", command.roomId(), signal));
+                // 5) 종단: 활성 스트림 -1, 전체 소요/종료신호 기록 + 추적 기준선 로그(정상도 1줄).
+                //    durationMs 는 async 라 HTTP 메트릭보다 이 값이 정확하다.
+                .doFinally(signal -> {
+                    long elapsedNanos = System.nanoTime() - startNanos;
+                    streamMetricsPort.onStreamEnd(elapsedNanos, outcome.get(), signal.toString());
+                    log.info("event=chat_stream_end userId={} roomId={} signal={} outcome={} durationMs={} userMessageLength={} traceId={}",
+                            command.userId(), command.roomId(), signal, outcome.get(),
+                            elapsedNanos / 1_000_000,
+                            command.userMessage() == null ? 0 : command.userMessage().length(),
+                            command.traceId());
+                });
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomCommandService.java
@@ -34,7 +34,7 @@ public class ChatRoomCommandService implements ChatRoomCommandUseCase {
         return Flux.concat(
                 Flux.just(new AiChatStreamChunk.Room(room.getId())),
                 chatMessageCommandUseCase.send(
-                        new SendMessageCommand(command.userId(), room.getId(), command.userMessage()))
+                        new SendMessageCommand(command.userId(), room.getId(), command.userMessage(), command.traceId()))
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatClient.java
@@ -32,17 +32,24 @@ public class FastApiChatClient implements AiChatClient {
     private final ObjectMapper objectMapper;
 
     @Override
-    public Flux<AiChatStreamChunk> stream(ChatContext context) {
+    public Flux<AiChatStreamChunk> stream(ChatContext context, String traceId) {
         FastApiChatRequest request = toRequest(context);
 
         return webClient.post()
                 .uri("/chat")
+                // BE↔FastAPI 로그를 같은 traceId로 엮기 위해 상관 ID를 헤더로 전파한다.
+                .headers(h -> {
+                    if (traceId != null) {
+                        h.set("X-Trace-Id", traceId);
+                    }
+                })
                 .bodyValue(request)
                 .retrieve()
                 .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
                 .map(this::toChunk)
                 .onErrorResume(e -> {
-                    log.error("FastAPI 스트리밍 호출 실패", e);
+                    // raw 예외는 stack trace 만(WARN). "누구/어디" 책임 로그는 application(chat_ai_error_chunk)에서.
+                    log.warn("event=chat_ai_call_failed traceId={} - FastAPI 스트리밍 호출 실패", traceId, e);
                     return Flux.just(new AiChatStreamChunk.Error(
                             ChatErrorCode.AI_RESPONSE_FAILED.getCode(),
                             ChatErrorCode.AI_RESPONSE_FAILED.getMessage()

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/MockAiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/MockAiChatClient.java
@@ -17,7 +17,7 @@ public class MockAiChatClient implements AiChatClient {
     private final AtomicInteger callCount = new AtomicInteger(0);
 
     @Override
-    public Flux<AiChatStreamChunk> stream(ChatContext context) {
+    public Flux<AiChatStreamChunk> stream(ChatContext context, String traceId) {
         int count = callCount.incrementAndGet();
         String answer = "Fastapi 반환 mock입니다." + count + " 토큰 단위로 스트리밍됩니다.";
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/metrics/ChatMetrics.java
@@ -1,14 +1,17 @@
 package com.wanted.codebombalms.chatbot.infrastructure.metrics;
 
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
+import com.wanted.codebombalms.chatbot.application.port.ChatStreamMetricsPort;
 import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * 챗봇 도메인 커스텀 메트릭 (관측 Layer 3).
@@ -19,16 +22,25 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>토큰 사용량 Counter 는 입력/출력을 분리 누적한다(단가가 달라 비용 계산 시 분리 필수).
  * total 은 두 Counter 의 합이라 별도 등록하지 않는다.
+ *
+ * <p>스트림 생명주기 메트릭({@link ChatStreamMetricsPort}) — 운영 대시보드의 "외부 AI 의존"·
+ * "스트리밍 건강성" 행을 채운다. AI Timer 두 개는 외부연동 p95 가 핵심 SLI 라
+ * {@code publishPercentileHistogram()} 으로 히스토그램 버킷을 노출한다(PromQL {@code histogram_quantile}).
+ * outcome/signal 은 동적 태그라 {@link MeterRegistry} 에서 그때그때 빌드한다(같은 name+tag 는 캐시됨).
  */
 @Slf4j
 @Component
-public class ChatMetrics implements RecordTokenUsagePort {
+public class ChatMetrics implements RecordTokenUsagePort, ChatStreamMetricsPort {
 
+    private final MeterRegistry registry;
     private final Timer listQueryTimer;
     private final Counter promptTokensCounter;
     private final Counter completionTokensCounter;
+    private final Timer timeToFirstTokenTimer;
+    private final AtomicInteger activeStreams = new AtomicInteger();
 
     public ChatMetrics(MeterRegistry registry) {
+        this.registry = registry;
         // 등록명엔 _seconds 를 붙이지 않는다. Timer 라서 Prometheus 가
         // chat_room_list_query_duration_seconds_{count,sum,max} 로 자동 변환한다.
         this.listQueryTimer = Timer.builder("chat_room_list_query_duration")
@@ -42,11 +54,45 @@ public class ChatMetrics implements RecordTokenUsagePort {
         this.completionTokensCounter = Counter.builder("chat_completion_tokens")
                 .description("AI 응답 출력(completion) 토큰 누적량")
                 .register(registry);
+        this.timeToFirstTokenTimer = Timer.builder("chat_ai_time_to_first_token")
+                .description("스트림 구독부터 첫 토큰 수신까지(TTFT, 사용자 체감 지연)")
+                .publishPercentileHistogram()
+                .register(registry);
+        // 현재 동시 SSE 스트림 수. 단위 suffix 없이 chat_active_streams 로 노출.
+        Gauge.builder("chat_active_streams", activeStreams, AtomicInteger::get)
+                .description("현재 동시 AI 스트림 수")
+                .register(registry);
     }
 
     /** 채팅방 목록 조회(제목 fanout 포함) 구간 소요 시간 기록. */
     public void recordListQuery(long elapsedNanos) {
         listQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void onStreamStart() {
+        activeStreams.incrementAndGet();
+    }
+
+    @Override
+    public void onFirstToken(long ttftNanos) {
+        timeToFirstTokenTimer.record(ttftNanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void onStreamEnd(long durationNanos, String outcome, String signal) {
+        activeStreams.decrementAndGet();
+        Timer.builder("chat_ai_stream_duration")
+                .description("AI 스트림 전체 소요시간(outcome 별)")
+                .tag("outcome", outcome)
+                .publishPercentileHistogram()
+                .register(registry)
+                .record(durationNanos, TimeUnit.NANOSECONDS);
+        Counter.builder("chat_stream_terminations")
+                .description("스트림 종료 신호 분포(정상완료 vs 중도이탈)")
+                .tag("signal", signal)
+                .register(registry)
+                .increment();
     }
 
     /**

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatRoomController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -59,11 +60,14 @@ public class ChatRoomController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody SendFirstMessageRequest request
     ) {
+        // SSE 스트림 콜백은 별도 reactor 스레드라 MDC(traceId)가 전파되지 않는다.
+        // 호출 스레드인 여기서 캡처해 command 로 넘겨야 스트림 로그에 traceId 가 박힌다.
         SendFirstMessageCommand command = new SendFirstMessageCommand(
                 userId,
                 request.userMessage(),
                 request.problemSetId(),
-                request.problemId()
+                request.problemId(),
+                MDC.get("traceId")
         );
 
         // sendFirst() 호출 시 방 준비(tx)가 동기 실행됨 → 진입부 예외는 여기서 JSON으로 처리됨
@@ -165,7 +169,8 @@ public class ChatRoomController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ChatMessageRequest request
     ) {
-        SendMessageCommand command = new SendMessageCommand(userId, roomId, request.userMessage());
+        SendMessageCommand command = new SendMessageCommand(
+                userId, roomId, request.userMessage(), MDC.get("traceId"));
 
         Flux<ServerSentEvent<Object>> body = chatMessageCommandUseCase.send(command)
                 .map(this::toServerSentEvent);

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -24,4 +24,16 @@ public class SchedulingConfig {
         executor.initialize();
         return executor;
     }
+
+    /** 이메일(SMTP) 발송을 로그인 응답 스레드와 분리 — 발송 지연이 응답을 막지 않도록 전용 풀 사용. */
+    @Bean(name = "mailTaskExecutor")
+    public Executor mailTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("mail-async-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -33,6 +33,8 @@ public class SchedulingConfig {
         executor.setMaxPoolSize(5);
         executor.setQueueCapacity(50);
         executor.setThreadNamePrefix("mail-async-");
+        // 풀+큐 포화 시 호출 스레드에서 직접 실행 — 메일 유실·로그인 실패(TaskRejectedException) 방지
+        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/SecurityEventReporter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/SecurityEventReporter.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.global.infrastructure.metrics;
+
+/** ErrorCode(예: AUT-001) 기반 보안 이벤트 기록 포트. 구현체는 도메인 계층(auth)에 위치한다. */
+public interface SecurityEventReporter {
+    void reportByErrorCode(String errorCode);
+}

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -2,10 +2,12 @@ package com.wanted.codebombalms.global.presentation.api.common;
 
 import com.wanted.codebombalms.global.domain.common.error.DomainException;
 import com.wanted.codebombalms.global.domain.common.error.exception.*;
+import com.wanted.codebombalms.global.infrastructure.metrics.SecurityEventReporter;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
@@ -30,11 +32,13 @@ import java.util.Arrays;
 public class GlobalExceptionHandler {
 
     private final Environment env;
+    private final ObjectProvider<SecurityEventReporter> securityEventReporter;
 
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<ApiErrorResponse> handleDomainException(
             DomainException e, HttpServletRequest request) {
         log.warn("[{}] {} - path: {}", e.getHttpStatus(), e.getMessage(), request.getRequestURI());
+        securityEventReporter.ifAvailable(r -> r.reportByErrorCode(e.getErrorCode().getCode()));
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ApiErrorResponse.of(e.getHttpStatus(), e.getErrorCode(), request.getRequestURI()));
     }

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -38,7 +38,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleDomainException(
             DomainException e, HttpServletRequest request) {
         log.warn("[{}] {} - path: {}", e.getHttpStatus(), e.getMessage(), request.getRequestURI());
-        securityEventReporter.ifAvailable(r -> r.reportByErrorCode(e.getErrorCode().getCode()));
+        // 보안 이벤트 기록 실패가 원래 에러 응답을 깨지 않도록 삼킨다.
+        try {
+            securityEventReporter.ifAvailable(r -> r.reportByErrorCode(e.getErrorCode().getCode()));
+        } catch (Exception ignored) {
+            log.warn("보안 이벤트 기록 실패 (무시): {}", ignored.getMessage());
+        }
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ApiErrorResponse.of(e.getHttpStatus(), e.getErrorCode(), request.getRequestURI()));
     }

--- a/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.reward.point.application.port;
+
+public interface RecordRewardMetricsPort {
+
+    void recordScheduled();
+
+    void recordProcessed(ProcessResult result);
+
+    void recordProcess(long elapsedNanos);
+
+    void updatePending(long pendingCount);
+
+    enum ProcessResult {
+        COMPLETED("completed"),
+        RETRY("retry"),
+        FAILED("failed"),
+        SKIPPED("skipped"),
+        NOT_FOUND("not_found"),
+        ERROR("error");
+
+        private final String tagValue;
+
+        ProcessResult(String tagValue) {
+            this.tagValue = tagValue;
+        }
+
+        public String tagValue() {
+            return tagValue;
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
@@ -2,6 +2,8 @@ package com.wanted.codebombalms.reward.point.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.DomainException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort.ProcessResult;
 import com.wanted.codebombalms.reward.point.application.usecase.GrantProblemPointUseCase;
 import com.wanted.codebombalms.reward.point.application.usecase.ProcessPointRewardTaskUseCase;
 import com.wanted.codebombalms.reward.point.application.usecase.SchedulePointRewardTaskUseCase;
@@ -10,13 +12,16 @@ import com.wanted.codebombalms.reward.point.domain.model.PointRewardTask;
 import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
 import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PointRewardTaskService
@@ -26,6 +31,7 @@ public class PointRewardTaskService
 
     private final PointRewardTaskRepository pointRewardTaskRepository;
     private final GrantProblemPointUseCase grantProblemPointUseCase;
+    private final RecordRewardMetricsPort rewardMetrics;
     private final Clock clock;
     private static final long MAX_RETRY_DELAY_MINUTES = 16L;
 
@@ -49,16 +55,57 @@ public class PointRewardTaskService
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void process(Long submissionId) {
-        PointRewardTask task = pointRewardTaskRepository
-                .findBySubmissionIdForUpdate(submissionId)
-                .orElseThrow(() -> new NotFoundException(
-                        RewardErrorCode.REWARD_POINT_TASK_NOT_FOUND
-                ));
+        long startedAtNanos = System.nanoTime();
+        ProcessResult result = null;
+        try {
+            PointRewardTask task = pointRewardTaskRepository
+                    .findBySubmissionIdForUpdate(submissionId)
+                    .orElseThrow(() -> new NotFoundException(
+                            RewardErrorCode.REWARD_POINT_TASK_NOT_FOUND
+                    ));
 
-        if (task.status() != PointRewardTaskStatus.PENDING) {
-            return;
+            if (task.status() != PointRewardTaskStatus.PENDING) {
+                result = ProcessResult.SKIPPED;
+                log.info(
+                        "event=reward_point_task_skipped submissionId={} status={} durationMs={}",
+                        submissionId,
+                        task.status(),
+                        elapsedMillis(startedAtNanos)
+                );
+                return;
+            }
+
+            result = processPendingTask(task, startedAtNanos);
+        } catch (NotFoundException e) {
+            result = ProcessResult.NOT_FOUND;
+            log.warn(
+                    "event=reward_point_task_not_found submissionId={} durationMs={}",
+                    submissionId,
+                    elapsedMillis(startedAtNanos)
+            );
+            throw e;
+        } catch (Exception e) {
+            result = ProcessResult.ERROR;
+            log.error(
+                    "event=reward_point_task_processing_failed submissionId={} exceptionType={} durationMs={}",
+                    submissionId,
+                    e.getClass().getSimpleName(),
+                    elapsedMillis(startedAtNanos),
+                    e
+            );
+            throw e;
+        } finally {
+            if (result != null) {
+                rewardMetrics.recordProcessed(result);
+            }
+            rewardMetrics.recordProcess(System.nanoTime() - startedAtNanos);
         }
+    }
 
+    private ProcessResult processPendingTask(
+            PointRewardTask task,
+            long startedAtNanos
+    ) {
         try {
             grantProblemPointUseCase.grant(
                     task.userId(),
@@ -68,31 +115,65 @@ public class PointRewardTaskService
             );
 
             pointRewardTaskRepository.save(task.complete());
+            log.info(
+                    "event=reward_point_task_completed userId={} problemId={} submissionId={} point={} retryCount={} durationMs={}",
+                    task.userId(),
+                    task.problemId(),
+                    task.submissionId(),
+                    task.point(),
+                    task.retryCount(),
+                    elapsedMillis(startedAtNanos)
+            );
+            return ProcessResult.COMPLETED;
         } catch (DomainException e) {
-            handleDomainFailure(task, e);
+            return handleDomainFailure(task, e, startedAtNanos);
         } catch (Exception e) {
-            handleFailure(task, e);
+            return handleFailure(task, e, startedAtNanos);
         }
     }
 
-    private void handleDomainFailure(
+    private ProcessResult handleDomainFailure(
             PointRewardTask task,
-            DomainException exception
+            DomainException exception,
+            long startedAtNanos
     ) {
         if (isAlreadyGranted(exception)) {
             pointRewardTaskRepository.save(task.complete());
-            return;
+            log.info(
+                    "event=reward_point_task_completed userId={} problemId={} submissionId={} point={} retryCount={} reason=already_granted durationMs={}",
+                    task.userId(),
+                    task.problemId(),
+                    task.submissionId(),
+                    task.point(),
+                    task.retryCount(),
+                    elapsedMillis(startedAtNanos)
+            );
+            return ProcessResult.COMPLETED;
         }
 
         pointRewardTaskRepository.save(
                 task.failPermanently(exception.getMessage())
         );
+        log.warn(
+                "event=reward_point_task_failed userId={} problemId={} submissionId={} retryCount={} reason=domain_failure exceptionType={} durationMs={}",
+                task.userId(),
+                task.problemId(),
+                task.submissionId(),
+                task.retryCount(),
+                exception.getClass().getSimpleName(),
+                elapsedMillis(startedAtNanos)
+        );
+        return ProcessResult.FAILED;
     }
 
-    private void handleFailure(PointRewardTask task, Exception exception) {
+    private ProcessResult handleFailure(
+            PointRewardTask task,
+            Exception exception,
+            long startedAtNanos
+    ) {
         if (isAlreadyGranted(exception)) {
             pointRewardTaskRepository.save(task.complete());
-            return;
+            return ProcessResult.COMPLETED;
         }
 
         long retryDelayMinutes = Math.min(
@@ -100,11 +181,38 @@ public class PointRewardTaskService
                 1L << task.retryCount()
         );
 
-        pointRewardTaskRepository.save(task.retry(
+        PointRewardTask updatedTask = task.retry(
                 exception.getMessage(),
                 now().plusMinutes(retryDelayMinutes),
                 MAX_RETRY_COUNT
-        ));
+        );
+        pointRewardTaskRepository.save(updatedTask);
+
+        if (updatedTask.status() == PointRewardTaskStatus.FAILED) {
+            log.error(
+                    "event=reward_point_task_failed userId={} problemId={} submissionId={} retryCount={} reason=max_retry_exceeded exceptionType={} durationMs={}",
+                    task.userId(),
+                    task.problemId(),
+                    task.submissionId(),
+                    updatedTask.retryCount(),
+                    exception.getClass().getSimpleName(),
+                    elapsedMillis(startedAtNanos),
+                    exception
+            );
+            return ProcessResult.FAILED;
+        }
+
+        log.warn(
+                "event=reward_point_task_retry_scheduled userId={} problemId={} submissionId={} retryCount={} exceptionType={} nextRetryAt={} durationMs={}",
+                task.userId(),
+                task.problemId(),
+                task.submissionId(),
+                updatedTask.retryCount(),
+                exception.getClass().getSimpleName(),
+                updatedTask.nextRetryAt(),
+                elapsedMillis(startedAtNanos)
+        );
+        return ProcessResult.RETRY;
     }
 
     private boolean isAlreadyGranted(Exception exception) {
@@ -115,5 +223,11 @@ public class PointRewardTaskService
 
     private LocalDateTime now() {
         return LocalDateTime.now(clock);
+    }
+
+    private long elapsedMillis(long startedAtNanos) {
+        return TimeUnit.NANOSECONDS.toMillis(
+                System.nanoTime() - startedAtNanos
+        );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/reward/point/domain/repository/PointRewardTaskRepository.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/domain/repository/PointRewardTaskRepository.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.reward.point.domain.repository;
 
 import com.wanted.codebombalms.reward.point.domain.model.PointRewardTask;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,4 +17,6 @@ public interface PointRewardTaskRepository {
             LocalDateTime now,
             int limit
     );
+
+    long countByStatus(PointRewardTaskStatus status);
 }

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandler.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandler.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.reward.point.infrastructure.event;
 
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
 import com.wanted.codebombalms.reward.point.application.usecase.ProcessPointRewardTaskUseCase;
 import com.wanted.codebombalms.reward.point.application.usecase.SchedulePointRewardTaskUseCase;
 import com.wanted.codebombalms.submission.domain.event.ProblemSolvedEvent;
@@ -16,6 +17,7 @@ public class PointRewardEventHandler {
 
     private final SchedulePointRewardTaskUseCase schedulePointRewardTaskUseCase;
     private final ProcessPointRewardTaskUseCase processPointRewardTaskUseCase;
+    private final RecordRewardMetricsPort rewardMetrics;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void schedule(ProblemSolvedEvent event) {
@@ -29,6 +31,15 @@ public class PointRewardEventHandler {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void process(ProblemSolvedEvent event) {
+        rewardMetrics.recordScheduled();
+        log.info(
+                "event=reward_point_task_scheduled userId={} problemId={} submissionId={} point={}",
+                event.userId(),
+                event.problemId(),
+                event.submissionId(),
+                event.point()
+        );
+
         try {
             processPointRewardTaskUseCase.process(event.submissionId());
         } catch (Exception e) {

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
@@ -1,0 +1,71 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class RewardMetrics implements RecordRewardMetricsPort {
+
+    private final Counter scheduledCounter;
+    private final Map<ProcessResult, Counter> processedCounters;
+    private final Timer processTimer;
+    private final AtomicLong pendingTasks = new AtomicLong();
+
+    public RewardMetrics(MeterRegistry registry) {
+        this.scheduledCounter = Counter.builder("reward_point_task_scheduled")
+                .description("Committed point reward tasks")
+                .register(registry);
+
+        this.processedCounters = new EnumMap<>(ProcessResult.class);
+        for (ProcessResult result : ProcessResult.values()) {
+            processedCounters.put(
+                    result,
+                    Counter.builder("reward_point_task_processed")
+                            .description("Point reward task processing outcomes")
+                            .tag("result", result.tagValue())
+                            .register(registry)
+            );
+        }
+
+        this.processTimer = Timer.builder("reward_point_task_process_duration")
+                .description("Point reward task processing duration")
+                .register(registry);
+
+        Gauge.builder(
+                        "reward_point_task_pending",
+                        pendingTasks,
+                        AtomicLong::doubleValue
+                )
+                .description("Current pending point reward task count")
+                .register(registry);
+    }
+
+    @Override
+    public void recordScheduled() {
+        scheduledCounter.increment();
+    }
+
+    @Override
+    public void recordProcessed(ProcessResult result) {
+        processedCounters.get(result).increment();
+    }
+
+    @Override
+    public void recordProcess(long elapsedNanos) {
+        processTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    @Override
+    public void updatePending(long pendingCount) {
+        pendingTasks.set(Math.max(pendingCount, 0));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsScheduler.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
+import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RewardPendingMetricsScheduler {
+
+    private final PointRewardTaskRepository pointRewardTaskRepository;
+    private final RecordRewardMetricsPort rewardMetrics;
+
+    @Scheduled(
+            fixedDelayString = "${reward.point.metrics.pending-refresh-ms:30000}",
+            initialDelayString = "${reward.point.metrics.pending-initial-delay-ms:0}"
+    )
+    public void refreshPendingCount() {
+        try {
+            long pendingCount = pointRewardTaskRepository.countByStatus(
+                    PointRewardTaskStatus.PENDING
+            );
+            rewardMetrics.updatePending(pendingCount);
+        } catch (Exception e) {
+            log.warn(
+                    "event=reward_point_pending_metric_refresh_failed exceptionType={}",
+                    e.getClass().getSimpleName(),
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/PointRewardTaskPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/PointRewardTaskPersistenceAdapter.java
@@ -44,4 +44,9 @@ public class PointRewardTaskPersistenceAdapter
                 .map(PointRewardTaskJpaEntity::toDomain)
                 .toList();
     }
+
+    @Override
+    public long countByStatus(PointRewardTaskStatus status) {
+        return repository.countByStatus(status);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/SpringDataPointRewardTaskRepository.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/persistence/SpringDataPointRewardTaskRepository.java
@@ -31,4 +31,6 @@ public interface SpringDataPointRewardTaskRepository
             LocalDateTime now,
             Pageable pageable
     );
+
+    long countByStatus(PointRewardTaskStatus status);
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
@@ -1,10 +1,31 @@
 package com.wanted.codebombalms.submission.infrastructure.persistence;
 
+import com.wanted.codebombalms.submission.domain.model.CodeSubmissionTestCaseResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface SpringDataSubmissionTestResultRepository extends JpaRepository<SubmissionTestResultJpaEntity, Long> {
+public interface SpringDataSubmissionTestResultRepository
+        extends JpaRepository<SubmissionTestResultJpaEntity, Long> {
 
-    List<SubmissionTestResultJpaEntity> findBySubmission_SubmissionIdOrderByTestCase_TestOrderAsc(Long submissionId);
+
+    @Query("""
+            select new com.wanted.codebombalms.submission.domain.model.CodeSubmissionTestCaseResult(
+                testCase.testCaseId,
+                result.passed,
+                testCase.hidden,
+                result.actualOutput,
+                result.errorMessage,
+                result.executionTimeMs
+            )
+            from SubmissionTestResultJpaEntity result
+            join result.testCase testCase
+            where result.submission.submissionId = :submissionId
+            order by testCase.testOrder asc
+            """)
+    List<CodeSubmissionTestCaseResult> findResultDetailsBySubmissionId(
+            @Param("submissionId") Long submissionId
+    );
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SpringDataSubmissionTestResultRepository.java
@@ -23,7 +23,7 @@ public interface SpringDataSubmissionTestResultRepository
             from SubmissionTestResultJpaEntity result
             join result.testCase testCase
             where result.submission.submissionId = :submissionId
-            order by testCase.testOrder asc
+            order by testCase.testOrder asc, testCase.testCaseId asc
             """)
     List<CodeSubmissionTestCaseResult> findResultDetailsBySubmissionId(
             @Param("submissionId") Long submissionId

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionResultQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionResultQueryPersistenceAdapter.java
@@ -28,11 +28,9 @@ public class SubmissionResultQueryPersistenceAdapter implements SubmissionResult
         SubmissionJpaEntity submission = submissionRepository.findBySubmissionIdAndUserId(submissionId, userId)
                 .orElseThrow(() -> new NotFoundException(SubmissionErrorCode.SUBMISSION_NOT_FOUND));
 
-        List<CodeSubmissionTestCaseResult> testCaseResults = submissionTestResultRepository
-                .findBySubmission_SubmissionIdOrderByTestCase_TestOrderAsc(submissionId)
-                .stream()
-                .map(this::toTestCaseResult)
-                .toList();
+        List<CodeSubmissionTestCaseResult> testCaseResults =
+                submissionTestResultRepository
+                        .findResultDetailsBySubmissionId(submissionId);
 
         return new CodeSubmissionResult(
                 submission.getSubmissionId(),
@@ -48,14 +46,4 @@ public class SubmissionResultQueryPersistenceAdapter implements SubmissionResult
         );
     }
 
-    private CodeSubmissionTestCaseResult toTestCaseResult(SubmissionTestResultJpaEntity result) {
-        return new CodeSubmissionTestCaseResult(
-                result.getTestCase().getTestCaseId(),
-                result.getPassed(),
-                result.getTestCase().getHidden(),
-                result.getActualOutput(),
-                result.getErrorMessage(),
-                result.getExecutionTimeMs()
-        );
-    }
 }

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.auth.application.service;
 
 import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
 import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.model.GeoLocation;
 import com.wanted.codebombalms.auth.domain.model.LoginHistory;
 import com.wanted.codebombalms.auth.domain.model.RefreshToken;
@@ -12,6 +13,7 @@ import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
 import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
 import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -58,14 +61,15 @@ class GoogleCallbackServiceTest {
 
     @BeforeEach
     void setUp() {
-        given(oAuthStateRepository.validateAndDelete(STATE)).willReturn(true);
-        given(googleOAuthClient.exchangeCodeForAccessToken(CODE)).willReturn("GOOGLE_AT");
-        given(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
-                .willReturn(new OAuthUserInfo(EMAIL, "구글유저", true));
+        // 해피패스 공통 스텁 (실패 테스트에선 일부 미사용 → lenient)
+        lenient().when(oAuthStateRepository.validateAndDelete(STATE)).thenReturn(true);
+        lenient().when(googleOAuthClient.exchangeCodeForAccessToken(CODE)).thenReturn("GOOGLE_AT");
+        lenient().when(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
+                .thenReturn(new OAuthUserInfo(EMAIL, "구글유저", true));
     }
 
     @Test
-    @DisplayName("기존 구글 회원 + 신규 기기 → 로그인 이력 기록 + 신뢰기기 신규 등록 후 토큰 발급")
+    @DisplayName("기존 구글 회원 + 신규 기기 → 의심 이력 기록 + 신뢰기기 신규 등록 후 토큰 발급")
     void 기존회원_신규기기_이력_및_신뢰기기등록() {
         // given
         User user = googleUser(1L);
@@ -79,18 +83,32 @@ class GoogleCallbackServiceTest {
         // when
         GoogleCallbackResult result = service.handleCallback(CODE, STATE, request, DEVICE_FP);
 
-        // then
+        // then — 토큰 발급
         assertFalse(result.newUser());
         assertEquals("AT", result.accessToken());
         assertEquals("RT", result.refreshToken());
-        verify(loginHistoryRepository).save(any(LoginHistory.class));   // 이력 기록
-        verify(trustedDeviceRepository).save(any(TrustedDevice.class)); // 신뢰기기 등록
+
+        // 이력 내용 검증 — 신규 기기이므로 suspicious=true
+        ArgumentCaptor<LoginHistory> historyCaptor = ArgumentCaptor.forClass(LoginHistory.class);
+        verify(loginHistoryRepository).save(historyCaptor.capture());
+        LoginHistory history = historyCaptor.getValue();
+        assertEquals(1L, history.getUserId());
+        assertEquals(DEVICE_FP, history.getDeviceFp());
+        assertTrue(history.isSuspicious());
+
+        // 신뢰기기 내용 검증 — 신규 등록
+        ArgumentCaptor<TrustedDevice> deviceCaptor = ArgumentCaptor.forClass(TrustedDevice.class);
+        verify(trustedDeviceRepository).save(deviceCaptor.capture());
+        TrustedDevice saved = deviceCaptor.getValue();
+        assertEquals(1L, saved.getUserId());
+        assertEquals(DEVICE_FP, saved.getDeviceFp());
+
         verify(refreshTokenRepository).deleteByUserId(1L);
         verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
 
     @Test
-    @DisplayName("기존 구글 회원 + 기존 신뢰기기 → 신규 등록 없이 markUsed 갱신만 한다")
+    @DisplayName("기존 구글 회원 + 기존 신뢰기기(국가 동일) → 정상 이력 + markUsed 갱신만 한다")
     void 기존회원_기존기기_markUsed_갱신() {
         // given
         User user = googleUser(1L);
@@ -105,15 +123,71 @@ class GoogleCallbackServiceTest {
         // when
         service.handleCallback(CODE, STATE, request, DEVICE_FP);
 
-        // then
-        verify(existing).markUsed(any(), any());                       // 기존 기기 갱신
+        // then — 기존 기기 + 국가 동일 → suspicious=false
+        ArgumentCaptor<LoginHistory> historyCaptor = ArgumentCaptor.forClass(LoginHistory.class);
+        verify(loginHistoryRepository).save(historyCaptor.capture());
+        assertFalse(historyCaptor.getValue().isSuspicious());
+
+        verify(existing).markUsed(any(), any());          // 기존 기기 갱신
         verify(trustedDeviceRepository).save(existing);
-        verify(loginHistoryRepository).save(any(LoginHistory.class));
+    }
+
+    @Test
+    @DisplayName("state 검증 실패 → ValidationException(OAUTH_STATE_INVALID), 이력·신뢰기기·토큰 모두 미발생")
+    void state_검증실패() {
+        // given
+        given(oAuthStateRepository.validateAndDelete(STATE)).willReturn(false);
+
+        // when & then
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> service.handleCallback(CODE, STATE, request, DEVICE_FP));
+        assertEquals(AuthErrorCode.OAUTH_STATE_INVALID, ex.getErrorCode());
+        verify(loginHistoryRepository, never()).save(any());
+        verify(trustedDeviceRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("구글 미인증 이메일 → ValidationException(OAUTH_EMAIL_NOT_VERIFIED), 기록 미발생")
+    void 미인증_이메일_거부() {
+        // given
+        given(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
+                .willReturn(new OAuthUserInfo(EMAIL, "구글유저", false));
+
+        // when & then
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> service.handleCallback(CODE, STATE, request, DEVICE_FP));
+        assertEquals(AuthErrorCode.OAUTH_EMAIL_NOT_VERIFIED, ex.getErrorCode());
+        verify(loginHistoryRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("동일 이메일 LOCAL 계정 존재 → ValidationException(OAUTH_EMAIL_ALREADY_LOCAL), 기록 미발생")
+    void 이메일충돌_LOCAL계정() {
+        // given
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(localUser(1L)));
+
+        // when & then
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> service.handleCallback(CODE, STATE, request, DEVICE_FP));
+        assertEquals(AuthErrorCode.OAUTH_EMAIL_ALREADY_LOCAL, ex.getErrorCode());
+        verify(loginHistoryRepository, never()).save(any());
+        verify(trustedDeviceRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).save(any());
     }
 
     // ===== 테스트 헬퍼 =====
 
     private User googleUser(Long userId) {
+        return userWith(userId, AuthProvider.GOOGLE);
+    }
+
+    private User localUser(Long userId) {
+        return userWith(userId, AuthProvider.LOCAL);
+    }
+
+    private User userWith(Long userId, AuthProvider provider) {
         return User.restore(
                 userId,
                 UserRole.STUDENT,
@@ -122,7 +196,7 @@ class GoogleCallbackServiceTest {
                 "홍길동",
                 "길동이",
                 "010-1234-5678",
-                AuthProvider.GOOGLE,
+                provider,
                 null,
                 true,
                 false,

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEventRecorder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -55,6 +56,7 @@ class GoogleCallbackServiceTest {
     @Mock private LoginHistoryRepository loginHistoryRepository;
     @Mock private TrustedDeviceRepository trustedDeviceRepository;
     @Mock private HttpServletRequest request;
+    @Mock private AuthSecurityEventRecorder securityEventRecorder;
 
     @InjectMocks
     private GoogleCallbackService service;

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
@@ -1,0 +1,136 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.dto.GoogleCallbackResult;
+import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
+import com.wanted.codebombalms.auth.domain.model.GeoLocation;
+import com.wanted.codebombalms.auth.domain.model.LoginHistory;
+import com.wanted.codebombalms.auth.domain.model.RefreshToken;
+import com.wanted.codebombalms.auth.domain.model.TrustedDevice;
+import com.wanted.codebombalms.auth.domain.repository.LoginHistoryRepository;
+import com.wanted.codebombalms.auth.domain.repository.OAuthStateRepository;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.auth.domain.repository.TrustedDeviceRepository;
+import com.wanted.codebombalms.auth.domain.service.GeoIpResolver;
+import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GoogleCallbackService 단위 테스트")
+class GoogleCallbackServiceTest {
+
+    private static final String CODE = "AUTH_CODE";
+    private static final String STATE = "STATE";
+    private static final String DEVICE_FP = "DEVICE_FP";
+    private static final String EMAIL = "google@example.com";
+
+    @Mock private OAuthStateRepository oAuthStateRepository;
+    @Mock private GoogleOAuthClient googleOAuthClient;
+    @Mock private UserRepository userRepository;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private GeoIpResolver geoIpResolver;
+    @Mock private LoginHistoryRepository loginHistoryRepository;
+    @Mock private TrustedDeviceRepository trustedDeviceRepository;
+    @Mock private HttpServletRequest request;
+
+    @InjectMocks
+    private GoogleCallbackService service;
+
+    @BeforeEach
+    void setUp() {
+        given(oAuthStateRepository.validateAndDelete(STATE)).willReturn(true);
+        given(googleOAuthClient.exchangeCodeForAccessToken(CODE)).willReturn("GOOGLE_AT");
+        given(googleOAuthClient.fetchUserInfo("GOOGLE_AT"))
+                .willReturn(new OAuthUserInfo(EMAIL, "구글유저", true));
+    }
+
+    @Test
+    @DisplayName("기존 구글 회원 + 신규 기기 → 로그인 이력 기록 + 신뢰기기 신규 등록 후 토큰 발급")
+    void 기존회원_신규기기_이력_및_신뢰기기등록() {
+        // given
+        User user = googleUser(1L);
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.empty());
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("AT");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("RT");
+        given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
+
+        // when
+        GoogleCallbackResult result = service.handleCallback(CODE, STATE, request, DEVICE_FP);
+
+        // then
+        assertFalse(result.newUser());
+        assertEquals("AT", result.accessToken());
+        assertEquals("RT", result.refreshToken());
+        verify(loginHistoryRepository).save(any(LoginHistory.class));   // 이력 기록
+        verify(trustedDeviceRepository).save(any(TrustedDevice.class)); // 신뢰기기 등록
+        verify(refreshTokenRepository).deleteByUserId(1L);
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("기존 구글 회원 + 기존 신뢰기기 → 신규 등록 없이 markUsed 갱신만 한다")
+    void 기존회원_기존기기_markUsed_갱신() {
+        // given
+        User user = googleUser(1L);
+        TrustedDevice existing = spy(TrustedDevice.register(1L, DEVICE_FP, "Chrome · macOS", null, null));
+        given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.of(existing));
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("AT");
+        given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("RT");
+        given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
+
+        // when
+        service.handleCallback(CODE, STATE, request, DEVICE_FP);
+
+        // then
+        verify(existing).markUsed(any(), any());                       // 기존 기기 갱신
+        verify(trustedDeviceRepository).save(existing);
+        verify(loginHistoryRepository).save(any(LoginHistory.class));
+    }
+
+    // ===== 테스트 헬퍼 =====
+
+    private User googleUser(Long userId) {
+        return User.restore(
+                userId,
+                UserRole.STUDENT,
+                EMAIL,
+                "ENCODED_PW",
+                "홍길동",
+                "길동이",
+                "010-1234-5678",
+                AuthProvider.GOOGLE,
+                null,
+                true,
+                false,
+                null,
+                null,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -211,12 +211,13 @@ class LoginServiceTest {
         LoginResult first = loginService.login(command, httpRequest, DEVICE_FP);
         LoginResult second = loginService.login(command, httpRequest, DEVICE_FP);
 
-        // then — 메일/챌린지 저장은 1회만, 2번째는 같은 토큰 재사용
+        // then — 메일·잠금토큰은 신규 발급분 1회만, 2번째는 같은 토큰 재사용
         assertTrue(first.stepUpRequired());
         assertTrue(second.stepUpRequired());
         assertEquals("EXISTING_TOKEN", second.stepUpToken());
         verify(emailSender, times(1)).sendStepUpCode(eq("test@example.com"), anyString(), anyString());
-        verify(stepUpTokenRepository, times(1)).save(anyString(), any());
+        verify(lockTokenRepository, times(1)).save(anyString(), anyLong());  // 잠금 토큰도 1회만 (#10)
+        verify(stepUpTokenRepository, times(2)).save(anyString(), any());    // 챌린지는 예약 전 저장 → 호출 2회(2번째 미사용)
     }
 
     // ===== 테스트 헬퍼 =====

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -22,6 +22,7 @@ import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEventRecorder;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,6 +58,7 @@ class LoginServiceTest {
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private HttpServletRequest httpRequest;
+    @Mock private AuthSecurityEventRecorder securityEventRecorder;
 
     @InjectMocks
     private LoginService loginService;

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -194,6 +194,31 @@ class LoginServiceTest {
         inOrder.verify(refreshTokenRepository).save(any(RefreshToken.class));
     }
 
+    @Test
+    @DisplayName("미신뢰 기기에서 동일 요청이 중복 유입돼도 step-up 메일은 1회만 발송한다. (멱등)")
+    void 미신뢰기기_중복요청_메일_1회만() {
+        // given — 같은 userId+deviceFp 로 두 번째 요청은 이미 발급된 토큰을 재사용
+        User user = createUser(1L, "test@example.com", "ENCODED_PW", false);
+        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
+        given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
+        given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.empty());
+        given(stepUpTokenRepository.reserveDeviceChallenge(eq(1L), eq(DEVICE_FP), anyString()))
+                .willReturn(Optional.empty())               // 1번째 요청 → 발급권 선점
+                .willReturn(Optional.of("EXISTING_TOKEN"));  // 2번째 요청 → 기존 토큰 재사용
+
+        // when — 동일 로그인 2회(재시도 시뮬레이션)
+        LoginResult first = loginService.login(command, httpRequest, DEVICE_FP);
+        LoginResult second = loginService.login(command, httpRequest, DEVICE_FP);
+
+        // then — 메일/챌린지 저장은 1회만, 2번째는 같은 토큰 재사용
+        assertTrue(first.stepUpRequired());
+        assertTrue(second.stepUpRequired());
+        assertEquals("EXISTING_TOKEN", second.stepUpToken());
+        verify(emailSender, times(1)).sendStepUpCode(eq("test@example.com"), anyString(), anyString());
+        verify(stepUpTokenRepository, times(1)).save(anyString(), any());
+    }
+
     // ===== 테스트 헬퍼 =====
 
     private User createUser(Long userId, String email, String encodedPassword, boolean isLocked) {

--- a/src/test/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.chatbot.application.service;
 import com.wanted.codebombalms.chatbot.application.command.SendMessageCommand;
 import com.wanted.codebombalms.chatbot.application.model.AiChatStreamChunk;
 import com.wanted.codebombalms.chatbot.application.port.AiChatClient;
+import com.wanted.codebombalms.chatbot.application.port.ChatStreamMetricsPort;
 import com.wanted.codebombalms.chatbot.application.port.RecordTokenUsagePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,16 +41,18 @@ class ChatMessageCommandServiceTest {
     private ChatMessageTransactionService txService;
     @Mock
     private RecordTokenUsagePort recordTokenUsagePort;
+    @Mock
+    private ChatStreamMetricsPort streamMetricsPort;
     @InjectMocks
     private ChatMessageCommandService service;
 
-    private final SendMessageCommand command = new SendMessageCommand(1L, 10L, "안녕");
+    private final SendMessageCommand command = new SendMessageCommand(1L, 10L, "안녕", "test-trace");
 
     @Test
     @DisplayName("AI 답변 저장이 실패해도 스트림은 onError 로 끊기지 않고 done 으로 정상 완료된다")
     void 저장실패_정상종료() {
         given(txService.prepare(any())).willReturn(null);
-        given(aiChatClient.stream(any())).willReturn(Flux.just(
+        given(aiChatClient.stream(any(), any())).willReturn(Flux.just(
                 new AiChatStreamChunk.Token("안"),
                 new AiChatStreamChunk.Token("녕"),
                 new AiChatStreamChunk.Done(new AiChatStreamChunk.TokenUsage(10, 2, 12))
@@ -69,7 +72,7 @@ class ChatMessageCommandServiceTest {
     @DisplayName("스트림 중간 에러 신호도 error 프레임으로 변환되어 정상 완료된다")
     void 중간에러_정상종료() {
         given(txService.prepare(any())).willReturn(null);
-        given(aiChatClient.stream(any())).willReturn(Flux.concat(
+        given(aiChatClient.stream(any(), any())).willReturn(Flux.concat(
                 Flux.just(new AiChatStreamChunk.Token("부분")),
                 Flux.error(new RuntimeException("stream broke"))
         ));

--- a/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
@@ -1,0 +1,146 @@
+package com.wanted.codebombalms.reward.point.application.service;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort.ProcessResult;
+import com.wanted.codebombalms.reward.point.application.usecase.GrantProblemPointUseCase;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTask;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
+import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PointRewardTaskServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-06-30T00:00:00Z");
+
+    @Mock
+    private PointRewardTaskRepository pointRewardTaskRepository;
+
+    @Mock
+    private GrantProblemPointUseCase grantProblemPointUseCase;
+
+    @Mock
+    private RecordRewardMetricsPort rewardMetrics;
+
+    private PointRewardTaskService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PointRewardTaskService(
+                pointRewardTaskRepository,
+                grantProblemPointUseCase,
+                rewardMetrics,
+                Clock.fixed(NOW, ZoneOffset.UTC)
+        );
+    }
+
+    @Test
+    void recordsCompletedResultWhenGrantSucceeds() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        service.process(30L);
+
+        ArgumentCaptor<PointRewardTask> savedTask =
+                ArgumentCaptor.forClass(PointRewardTask.class);
+        verify(pointRewardTaskRepository).save(savedTask.capture());
+        assertThat(savedTask.getValue().status())
+                .isEqualTo(PointRewardTaskStatus.COMPLETED);
+        verify(rewardMetrics).recordProcessed(ProcessResult.COMPLETED);
+        verify(rewardMetrics).recordProcess(anyLong());
+    }
+
+    @Test
+    void recordsRetryResultWhenGrantThrowsTransientError() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+        doThrow(new IllegalStateException("temporary DB failure"))
+                .when(grantProblemPointUseCase)
+                .grant(10L, 20L, 30L, 100);
+
+        service.process(30L);
+
+        ArgumentCaptor<PointRewardTask> savedTask =
+                ArgumentCaptor.forClass(PointRewardTask.class);
+        verify(pointRewardTaskRepository).save(savedTask.capture());
+        assertThat(savedTask.getValue().status())
+                .isEqualTo(PointRewardTaskStatus.PENDING);
+        assertThat(savedTask.getValue().retryCount()).isEqualTo(1);
+        verify(rewardMetrics).recordProcessed(ProcessResult.RETRY);
+    }
+
+    @Test
+    void recordsFailedResultWhenRetryLimitIsReached() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 4);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+        doThrow(new IllegalStateException("persistent DB failure"))
+                .when(grantProblemPointUseCase)
+                .grant(10L, 20L, 30L, 100);
+
+        service.process(30L);
+
+        ArgumentCaptor<PointRewardTask> savedTask =
+                ArgumentCaptor.forClass(PointRewardTask.class);
+        verify(pointRewardTaskRepository).save(savedTask.capture());
+        assertThat(savedTask.getValue().status())
+                .isEqualTo(PointRewardTaskStatus.FAILED);
+        assertThat(savedTask.getValue().retryCount()).isEqualTo(5);
+        verify(rewardMetrics).recordProcessed(ProcessResult.FAILED);
+    }
+
+    @Test
+    void recordsSkippedResultForAlreadyProcessedTask() {
+        PointRewardTask task = task(PointRewardTaskStatus.COMPLETED, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        service.process(30L);
+
+        verify(grantProblemPointUseCase, never())
+                .grant(10L, 20L, 30L, 100);
+        verify(pointRewardTaskRepository, never()).save(any(PointRewardTask.class));
+        verify(rewardMetrics).recordProcessed(ProcessResult.SKIPPED);
+    }
+
+    private PointRewardTask task(
+            PointRewardTaskStatus status,
+            int retryCount
+    ) {
+        LocalDateTime now = LocalDateTime.ofInstant(NOW, ZoneOffset.UTC);
+        return new PointRewardTask(
+                1L,
+                10L,
+                20L,
+                30L,
+                100,
+                status,
+                retryCount,
+                null,
+                now,
+                now,
+                now
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandlerTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/event/PointRewardEventHandlerTest.java
@@ -1,0 +1,63 @@
+package com.wanted.codebombalms.reward.point.infrastructure.event;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.application.usecase.ProcessPointRewardTaskUseCase;
+import com.wanted.codebombalms.reward.point.application.usecase.SchedulePointRewardTaskUseCase;
+import com.wanted.codebombalms.submission.domain.event.ProblemSolvedEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PointRewardEventHandlerTest {
+
+    @Mock
+    private SchedulePointRewardTaskUseCase schedulePointRewardTaskUseCase;
+
+    @Mock
+    private ProcessPointRewardTaskUseCase processPointRewardTaskUseCase;
+
+    @Mock
+    private RecordRewardMetricsPort rewardMetrics;
+
+    @InjectMocks
+    private PointRewardEventHandler handler;
+
+    @Test
+    void recordsScheduledMetricAfterCommittedEvent() {
+        ProblemSolvedEvent event = new ProblemSolvedEvent(
+                10L,
+                20L,
+                30L,
+                100
+        );
+
+        handler.process(event);
+
+        verify(rewardMetrics).recordScheduled();
+        verify(processPointRewardTaskUseCase).process(30L);
+    }
+
+    @Test
+    void schedulesPersistentTaskBeforeCommit() {
+        ProblemSolvedEvent event = new ProblemSolvedEvent(
+                10L,
+                20L,
+                30L,
+                100
+        );
+
+        handler.schedule(event);
+
+        verify(schedulePointRewardTaskUseCase).schedule(
+                10L,
+                20L,
+                30L,
+                100
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort.ProcessResult;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RewardMetricsTest {
+
+    @Test
+    void rewardMetricsExposeExpectedNamesAndTags() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RewardMetrics metrics = new RewardMetrics(registry);
+
+        metrics.recordScheduled();
+        metrics.recordProcessed(ProcessResult.COMPLETED);
+        metrics.recordProcessed(ProcessResult.RETRY);
+        metrics.recordProcessed(ProcessResult.FAILED);
+        metrics.recordProcess(TimeUnit.MILLISECONDS.toNanos(250));
+        metrics.updatePending(7);
+
+        assertThat(registry.get("reward_point_task_scheduled").counter().count())
+                .isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_processed")
+                .tag("result", "completed")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_processed")
+                .tag("result", "retry")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_processed")
+                .tag("result", "failed")
+                .counter()
+                .count()).isEqualTo(1.0);
+        assertThat(registry.get("reward_point_task_process_duration")
+                .timer()
+                .totalTime(TimeUnit.MILLISECONDS)).isEqualTo(250.0);
+        assertThat(registry.get("reward_point_task_pending").gauge().value())
+                .isEqualTo(7.0);
+    }
+
+    @Test
+    void pendingGaugeDoesNotAcceptNegativeValues() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RewardMetrics metrics = new RewardMetrics(registry);
+
+        metrics.updatePending(-1);
+
+        assertThat(registry.get("reward_point_task_pending").gauge().value())
+                .isZero();
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsSchedulerTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardPendingMetricsSchedulerTest.java
@@ -1,0 +1,36 @@
+package com.wanted.codebombalms.reward.point.infrastructure.metrics;
+
+import com.wanted.codebombalms.reward.point.application.port.RecordRewardMetricsPort;
+import com.wanted.codebombalms.reward.point.domain.model.PointRewardTaskStatus;
+import com.wanted.codebombalms.reward.point.domain.repository.PointRewardTaskRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RewardPendingMetricsSchedulerTest {
+
+    @Mock
+    private PointRewardTaskRepository pointRewardTaskRepository;
+
+    @Mock
+    private RecordRewardMetricsPort rewardMetrics;
+
+    @InjectMocks
+    private RewardPendingMetricsScheduler scheduler;
+
+    @Test
+    void refreshesPendingGaugeFromPersistentTasks() {
+        given(pointRewardTaskRepository.countByStatus(PointRewardTaskStatus.PENDING))
+                .willReturn(12L);
+
+        scheduler.refreshPendingCount();
+
+        verify(rewardMetrics).updatePending(12L);
+    }
+}


### PR DESCRIPTION
# 🚀 Backend Release Pull Request

## 📌 릴리즈 정보

| 항목 | 내용 |
|------|------|
| **버전** | `v1.2.0 → v1.3.0` |
| **릴리즈 날짜** | 2026-06-30 |
| **기준 브랜치** | `develop` |
| **병합 브랜치** | `main` |
| **배포 환경** | `EC2 / Docker Compose / ECR / SSM / RDS / Redis / GCP Storage` |

---

# 📖 릴리즈 요약

- Auth 비정상 로그인/국가 변경/step-up 관련 보안 메트릭과 구글 로그인 이력·신뢰기기 기록을 보강했습니다.
- Chatbot SSE 스트림 traceId 전파, TTFT/스트림 종료/활성 스트림 메트릭과 운영 대시보드를 추가했습니다.
- Reward 포인트 지급 작업의 pending/processed/duration 메트릭과 재시도·실패 로그를 추가했습니다.
- Submission 제출 결과 조회 N+1 쿼리를 개선하고 도메인별 Grafana 대시보드를 확장했습니다.

---

# 📋 릴리즈 노트

## Auth / User

### Added

- Auth 보안 이벤트 메트릭 `auth_security_event_total{category,type}` 추가
- 구글 로그인 시 로그인 이력 및 신뢰기기 기록 추가

### Changed

- step-up 중복 요청 시 기존 토큰을 재사용해 이메일 중복 발송 방지
- OAuth 실패 redirect 응답에서 `message` 쿼리 제거, `error` 코드 중심으로 변경

### Fixed

- step-up 집계 타이밍 및 예외 핸들러 안정화

---

## Course / Lecture / Enrollment / Learning

### Added

- 없음

### Changed

- 없음

### Fixed

- 없음

---

## Problem / Submission / Ranking / Badge / Recommendation

### Added

- Problem / Submission / Ranking / Badge / Reward 도메인 상세 Grafana 대시보드 추가
- Reward 포인트 지급 작업 메트릭 및 pending refresh 스케줄러 추가

### Changed

- Submission 제출 결과 조회에서 테스트 결과 상세 조회 N+1 쿼리 개선

### Fixed

- Python runner import 오타 수정

---

## Admin / Monitoring / Deploy

### Added

- Chatbot 운영 메트릭 및 Grafana 대시보드 추가
- Submission 운영 기준선 문서 추가

### Changed

- 공용 LMS 도메인 대시보드와 User 도메인 대시보드 갱신
- BE ↔ FastAPI traceId 전파로 스트림 로그 추적성 개선

### Fixed

- 없음

---

# 🔌 API / DB / 환경변수 변경 사항

## API 변경

- [ ] 없음
- [x] 있음

| 구분 | Method | URL | 변경 내용 | 프론트 영향 |
|------|--------|-----|----------|------------|
| 변경 | `GET` | `/api/v1/auth/oauth2/callback/google` | 실패 redirect 시 `message` 쿼리 파라미터 제거, `error` 코드만 전달 | 있음 |
| 변경 | `POST` | Chatbot SSE 관련 기존 API | 요청/응답 스펙 변경 없음, 내부 traceId 전달 및 메트릭 계측 추가 | 없음 |

## DB 변경

- [x] 없음
- [ ] 있음

변경 내용:

- Entity/schema/resource DB 변경 파일 없음
- Repository 조회 최적화 및 메트릭 집계용 count 조회 추가

## 환경변수 / Secrets 변경

- [ ] 없음
- [x] 있음

변경 내용:

- `reward.point.metrics.pending-refresh-ms` 선택 설정 추가 가능, 기본값 `30000`
- `reward.point.metrics.pending-initial-delay-ms` 선택 설정 추가 가능, 기본값 `0`
- Secret 값 변경 없음

운영 반영 필요 여부:

- [x] 없음
- [ ] GitHub Secrets 변경 필요
- [ ] EC2 `.env` 변경 필요
- [ ] SSM Parameter Store 변경 필요

> Secret 값은 PR에 작성하지 않고, 키 이름과 반영 위치만 작성합니다.

---

# 🧪 릴리즈 체크리스트

- [x] `develop` 브랜치의 최신 코드가 반영되었습니다.
- [x] `develop → main` 방향의 Release PR입니다.
- [ ] GitHub Actions CI build가 통과했습니다.
- [ ] 로컬 또는 테스트 환경에서 `./gradlew build`를 확인했습니다.
- [ ] 주요 API 및 도메인 기능 테스트를 완료했습니다.
- [ ] 인증/인가가 필요한 API의 권한 검증을 확인했습니다.
- [ ] API 변경사항이 Swagger 또는 `.ai/API.md`에 반영되었습니다.
- [ ] DB 스키마 / 시드 데이터 변경사항을 확인했습니다.
- [x] 운영 환경변수 또는 Secrets 변경사항을 확인했습니다.
- [x] 환경변수 / Secrets 키 추가·변경·삭제 여부를 확인했습니다.
- [x] Secret 값은 PR 본문에 노출하지 않았습니다.
- [x] Docker / EC2 배포 설정 변경사항을 확인했습니다.
- [x] Merge Conflict가 없습니다.
- [x] 릴리즈 노트를 작성했습니다.
- [x] main 머지 후 생성할 Git Tag 버전을 확인했습니다.

---

# 🏷 버전 정보

| 이전 버전 | 변경 버전 | 버전 변경 유형 |
|----------|----------|----------------|
| `v1.2.0` | `v1.3.0` | `MINOR` |

### 버전 변경 사유

- 신규 운영/보안/도메인 메트릭과 Grafana 대시보드가 추가되었습니다.
- Auth, Chatbot, Reward 도메인에 운영 관측 기능이 추가되었습니다.
- 기존 API 하위 호환을 크게 깨는 구조 변경이나 DB 마이그레이션은 확인되지 않아 `MINOR`로 제안합니다.

---

# 📦 Git Tag

> 태그는 Release PR이 `main`에 머지된 후, `main` 브랜치 기준으로만 생성합니다.

```bash
git checkout main
git pull origin main

git tag v1.3.0
git push origin v1.3.0
```

---

# ✅ 배포 후 검증

```bash
curl http://<BACKEND_HOST>:8080/actuator/health
```

- [ ] `/actuator/health` 상태가 정상입니다.
- [ ] 로그인 / 회원가입이 정상 동작합니다.
- [ ] 주요 조회 API가 정상 동작합니다.
- [ ] DB / Redis / GCP Storage 연결이 정상입니다.
- [ ] EC2 Docker 컨테이너 로그를 확인했습니다.

---

# 💬 기타 사항

- 원격 기준 확인 범위: `origin/main..origin/develop`
- 최신 main 태그: `v1.2.0`
- 로컬 브랜치는 `refactor/lecture`이며 추적 원격 브랜치가 삭제된 상태라, GitHub에서 `develop → main` 기준으로 PR을 생성해주세요.