### PR TITLE
[Fix] GCS 업로드 인증 환경변수 설정 추가

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     container_name: lms-spring
     restart: unless-stopped
     env_file: .env                 # DB/Redis/JWT/OAuth/GCP 등 런타임 비밀값
+    environment:
+      # Default path for GoogleCredentials.getApplicationDefault() inside the container.
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/secrets/gcp-storage-key.json}
     ports:
       - "8080:8080"
     volumes:

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -6,7 +6,7 @@
 #   - DB_URL / DB_USERNAME / DB_PASSWORD / DDL_AUTO
 #   - REDIS_HOST / REDIS_PORT / REDIS_PASSWORD
 #   - CORS_ALLOWED_ORIGINS / FASTAPI_URL / JWT_SECRET
-#   - MAIL_* / GOOGLE_* / OAUTH_* / COOKIE_SECURE / GCP_*
+#   - MAIL_* / GOOGLE_* / OAUTH_* / COOKIE_SECURE / GCP_* / GOOGLE_APPLICATION_CREDENTIALS
 #
 # 활성화: .env 의 SPRING_PROFILES_ACTIVE=deploy
 #   (base 의 profiles.active=local 을 환경변수 우선순위로 override → local.yml 미로드)


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #

---

## 🛠️ 기능 관련 작업 내용

- Spring 컨테이너에서 GCP ADC 인증 파일을 찾을 수 있도록 `GOOGLE_APPLICATION_CREDENTIALS` 기본 경로를 추가했습니다.
- GCS 업로드 시 사용하는 서비스 계정 키 파일 경로를 `/app/secrets/gcp-storage-key.json`로 연결했습니다.
- 운영 프로필 주석에 `GOOGLE_APPLICATION_CREDENTIALS` 환경변수 확인 대상을 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `project/deploy`: Spring 컨테이너 환경변수에 GCP 인증 키 파일 경로 추가
- `project/src/main/resources`: deploy 프로필 환경변수 주석 보완
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 배포 프로파일 주석의 환경변수 목록에 `GOOGLE_APPLICATION_CREDENTIALS`가 추가되었습니다.
  * 관련 `GCP_*` 및 `GOOGLE_*` 항목의 주석 표기가 일부 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->