### PR TITLE
[Update] 보상 포인트 메트릭 기록 정합성 개선

### DIFF
--- a/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
@@ -6,7 +6,7 @@ public interface RecordRewardMetricsPort {
 
     void recordProcessed(ProcessResult result);
 
-    void recordProcess(long elapsedNanos);
+    void recordProcess(ProcessResult result, long elapsedNanos);
 
     void updatePending(long pendingCount);
 

--- a/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
@@ -16,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -96,10 +98,44 @@ public class PointRewardTaskService
             throw e;
         } finally {
             if (result != null) {
-                rewardMetrics.recordProcessed(result);
+                recordMetricsAfterTransaction(
+                        result,
+                        System.nanoTime() - startedAtNanos
+                );
             }
-            rewardMetrics.recordProcess(System.nanoTime() - startedAtNanos);
         }
+    }
+
+    private void recordMetricsAfterTransaction(
+            ProcessResult result,
+            long elapsedNanos
+    ) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            rewardMetrics.recordProcessed(result);
+            rewardMetrics.recordProcess(result, elapsedNanos);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCompletion(int status) {
+                        ProcessResult finalResult = status == STATUS_COMMITTED
+                                ? result
+                                : rollbackResult(result);
+
+                        rewardMetrics.recordProcessed(finalResult);
+                        rewardMetrics.recordProcess(finalResult, elapsedNanos);
+                    }
+                }
+        );
+    }
+
+    private ProcessResult rollbackResult(ProcessResult result) {
+        return switch (result) {
+            case NOT_FOUND, ERROR -> result;
+            default -> ProcessResult.ERROR;
+        };
     }
 
     private ProcessResult processPendingTask(

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
@@ -17,8 +17,8 @@ public class RewardMetrics implements RecordRewardMetricsPort {
 
     private final Counter scheduledCounter;
     private final Map<ProcessResult, Counter> processedCounters;
-    private final Timer processTimer;
     private final AtomicLong pendingTasks = new AtomicLong();
+    private final Map<ProcessResult, Timer> processTimers;
 
     public RewardMetrics(MeterRegistry registry) {
         this.scheduledCounter = Counter.builder("reward_point_task_scheduled")
@@ -36,10 +36,6 @@ public class RewardMetrics implements RecordRewardMetricsPort {
             );
         }
 
-        this.processTimer = Timer.builder("reward_point_task_process_duration")
-                .description("Point reward task processing duration")
-                .register(registry);
-
         Gauge.builder(
                         "reward_point_task_pending",
                         pendingTasks,
@@ -47,6 +43,16 @@ public class RewardMetrics implements RecordRewardMetricsPort {
                 )
                 .description("Current pending point reward task count")
                 .register(registry);
+        this.processTimers = new EnumMap<>(ProcessResult.class);
+        for (ProcessResult result : ProcessResult.values()) {
+            processTimers.put(
+                    result,
+                    Timer.builder("reward_point_task_process_duration")
+                            .description("Point reward task processing duration")
+                            .tag("result", result.tagValue())
+                            .register(registry)
+            );
+        }
     }
 
     @Override
@@ -59,13 +65,14 @@ public class RewardMetrics implements RecordRewardMetricsPort {
         processedCounters.get(result).increment();
     }
 
-    @Override
-    public void recordProcess(long elapsedNanos) {
-        processTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
-    }
 
     @Override
     public void updatePending(long pendingCount) {
         pendingTasks.set(Math.max(pendingCount, 0));
+    }
+
+    @Override
+    public void recordProcess(ProcessResult result, long elapsedNanos) {
+        processTimers.get(result).record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
 }

--- a/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -67,7 +68,8 @@ class PointRewardTaskServiceTest {
         assertThat(savedTask.getValue().status())
                 .isEqualTo(PointRewardTaskStatus.COMPLETED);
         verify(rewardMetrics).recordProcessed(ProcessResult.COMPLETED);
-        verify(rewardMetrics).recordProcess(anyLong());
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.COMPLETED), anyLong());
     }
 
     @Test
@@ -88,6 +90,8 @@ class PointRewardTaskServiceTest {
                 .isEqualTo(PointRewardTaskStatus.PENDING);
         assertThat(savedTask.getValue().retryCount()).isEqualTo(1);
         verify(rewardMetrics).recordProcessed(ProcessResult.RETRY);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.RETRY), anyLong());
     }
 
     @Test
@@ -108,6 +112,8 @@ class PointRewardTaskServiceTest {
                 .isEqualTo(PointRewardTaskStatus.FAILED);
         assertThat(savedTask.getValue().retryCount()).isEqualTo(5);
         verify(rewardMetrics).recordProcessed(ProcessResult.FAILED);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.FAILED), anyLong());
     }
 
     @Test
@@ -122,6 +128,8 @@ class PointRewardTaskServiceTest {
                 .grant(10L, 20L, 30L, 100);
         verify(pointRewardTaskRepository, never()).save(any(PointRewardTask.class));
         verify(rewardMetrics).recordProcessed(ProcessResult.SKIPPED);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.SKIPPED), anyLong());
     }
 
     private PointRewardTask task(

--- a/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +30,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class PointRewardTaskServiceTest {
@@ -132,6 +136,50 @@ class PointRewardTaskServiceTest {
                 .recordProcess(eq(ProcessResult.SKIPPED), anyLong());
     }
 
+    @Test
+    void defersCompletedMetricsUntilTransactionCommits() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        initTransactionSynchronization();
+        try {
+            service.process(30L);
+
+            verifyNoInteractions(rewardMetrics);
+
+            completeTransaction(TransactionSynchronization.STATUS_COMMITTED);
+        } finally {
+            clearTransactionSynchronization();
+        }
+
+        verify(rewardMetrics).recordProcessed(ProcessResult.COMPLETED);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.COMPLETED), anyLong());
+    }
+
+    @Test
+    void recordsErrorMetricsWhenTransactionRollsBackAfterCompletedResult() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        initTransactionSynchronization();
+        try {
+            service.process(30L);
+
+            verifyNoInteractions(rewardMetrics);
+
+            completeTransaction(TransactionSynchronization.STATUS_ROLLED_BACK);
+        } finally {
+            clearTransactionSynchronization();
+        }
+
+        verify(rewardMetrics).recordProcessed(ProcessResult.ERROR);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.ERROR), anyLong());
+    }
+
     private PointRewardTask task(
             PointRewardTaskStatus status,
             int retryCount
@@ -150,5 +198,26 @@ class PointRewardTaskServiceTest {
                 now,
                 now
         );
+    }
+
+    private void initTransactionSynchronization() {
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    private void completeTransaction(int status) {
+        List<TransactionSynchronization> synchronizations =
+                TransactionSynchronizationManager.getSynchronizations();
+
+        assertThat(synchronizations).hasSize(1);
+
+        synchronizations.forEach(
+                synchronization -> synchronization.afterCompletion(status)
+        );
+    }
+
+    private void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 }

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
@@ -16,33 +16,28 @@ class RewardMetricsTest {
         RewardMetrics metrics = new RewardMetrics(registry);
 
         metrics.recordScheduled();
-        metrics.recordProcessed(ProcessResult.COMPLETED);
-        metrics.recordProcessed(ProcessResult.RETRY);
-        metrics.recordProcessed(ProcessResult.FAILED);
-        metrics.recordProcess(
-                ProcessResult.COMPLETED,
-                TimeUnit.MILLISECONDS.toNanos(250)
-        );
+        for (ProcessResult result : ProcessResult.values()) {
+            metrics.recordProcessed(result);
+            metrics.recordProcess(
+                    result,
+                    TimeUnit.MILLISECONDS.toNanos(durationMillis(result))
+            );
+        }
         metrics.updatePending(7);
 
         assertThat(registry.get("reward_point_task_scheduled").counter().count())
                 .isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_processed")
-                .tag("result", "completed")
-                .counter()
-                .count()).isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_processed")
-                .tag("result", "retry")
-                .counter()
-                .count()).isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_processed")
-                .tag("result", "failed")
-                .counter()
-                .count()).isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_process_duration")
-                .tag("result", "completed")
-                .timer()
-                .totalTime(TimeUnit.MILLISECONDS)).isEqualTo(250.0);
+        for (ProcessResult result : ProcessResult.values()) {
+            assertThat(registry.get("reward_point_task_processed")
+                    .tag("result", result.tagValue())
+                    .counter()
+                    .count()).isEqualTo(1.0);
+            assertThat(registry.get("reward_point_task_process_duration")
+                    .tag("result", result.tagValue())
+                    .timer()
+                    .totalTime(TimeUnit.MILLISECONDS))
+                    .isEqualTo((double) durationMillis(result));
+        }
         assertThat(registry.get("reward_point_task_pending").gauge().value())
                 .isEqualTo(7.0);
     }
@@ -56,5 +51,9 @@ class RewardMetricsTest {
 
         assertThat(registry.get("reward_point_task_pending").gauge().value())
                 .isZero();
+    }
+
+    private long durationMillis(ProcessResult result) {
+        return 100L + result.ordinal();
     }
 }

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
@@ -19,7 +19,10 @@ class RewardMetricsTest {
         metrics.recordProcessed(ProcessResult.COMPLETED);
         metrics.recordProcessed(ProcessResult.RETRY);
         metrics.recordProcessed(ProcessResult.FAILED);
-        metrics.recordProcess(TimeUnit.MILLISECONDS.toNanos(250));
+        metrics.recordProcess(
+                ProcessResult.COMPLETED,
+                TimeUnit.MILLISECONDS.toNanos(250)
+        );
         metrics.updatePending(7);
 
         assertThat(registry.get("reward_point_task_scheduled").counter().count())
@@ -37,6 +40,7 @@ class RewardMetricsTest {
                 .counter()
                 .count()).isEqualTo(1.0);
         assertThat(registry.get("reward_point_task_process_duration")
+                .tag("result", "completed")
                 .timer()
                 .totalTime(TimeUnit.MILLISECONDS)).isEqualTo(250.0);
         assertThat(registry.get("reward_point_task_pending").gauge().value())


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
---

## 🛠️ 기능 관련 작업 내용
- 보상 포인트 작업 처리 메트릭이 트랜잭션 완료 이후 기록되도록 수정
- 트랜잭션 롤백 시 성공/실패 결과가 잘못 집계되지 않도록 `ERROR` 결과로 보정
- 보상 포인트 처리 시간 메트릭에 `result` 태그를 추가해 성공/재시도/실패/스킵별 처리 시간을 분리
- 변경된 메트릭 기록 방식에 맞춰 기존 테스트 검증을 수정

---

## ♻️ 패키지 변경 사항
- `project/reward/point/application/port`: 보상 메트릭 기록 포트에 처리 결과 인자 추가
- `project/reward/point/application/service`: 보상 작업 처리 메트릭을 트랜잭션 완료 이후 기록하도록 변경
- `project/reward/point/infrastructure/metrics`: 결과별 Timer 메트릭 등록 및 기록 방식 개선
- `project/test/reward/point`: 변경된 메트릭 시그니처와 `result` 태그 검증 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 처리 결과(완료/재시도/실패/스킵)별로 실행 시간이 구분되어 메트릭에 기록됩니다.
* **버그 수정**
  * 트랜잭션 커밋 여부에 따라 메트릭 최종 반영이 정확해지도록 개선했으며, 롤백 시에도 결과 집계가 일관되게 반영되도록 조정했습니다.
* **테스트**
  * 결과별 메트릭 기록 및 태그 검증 케이스를 확장하고, 커밋/롤백 타이밍에 따른 기록 동작을 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->