### PR TITLE
[Feat] 강좌 삭제 시 GCS 연관 파일 자동 삭제 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,6 @@ architecture-user-auth.html
 /monitoring-local/k6/results/auth-reissue-before-summary.json
 /monitoring-local/k6/results/auth-reissue-after-summary.md
 /monitoring-local/k6/results/auth-reissue-after-summary.json
+/monitoring-deploy/k6/results/
 /src/main/resources/db/seed/03_trusted_device_loadtest.sql
 /rds-tunnel.sh

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "groups": [],
+    "checks": [
+        {
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 4327,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200"
+        },
+        {
+          "fails": 0,
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 4327
+        }
+      ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 70827.651158,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": -6.248796,
+        "med": 0.123195,
+        "p(90)": 0.2190708,
+        "p(95)": 0.25653960000000003,
+        "p(99)": 0.34640303999999944,
+        "max": 10.298438,
+        "avg": 0.14075950080887473
+      }
+    },
+    "data_sent": {
+      "values": {
+        "count": 238814,
+        "rate": 3371.762243918856
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 100,
+        "value": 100,
+        "min": 100
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 4327,
+        "rate": 61.091959556126895
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 2017.1062161999996,
+        "max": 2128.882515,
+        "avg": 1287.6442447213499,
+        "min": 0.003094,
+        "med": 1291.4990225000001,
+        "p(90)": 1890.5991861,
+        "p(95)": 1960.09398485
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 103.834931,
+        "avg": 1.0686046353131462,
+        "min": 0.000207,
+        "med": 0.000365,
+        "p(90)": 0.0006204000000000001,
+        "p(95)": 0.0007776999999999999,
+        "p(99)": 46.29211267999997
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 71.22881465999976,
+        "max": 278.719933,
+        "avg": 28.679858201063052,
+        "min": 14.538052,
+        "med": 25.984371,
+        "p(90)": 36.5430668,
+        "p(95)": 41.7983894
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 69.41318571999999,
+        "max": 278.245547,
+        "avg": 28.110107198289768,
+        "min": 16.917553,
+        "med": 25.467109,
+        "p(90)": 35.7672558,
+        "p(95)": 40.78138129999999
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "min": 5,
+        "max": 100,
+        "value": 7
+      },
+      "type": "gauge"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 2961312,
+        "rate": 41810.111610139415
+      }
+    },
+    "http_req_connecting": {
+      "values": {
+        "max": 47.268548,
+        "avg": 0.48079425375548895,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 20.715245999999972
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.5689872625375549,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 25.435910179999997,
+        "max": 41.260758
+      }
+    },
+    "http_req_receiving": {
+      "values": {
+        "min": 0.021557,
+        "med": 0.130201,
+        "p(90)": 0.8357544000000001,
+        "p(95)": 1.6300011999999973,
+        "p(99)": 5.264014739999995,
+        "max": 22.805274,
+        "avg": 0.42899150196440966
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 278.719933,
+        "avg": 28.679858201063052,
+        "min": 14.538052,
+        "med": 25.984371,
+        "p(90)": 36.5430668,
+        "p(95)": 41.7983894,
+        "p(99)": 71.22881465999976
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 4327
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 8654,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 4327,
+        "rate": 61.091959556126895
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 41.7983894,
+        "p(99)": 71.22881465999976,
+        "max": 278.719933,
+        "avg": 28.679858201063052,
+        "min": 14.538052,
+        "med": 25.984371,
+        "p(90)": 36.5430668
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-100vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 4327 |
+| iterations | 4327 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 2961312 |
+| data_sent bytes | 238814 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 28.68 | 14.54 | 25.98 | 36.54 | 41.80 | 71.23 | 278.72 |
+| http_req_waiting | 28.11 | 16.92 | 25.47 | 35.77 | 40.78 | 69.41 | 278.25 |
+| http_req_blocked | 1.07 | 0.00 | 0.00 | 0.00 | 0.00 | 46.29 | 103.83 |
+| http_req_connecting | 0.48 | 0 | 0 | 0 | 0 | 20.72 | 47.27 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 4327 pass / 0 fail |
+| has page content array | 4327 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71152.871755
+  },
+  "metrics": {
+    "vus_max": {
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 0.7729835584062014,
+        "count": 55
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 55,
+        "rate": 0.7729835584062014
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 55
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "contains": "time",
+      "values": {
+        "avg": 35.00723812727274,
+        "min": 22.84574,
+        "med": 32.891309,
+        "p(90)": 45.5687074,
+        "p(95)": 55.35622059999998,
+        "p(99)": 65.57562594000001,
+        "max": 66.983562
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 2093.257865,
+        "avg": 1270.6297463750002,
+        "min": 0.003086,
+        "med": 1242.199744,
+        "p(90)": 1876.2301355,
+        "p(95)": 1988.46397725,
+        "p(99)": 2055.72826685
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 12.916628420000023,
+        "max": 28.079627,
+        "avg": 0.5105386727272727,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 34.15129401818181,
+        "min": 22.595454,
+        "med": 32.475079,
+        "p(90)": 43.969723800000004,
+        "p(95)": 55.00417909999997,
+        "p(99)": 62.66233426,
+        "max": 62.807395
+      }
+    },
+    "http_req_sending": {
+      "values": {
+        "avg": 0.2744119636363637,
+        "min": 0.118187,
+        "med": 0.244882,
+        "p(90)": 0.3896606,
+        "p(95)": 0.41702379999999994,
+        "p(99)": 0.8455272000000007,
+        "max": 1.326786
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 35.00723812727274,
+        "min": 22.84574,
+        "med": 32.891309,
+        "p(90)": 45.5687074,
+        "p(95)": 55.35622059999998,
+        "p(99)": 65.57562594000001,
+        "max": 66.983562
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.0010416,
+        "p(99)": 36.46551976000008,
+        "max": 79.270891,
+        "avg": 1.4418218363636366,
+        "min": 0.000217,
+        "med": 0.000468,
+        "p(90)": 0.0009202
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 5.6056315400000045,
+        "max": 8.84123,
+        "avg": 0.5815321454545453,
+        "min": 0.086147,
+        "med": 0.176164,
+        "p(90)": 1.6765336000000002,
+        "p(95)": 2.6044576999999993
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 511.72916991142176,
+        "count": 36411
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 32.891309,
+        "p(90)": 45.5687074,
+        "p(95)": 55.35622059999998,
+        "p(99)": 65.57562594000001,
+        "max": 66.983562,
+        "avg": 35.00723812727274,
+        "min": 22.84574
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 2861,
+        "rate": 40.209199283638945
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 110,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 7.224864420000014,
+        "max": 15.706227,
+        "avg": 0.28556776363636366,
+        "min": 0,
+        "med": 0
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3"
+  },
+  "root_group": {
+    "checks": [
+      {
+        "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+        "passes": 55,
+        "fails": 0,
+        "name": "status is 200",
+        "path": "::status is 200"
+      },
+      {
+        "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+        "passes": 55,
+        "fails": 0,
+        "name": "has page content array",
+        "path": "::has page content array"
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-1vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 55 |
+| iterations | 55 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 36411 |
+| data_sent bytes | 2861 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 35.01 | 22.85 | 32.89 | 45.57 | 55.36 | 65.58 | 66.98 |
+| http_req_waiting | 34.15 | 22.60 | 32.48 | 43.97 | 55.00 | 62.66 | 62.81 |
+| http_req_blocked | 1.44 | 0.00 | 0.00 | 0.00 | 0.00 | 36.47 | 79.27 |
+| http_req_connecting | 0.29 | 0 | 0 | 0 | 0 | 7.22 | 15.71 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 55 pass / 0 fail |
+| has page content array | 55 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": ""
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 70870.521226
+  },
+  "metrics": {
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 8340,
+        "rate": 117.67939413630751
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 44.34612979000004,
+        "max": 138.406882,
+        "avg": 1.0646819631894449,
+        "min": 0.000203,
+        "med": 0.000373,
+        "p(90)": 0.000563,
+        "p(95)": 0.0006990499999999992
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 2000.086329,
+        "p(99)": 3307.2750424000055,
+        "max": 5320.689395,
+        "avg": 1334.8729794551002,
+        "min": 0.002208,
+        "med": 1308.069258,
+        "p(90)": 1923.475227
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 1915.445251620007,
+        "max": 3529.830764,
+        "avg": 81.37849361139058,
+        "min": 13.962873,
+        "med": 26.277190500000003,
+        "p(90)": 41.37796190000001,
+        "p(95)": 64.79423799999988
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "values": {
+        "max": 3590.150746,
+        "avg": 82.92245680683472,
+        "min": 14.155709,
+        "med": 26.8829885,
+        "p(90)": 42.28780740000001,
+        "p(95)": 67.62214679999988,
+        "p(99)": 1925.581238160005
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 0,
+        "rate": 1,
+        "passes": 16680
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 13,
+        "min": 10,
+        "max": 200
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.19166610000000003,
+        "p(95)": 0.22804879999999977,
+        "p(99)": 0.32248204,
+        "max": 11.550848,
+        "avg": 0.12151146151079138,
+        "min": 0.024778,
+        "med": 0.103808
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.4969483387290169,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 19.770972010000012,
+        "max": 44.579699
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 8340,
+        "rate": 117.67939413630751
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 5741098,
+        "rate": 81008.26550565548
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 465380,
+        "rate": 6566.623074718799
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 200,
+        "value": 200,
+        "min": 200
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 82.92245680683472,
+        "min": 14.155709,
+        "med": 26.8829885,
+        "p(90)": 42.28780740000001,
+        "p(95)": 67.62214679999988,
+        "p(99)": 1925.581238160005,
+        "max": 3590.150746
+      }
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "avg": 0.5488325292565949,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 23.47119034000004,
+        "max": 81.038628
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 8340,
+        "rate": 0
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 1.5769640000000027,
+        "p(95)": 3.4302430999999953,
+        "p(99)": 24.591678220000055,
+        "max": 284.876743,
+        "avg": 1.422451733932856,
+        "min": 0.019806,
+        "med": 0.1627045
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 82.92245680683472,
+        "min": 14.155709,
+        "med": 26.8829885,
+        "p(90)": 42.28780740000001,
+        "p(95)": 67.62214679999988,
+        "p(99)": 1925.581238160005,
+        "max": 3590.150746
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 8340
+        },
+        {
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 8340,
+          "fails": 0,
+          "name": "has page content array"
+        }
+      ],
+    "name": "",
+    "path": ""
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-200vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 8340 |
+| iterations | 8340 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 5741098 |
+| data_sent bytes | 465380 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 82.92 | 14.16 | 26.88 | 42.29 | 67.62 | 1925.58 | 3590.15 |
+| http_req_waiting | 81.38 | 13.96 | 26.28 | 41.38 | 64.79 | 1915.45 | 3529.83 |
+| http_req_blocked | 1.06 | 0.00 | 0.00 | 0.00 | 0.00 | 44.35 | 138.41 |
+| http_req_connecting | 0.50 | 0 | 0 | 0 | 0 | 19.77 | 44.58 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 8340 pass / 0 fail |
+| has page content array | 8340 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71712.79445
+  },
+  "metrics": {
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 12936
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 18.73205124999995,
+        "max": 59.408678,
+        "avg": 0.44445274404761886,
+        "min": 0
+      }
+    },
+    "http_req_waiting": {
+      "values": {
+        "p(99)": 297.5511818999999,
+        "max": 804.950287,
+        "avg": 36.23722383379714,
+        "min": 13.783648,
+        "med": 26.901235,
+        "p(90)": 42.564029500000004,
+        "p(95)": 61.68689175
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 13.982825,
+        "med": 27.5578795,
+        "p(90)": 44.320156499999996,
+        "p(95)": 64.403413,
+        "p(99)": 305.01614684999987,
+        "max": 808.238761,
+        "avg": 37.39969064687707
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 12936,
+        "rate": 180.3862211647506
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.20293325,
+        "p(99)": 0.3065131499999999,
+        "max": 1.460942,
+        "avg": 0.10925810977118092,
+        "min": 0.020738,
+        "med": 0.096094,
+        "p(90)": 0.167225
+      }
+    },
+    "http_req_tls_handshaking": {
+      "contains": "time",
+      "values": {
+        "max": 50.245666,
+        "avg": 0.49727342756648124,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.13636869999998
+      },
+      "type": "trend"
+    },
+    "http_req_duration{type:student-progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 37.39969064687707,
+        "min": 13.982825,
+        "med": 27.5578795,
+        "p(90)": 44.320156499999996,
+        "p(95)": 64.403413,
+        "p(99)": 305.01614684999987,
+        "max": 808.238761
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.00053,
+        "p(95)": 0.00064625,
+        "p(99)": 40.993617,
+        "max": 86.807392,
+        "avg": 0.9513060620748233,
+        "min": 0.000137,
+        "med": 0.000346
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 25872,
+        "fails": 0
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 300,
+        "max": 300,
+        "value": 300
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 123518.51671567373,
+        "count": 8857858
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.017091,
+        "med": 0.2106045,
+        "p(90)": 2.0542205,
+        "p(95)": 4.07213225,
+        "p(99)": 14.315141499999996,
+        "max": 139.500265,
+        "avg": 1.0532087033085968
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 714672,
+        "rate": 9965.753049803234
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "min": 3,
+        "max": 300,
+        "value": 3
+      },
+      "type": "gauge"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 808.238761,
+        "avg": 37.39969064687707,
+        "min": 13.982825,
+        "med": 27.5578795,
+        "p(90)": 44.320156499999996,
+        "p(95)": 64.403413,
+        "p(99)": 305.01614684999987
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.002723,
+        "med": 1298.001729,
+        "p(90)": 1891.9850614,
+        "p(95)": 1963.2058332000001,
+        "p(99)": 2027.7860784799998,
+        "max": 2441.8457,
+        "avg": 1291.8858491464784
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 12936,
+        "rate": 180.3862211647506
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 12936,
+          "fails": 0
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 12936,
+          "fails": 0
+        }
+      ],
+    "name": "",
+    "path": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-300vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 12936 |
+| iterations | 12936 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 8857858 |
+| data_sent bytes | 714672 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 37.40 | 13.98 | 27.56 | 44.32 | 64.40 | 305.02 | 808.24 |
+| http_req_waiting | 36.24 | 13.78 | 26.90 | 42.56 | 61.69 | 297.55 | 804.95 |
+| http_req_blocked | 0.95 | 0.00 | 0.00 | 0.00 | 0.00 | 40.99 | 86.81 |
+| http_req_connecting | 0.44 | 0 | 0 | 0 | 0 | 18.73 | 59.41 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 12936 pass / 0 fail |
+| has page content array | 12936 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 1301,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 1301,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTimeUnit": "",
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ]
+  },
+  "state": {
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71619.739363,
+    "isStdOutTTY": true
+  },
+  "metrics": {
+    "http_req_duration{type:student-progress}": {
+      "values": {
+        "max": 280.672868,
+        "avg": 30.05186383013069,
+        "min": 18.758053,
+        "med": 26.663157,
+        "p(90)": 37.730246,
+        "p(95)": 44.907513,
+        "p(99)": 71.277072
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 280.672868,
+        "avg": 30.05186383013069,
+        "min": 18.758053,
+        "med": 26.663157,
+        "p(90)": 37.730246,
+        "p(95)": 44.907513,
+        "p(99)": 71.277072
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.6199121544965411,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 26.754194,
+        "max": 43.502233
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 30,
+        "max": 30,
+        "value": 30
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.016483,
+        "max": 35.379209,
+        "avg": 0.4968947794004613
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.024666,
+        "med": 0.164666,
+        "p(90)": 0.276125,
+        "p(95)": 0.314393,
+        "p(99)": 0.547441,
+        "max": 2.879556,
+        "avg": 0.18566693389700234
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1301,
+        "rate": 18.165383057399385
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1301
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 2,
+        "max": 30
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1301,
+        "rate": 18.165383057399385
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 48.662353,
+        "max": 115.65358,
+        "avg": 1.178432447348195,
+        "min": 0.000215,
+        "med": 0.000423,
+        "p(90)": 0.000783,
+        "p(95)": 0.001
+      }
+    },
+    "http_req_duration": {
+      "contains": "time",
+      "values": {
+        "p(90)": 37.730246,
+        "p(95)": 44.907513,
+        "p(99)": 71.277072,
+        "max": 280.672868,
+        "avg": 30.05186383013069,
+        "min": 18.758053,
+        "med": 26.663157
+      },
+      "type": "trend"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 2602,
+        "fails": 0
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 890143,
+        "rate": 12428.738332715344
+      },
+      "type": "counter"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 29.43401865334362,
+        "min": 18.546196,
+        "med": 26.111094,
+        "p(90)": 37.213501,
+        "p(95)": 44.375476,
+        "p(99)": 70.562794,
+        "max": 273.964318
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.033815,
+        "med": 0.14495,
+        "p(90)": 0.813792,
+        "p(95)": 1.632379,
+        "p(99)": 5.915678,
+        "max": 19.151998,
+        "avg": 0.4321782428900852
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 1002.4750248824779,
+        "count": 71797
+      }
+    },
+    "iteration_duration": {
+      "contains": "time",
+      "values": {
+        "max": 2161.026162,
+        "avg": 1289.486464821815,
+        "min": 0.002779,
+        "med": 1295.03284,
+        "p(90)": 1907.2899041,
+        "p(95)": 1968.914592,
+        "p(99)": 2020.79022482
+      },
+      "type": "trend"
+    }
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-30vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 1301 |
+| iterations | 1301 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 890143 |
+| data_sent bytes | 71797 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 30.05 | 18.76 | 26.66 | 37.73 | 44.91 | 71.28 | 280.67 |
+| http_req_waiting | 29.43 | 18.55 | 26.11 | 37.21 | 44.38 | 70.56 | 273.96 |
+| http_req_blocked | 1.18 | 0.00 | 0.00 | 0.00 | 0.00 | 48.66 | 115.65 |
+| http_req_connecting | 0.50 | 0 | 0 | 0 | 0 | 21.02 | 35.38 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 1301 pass / 0 fail |
+| has page content array | 1301 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "groups": [],
+    "checks": [
+        {
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 17125,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200"
+        },
+        {
+          "fails": 0,
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 17125
+        }
+      ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71401.616685
+  },
+  "metrics": {
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 45.066515594393934,
+        "min": 14.738453,
+        "med": 32.712766,
+        "p(90)": 64.80532160000001,
+        "p(95)": 89.84278119999998,
+        "p(99)": 310.5841859599958,
+        "max": 1039.391281
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 17125
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 34250,
+        "fails": 0
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 11745764,
+        "rate": 164502.77382119195
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 400,
+        "min": 400,
+        "max": 400
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.09985045290510934,
+        "min": 0.022829,
+        "med": 0.086294,
+        "p(90)": 0.1560572,
+        "p(95)": 0.1911704,
+        "p(99)": 0.29291471999999974,
+        "max": 2.293236
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 4.891604,
+        "p(95)": 9.172378199999999,
+        "p(99)": 22.452373559999977,
+        "max": 188.688619,
+        "avg": 1.900528633401473,
+        "min": -2.620509,
+        "med": 0.344218
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 17125,
+        "rate": 239.84050775138275
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 948030,
+        "rate": 13277.430456265307
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 19.308176279999874,
+        "max": 58.118392,
+        "avg": 0.4716849981897813,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 32.712766,
+        "p(90)": 64.80532160000001,
+        "p(95)": 89.84278119999998,
+        "p(99)": 310.5841859599958,
+        "max": 1039.391281,
+        "avg": 45.066515594393934,
+        "min": 14.738453
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 310.5841859599958,
+        "max": 1039.391281,
+        "avg": 45.066515594393934,
+        "min": 14.738453,
+        "med": 32.712766,
+        "p(90)": 64.80532160000001,
+        "p(95)": 89.84278119999998
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "min": 5,
+        "max": 400,
+        "value": 5
+      },
+      "type": "gauge"
+    },
+    "http_reqs": {
+      "values": {
+        "count": 17125,
+        "rate": 239.84050775138275
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.000508,
+        "p(95)": 0.0006317999999999992,
+        "p(99)": 42.19504019999975,
+        "max": 94.259961,
+        "avg": 1.0008812295474503,
+        "min": 0.000111,
+        "med": 0.000311
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 2038.756408,
+        "max": 2915.098144,
+        "avg": 1301.874295561429,
+        "min": 0.021485,
+        "med": 1302.851739,
+        "p(90)": 1896.728468,
+        "p(95)": 1974.216146
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 50.24216,
+        "avg": 0.5200910600291972,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.375641079999973
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 82.94183539999999,
+        "p(99)": 300.97591519999975,
+        "max": 1039.257264,
+        "avg": 43.066136508087745,
+        "min": 14.41977,
+        "med": 31.578837,
+        "p(90)": 60.2786234
+      }
+    }
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-400vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 17125 |
+| iterations | 17125 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 11745764 |
+| data_sent bytes | 948030 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 45.07 | 14.74 | 32.71 | 64.81 | 89.84 | 310.58 | 1039.39 |
+| http_req_waiting | 43.07 | 14.42 | 31.58 | 60.28 | 82.94 | 300.98 | 1039.26 |
+| http_req_blocked | 1.00 | 0.00 | 0.00 | 0.00 | 0.00 | 42.20 | 94.26 |
+| http_req_connecting | 0.47 | 0 | 0 | 0 | 0 | 19.31 | 58.12 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 17125 pass / 0 fail |
+| has page content array | 17125 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 20266,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 20266,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 71514.819355,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "http_reqs": {
+      "values": {
+        "count": 20266,
+        "rate": 283.38182467328136
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "p(90)": 203.2452485,
+        "p(95)": 441.7661025,
+        "p(99)": 1727.0936595499977,
+        "max": 3638.993652,
+        "avg": 126.06561503809344,
+        "min": 14.556685,
+        "med": 50.136382499999996
+      },
+      "type": "trend"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 32.83314209999992,
+        "max": 331.239101,
+        "avg": 4.415384376147243,
+        "min": -2.092211,
+        "med": 0.7304705,
+        "p(90)": 14.1502465,
+        "p(95)": 19.4547775
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 40532,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.000299,
+        "p(90)": 0.000445,
+        "p(95)": 0.00059375,
+        "p(99)": 41.734172999999934,
+        "max": 107.86868,
+        "avg": 1.0285371208428096,
+        "min": 0.000133
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 6,
+        "min": 6,
+        "max": 500
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 126.06561503809344,
+        "min": 14.556685,
+        "med": 50.136382499999996,
+        "p(90)": 203.2452485,
+        "p(95)": 441.7661025,
+        "p(99)": 1727.0936595499977,
+        "max": 3638.993652
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 14015387,
+        "rate": 195978.77931324323
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 19.26433594999998,
+        "max": 67.804053,
+        "avg": 0.49594883583341615,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      },
+      "type": "trend"
+    },
+    "http_req_duration": {
+      "values": {
+        "med": 50.136382499999996,
+        "p(90)": 203.2452485,
+        "p(95)": 441.7661025,
+        "p(99)": 1727.0936595499977,
+        "max": 3638.993652,
+        "avg": 126.06561503809344,
+        "min": 14.556685
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 20266
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 195.28834899999998,
+        "p(95)": 431.5437025,
+        "p(99)": 1715.7555499499992,
+        "max": 3625.038229,
+        "avg": 121.55341454628413,
+        "min": 13.810544,
+        "med": 46.5725595
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 20266,
+        "rate": 283.38182467328136
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.5236908791572091,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 20.64996504999998,
+        "max": 87.420027
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.084007,
+        "p(90)": 0.14851799999999998,
+        "p(95)": 0.18605025,
+        "p(99)": 0.28237909999999933,
+        "max": 4.45685,
+        "avg": 0.09681611566169936,
+        "min": 0.019743
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1140687,
+        "rate": 15950.358405264547
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.003208,
+        "med": 1356.051051,
+        "p(90)": 1965.8365648,
+        "p(95)": 2054.7062052,
+        "p(99)": 3121.2911557,
+        "max": 5429.390168,
+        "avg": 1375.4762442082667
+      }
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 500,
+        "min": 500,
+        "max": 500
+      },
+      "type": "gauge"
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-500vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 20266 |
+| iterations | 20266 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 14015387 |
+| data_sent bytes | 1140687 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 126.07 | 14.56 | 50.14 | 203.25 | 441.77 | 1727.09 | 3638.99 |
+| http_req_waiting | 121.55 | 13.81 | 46.57 | 195.29 | 431.54 | 1715.76 | 3625.04 |
+| http_req_blocked | 1.03 | 0.00 | 0.00 | 0.00 | 0.00 | 41.73 | 107.87 |
+| http_req_connecting | 0.50 | 0 | 0 | 0 | 0 | 19.26 | 67.80 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 20266 pass / 0 fail |
+| has page content array | 20266 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2185,
+          "fails": 0
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 2185,
+          "fails": 0
+        }
+      ],
+    "name": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 70816.267526
+  },
+  "metrics": {
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.025474,
+        "med": 0.151297,
+        "p(90)": 0.25206140000000005,
+        "p(95)": 0.2955273999999999,
+        "p(99)": 0.3941981199999997,
+        "max": 11.506613,
+        "avg": 0.17286835697940517
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 58.90148439999999,
+        "p(99)": 95.52536451999988,
+        "max": 340.042216,
+        "avg": 31.17564078764308,
+        "min": 16.849463,
+        "med": 26.932644,
+        "p(90)": 42.8724812
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2185,
+        "rate": 30.854492566948448
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 120255,
+        "rate": 1698.1267751205428
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 50,
+        "max": 50,
+        "value": 50
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 2210.955212,
+        "avg": 1276.9228455484913,
+        "min": 0.005027,
+        "med": 1283.726271,
+        "p(90)": 1868.7182515,
+        "p(95)": 1943.325664,
+        "p(99)": 2018.9820702000002
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "avg": 0.5295197304347828,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.733991599999996,
+        "max": 59.894716
+      },
+      "type": "trend"
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 25.685255359999964,
+        "max": 72.68813,
+        "avg": 0.6118410549199084
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_failed": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2185
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 6,
+        "min": 3,
+        "max": 50
+      }
+    },
+    "http_req_blocked": {
+      "values": {
+        "avg": 1.1858285963386732,
+        "min": 0.000172,
+        "med": 0.000419,
+        "p(90)": 0.000706,
+        "p(95)": 0.0008997999999999996,
+        "p(99)": 47.77071667999999,
+        "max": 132.055198
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 96.43965995999994,
+        "max": 340.520179,
+        "avg": 31.798043278260888,
+        "min": 17.428817,
+        "med": 27.557316,
+        "p(90)": 43.761989400000026,
+        "p(95)": 59.70704419999992
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 1493122,
+        "rate": 21084.44926798499
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_duration{type:student-progress}": {
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 17.428817,
+        "med": 27.557316,
+        "p(90)": 43.761989400000026,
+        "p(95)": 59.70704419999992,
+        "p(99)": 96.43965995999994,
+        "max": 340.520179,
+        "avg": 31.798043278260888
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.4495341336384443,
+        "min": 0.025681,
+        "med": 0.142824,
+        "p(90)": 0.7863820000000011,
+        "p(95)": 1.5436289999999977,
+        "p(99)": 4.7299029599999916,
+        "max": 52.655623
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2185,
+        "rate": 30.854492566948448
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 17.428817,
+        "med": 27.557316,
+        "p(90)": 43.761989400000026,
+        "p(95)": 59.70704419999992,
+        "p(99)": 96.43965995999994,
+        "max": 340.520179,
+        "avg": 31.798043278260888
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 4370,
+        "fails": 0
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-50vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2185 |
+| iterations | 2185 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 1493122 |
+| data_sent bytes | 120255 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 31.80 | 17.43 | 27.56 | 43.76 | 59.71 | 96.44 | 340.52 |
+| http_req_waiting | 31.18 | 16.85 | 26.93 | 42.87 | 58.90 | 95.53 | 340.04 |
+| http_req_blocked | 1.19 | 0.00 | 0.00 | 0.00 | 0.00 | 47.77 | 132.06 |
+| http_req_connecting | 0.53 | 0 | 0 | 0 | 0 | 21.73 | 59.89 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2185 pass / 0 fail |
+| has page content array | 2185 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/scripts/learning/01-student-progress-baseline.js
+++ b/monitoring-deploy/k6/scripts/learning/01-student-progress-baseline.js
@@ -8,10 +8,12 @@
 //   - admin/operator 권한 계정으로 로그인해야 한다.
 //   - COURSE_ID 에 해당하는 강좌에 수강생/강의/문제세트/진행률 데이터가 있어야 병목이 드러난다.
 //
-// 실행 (monitoring/ 에서):
-//   docker compose run --rm -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
-//     -e COURSE_ID=2000 -e RESULT_NAME=learning-student-progress-before \
-//     k6 run -o experimental-prometheus-rw /scripts/learning/01-student-progress-baseline.js
+// 실행 (monitoring-deploy/ 에서):
+//   docker compose run --rm -e BASE_URL=https://codebomba.com \
+//     -e ACCESS_TOKEN=<브라우저에서_복사한_accessToken> \
+//     -e COURSE_ID=2000 -e TARGET=30 -e RESULT_NAME=learning-student-progress-deploy-30vu \
+//     k6 run /scripts/learning/01-student-progress-baseline.js
+//   ⚠️ -o experimental-prometheus-rw 붙이지 마라(배포 키트엔 로컬 prometheus 없음 → 에러).
 
 import http from "k6/http";
 import { check, sleep } from "k6";
@@ -20,11 +22,13 @@ import { login, authCookies } from "../../lib/auth.js";
 import { createSummaryHandler } from "../../lib/summary.js";
 
 const COURSE_ID = __ENV.COURSE_ID || "2000";     // 강좌 아이디가 2000번인 부분에서 테스트를 한다.
+const TARGET = Number(__ENV.TARGET || 30);       // 배포 최소 기준은 30 VU. 필요하면 1 → 5 → 10 → 30 순서로 올린다.
+const ACCESS_TOKEN = __ENV.ACCESS_TOKEN || "";   // 배포 step-up 인증 우회용. 있으면 login() 을 건너뛴다.
 
 export const options = {
     stages: [
-        { duration: "20s", target: 30 },    // VU를 0명에서 30명까지 증가
-        { duration: "40s", target: 30 },    // VU 30명 유지
+        { duration: "20s", target: TARGET },    // VU를 0명에서 TARGET명까지 증가
+        { duration: "40s", target: TARGET },    // TARGET명 유지
         { duration: "10s", target: 0 },
     ],
     thresholds: {
@@ -36,8 +40,11 @@ export const options = {
     summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
 };
 
-// 부하 시작 전 1회만 로그인한다. 로그인 부하는 본 측정에 섞지 않는다.
+// 부하 시작 전 1회만 인증한다. 배포(step-up) 환경에서는 ACCESS_TOKEN 직접 주입을 권장한다.
 export function setup() {
+    if (ACCESS_TOKEN) {
+        return { token: ACCESS_TOKEN };
+    }
     return { token: login() };
 }
 

--- a/src/main/java/com/wanted/codebombalms/course/application/port/CourseThumbnailStoragePort.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/port/CourseThumbnailStoragePort.java
@@ -9,6 +9,8 @@ public interface CourseThumbnailStoragePort {
             byte[] imageBytes
     );
 
+    void delete(String thumbnailUrl);
+
     record StoredCourseThumbnail(
             String originalFileName,
             String objectName,

--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.course.application.command.UpdateCourseCommand;
 import com.wanted.codebombalms.course.application.policy.CourseAuthorPolicy;
 import com.wanted.codebombalms.course.application.policy.CourseCategoryPolicy;
 import com.wanted.codebombalms.course.application.policy.CoursePublishPolicy;
+import com.wanted.codebombalms.course.application.port.CourseThumbnailStoragePort;
 import com.wanted.codebombalms.course.application.port.LectureManagementPort;
 import com.wanted.codebombalms.course.application.usecase.CourseCommandUseCase;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
@@ -34,6 +35,7 @@ public class CourseCommandService implements CourseCommandUseCase {
     private final CourseCategoryPolicy courseCategoryPolicy;
     private final CoursePublishPolicy coursePublishPolicy;
     private final LectureManagementPort lectureManagementPort;
+    private final CourseThumbnailStoragePort courseThumbnailStoragePort;
 
     @LogBusiness
     @LogPerformance
@@ -113,6 +115,7 @@ public class CourseCommandService implements CourseCommandUseCase {
         lectureManagementPort.deleteLecturesByCourseId(courseId);
         course.delete();
         courseRepository.save(course);
+        courseThumbnailStoragePort.delete(course.getThumbnailUrl());
 
         log.info("[CourseCommandService] deleted course - courseId: {}", courseId);
     }

--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -115,9 +117,33 @@ public class CourseCommandService implements CourseCommandUseCase {
         lectureManagementPort.deleteLecturesByCourseId(courseId);
         course.delete();
         courseRepository.save(course);
-        courseThumbnailStoragePort.delete(course.getThumbnailUrl());
+        deleteThumbnailAfterCommit(course.getThumbnailUrl());
 
         log.info("[CourseCommandService] deleted course - courseId: {}", courseId);
+    }
+
+    private void deleteThumbnailAfterCommit(String thumbnailUrl) {
+        runAfterCommit(() -> {
+            try {
+                courseThumbnailStoragePort.delete(thumbnailUrl);
+            } catch (RuntimeException e) {
+                log.warn("Failed to delete course thumbnail after course deletion. thumbnailUrl={}", thumbnailUrl, e);
+            }
+        });
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            task.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                task.run();
+            }
+        });
     }
 
     private void validateStatusChange(CourseStatus requestedStatus, CourseStatus currentStatus) {

--- a/src/main/java/com/wanted/codebombalms/course/domain/exception/CourseErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/exception/CourseErrorCode.java
@@ -23,7 +23,8 @@ public enum CourseErrorCode implements ErrorCode {
     COURSE_PROBLEM_LECTURE_NOT_FOUND("CRS-013", "선택한 강좌에 존재하지 않는 강의입니다."),
     COURSE_FINAL_PROBLEM_LECTURE_NOT_ALLOWED("CRS-014", "FINAL 문제 단계에는 강의를 지정할 수 없습니다."),
     COURSE_THUMBNAIL_INVALID_FILE("CRS-015", "올바른 강좌 썸네일 이미지 파일이 아닙니다."),
-    COURSE_THUMBNAIL_UPLOAD_FAILED("CRS-016", "강좌 썸네일 이미지 업로드에 실패했습니다.");
+    COURSE_THUMBNAIL_UPLOAD_FAILED("CRS-016", "강좌 썸네일 이미지 업로드에 실패했습니다."),
+    COURSE_THUMBNAIL_DELETE_FAILED("CRS-017", "강좌 썸네일 이미지 삭제에 실패했습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
@@ -5,11 +5,16 @@ import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePo
 import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LectureManagementAdapter implements LectureManagementPort {
 
     private final LectureRepository lectureRepository;
@@ -18,22 +23,48 @@ public class LectureManagementAdapter implements LectureManagementPort {
 
     @Override
     public void deleteLecturesByCourseId(Long courseId) {
-        lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId)
-                .forEach(lecture -> {
-                    deleteMaterialsByLectureId(lecture.getLectureId());
-                    lecture.delete();
-                    lectureRepository.save(lecture);
-                });
-    }
+        var lectures = lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId);
+        var lectureIds = lectures.stream()
+                .map(lecture -> lecture.getLectureId())
+                .toList();
 
-    private void deleteMaterialsByLectureId(Long lectureId) {
-        lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
-                .forEach(this::deleteMaterial);
+        if (!lectureIds.isEmpty()) {
+            lectureMaterialRepository.findByLectureIdInAndDeletedAtIsNull(lectureIds)
+                    .forEach(this::deleteMaterial);
+        }
+
+        lectures.forEach(lecture -> {
+            lecture.delete();
+            lectureRepository.save(lecture);
+        });
     }
 
     private void deleteMaterial(LectureMaterial material) {
+        String filePath = material.getFilePath();
         material.delete();
         lectureMaterialRepository.save(material);
-        lectureMaterialStoragePort.delete(material.getFilePath());
+        runAfterCommit(() -> deleteMaterialFileQuietly(filePath));
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            task.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                task.run();
+            }
+        });
+    }
+
+    private void deleteMaterialFileQuietly(String filePath) {
+        try {
+            lectureMaterialStoragePort.delete(filePath);
+        } catch (RuntimeException e) {
+            log.warn("Failed to delete lecture material file after course deletion. filePath={}", filePath, e);
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
@@ -1,6 +1,9 @@
 package com.wanted.codebombalms.course.infrastructure.lecture;
 
 import com.wanted.codebombalms.course.application.port.LectureManagementPort;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -10,13 +13,27 @@ import org.springframework.stereotype.Component;
 public class LectureManagementAdapter implements LectureManagementPort {
 
     private final LectureRepository lectureRepository;
+    private final LectureMaterialRepository lectureMaterialRepository;
+    private final LectureMaterialStoragePort lectureMaterialStoragePort;
 
     @Override
     public void deleteLecturesByCourseId(Long courseId) {
         lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId)
                 .forEach(lecture -> {
+                    deleteMaterialsByLectureId(lecture.getLectureId());
                     lecture.delete();
                     lectureRepository.save(lecture);
                 });
+    }
+
+    private void deleteMaterialsByLectureId(Long lectureId) {
+        lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
+                .forEach(this::deleteMaterial);
+    }
+
+    private void deleteMaterial(LectureMaterial material) {
+        material.delete();
+        lectureMaterialRepository.save(material);
+        lectureMaterialStoragePort.delete(material.getFilePath());
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -70,6 +70,7 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
         }
         if (!lectureIds.isEmpty()) {
             deleteLectureProgressesByLectureIds(lectureIds);
+            deleteLectureMaterialsByLectureIds(lectureIds);
         }
 
         deleteLectureProblemSetsByCourseIds(courseIds);
@@ -124,6 +125,13 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
             where p.lectureId in :lectureIds
             """)
     int deleteLectureProgressesByLectureIds(@Param("lectureIds") List<Long> lectureIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureMaterialJpaEntity m
+            where m.lectureId in :lectureIds
+            """)
+    int deleteLectureMaterialsByLectureIds(@Param("lectureIds") List<Long> lectureIds);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
@@ -123,10 +123,16 @@ public class GcsCourseThumbnailStorageAdapter implements CourseThumbnailStorageP
                 return null;
             }
 
-            return URLDecoder.decode(
+            String objectName = URLDecoder.decode(
                     path.substring(bucketPrefix.length()),
                     StandardCharsets.UTF_8
             );
+            String thumbnailPrefix = normalizePrefix(properties.getStorage().getCourseThumbnailPrefix());
+            if (!thumbnailPrefix.isBlank() && !objectName.startsWith(thumbnailPrefix + "/")) {
+                return null;
+            }
+
+            return objectName;
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
@@ -9,6 +9,8 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServ
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
+import java.net.URI;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -80,6 +82,53 @@ public class GcsCourseThumbnailStorageAdapter implements CourseThumbnailStorageP
                     CourseErrorCode.COURSE_THUMBNAIL_UPLOAD_FAILED,
                     e
             );
+        }
+    }
+
+    @Override
+    public void delete(String thumbnailUrl) {
+        String objectName = extractObjectName(thumbnailUrl);
+        if (objectName == null || objectName.isBlank()) {
+            return;
+        }
+
+        try {
+            getStorage().delete(
+                    BlobId.of(
+                            properties.getStorage().getBucket(),
+                            objectName
+                    )
+            );
+        } catch (Exception e) {
+            throw new ExternalServiceException(
+                    CourseErrorCode.COURSE_THUMBNAIL_DELETE_FAILED,
+                    e
+            );
+        }
+    }
+
+    private String extractObjectName(String thumbnailUrl) {
+        if (thumbnailUrl == null || thumbnailUrl.isBlank()) {
+            return null;
+        }
+
+        try {
+            URI uri = URI.create(thumbnailUrl);
+            String expectedHost = "storage.googleapis.com";
+            String bucket = properties.getStorage().getBucket();
+            String path = uri.getPath();
+            String bucketPrefix = "/" + bucket + "/";
+
+            if (!expectedHost.equals(uri.getHost()) || path == null || !path.startsWith(bucketPrefix)) {
+                return null;
+            }
+
+            return URLDecoder.decode(
+                    path.substring(bucketPrefix.length()),
+                    StandardCharsets.UTF_8
+            );
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureMaterialRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureMaterialRepository.java
@@ -10,5 +10,7 @@ public interface LectureMaterialRepository {
 
     List<LectureMaterial> findByLectureIdAndDeletedAtIsNull(Long lectureId);
 
+    List<LectureMaterial> findByLectureIdInAndDeletedAtIsNull(List<Long> lectureIds);
+
     Optional<LectureMaterial> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
@@ -39,6 +39,15 @@ public class LectureMaterialRepositoryAdapter implements LectureMaterialReposito
     }
 
     @Override
+    public List<LectureMaterial> findByLectureIdInAndDeletedAtIsNull(List<Long> lectureIds) {
+        return springDataLectureMaterialRepository
+                .findByLectureIdInAndDeletedAtIsNull(lectureIds)
+                .stream()
+                .map(LectureMaterialJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public Optional<LectureMaterial> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId) {
         return springDataLectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId)
                 .map(LectureMaterialJpaEntity::toDomain);

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureMaterialRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureMaterialRepository.java
@@ -8,5 +8,7 @@ public interface SpringDataLectureMaterialRepository extends JpaRepository<Lectu
 
     List<LectureMaterialJpaEntity> findByLectureIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long lectureId);
 
+    List<LectureMaterialJpaEntity> findByLectureIdInAndDeletedAtIsNull(List<Long> lectureIds);
+
     Optional<LectureMaterialJpaEntity> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId);
 }

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -268,6 +268,24 @@ class CourseServiceTest {
     }
 
     @Test
+    void deleteCourse_keepsCourseDeleted_whenThumbnailDeleteFails() {
+        Long courseId = 1L;
+        Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.ACTIVE);
+
+        given(courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)).willReturn(Optional.of(course));
+        doThrow(new RuntimeException("thumbnail delete failed"))
+                .when(courseThumbnailStoragePort)
+                .delete("java.png");
+
+        courseCommandService.deleteCourse(courseId);
+
+        assertEquals(CourseStatus.DELETED, course.getStatus());
+        assertNotNull(course.getDeletedAt());
+        verify(courseRepository).save(course);
+        verify(courseThumbnailStoragePort).delete("java.png");
+    }
+
+    @Test
     void publishCourse_activatesDraftCourse() {
         Long courseId = 1L;
         Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.DRAFT);

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.course.application.command.UpdateCourseCommand;
 import com.wanted.codebombalms.course.application.policy.CourseAuthorPolicy;
 import com.wanted.codebombalms.course.application.policy.CourseCategoryPolicy;
 import com.wanted.codebombalms.course.application.policy.CoursePublishPolicy;
+import com.wanted.codebombalms.course.application.port.CourseThumbnailStoragePort;
 import com.wanted.codebombalms.course.application.port.LectureManagementPort;
 import com.wanted.codebombalms.course.application.service.CourseCommandService;
 import com.wanted.codebombalms.course.application.service.CourseQueryService;
@@ -52,6 +53,9 @@ class CourseServiceTest {
 
     @Mock
     private LectureManagementPort lectureManagementPort;
+
+    @Mock
+    private CourseThumbnailStoragePort courseThumbnailStoragePort;
 
     @InjectMocks
     private CourseCommandService courseCommandService;
@@ -238,9 +242,10 @@ class CourseServiceTest {
 
         assertEquals(CourseStatus.DELETED, course.getStatus());
         assertNotNull(course.getDeletedAt());
-        var inOrder = inOrder(lectureManagementPort, courseRepository);
+        var inOrder = inOrder(lectureManagementPort, courseRepository, courseThumbnailStoragePort);
         inOrder.verify(lectureManagementPort).deleteLecturesByCourseId(courseId);
         inOrder.verify(courseRepository).save(course);
+        inOrder.verify(courseThumbnailStoragePort).delete("java.png");
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
@@ -1,0 +1,101 @@
+package com.wanted.codebombalms.course.infrastructure.lecture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
+import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LectureManagementAdapter unit test")
+class LectureManagementAdapterTest {
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @Mock
+    private LectureMaterialRepository lectureMaterialRepository;
+
+    @Mock
+    private LectureMaterialStoragePort lectureMaterialStoragePort;
+
+    @InjectMocks
+    private LectureManagementAdapter lectureManagementAdapter;
+
+    @Test
+    void deleteLecturesByCourseId_deletesLectureMaterialsBeforeLectures() {
+        Long courseId = 1L;
+        Lecture lecture = createLecture(10L, courseId);
+        LectureMaterial material = createMaterial(100L, lecture.getLectureId());
+
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(lecture));
+        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lecture.getLectureId()))
+                .willReturn(List.of(material));
+
+        lectureManagementAdapter.deleteLecturesByCourseId(courseId);
+
+        assertNotNull(material.getDeletedAt());
+        assertEquals(LectureStatus.DELETED, lecture.getStatus());
+        assertNotNull(lecture.getDeletedAt());
+
+        InOrder inOrder = inOrder(
+                lectureMaterialRepository,
+                lectureMaterialStoragePort,
+                lectureRepository
+        );
+        inOrder.verify(lectureMaterialRepository).save(material);
+        inOrder.verify(lectureMaterialStoragePort).delete("lecture_materials/stored-guide.pdf");
+        inOrder.verify(lectureRepository).save(lecture);
+    }
+
+    private Lecture createLecture(Long lectureId, Long courseId) {
+        Course course = new Course();
+        course.setCourseId(courseId);
+
+        return Lecture.restore(
+                lectureId,
+                course,
+                "Java lecture",
+                "description",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "thumbnail.png",
+                null,
+                LectureStatus.ACTIVE,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null,
+                1
+        );
+    }
+
+    private LectureMaterial createMaterial(Long lectureMaterialId, Long lectureId) {
+        return LectureMaterial.restore(
+                lectureMaterialId,
+                lectureId,
+                "guide.pdf",
+                "stored-guide.pdf",
+                "lecture_materials/stored-guide.pdf",
+                "application/pdf",
+                1024L,
+                LocalDateTime.now(),
+                null
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
@@ -3,7 +3,9 @@ package com.wanted.codebombalms.course.infrastructure.lecture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
@@ -46,7 +48,7 @@ class LectureManagementAdapterTest {
 
         given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
                 .willReturn(List.of(lecture));
-        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lecture.getLectureId()))
+        given(lectureMaterialRepository.findByLectureIdInAndDeletedAtIsNull(List.of(lecture.getLectureId())))
                 .willReturn(List.of(material));
 
         lectureManagementAdapter.deleteLecturesByCourseId(courseId);
@@ -63,6 +65,29 @@ class LectureManagementAdapterTest {
         inOrder.verify(lectureMaterialRepository).save(material);
         inOrder.verify(lectureMaterialStoragePort).delete("lecture_materials/stored-guide.pdf");
         inOrder.verify(lectureRepository).save(lecture);
+    }
+
+    @Test
+    void deleteLecturesByCourseId_keepsLectureDeleted_whenMaterialFileDeleteFails() {
+        Long courseId = 1L;
+        Lecture lecture = createLecture(10L, courseId);
+        LectureMaterial material = createMaterial(100L, lecture.getLectureId());
+
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(lecture));
+        given(lectureMaterialRepository.findByLectureIdInAndDeletedAtIsNull(List.of(lecture.getLectureId())))
+                .willReturn(List.of(material));
+        doThrow(new RuntimeException("material delete failed"))
+                .when(lectureMaterialStoragePort)
+                .delete("lecture_materials/stored-guide.pdf");
+
+        lectureManagementAdapter.deleteLecturesByCourseId(courseId);
+
+        assertNotNull(material.getDeletedAt());
+        assertEquals(LectureStatus.DELETED, lecture.getStatus());
+        assertNotNull(lecture.getDeletedAt());
+        verify(lectureMaterialRepository).save(material);
+        verify(lectureRepository).save(lecture);
     }
 
     private Lecture createLecture(Long lectureId, Long courseId) {

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
@@ -1,9 +1,17 @@
 package com.wanted.codebombalms.course.infrastructure.storage;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -50,5 +58,38 @@ class GcsCourseThumbnailStorageAdapterTest {
                 .isInstanceOf(ValidationException.class)
                 .extracting("errorCode")
                 .isEqualTo(CourseErrorCode.COURSE_THUMBNAIL_INVALID_FILE);
+    }
+
+    @Test
+    void delete_deletesGcsObject_whenUrlBelongsToConfiguredBucket() throws Exception {
+        Storage storage = mock(Storage.class);
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        when(storageClientFactory.create()).thenReturn(storage);
+
+        adapter.delete("https://storage.googleapis.com/codebombalms/course_thumbnail_images/java.png");
+
+        verify(storage).delete(BlobId.of("codebombalms", "course_thumbnail_images/java.png"));
+    }
+
+    @Test
+    void delete_ignoresUrl_whenUrlDoesNotBelongToConfiguredBucket() throws Exception {
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        adapter.delete("https://example.com/images/java.png");
+
+        verify(storageClientFactory, never()).create();
+    }
+
+    private GcpStorageProperties createProperties(String bucket) {
+        GcpStorageProperties properties = new GcpStorageProperties();
+        properties.getStorage().setBucket(bucket);
+        return properties;
     }
 }

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.course.infrastructure.storage;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
@@ -85,6 +87,47 @@ class GcsCourseThumbnailStorageAdapterTest {
         adapter.delete("https://example.com/images/java.png");
 
         verify(storageClientFactory, never()).create();
+    }
+
+    @Test
+    void delete_ignoresUrl_whenObjectIsOutsideCourseThumbnailPrefix() throws Exception {
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        adapter.delete("https://storage.googleapis.com/codebombalms/lecture_materials/guide.pdf");
+
+        verify(storageClientFactory, never()).create();
+    }
+
+    @Test
+    void delete_ignoresMalformedUrl() {
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        assertThatCode(() -> adapter.delete("://not-a-url"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void delete_throwsExternalServiceException_whenStorageDeleteFails() throws Exception {
+        Storage storage = mock(Storage.class);
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+        BlobId blobId = BlobId.of("codebombalms", "course_thumbnail_images/java.png");
+
+        when(storageClientFactory.create()).thenReturn(storage);
+        when(storage.delete(blobId)).thenThrow(new RuntimeException("delete failed"));
+
+        assertThatThrownBy(() -> adapter.delete("https://storage.googleapis.com/codebombalms/course_thumbnail_images/java.png"))
+                .isInstanceOf(ExternalServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(CourseErrorCode.COURSE_THUMBNAIL_DELETE_FAILED);
     }
 
     private GcpStorageProperties createProperties(String bucket) {


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #517

---

## 🛠️ 기능 관련 작업 내용

- 강좌 삭제 시 `thumbnailUrl` 기반으로 GCS 강좌 썸네일 파일을 삭제하도록 처리했습니다.
- 강좌 하위 강의 삭제 시 연결된 강의자료를 soft delete하고 GCS `lecture_materials` 파일도 함께 삭제하도록 보완했습니다.
- 강좌 hard delete 시 `lecture_material` DB row도 함께 정리되도록 삭제 순서를 추가했습니다.
- 썸네일/강의자료 삭제 흐름에 대한 단위 테스트를 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `project/course`: 강좌 삭제 서비스, 썸네일 스토리지 포트/어댑터, hard delete repository 로직 수정
- `project/course/infrastructure/lecture`: 강좌 하위 강의 삭제 시 강의자료 soft delete 및 GCS 삭제 처리 추가
- `project/course/test`: 강좌 썸네일 삭제, 강의자료 삭제 순서, hard delete 관련 테스트 보강
- `project/.ai`: 삭제 실패 에러 코드 문서 반영
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 강의 삭제 시 연결된 썸네일과 강의 자료도 함께 정리되도록 지원이 확장되었습니다.
* **Bug Fixes**
  * 삭제 대상 파일이 스토리지에 남는 문제를 줄여, 더 깔끔한 삭제 처리가 가능해졌습니다.
  * 썸네일 삭제 실패 시 적절한 오류가 반환되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->