### PR TITLE
[Release] v1.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,6 @@ architecture-user-auth.html
 /monitoring-local/k6/results/auth-reissue-before-summary.json
 /monitoring-local/k6/results/auth-reissue-after-summary.md
 /monitoring-local/k6/results/auth-reissue-after-summary.json
+/monitoring-deploy/k6/results/
 /src/main/resources/db/seed/03_trusted_device_loadtest.sql
 /rds-tunnel.sh

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     container_name: lms-spring
     restart: unless-stopped
     env_file: .env                 # DB/Redis/JWT/OAuth/GCP 등 런타임 비밀값
+    environment:
+      # Default path for GoogleCredentials.getApplicationDefault() inside the container.
+      GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-/app/secrets/gcp-storage-key.json}
     ports:
       - "8080:8080"
     volumes:

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "groups": [],
+    "checks": [
+        {
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 4327,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200"
+        },
+        {
+          "fails": 0,
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 4327
+        }
+      ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 70827.651158,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": -6.248796,
+        "med": 0.123195,
+        "p(90)": 0.2190708,
+        "p(95)": 0.25653960000000003,
+        "p(99)": 0.34640303999999944,
+        "max": 10.298438,
+        "avg": 0.14075950080887473
+      }
+    },
+    "data_sent": {
+      "values": {
+        "count": 238814,
+        "rate": 3371.762243918856
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 100,
+        "value": 100,
+        "min": 100
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 4327,
+        "rate": 61.091959556126895
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 2017.1062161999996,
+        "max": 2128.882515,
+        "avg": 1287.6442447213499,
+        "min": 0.003094,
+        "med": 1291.4990225000001,
+        "p(90)": 1890.5991861,
+        "p(95)": 1960.09398485
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 103.834931,
+        "avg": 1.0686046353131462,
+        "min": 0.000207,
+        "med": 0.000365,
+        "p(90)": 0.0006204000000000001,
+        "p(95)": 0.0007776999999999999,
+        "p(99)": 46.29211267999997
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 71.22881465999976,
+        "max": 278.719933,
+        "avg": 28.679858201063052,
+        "min": 14.538052,
+        "med": 25.984371,
+        "p(90)": 36.5430668,
+        "p(95)": 41.7983894
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 69.41318571999999,
+        "max": 278.245547,
+        "avg": 28.110107198289768,
+        "min": 16.917553,
+        "med": 25.467109,
+        "p(90)": 35.7672558,
+        "p(95)": 40.78138129999999
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "min": 5,
+        "max": 100,
+        "value": 7
+      },
+      "type": "gauge"
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 2961312,
+        "rate": 41810.111610139415
+      }
+    },
+    "http_req_connecting": {
+      "values": {
+        "max": 47.268548,
+        "avg": 0.48079425375548895,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 20.715245999999972
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.5689872625375549,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 25.435910179999997,
+        "max": 41.260758
+      }
+    },
+    "http_req_receiving": {
+      "values": {
+        "min": 0.021557,
+        "med": 0.130201,
+        "p(90)": 0.8357544000000001,
+        "p(95)": 1.6300011999999973,
+        "p(99)": 5.264014739999995,
+        "max": 22.805274,
+        "avg": 0.42899150196440966
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 278.719933,
+        "avg": 28.679858201063052,
+        "min": 14.538052,
+        "med": 25.984371,
+        "p(90)": 36.5430668,
+        "p(95)": 41.7983894,
+        "p(99)": 71.22881465999976
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 4327
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 8654,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 4327,
+        "rate": 61.091959556126895
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 41.7983894,
+        "p(99)": 71.22881465999976,
+        "max": 278.719933,
+        "avg": 28.679858201063052,
+        "min": 14.538052,
+        "med": 25.984371,
+        "p(90)": 36.5430668
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-100vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-100vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 4327 |
+| iterations | 4327 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 2961312 |
+| data_sent bytes | 238814 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 28.68 | 14.54 | 25.98 | 36.54 | 41.80 | 71.23 | 278.72 |
+| http_req_waiting | 28.11 | 16.92 | 25.47 | 35.77 | 40.78 | 69.41 | 278.25 |
+| http_req_blocked | 1.07 | 0.00 | 0.00 | 0.00 | 0.00 | 46.29 | 103.83 |
+| http_req_connecting | 0.48 | 0 | 0 | 0 | 0 | 20.72 | 47.27 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 4327 pass / 0 fail |
+| has page content array | 4327 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71152.871755
+  },
+  "metrics": {
+    "vus_max": {
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      },
+      "type": "gauge",
+      "contains": "default"
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "rate": 0.7729835584062014,
+        "count": 55
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 55,
+        "rate": 0.7729835584062014
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 55
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "contains": "time",
+      "values": {
+        "avg": 35.00723812727274,
+        "min": 22.84574,
+        "med": 32.891309,
+        "p(90)": 45.5687074,
+        "p(95)": 55.35622059999998,
+        "p(99)": 65.57562594000001,
+        "max": 66.983562
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend"
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 2093.257865,
+        "avg": 1270.6297463750002,
+        "min": 0.003086,
+        "med": 1242.199744,
+        "p(90)": 1876.2301355,
+        "p(95)": 1988.46397725,
+        "p(99)": 2055.72826685
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 12.916628420000023,
+        "max": 28.079627,
+        "avg": 0.5105386727272727,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 34.15129401818181,
+        "min": 22.595454,
+        "med": 32.475079,
+        "p(90)": 43.969723800000004,
+        "p(95)": 55.00417909999997,
+        "p(99)": 62.66233426,
+        "max": 62.807395
+      }
+    },
+    "http_req_sending": {
+      "values": {
+        "avg": 0.2744119636363637,
+        "min": 0.118187,
+        "med": 0.244882,
+        "p(90)": 0.3896606,
+        "p(95)": 0.41702379999999994,
+        "p(99)": 0.8455272000000007,
+        "max": 1.326786
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 35.00723812727274,
+        "min": 22.84574,
+        "med": 32.891309,
+        "p(90)": 45.5687074,
+        "p(95)": 55.35622059999998,
+        "p(99)": 65.57562594000001,
+        "max": 66.983562
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.0010416,
+        "p(99)": 36.46551976000008,
+        "max": 79.270891,
+        "avg": 1.4418218363636366,
+        "min": 0.000217,
+        "med": 0.000468,
+        "p(90)": 0.0009202
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 5.6056315400000045,
+        "max": 8.84123,
+        "avg": 0.5815321454545453,
+        "min": 0.086147,
+        "med": 0.176164,
+        "p(90)": 1.6765336000000002,
+        "p(95)": 2.6044576999999993
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 511.72916991142176,
+        "count": 36411
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 1,
+        "min": 1,
+        "max": 1
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 32.891309,
+        "p(90)": 45.5687074,
+        "p(95)": 55.35622059999998,
+        "p(99)": 65.57562594000001,
+        "max": 66.983562,
+        "avg": 35.00723812727274,
+        "min": 22.84574
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 2861,
+        "rate": 40.209199283638945
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 110,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 7.224864420000014,
+        "max": 15.706227,
+        "avg": 0.28556776363636366,
+        "min": 0,
+        "med": 0
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3"
+  },
+  "root_group": {
+    "checks": [
+      {
+        "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+        "passes": 55,
+        "fails": 0,
+        "name": "status is 200",
+        "path": "::status is 200"
+      },
+      {
+        "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+        "passes": 55,
+        "fails": 0,
+        "name": "has page content array",
+        "path": "::has page content array"
+      }
+    ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": []
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-1vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-1vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 55 |
+| iterations | 55 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 36411 |
+| data_sent bytes | 2861 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 35.01 | 22.85 | 32.89 | 45.57 | 55.36 | 65.58 | 66.98 |
+| http_req_waiting | 34.15 | 22.60 | 32.48 | 43.97 | 55.00 | 62.66 | 62.81 |
+| http_req_blocked | 1.44 | 0.00 | 0.00 | 0.00 | 0.00 | 36.47 | 79.27 |
+| http_req_connecting | 0.29 | 0 | 0 | 0 | 0 | 7.22 | 15.71 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 55 pass / 0 fail |
+| has page content array | 55 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "options": {
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": ""
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 70870.521226
+  },
+  "metrics": {
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 8340,
+        "rate": 117.67939413630751
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 44.34612979000004,
+        "max": 138.406882,
+        "avg": 1.0646819631894449,
+        "min": 0.000203,
+        "med": 0.000373,
+        "p(90)": 0.000563,
+        "p(95)": 0.0006990499999999992
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 2000.086329,
+        "p(99)": 3307.2750424000055,
+        "max": 5320.689395,
+        "avg": 1334.8729794551002,
+        "min": 0.002208,
+        "med": 1308.069258,
+        "p(90)": 1923.475227
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 1915.445251620007,
+        "max": 3529.830764,
+        "avg": 81.37849361139058,
+        "min": 13.962873,
+        "med": 26.277190500000003,
+        "p(90)": 41.37796190000001,
+        "p(95)": 64.79423799999988
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "values": {
+        "max": 3590.150746,
+        "avg": 82.92245680683472,
+        "min": 14.155709,
+        "med": 26.8829885,
+        "p(90)": 42.28780740000001,
+        "p(95)": 67.62214679999988,
+        "p(99)": 1925.581238160005
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "fails": 0,
+        "rate": 1,
+        "passes": 16680
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 13,
+        "min": 10,
+        "max": 200
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.19166610000000003,
+        "p(95)": 0.22804879999999977,
+        "p(99)": 0.32248204,
+        "max": 11.550848,
+        "avg": 0.12151146151079138,
+        "min": 0.024778,
+        "med": 0.103808
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.4969483387290169,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 19.770972010000012,
+        "max": 44.579699
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 8340,
+        "rate": 117.67939413630751
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 5741098,
+        "rate": 81008.26550565548
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 465380,
+        "rate": 6566.623074718799
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "max": 200,
+        "value": 200,
+        "min": 200
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 82.92245680683472,
+        "min": 14.155709,
+        "med": 26.8829885,
+        "p(90)": 42.28780740000001,
+        "p(95)": 67.62214679999988,
+        "p(99)": 1925.581238160005,
+        "max": 3590.150746
+      }
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "avg": 0.5488325292565949,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 23.47119034000004,
+        "max": 81.038628
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "passes": 0,
+        "fails": 8340,
+        "rate": 0
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 1.5769640000000027,
+        "p(95)": 3.4302430999999953,
+        "p(99)": 24.591678220000055,
+        "max": 284.876743,
+        "avg": 1.422451733932856,
+        "min": 0.019806,
+        "med": 0.1627045
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 82.92245680683472,
+        "min": 14.155709,
+        "med": 26.8829885,
+        "p(90)": 42.28780740000001,
+        "p(95)": 67.62214679999988,
+        "p(99)": 1925.581238160005,
+        "max": 3590.150746
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 8340
+        },
+        {
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 8340,
+          "fails": 0,
+          "name": "has page content array"
+        }
+      ],
+    "name": "",
+    "path": ""
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-200vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-200vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 8340 |
+| iterations | 8340 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 5741098 |
+| data_sent bytes | 465380 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 82.92 | 14.16 | 26.88 | 42.29 | 67.62 | 1925.58 | 3590.15 |
+| http_req_waiting | 81.38 | 13.96 | 26.28 | 41.38 | 64.79 | 1915.45 | 3529.83 |
+| http_req_blocked | 1.06 | 0.00 | 0.00 | 0.00 | 0.00 | 44.35 | 138.41 |
+| http_req_connecting | 0.50 | 0 | 0 | 0 | 0 | 19.77 | 44.58 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 8340 pass / 0 fail |
+| has page content array | 8340 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71712.79445
+  },
+  "metrics": {
+    "http_req_failed": {
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 12936
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 18.73205124999995,
+        "max": 59.408678,
+        "avg": 0.44445274404761886,
+        "min": 0
+      }
+    },
+    "http_req_waiting": {
+      "values": {
+        "p(99)": 297.5511818999999,
+        "max": 804.950287,
+        "avg": 36.23722383379714,
+        "min": 13.783648,
+        "med": 26.901235,
+        "p(90)": 42.564029500000004,
+        "p(95)": 61.68689175
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 13.982825,
+        "med": 27.5578795,
+        "p(90)": 44.320156499999996,
+        "p(95)": 64.403413,
+        "p(99)": 305.01614684999987,
+        "max": 808.238761,
+        "avg": 37.39969064687707
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 12936,
+        "rate": 180.3862211647506
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 0.20293325,
+        "p(99)": 0.3065131499999999,
+        "max": 1.460942,
+        "avg": 0.10925810977118092,
+        "min": 0.020738,
+        "med": 0.096094,
+        "p(90)": 0.167225
+      }
+    },
+    "http_req_tls_handshaking": {
+      "contains": "time",
+      "values": {
+        "max": 50.245666,
+        "avg": 0.49727342756648124,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.13636869999998
+      },
+      "type": "trend"
+    },
+    "http_req_duration{type:student-progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 37.39969064687707,
+        "min": 13.982825,
+        "med": 27.5578795,
+        "p(90)": 44.320156499999996,
+        "p(95)": 64.403413,
+        "p(99)": 305.01614684999987,
+        "max": 808.238761
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.00053,
+        "p(95)": 0.00064625,
+        "p(99)": 40.993617,
+        "max": 86.807392,
+        "avg": 0.9513060620748233,
+        "min": 0.000137,
+        "med": 0.000346
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 25872,
+        "fails": 0
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 300,
+        "max": 300,
+        "value": 300
+      }
+    },
+    "data_received": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 123518.51671567373,
+        "count": 8857858
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.017091,
+        "med": 0.2106045,
+        "p(90)": 2.0542205,
+        "p(95)": 4.07213225,
+        "p(99)": 14.315141499999996,
+        "max": 139.500265,
+        "avg": 1.0532087033085968
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 714672,
+        "rate": 9965.753049803234
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "min": 3,
+        "max": 300,
+        "value": 3
+      },
+      "type": "gauge"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 808.238761,
+        "avg": 37.39969064687707,
+        "min": 13.982825,
+        "med": 27.5578795,
+        "p(90)": 44.320156499999996,
+        "p(95)": 64.403413,
+        "p(99)": 305.01614684999987
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.002723,
+        "med": 1298.001729,
+        "p(90)": 1891.9850614,
+        "p(95)": 1963.2058332000001,
+        "p(99)": 2027.7860784799998,
+        "max": 2441.8457,
+        "avg": 1291.8858491464784
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 12936,
+        "rate": 180.3862211647506
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 12936,
+          "fails": 0
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 12936,
+          "fails": 0
+        }
+      ],
+    "name": "",
+    "path": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-300vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-300vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 12936 |
+| iterations | 12936 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 8857858 |
+| data_sent bytes | 714672 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 37.40 | 13.98 | 27.56 | 44.32 | 64.40 | 305.02 | 808.24 |
+| http_req_waiting | 36.24 | 13.78 | 26.90 | 42.56 | 61.69 | 297.55 | 804.95 |
+| http_req_blocked | 0.95 | 0.00 | 0.00 | 0.00 | 0.00 | 40.99 | 86.81 |
+| http_req_connecting | 0.44 | 0 | 0 | 0 | 0 | 18.73 | 59.41 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 12936 pass / 0 fail |
+| has page content array | 12936 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 1301,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 1301,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTimeUnit": "",
+    "noColor": false,
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ]
+  },
+  "state": {
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71619.739363,
+    "isStdOutTTY": true
+  },
+  "metrics": {
+    "http_req_duration{type:student-progress}": {
+      "values": {
+        "max": 280.672868,
+        "avg": 30.05186383013069,
+        "min": 18.758053,
+        "med": 26.663157,
+        "p(90)": 37.730246,
+        "p(95)": 44.907513,
+        "p(99)": 71.277072
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 280.672868,
+        "avg": 30.05186383013069,
+        "min": 18.758053,
+        "med": 26.663157,
+        "p(90)": 37.730246,
+        "p(95)": 44.907513,
+        "p(99)": 71.277072
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.6199121544965411,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 26.754194,
+        "max": 43.502233
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 30,
+        "max": 30,
+        "value": 30
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.016483,
+        "max": 35.379209,
+        "avg": 0.4968947794004613
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.024666,
+        "med": 0.164666,
+        "p(90)": 0.276125,
+        "p(95)": 0.314393,
+        "p(99)": 0.547441,
+        "max": 2.879556,
+        "avg": 0.18566693389700234
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1301,
+        "rate": 18.165383057399385
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 1301
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 2,
+        "min": 2,
+        "max": 30
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 1301,
+        "rate": 18.165383057399385
+      }
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 48.662353,
+        "max": 115.65358,
+        "avg": 1.178432447348195,
+        "min": 0.000215,
+        "med": 0.000423,
+        "p(90)": 0.000783,
+        "p(95)": 0.001
+      }
+    },
+    "http_req_duration": {
+      "contains": "time",
+      "values": {
+        "p(90)": 37.730246,
+        "p(95)": 44.907513,
+        "p(99)": 71.277072,
+        "max": 280.672868,
+        "avg": 30.05186383013069,
+        "min": 18.758053,
+        "med": 26.663157
+      },
+      "type": "trend"
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 2602,
+        "fails": 0
+      }
+    },
+    "data_received": {
+      "contains": "data",
+      "values": {
+        "count": 890143,
+        "rate": 12428.738332715344
+      },
+      "type": "counter"
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 29.43401865334362,
+        "min": 18.546196,
+        "med": 26.111094,
+        "p(90)": 37.213501,
+        "p(95)": 44.375476,
+        "p(99)": 70.562794,
+        "max": 273.964318
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.033815,
+        "med": 0.14495,
+        "p(90)": 0.813792,
+        "p(95)": 1.632379,
+        "p(99)": 5.915678,
+        "max": 19.151998,
+        "avg": 0.4321782428900852
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "rate": 1002.4750248824779,
+        "count": 71797
+      }
+    },
+    "iteration_duration": {
+      "contains": "time",
+      "values": {
+        "max": 2161.026162,
+        "avg": 1289.486464821815,
+        "min": 0.002779,
+        "med": 1295.03284,
+        "p(90)": 1907.2899041,
+        "p(95)": 1968.914592,
+        "p(99)": 2020.79022482
+      },
+      "type": "trend"
+    }
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-30vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-30vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 1301 |
+| iterations | 1301 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 890143 |
+| data_sent bytes | 71797 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 30.05 | 18.76 | 26.66 | 37.73 | 44.91 | 71.28 | 280.67 |
+| http_req_waiting | 29.43 | 18.55 | 26.11 | 37.21 | 44.38 | 70.56 | 273.96 |
+| http_req_blocked | 1.18 | 0.00 | 0.00 | 0.00 | 0.00 | 48.66 | 115.65 |
+| http_req_connecting | 0.50 | 0 | 0 | 0 | 0 | 21.02 | 35.38 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 1301 pass / 0 fail |
+| has page content array | 1301 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  },
+  "root_group": {
+    "groups": [],
+    "checks": [
+        {
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 17125,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200"
+        },
+        {
+          "fails": 0,
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 17125
+        }
+      ],
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 71401.616685
+  },
+  "metrics": {
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 45.066515594393934,
+        "min": 14.738453,
+        "med": 32.712766,
+        "p(90)": 64.80532160000001,
+        "p(95)": 89.84278119999998,
+        "p(99)": 310.5841859599958,
+        "max": 1039.391281
+      }
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 17125
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 34250,
+        "fails": 0
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 11745764,
+        "rate": 164502.77382119195
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 400,
+        "min": 400,
+        "max": 400
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.09985045290510934,
+        "min": 0.022829,
+        "med": 0.086294,
+        "p(90)": 0.1560572,
+        "p(95)": 0.1911704,
+        "p(99)": 0.29291471999999974,
+        "max": 2.293236
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 4.891604,
+        "p(95)": 9.172378199999999,
+        "p(99)": 22.452373559999977,
+        "max": 188.688619,
+        "avg": 1.900528633401473,
+        "min": -2.620509,
+        "med": 0.344218
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 17125,
+        "rate": 239.84050775138275
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 948030,
+        "rate": 13277.430456265307
+      }
+    },
+    "http_req_connecting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 19.308176279999874,
+        "max": 58.118392,
+        "avg": 0.4716849981897813,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0
+      }
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 32.712766,
+        "p(90)": 64.80532160000001,
+        "p(95)": 89.84278119999998,
+        "p(99)": 310.5841859599958,
+        "max": 1039.391281,
+        "avg": 45.066515594393934,
+        "min": 14.738453
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 310.5841859599958,
+        "max": 1039.391281,
+        "avg": 45.066515594393934,
+        "min": 14.738453,
+        "med": 32.712766,
+        "p(90)": 64.80532160000001,
+        "p(95)": 89.84278119999998
+      },
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      }
+    },
+    "vus": {
+      "contains": "default",
+      "values": {
+        "min": 5,
+        "max": 400,
+        "value": 5
+      },
+      "type": "gauge"
+    },
+    "http_reqs": {
+      "values": {
+        "count": 17125,
+        "rate": 239.84050775138275
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 0.000508,
+        "p(95)": 0.0006317999999999992,
+        "p(99)": 42.19504019999975,
+        "max": 94.259961,
+        "avg": 1.0008812295474503,
+        "min": 0.000111,
+        "med": 0.000311
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 2038.756408,
+        "max": 2915.098144,
+        "avg": 1301.874295561429,
+        "min": 0.021485,
+        "med": 1302.851739,
+        "p(90)": 1896.728468,
+        "p(95)": 1974.216146
+      }
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 50.24216,
+        "avg": 0.5200910600291972,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.375641079999973
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 82.94183539999999,
+        "p(99)": 300.97591519999975,
+        "max": 1039.257264,
+        "avg": 43.066136508087745,
+        "min": 14.41977,
+        "med": 31.578837,
+        "p(90)": 60.2786234
+      }
+    }
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-400vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-400vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 17125 |
+| iterations | 17125 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 11745764 |
+| data_sent bytes | 948030 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 45.07 | 14.74 | 32.71 | 64.81 | 89.84 | 310.58 | 1039.39 |
+| http_req_waiting | 43.07 | 14.42 | 31.58 | 60.28 | 82.94 | 300.98 | 1039.26 |
+| http_req_blocked | 1.00 | 0.00 | 0.00 | 0.00 | 0.00 | 42.20 | 94.26 |
+| http_req_connecting | 0.47 | 0 | 0 | 0 | 0 | 19.31 | 58.12 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 17125 pass / 0 fail |
+| has page content array | 17125 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "name": "",
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "passes": 20266,
+          "fails": 0,
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f"
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 20266,
+          "fails": 0
+        }
+      ]
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "testRunDurationMs": 71514.819355,
+    "isStdOutTTY": true,
+    "isStdErrTTY": true
+  },
+  "metrics": {
+    "http_reqs": {
+      "values": {
+        "count": 20266,
+        "rate": 283.38182467328136
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_duration{expected_response:true}": {
+      "contains": "time",
+      "values": {
+        "p(90)": 203.2452485,
+        "p(95)": 441.7661025,
+        "p(99)": 1727.0936595499977,
+        "max": 3638.993652,
+        "avg": 126.06561503809344,
+        "min": 14.556685,
+        "med": 50.136382499999996
+      },
+      "type": "trend"
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 32.83314209999992,
+        "max": 331.239101,
+        "avg": 4.415384376147243,
+        "min": -2.092211,
+        "med": 0.7304705,
+        "p(90)": 14.1502465,
+        "p(95)": 19.4547775
+      }
+    },
+    "checks": {
+      "values": {
+        "rate": 1,
+        "passes": 40532,
+        "fails": 0
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "http_req_blocked": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.000299,
+        "p(90)": 0.000445,
+        "p(95)": 0.00059375,
+        "p(99)": 41.734172999999934,
+        "max": 107.86868,
+        "avg": 1.0285371208428096,
+        "min": 0.000133
+      }
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 6,
+        "min": 6,
+        "max": 500
+      }
+    },
+    "http_req_duration{type:student-progress}": {
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 126.06561503809344,
+        "min": 14.556685,
+        "med": 50.136382499999996,
+        "p(90)": 203.2452485,
+        "p(95)": 441.7661025,
+        "p(99)": 1727.0936595499977,
+        "max": 3638.993652
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 14015387,
+        "rate": 195978.77931324323
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "p(95)": 0,
+        "p(99)": 19.26433594999998,
+        "max": 67.804053,
+        "avg": 0.49594883583341615,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0
+      },
+      "type": "trend"
+    },
+    "http_req_duration": {
+      "values": {
+        "med": 50.136382499999996,
+        "p(90)": 203.2452485,
+        "p(95)": 441.7661025,
+        "p(99)": 1727.0936595499977,
+        "max": 3638.993652,
+        "avg": 126.06561503809344,
+        "min": 14.556685
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_failed": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 20266
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(90)": 195.28834899999998,
+        "p(95)": 431.5437025,
+        "p(99)": 1715.7555499499992,
+        "max": 3625.038229,
+        "avg": 121.55341454628413,
+        "min": 13.810544,
+        "med": 46.5725595
+      }
+    },
+    "iterations": {
+      "values": {
+        "count": 20266,
+        "rate": 283.38182467328136
+      },
+      "type": "counter",
+      "contains": "default"
+    },
+    "http_req_tls_handshaking": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.5236908791572091,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 20.64996504999998,
+        "max": 87.420027
+      }
+    },
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "med": 0.084007,
+        "p(90)": 0.14851799999999998,
+        "p(95)": 0.18605025,
+        "p(99)": 0.28237909999999933,
+        "max": 4.45685,
+        "avg": 0.09681611566169936,
+        "min": 0.019743
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 1140687,
+        "rate": 15950.358405264547
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.003208,
+        "med": 1356.051051,
+        "p(90)": 1965.8365648,
+        "p(95)": 2054.7062052,
+        "p(99)": 3121.2911557,
+        "max": 5429.390168,
+        "avg": 1375.4762442082667
+      }
+    },
+    "vus_max": {
+      "contains": "default",
+      "values": {
+        "value": 500,
+        "min": 500,
+        "max": 500
+      },
+      "type": "gauge"
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-500vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-500vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 20266 |
+| iterations | 20266 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 14015387 |
+| data_sent bytes | 1140687 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 126.07 | 14.56 | 50.14 | 203.25 | 441.77 | 1727.09 | 3638.99 |
+| http_req_waiting | 121.55 | 13.81 | 46.57 | 195.29 | 431.54 | 1715.76 | 3625.04 |
+| http_req_blocked | 1.03 | 0.00 | 0.00 | 0.00 | 0.00 | 41.73 | 107.87 |
+| http_req_connecting | 0.50 | 0 | 0 | 0 | 0 | 19.26 | 67.80 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 20266 pass / 0 fail |
+| has page content array | 20266 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.json
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.json
@@ -1,0 +1,255 @@
+{
+  "root_group": {
+    "path": "",
+    "id": "d41d8cd98f00b204e9800998ecf8427e",
+    "groups": [],
+    "checks": [
+        {
+          "name": "status is 200",
+          "path": "::status is 200",
+          "id": "6210a8cd14cd70477eba5c5e4cb3fb5f",
+          "passes": 2185,
+          "fails": 0
+        },
+        {
+          "name": "has page content array",
+          "path": "::has page content array",
+          "id": "e0c3c1f6d3ce97e3b9c59718a947cab1",
+          "passes": 2185,
+          "fails": 0
+        }
+      ],
+    "name": ""
+  },
+  "options": {
+    "summaryTrendStats": [
+      "avg",
+      "min",
+      "med",
+      "p(90)",
+      "p(95)",
+      "p(99)",
+      "max"
+    ],
+    "summaryTimeUnit": "",
+    "noColor": false
+  },
+  "state": {
+    "isStdOutTTY": true,
+    "isStdErrTTY": true,
+    "testRunDurationMs": 70816.267526
+  },
+  "metrics": {
+    "http_req_sending": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 0.025474,
+        "med": 0.151297,
+        "p(90)": 0.25206140000000005,
+        "p(95)": 0.2955273999999999,
+        "p(99)": 0.3941981199999997,
+        "max": 11.506613,
+        "avg": 0.17286835697940517
+      }
+    },
+    "http_req_waiting": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(95)": 58.90148439999999,
+        "p(99)": 95.52536451999988,
+        "max": 340.042216,
+        "avg": 31.17564078764308,
+        "min": 16.849463,
+        "med": 26.932644,
+        "p(90)": 42.8724812
+      }
+    },
+    "iterations": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2185,
+        "rate": 30.854492566948448
+      }
+    },
+    "data_sent": {
+      "type": "counter",
+      "contains": "data",
+      "values": {
+        "count": 120255,
+        "rate": 1698.1267751205428
+      }
+    },
+    "vus_max": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "min": 50,
+        "max": 50,
+        "value": 50
+      }
+    },
+    "iteration_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "max": 2210.955212,
+        "avg": 1276.9228455484913,
+        "min": 0.005027,
+        "med": 1283.726271,
+        "p(90)": 1868.7182515,
+        "p(95)": 1943.325664,
+        "p(99)": 2018.9820702000002
+      }
+    },
+    "http_req_connecting": {
+      "contains": "time",
+      "values": {
+        "avg": 0.5295197304347828,
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 21.733991599999996,
+        "max": 59.894716
+      },
+      "type": "trend"
+    },
+    "http_req_tls_handshaking": {
+      "values": {
+        "min": 0,
+        "med": 0,
+        "p(90)": 0,
+        "p(95)": 0,
+        "p(99)": 25.685255359999964,
+        "max": 72.68813,
+        "avg": 0.6118410549199084
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_failed": {
+      "values": {
+        "rate": 0,
+        "passes": 0,
+        "fails": 2185
+      },
+      "thresholds": {
+        "rate<0.01": {
+          "ok": true
+        }
+      },
+      "type": "rate",
+      "contains": "default"
+    },
+    "vus": {
+      "type": "gauge",
+      "contains": "default",
+      "values": {
+        "value": 6,
+        "min": 3,
+        "max": 50
+      }
+    },
+    "http_req_blocked": {
+      "values": {
+        "avg": 1.1858285963386732,
+        "min": 0.000172,
+        "med": 0.000419,
+        "p(90)": 0.000706,
+        "p(95)": 0.0008997999999999996,
+        "p(99)": 47.77071667999999,
+        "max": 132.055198
+      },
+      "type": "trend",
+      "contains": "time"
+    },
+    "http_req_duration{expected_response:true}": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "p(99)": 96.43965995999994,
+        "max": 340.520179,
+        "avg": 31.798043278260888,
+        "min": 17.428817,
+        "med": 27.557316,
+        "p(90)": 43.761989400000026,
+        "p(95)": 59.70704419999992
+      }
+    },
+    "data_received": {
+      "values": {
+        "count": 1493122,
+        "rate": 21084.44926798499
+      },
+      "type": "counter",
+      "contains": "data"
+    },
+    "http_req_duration{type:student-progress}": {
+      "thresholds": {
+        "p(95)<800": {
+          "ok": true
+        }
+      },
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 17.428817,
+        "med": 27.557316,
+        "p(90)": 43.761989400000026,
+        "p(95)": 59.70704419999992,
+        "p(99)": 96.43965995999994,
+        "max": 340.520179,
+        "avg": 31.798043278260888
+      }
+    },
+    "http_req_receiving": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "avg": 0.4495341336384443,
+        "min": 0.025681,
+        "med": 0.142824,
+        "p(90)": 0.7863820000000011,
+        "p(95)": 1.5436289999999977,
+        "p(99)": 4.7299029599999916,
+        "max": 52.655623
+      }
+    },
+    "http_reqs": {
+      "type": "counter",
+      "contains": "default",
+      "values": {
+        "count": 2185,
+        "rate": 30.854492566948448
+      }
+    },
+    "http_req_duration": {
+      "type": "trend",
+      "contains": "time",
+      "values": {
+        "min": 17.428817,
+        "med": 27.557316,
+        "p(90)": 43.761989400000026,
+        "p(95)": 59.70704419999992,
+        "p(99)": 96.43965995999994,
+        "max": 340.520179,
+        "avg": 31.798043278260888
+      }
+    },
+    "checks": {
+      "type": "rate",
+      "contains": "default",
+      "values": {
+        "rate": 1,
+        "passes": 4370,
+        "fails": 0
+      }
+    }
+  },
+  "setup_data": {
+    "token": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiI4IiwidHlwIjoiYWNjZXNzIiwibmlja25hbWUiOiJvcGVyYXRvciIsInJvbGUiOiJPUEVSQVRPUiIsImlhdCI6MTc4MjgzMjM2NywiZXhwIjoxNzgyODM1OTY3fQ.ixlrmYWToSv1bBobj0F-F63B6YW2zPY27RqO8PGmYCfT8OSXKxtGRqOGvBVUBOI3\n"
+  }
+}

--- a/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.md
+++ b/monitoring-deploy/k6/results/learning-student-progress-deploy-50vu-summary.md
@@ -1,0 +1,51 @@
+# k6 Result - learning-student-progress-deploy-50vu
+
+## Summary
+
+| Metric | Value |
+| --- | ---: |
+| http_reqs | 2185 |
+| iterations | 2185 |
+| checks success rate | 100.00% |
+| http_req_failed | 0.00% |
+| data_received bytes | 1493122 |
+| data_sent bytes | 120255 |
+
+## Duration Metrics
+
+| Metric | avg(ms) | min(ms) | med(ms) | p90(ms) | p95(ms) | p99(ms) | max(ms) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| http_req_duration | 31.80 | 17.43 | 27.56 | 43.76 | 59.71 | 96.44 | 340.52 |
+| http_req_waiting | 31.18 | 16.85 | 26.93 | 42.87 | 58.90 | 95.53 | 340.04 |
+| http_req_blocked | 1.19 | 0.00 | 0.00 | 0.00 | 0.00 | 47.77 | 132.06 |
+| http_req_connecting | 0.53 | 0 | 0 | 0 | 0 | 21.73 | 59.89 |
+
+## Metric Meaning
+
+| Value | Meaning |
+| --- | --- |
+| avg | 전체 요청 시간의 산술 평균입니다. outlier의 영향을 받을 수 있습니다. |
+| min | 가장 빠른 요청 시간입니다. 정상 동작의 하한선을 볼 때 사용합니다. |
+| med | 중앙값입니다. 요청의 절반은 이 값보다 빠르고 절반은 느립니다. |
+| p90 | 90% 요청이 이 값 이하로 완료됩니다. |
+| p95 | 95% 요청이 이 값 이하로 완료됩니다. 주요 합격 기준입니다. |
+| p99 | 99% 요청이 이 값 이하로 완료됩니다. tail latency 관찰에 사용합니다. |
+| max | 가장 느린 요청 시간입니다. 단일 outlier 여부를 확인할 때 사용합니다. |
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| status is 200 | 2185 pass / 0 fail |
+| has page content array | 2185 pass / 0 fail |
+
+## How To Compare
+
+| Compare Point | What To Look For |
+| --- | --- |
+| p95 | 사용자 대부분이 체감하는 지연 시간 악화 여부 |
+| http_req_failed | 4xx/5xx 또는 check 실패 증가 여부 |
+| http_req_waiting | 서버 처리나 DB 처리 지연 가능성 |
+| Prometheus | 서버 내부 HTTP/custom metric 추세 |
+| Loki | 느린 요청의 traceId와 event 로그 |
+

--- a/monitoring-deploy/k6/scripts/auth/02-nickname-check.js
+++ b/monitoring-deploy/k6/scripts/auth/02-nickname-check.js
@@ -1,44 +1,38 @@
 import http from "k6/http";
 import { check, sleep } from "k6";
-import { BASE_URL, randomEmail, randomSleep } from "../../lib/config.js";
+import { BASE_URL, randomInt, randomSleep } from "../../lib/config.js";
 import { createSummaryHandler } from "../../lib/summary.js";
 
-// ── 팀 Load Profiles 표준 ──
-// PROFILE=smoke | baseline | stress   (기본 baseline)
-// TARGET=30 (worst-case 앵커, __ENV.TARGET 으로 덮어씀)
-// ENV=ec2 면 latency 절대 SLO 를 하드 게이트로 (§0.2)
+// ── 팀 Load Profiles 표준 (01-email-check 과 동일 구조) ──
 const PROFILE = (__ENV.PROFILE || "baseline").toLowerCase();
 const TARGET = Number(__ENV.TARGET || 30);
 
 function buildThresholds() {
     const ENV = __ENV.ENV || "local";
     const base = {
-        http_req_failed: ["rate<0.01"], // 하드 (환경 독립)
-        checks: ["rate>0.99"],          // 하드
+        http_req_failed: ["rate<0.01"],
+        checks: ["rate>0.99"],
     };
     if (ENV === "ec2") {
-        base["http_req_duration{type:read}"] = ["p(95)<500"]; // EC2 에서만 하드
+        base["http_req_duration{type:read}"] = ["p(95)<500"];
     }
     return base;
 }
 
 const PROFILES = {
-    // ① smoke — 기능·스크립트 동작 확인
     smoke: {
         vus: 1,
         iterations: 5,
         thresholds: { http_req_failed: ["rate==0"], checks: ["rate==1.00"] },
     },
-    // ③ baseline — worst-case 30 정상상태 + SLO
     baseline: {
         stages: [
-            { duration: "30s", target: TARGET }, // 점진 워밍
-            { duration: "3m", target: TARGET },  // 정상상태 = 측정 구간
+            { duration: "30s", target: TARGET },
+            { duration: "3m", target: TARGET },
             { duration: "30s", target: 0 },
         ],
         thresholds: buildThresholds(),
     },
-    // ④ stress — 무릎(병목 위치) 탐색
     stress: {
         stages: [
             { duration: "30s", target: 20 },
@@ -48,7 +42,7 @@ const PROFILES = {
             { duration: "30s", target: 100 },
             { duration: "20s", target: 0 },
         ],
-        thresholds: { http_req_failed: ["rate<0.05"] }, // 관찰 위주(느슨)
+        thresholds: { http_req_failed: ["rate<0.05"] },
     },
 };
 
@@ -58,9 +52,9 @@ export const options = Object.assign({}, selectedProfile, {
 });
 
 export default function () {
-    const email = randomEmail();
-    const res = http.get(`${BASE_URL}/api/v1/auth/check/email?email=${email}`, {
-        tags: { type: "read", api: "GET /auth/check/email" }, // §3 게이트와 매칭
+    const nickname = `loadtest_${randomInt(1, 1000000)}`;
+    const res = http.get(`${BASE_URL}/api/v1/auth/check/nickname?nickname=${nickname}`, {
+        tags: { type: "read", api: "GET /auth/check/nickname" },
     });
 
     check(res, {
@@ -71,4 +65,4 @@ export default function () {
     sleep(randomSleep());
 }
 
-export const handleSummary = createSummaryHandler(`01-email-check-${PROFILE}`);
+export const handleSummary = createSummaryHandler(`02-nickname-check-${PROFILE}`);

--- a/monitoring-deploy/k6/scripts/learning/01-student-progress-baseline.js
+++ b/monitoring-deploy/k6/scripts/learning/01-student-progress-baseline.js
@@ -8,10 +8,12 @@
 //   - admin/operator 권한 계정으로 로그인해야 한다.
 //   - COURSE_ID 에 해당하는 강좌에 수강생/강의/문제세트/진행률 데이터가 있어야 병목이 드러난다.
 //
-// 실행 (monitoring/ 에서):
-//   docker compose run --rm -e LOGIN_EMAIL=admin@test.com -e LOGIN_PASSWORD=Test1234! \
-//     -e COURSE_ID=2000 -e RESULT_NAME=learning-student-progress-before \
-//     k6 run -o experimental-prometheus-rw /scripts/learning/01-student-progress-baseline.js
+// 실행 (monitoring-deploy/ 에서):
+//   docker compose run --rm -e BASE_URL=https://codebomba.com \
+//     -e ACCESS_TOKEN=<브라우저에서_복사한_accessToken> \
+//     -e COURSE_ID=2000 -e TARGET=30 -e RESULT_NAME=learning-student-progress-deploy-30vu \
+//     k6 run /scripts/learning/01-student-progress-baseline.js
+//   ⚠️ -o experimental-prometheus-rw 붙이지 마라(배포 키트엔 로컬 prometheus 없음 → 에러).
 
 import http from "k6/http";
 import { check, sleep } from "k6";
@@ -20,11 +22,13 @@ import { login, authCookies } from "../../lib/auth.js";
 import { createSummaryHandler } from "../../lib/summary.js";
 
 const COURSE_ID = __ENV.COURSE_ID || "2000";     // 강좌 아이디가 2000번인 부분에서 테스트를 한다.
+const TARGET = Number(__ENV.TARGET || 30);       // 배포 최소 기준은 30 VU. 필요하면 1 → 5 → 10 → 30 순서로 올린다.
+const ACCESS_TOKEN = __ENV.ACCESS_TOKEN || "";   // 배포 step-up 인증 우회용. 있으면 login() 을 건너뛴다.
 
 export const options = {
     stages: [
-        { duration: "20s", target: 30 },    // VU를 0명에서 30명까지 증가
-        { duration: "40s", target: 30 },    // VU 30명 유지
+        { duration: "20s", target: TARGET },    // VU를 0명에서 TARGET명까지 증가
+        { duration: "40s", target: TARGET },    // TARGET명 유지
         { duration: "10s", target: 0 },
     ],
     thresholds: {
@@ -36,8 +40,11 @@ export const options = {
     summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
 };
 
-// 부하 시작 전 1회만 로그인한다. 로그인 부하는 본 측정에 섞지 않는다.
+// 부하 시작 전 1회만 인증한다. 배포(step-up) 환경에서는 ACCESS_TOKEN 직접 주입을 권장한다.
 export function setup() {
+    if (ACCESS_TOKEN) {
+        return { token: ACCESS_TOKEN };
+    }
     return { token: login() };
 }
 

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/oauth/GoogleOAuthClient.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/oauth/GoogleOAuthClient.java
@@ -4,11 +4,13 @@ import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -20,6 +22,7 @@ import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GoogleOAuthClient {
@@ -32,6 +35,20 @@ public class GoogleOAuthClient {
             .clientConnector(new ReactorClientHttpConnector(
                     HttpClient.create().responseTimeout(Duration.ofSeconds(5))))
             .build();
+
+    /**
+     * 구글 응답 4xx/5xx 를 도메인 예외로 매핑한다.
+     * 업스트림 상태코드/응답본문을 로깅해 4xx(요청 오류) vs 5xx(구글 장애) 원인 추적을 남긴다.
+     */
+    private Mono<? extends Throwable> mapUpstreamError(ClientResponse resp, AuthErrorCode errorCode) {
+        return resp.bodyToMono(String.class)
+                .defaultIfEmpty("")
+                .map(body -> {
+                    log.warn("구글 OAuth 호출 실패 - upstreamStatus={}, mappedCode={}, body={}",
+                            resp.statusCode(), errorCode.getCode(), body);
+                    return new ValidationException(errorCode);
+                });
+    }
 
     /** 구글 동의 화면으로 보낼 authorization URL 생성 */
     public String buildAuthorizationUri(String state) {
@@ -65,8 +82,8 @@ public class GoogleOAuthClient {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .bodyValue(form)
                 .retrieve()
-                .onStatus(HttpStatusCode::isError, resp ->
-                        Mono.error(new ValidationException(AuthErrorCode.OAUTH_TOKEN_EXCHANGE_FAILED)))
+                .onStatus(HttpStatusCode::isError,
+                        resp -> mapUpstreamError(resp, AuthErrorCode.OAUTH_TOKEN_EXCHANGE_FAILED))
                 .bodyToMono(Map.class)
                 .block();
 
@@ -85,8 +102,8 @@ public class GoogleOAuthClient {
                 .uri(g.getUserInfoUri())
                 .headers(h -> h.setBearerAuth(accessToken))
                 .retrieve()
-                .onStatus(HttpStatusCode::isError, resp ->
-                        Mono.error(new ValidationException(AuthErrorCode.OAUTH_USER_INFO_FAILED)))
+                .onStatus(HttpStatusCode::isError,
+                        resp -> mapUpstreamError(resp, AuthErrorCode.OAUTH_USER_INFO_FAILED))
                 .bodyToMono(Map.class)
                 .block();
 

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/oauth/GoogleOAuthClient.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/oauth/GoogleOAuthClient.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.auth.application.dto.OAuthUserInfo;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -12,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 import java.time.Duration;
 
@@ -63,6 +65,8 @@ public class GoogleOAuthClient {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .bodyValue(form)
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        Mono.error(new ValidationException(AuthErrorCode.OAUTH_TOKEN_EXCHANGE_FAILED)))
                 .bodyToMono(Map.class)
                 .block();
 
@@ -81,6 +85,8 @@ public class GoogleOAuthClient {
                 .uri(g.getUserInfoUri())
                 .headers(h -> h.setBearerAuth(accessToken))
                 .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        Mono.error(new ValidationException(AuthErrorCode.OAUTH_USER_INFO_FAILED)))
                 .bodyToMono(Map.class)
                 .block();
 

--- a/src/main/java/com/wanted/codebombalms/course/application/port/CourseThumbnailStoragePort.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/port/CourseThumbnailStoragePort.java
@@ -9,6 +9,8 @@ public interface CourseThumbnailStoragePort {
             byte[] imageBytes
     );
 
+    void delete(String thumbnailUrl);
+
     record StoredCourseThumbnail(
             String originalFileName,
             String objectName,

--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.course.application.command.UpdateCourseCommand;
 import com.wanted.codebombalms.course.application.policy.CourseAuthorPolicy;
 import com.wanted.codebombalms.course.application.policy.CourseCategoryPolicy;
 import com.wanted.codebombalms.course.application.policy.CoursePublishPolicy;
+import com.wanted.codebombalms.course.application.port.CourseThumbnailStoragePort;
 import com.wanted.codebombalms.course.application.port.LectureManagementPort;
 import com.wanted.codebombalms.course.application.usecase.CourseCommandUseCase;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
@@ -34,6 +35,7 @@ public class CourseCommandService implements CourseCommandUseCase {
     private final CourseCategoryPolicy courseCategoryPolicy;
     private final CoursePublishPolicy coursePublishPolicy;
     private final LectureManagementPort lectureManagementPort;
+    private final CourseThumbnailStoragePort courseThumbnailStoragePort;
 
     @LogBusiness
     @LogPerformance
@@ -113,6 +115,7 @@ public class CourseCommandService implements CourseCommandUseCase {
         lectureManagementPort.deleteLecturesByCourseId(courseId);
         course.delete();
         courseRepository.save(course);
+        courseThumbnailStoragePort.delete(course.getThumbnailUrl());
 
         log.info("[CourseCommandService] deleted course - courseId: {}", courseId);
     }

--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -115,9 +117,33 @@ public class CourseCommandService implements CourseCommandUseCase {
         lectureManagementPort.deleteLecturesByCourseId(courseId);
         course.delete();
         courseRepository.save(course);
-        courseThumbnailStoragePort.delete(course.getThumbnailUrl());
+        deleteThumbnailAfterCommit(course.getThumbnailUrl());
 
         log.info("[CourseCommandService] deleted course - courseId: {}", courseId);
+    }
+
+    private void deleteThumbnailAfterCommit(String thumbnailUrl) {
+        runAfterCommit(() -> {
+            try {
+                courseThumbnailStoragePort.delete(thumbnailUrl);
+            } catch (RuntimeException e) {
+                log.warn("Failed to delete course thumbnail after course deletion. thumbnailUrl={}", thumbnailUrl, e);
+            }
+        });
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            task.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                task.run();
+            }
+        });
     }
 
     private void validateStatusChange(CourseStatus requestedStatus, CourseStatus currentStatus) {

--- a/src/main/java/com/wanted/codebombalms/course/domain/exception/CourseErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/course/domain/exception/CourseErrorCode.java
@@ -23,7 +23,8 @@ public enum CourseErrorCode implements ErrorCode {
     COURSE_PROBLEM_LECTURE_NOT_FOUND("CRS-013", "선택한 강좌에 존재하지 않는 강의입니다."),
     COURSE_FINAL_PROBLEM_LECTURE_NOT_ALLOWED("CRS-014", "FINAL 문제 단계에는 강의를 지정할 수 없습니다."),
     COURSE_THUMBNAIL_INVALID_FILE("CRS-015", "올바른 강좌 썸네일 이미지 파일이 아닙니다."),
-    COURSE_THUMBNAIL_UPLOAD_FAILED("CRS-016", "강좌 썸네일 이미지 업로드에 실패했습니다.");
+    COURSE_THUMBNAIL_UPLOAD_FAILED("CRS-016", "강좌 썸네일 이미지 업로드에 실패했습니다."),
+    COURSE_THUMBNAIL_DELETE_FAILED("CRS-017", "강좌 썸네일 이미지 삭제에 실패했습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
@@ -5,11 +5,16 @@ import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePo
 import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class LectureManagementAdapter implements LectureManagementPort {
 
     private final LectureRepository lectureRepository;
@@ -18,22 +23,48 @@ public class LectureManagementAdapter implements LectureManagementPort {
 
     @Override
     public void deleteLecturesByCourseId(Long courseId) {
-        lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId)
-                .forEach(lecture -> {
-                    deleteMaterialsByLectureId(lecture.getLectureId());
-                    lecture.delete();
-                    lectureRepository.save(lecture);
-                });
-    }
+        var lectures = lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId);
+        var lectureIds = lectures.stream()
+                .map(lecture -> lecture.getLectureId())
+                .toList();
 
-    private void deleteMaterialsByLectureId(Long lectureId) {
-        lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
-                .forEach(this::deleteMaterial);
+        if (!lectureIds.isEmpty()) {
+            lectureMaterialRepository.findByLectureIdInAndDeletedAtIsNull(lectureIds)
+                    .forEach(this::deleteMaterial);
+        }
+
+        lectures.forEach(lecture -> {
+            lecture.delete();
+            lectureRepository.save(lecture);
+        });
     }
 
     private void deleteMaterial(LectureMaterial material) {
+        String filePath = material.getFilePath();
         material.delete();
         lectureMaterialRepository.save(material);
-        lectureMaterialStoragePort.delete(material.getFilePath());
+        runAfterCommit(() -> deleteMaterialFileQuietly(filePath));
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            task.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                task.run();
+            }
+        });
+    }
+
+    private void deleteMaterialFileQuietly(String filePath) {
+        try {
+            lectureMaterialStoragePort.delete(filePath);
+        } catch (RuntimeException e) {
+            log.warn("Failed to delete lecture material file after course deletion. filePath={}", filePath, e);
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapter.java
@@ -1,6 +1,9 @@
 package com.wanted.codebombalms.course.infrastructure.lecture;
 
 import com.wanted.codebombalms.course.application.port.LectureManagementPort;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -10,13 +13,27 @@ import org.springframework.stereotype.Component;
 public class LectureManagementAdapter implements LectureManagementPort {
 
     private final LectureRepository lectureRepository;
+    private final LectureMaterialRepository lectureMaterialRepository;
+    private final LectureMaterialStoragePort lectureMaterialStoragePort;
 
     @Override
     public void deleteLecturesByCourseId(Long courseId) {
         lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId)
                 .forEach(lecture -> {
+                    deleteMaterialsByLectureId(lecture.getLectureId());
                     lecture.delete();
                     lectureRepository.save(lecture);
                 });
+    }
+
+    private void deleteMaterialsByLectureId(Long lectureId) {
+        lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
+                .forEach(this::deleteMaterial);
+    }
+
+    private void deleteMaterial(LectureMaterial material) {
+        material.delete();
+        lectureMaterialRepository.save(material);
+        lectureMaterialStoragePort.delete(material.getFilePath());
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/persistence/SpringDataCourseRepository.java
@@ -70,6 +70,7 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
         }
         if (!lectureIds.isEmpty()) {
             deleteLectureProgressesByLectureIds(lectureIds);
+            deleteLectureMaterialsByLectureIds(lectureIds);
         }
 
         deleteLectureProblemSetsByCourseIds(courseIds);
@@ -124,6 +125,13 @@ public interface SpringDataCourseRepository extends JpaRepository<CourseJpaEntit
             where p.lectureId in :lectureIds
             """)
     int deleteLectureProgressesByLectureIds(@Param("lectureIds") List<Long> lectureIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            delete from LectureMaterialJpaEntity m
+            where m.lectureId in :lectureIds
+            """)
+    int deleteLectureMaterialsByLectureIds(@Param("lectureIds") List<Long> lectureIds);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
@@ -123,10 +123,16 @@ public class GcsCourseThumbnailStorageAdapter implements CourseThumbnailStorageP
                 return null;
             }
 
-            return URLDecoder.decode(
+            String objectName = URLDecoder.decode(
                     path.substring(bucketPrefix.length()),
                     StandardCharsets.UTF_8
             );
+            String thumbnailPrefix = normalizePrefix(properties.getStorage().getCourseThumbnailPrefix());
+            if (!thumbnailPrefix.isBlank() && !objectName.startsWith(thumbnailPrefix + "/")) {
+                return null;
+            }
+
+            return objectName;
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapter.java
@@ -9,6 +9,8 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServ
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
+import java.net.URI;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -80,6 +82,53 @@ public class GcsCourseThumbnailStorageAdapter implements CourseThumbnailStorageP
                     CourseErrorCode.COURSE_THUMBNAIL_UPLOAD_FAILED,
                     e
             );
+        }
+    }
+
+    @Override
+    public void delete(String thumbnailUrl) {
+        String objectName = extractObjectName(thumbnailUrl);
+        if (objectName == null || objectName.isBlank()) {
+            return;
+        }
+
+        try {
+            getStorage().delete(
+                    BlobId.of(
+                            properties.getStorage().getBucket(),
+                            objectName
+                    )
+            );
+        } catch (Exception e) {
+            throw new ExternalServiceException(
+                    CourseErrorCode.COURSE_THUMBNAIL_DELETE_FAILED,
+                    e
+            );
+        }
+    }
+
+    private String extractObjectName(String thumbnailUrl) {
+        if (thumbnailUrl == null || thumbnailUrl.isBlank()) {
+            return null;
+        }
+
+        try {
+            URI uri = URI.create(thumbnailUrl);
+            String expectedHost = "storage.googleapis.com";
+            String bucket = properties.getStorage().getBucket();
+            String path = uri.getPath();
+            String bucketPrefix = "/" + bucket + "/";
+
+            if (!expectedHost.equals(uri.getHost()) || path == null || !path.startsWith(bucketPrefix)) {
+                return null;
+            }
+
+            return URLDecoder.decode(
+                    path.substring(bucketPrefix.length()),
+                    StandardCharsets.UTF_8
+            );
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/JpaAuditingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/JpaAuditingConfig.java
@@ -1,9 +1,20 @@
 package com.wanted.codebombalms.global.infrastructure.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "auditingDateTimeProvider")
 public class JpaAuditingConfig {
+
+    @Bean
+    public DateTimeProvider auditingDateTimeProvider(Clock clock) {
+        return () -> Optional.of(LocalDateTime.now(clock));
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureMaterialRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureMaterialRepository.java
@@ -10,5 +10,7 @@ public interface LectureMaterialRepository {
 
     List<LectureMaterial> findByLectureIdAndDeletedAtIsNull(Long lectureId);
 
+    List<LectureMaterial> findByLectureIdInAndDeletedAtIsNull(List<Long> lectureIds);
+
     Optional<LectureMaterial> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureMaterialRepositoryAdapter.java
@@ -39,6 +39,15 @@ public class LectureMaterialRepositoryAdapter implements LectureMaterialReposito
     }
 
     @Override
+    public List<LectureMaterial> findByLectureIdInAndDeletedAtIsNull(List<Long> lectureIds) {
+        return springDataLectureMaterialRepository
+                .findByLectureIdInAndDeletedAtIsNull(lectureIds)
+                .stream()
+                .map(LectureMaterialJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public Optional<LectureMaterial> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId) {
         return springDataLectureMaterialRepository.findByLectureMaterialIdAndDeletedAtIsNull(lectureMaterialId)
                 .map(LectureMaterialJpaEntity::toDomain);

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureMaterialRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureMaterialRepository.java
@@ -8,5 +8,7 @@ public interface SpringDataLectureMaterialRepository extends JpaRepository<Lectu
 
     List<LectureMaterialJpaEntity> findByLectureIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long lectureId);
 
+    List<LectureMaterialJpaEntity> findByLectureIdInAndDeletedAtIsNull(List<Long> lectureIds);
+
     Optional<LectureMaterialJpaEntity> findByLectureMaterialIdAndDeletedAtIsNull(Long lectureMaterialId);
 }

--- a/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/port/RecordRewardMetricsPort.java
@@ -6,7 +6,7 @@ public interface RecordRewardMetricsPort {
 
     void recordProcessed(ProcessResult result);
 
-    void recordProcess(long elapsedNanos);
+    void recordProcess(ProcessResult result, long elapsedNanos);
 
     void updatePending(long pendingCount);
 

--- a/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskService.java
@@ -16,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -96,10 +98,44 @@ public class PointRewardTaskService
             throw e;
         } finally {
             if (result != null) {
-                rewardMetrics.recordProcessed(result);
+                recordMetricsAfterTransaction(
+                        result,
+                        System.nanoTime() - startedAtNanos
+                );
             }
-            rewardMetrics.recordProcess(System.nanoTime() - startedAtNanos);
         }
+    }
+
+    private void recordMetricsAfterTransaction(
+            ProcessResult result,
+            long elapsedNanos
+    ) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            rewardMetrics.recordProcessed(result);
+            rewardMetrics.recordProcess(result, elapsedNanos);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCompletion(int status) {
+                        ProcessResult finalResult = status == STATUS_COMMITTED
+                                ? result
+                                : rollbackResult(result);
+
+                        rewardMetrics.recordProcessed(finalResult);
+                        rewardMetrics.recordProcess(finalResult, elapsedNanos);
+                    }
+                }
+        );
+    }
+
+    private ProcessResult rollbackResult(ProcessResult result) {
+        return switch (result) {
+            case NOT_FOUND, ERROR -> result;
+            default -> ProcessResult.ERROR;
+        };
     }
 
     private ProcessResult processPendingTask(

--- a/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetrics.java
@@ -17,8 +17,8 @@ public class RewardMetrics implements RecordRewardMetricsPort {
 
     private final Counter scheduledCounter;
     private final Map<ProcessResult, Counter> processedCounters;
-    private final Timer processTimer;
     private final AtomicLong pendingTasks = new AtomicLong();
+    private final Map<ProcessResult, Timer> processTimers;
 
     public RewardMetrics(MeterRegistry registry) {
         this.scheduledCounter = Counter.builder("reward_point_task_scheduled")
@@ -36,10 +36,6 @@ public class RewardMetrics implements RecordRewardMetricsPort {
             );
         }
 
-        this.processTimer = Timer.builder("reward_point_task_process_duration")
-                .description("Point reward task processing duration")
-                .register(registry);
-
         Gauge.builder(
                         "reward_point_task_pending",
                         pendingTasks,
@@ -47,6 +43,16 @@ public class RewardMetrics implements RecordRewardMetricsPort {
                 )
                 .description("Current pending point reward task count")
                 .register(registry);
+        this.processTimers = new EnumMap<>(ProcessResult.class);
+        for (ProcessResult result : ProcessResult.values()) {
+            processTimers.put(
+                    result,
+                    Timer.builder("reward_point_task_process_duration")
+                            .description("Point reward task processing duration")
+                            .tag("result", result.tagValue())
+                            .register(registry)
+            );
+        }
     }
 
     @Override
@@ -59,13 +65,14 @@ public class RewardMetrics implements RecordRewardMetricsPort {
         processedCounters.get(result).increment();
     }
 
-    @Override
-    public void recordProcess(long elapsedNanos) {
-        processTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
-    }
 
     @Override
     public void updatePending(long pendingCount) {
         pendingTasks.set(Math.max(pendingCount, 0));
+    }
+
+    @Override
+    public void recordProcess(ProcessResult result, long elapsedNanos) {
+        processTimers.get(result).record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
@@ -26,33 +26,32 @@ public class UpdateMyInfoService implements UpdateMyInfoUseCase {
 
     @Override
     public UpdateMyInfoResult update(Long userId, String nickname, String phone) {
-        // 0. 재인증 게이트 — verify-password 통과 도장 없으면 거부 (403 USR-011)
-        if (!profileEditVerificationRepository.isVerified(userId)) {
-            throw new ForbiddenException(UserErrorCode.USER_REVERIFICATION_REQUIRED);
-        }
-
         // 1. 본인 조회 (없으면 USER_NOT_FOUND)
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
 
-        // 2. 닉네임 변경 감지 + 중복 검사 (기존 닉네임과 다를 때만)
+        // 2. 재인증 게이트 — LOCAL 계정만 적용 (소셜 계정은 비밀번호가 없어 재인증 불가 → 스킵)
+        if (!user.isSocialAccount() && !profileEditVerificationRepository.isVerified(userId)) {
+            throw new ForbiddenException(UserErrorCode.USER_REVERIFICATION_REQUIRED);
+        }
+
+        // 3. 닉네임 변경 감지 + 중복 검사 (기존 닉네임과 다를 때만)
         boolean nicknameChanged = nickname != null && !nickname.equals(user.getNickname());
         if (nicknameChanged && userRepository.existsByNickname(nickname)) {
             throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED);
         }
 
-        // 3. 부분 수정 적용 (전달된 필드만) + 즉시 flush
+        // 4. 부분 수정 적용 (전달된 필드만) + 즉시 flush
         user.updateProfile(nickname, phone);
         try {
             userRepository.saveAndFlush(user); // 즉시 flush — 제약 위반을 이 자리에서 포착
         } catch (DataIntegrityViolationException e) {
-            // 사전 체크 통과했어도 동시성 레이스로 닉네임 unique 충돌 가능 → 닉네임 중복으로 정밀 매핑
             throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED);
         }
 
         log.info("개인정보 수정 완료 - userId={}, nicknameChanged={}", userId, nicknameChanged);
 
-        // 4. 토큰 재발급 판단용 정보 반환
+        // 5. 토큰 재발급 판단용 정보 반환
         return new UpdateMyInfoResult(nicknameChanged, user.getNickname(), user.getRole());
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UpdateMyInfoService.java
@@ -46,7 +46,8 @@ public class UpdateMyInfoService implements UpdateMyInfoUseCase {
         try {
             userRepository.saveAndFlush(user); // 즉시 flush — 제약 위반을 이 자리에서 포착
         } catch (DataIntegrityViolationException e) {
-            throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED);
+            // 사전 체크 통과했어도 동시성 레이스로 닉네임 unique 충돌 가능 → 닉네임 중복으로 정밀 매핑 (원인 보존)
+            throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED, e);
         }
 
         log.info("개인정보 수정 완료 - userId={}, nicknameChanged={}", userId, nicknameChanged);

--- a/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
@@ -40,8 +40,10 @@ public class WithdrawUserService implements WithdrawUserUseCase {
                 throw new ValidationException(UserErrorCode.USER_WITHDRAW_CONFIRM_MISMATCH);
             }
         } else {
-            // LOCAL 계정: 비밀번호 재확인 (불일치 시 400 AUT-013)
-            if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+            // LOCAL 계정: 비밀번호 필수 + 재확인
+            // null/blank 를 먼저 400 으로 정리 (BCrypt matches(null,...) IllegalArgument → 500 방지)
+            if (rawPassword == null || rawPassword.isBlank()
+                    || !passwordEncoder.matches(rawPassword, user.getPassword())) {
                 throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_MISMATCH);
             }
         }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
@@ -20,19 +20,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class WithdrawUserService implements WithdrawUserUseCase {
 
+    // 소셜 계정 탈퇴 확인 문구 (비밀번호 대체)
+    private static final String WITHDRAW_CONFIRM_PHRASE = "탈퇴하겠습니다";
+
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
-    public void withdraw(Long userId, String rawPassword) {
+    public void withdraw(Long userId, String rawPassword, String confirmText) {
         // 1. 본인 조회 (없으면 USER_NOT_FOUND)
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
 
-        // 2. 비밀번호 재확인 (불일치 시 400 AUT-013)
-        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
-            throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_MISMATCH);
+        // 2. 본인 재확인 — 계정 종류별 분기
+        if (user.isSocialAccount()) {
+            // 소셜 계정: 비밀번호가 없으므로 확인 문구로 대체 (불일치 시 400 USR-013)
+            if (!WITHDRAW_CONFIRM_PHRASE.equals(confirmText)) {
+                throw new ValidationException(UserErrorCode.USER_WITHDRAW_CONFIRM_MISMATCH);
+            }
+        } else {
+            // LOCAL 계정: 비밀번호 재확인 (불일치 시 400 AUT-013)
+            if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+                throw new ValidationException(AuthErrorCode.AUTH_PASSWORD_MISMATCH);
+            }
         }
 
         // 3. Soft Delete (deleted_at 기록)
@@ -43,6 +54,7 @@ public class WithdrawUserService implements WithdrawUserUseCase {
         refreshTokenRepository.deleteByUserId(userId);
 
         // 5. 감사 추적 로깅
-        log.info("회원 탈퇴 처리 완료 - userId={}, deletedAt={}", userId, user.getDeletedAt());
+        log.info("회원 탈퇴 처리 완료 - userId={}, social={}, deletedAt={}",
+                userId, user.isSocialAccount(), user.getDeletedAt());
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/WithdrawUserUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/WithdrawUserUseCase.java
@@ -2,5 +2,5 @@ package com.wanted.codebombalms.user.application.usecase;
 
 public interface WithdrawUserUseCase {
 
-    void withdraw(Long userId, String rawPassword);
+    void withdraw(Long userId, String rawPassword, String confirmText);
 }

--- a/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
@@ -29,7 +29,9 @@ public enum UserErrorCode implements ErrorCode {
 
     USER_REVERIFICATION_REQUIRED("USR-011", "비밀번호 재인증이 필요합니다. 다시 인증해주세요."),
 
-    TRUSTED_DEVICE_NOT_FOUND("USR-012", "신뢰 기기를 찾을 수 없습니다.");
+    TRUSTED_DEVICE_NOT_FOUND("USR-012", "신뢰 기기를 찾을 수 없습니다."),
+
+    USER_WITHDRAW_CONFIRM_MISMATCH("USR-013", "탈퇴 확인 문구가 일치하지 않습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/user/domain/model/User.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/model/User.java
@@ -124,6 +124,7 @@ public class User {
     }    public void lock()       { this.isLocked = true; }
     public void unlock()     { this.isLocked = false; }
     public boolean isDeleted() { return this.deletedAt != null; }
+    public boolean isSocialAccount() { return this.provider != AuthProvider.LOCAL; }
 
 
     // ===== 신규 소셜 회원 생성 (구글) =====

--- a/src/main/java/com/wanted/codebombalms/user/domain/model/User.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/model/User.java
@@ -124,8 +124,8 @@ public class User {
     }    public void lock()       { this.isLocked = true; }
     public void unlock()     { this.isLocked = false; }
     public boolean isDeleted() { return this.deletedAt != null; }
-    public boolean isSocialAccount() { return this.provider != AuthProvider.LOCAL; }
-
+    /** 소셜 가입 계정 여부. provider 가 null 이면 소셜로 보지 않음(fail-closed) — 비번 검증 우회 방지 */
+    public boolean isSocialAccount() { return this.provider != null && this.provider != AuthProvider.LOCAL; }
 
     // ===== 신규 소셜 회원 생성 (구글) =====
     public static User createSocialUser(

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/WithdrawUserController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/WithdrawUserController.java
@@ -40,8 +40,8 @@ public class WithdrawUserController {
             @Valid @RequestBody WithdrawUserRequest request,
             HttpServletResponse response
     ) {
-        // 1. 비번 재확인 + Soft Delete + RT 전체 삭제
-        withdrawUserUseCase.withdraw(userId, request.password());
+        // 1. 본인 재확인(LOCAL=비번 / 소셜=확인문구) + Soft Delete + RT 전체 삭제
+        withdrawUserUseCase.withdraw(userId, request.password(), request.confirmText());
 
         // 2. 쿠키 만료
         response.addCookie(authCookieFactory.expired("accessToken"));

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/request/WithdrawUserRequest.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/request/WithdrawUserRequest.java
@@ -1,10 +1,11 @@
 package com.wanted.codebombalms.user.presentation.api.request;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record WithdrawUserRequest(
 
-        @NotBlank(message = "비밀번호는 필수입니다.")
-        String password
+        // LOCAL 계정: 현재 비밀번호 (본인 재확인)
+        String password,
+
+        // 소셜 계정: 확인 문구 ("탈퇴하겠습니다")
+        String confirmText
 ) {
 }

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -6,7 +6,7 @@
 #   - DB_URL / DB_USERNAME / DB_PASSWORD / DDL_AUTO
 #   - REDIS_HOST / REDIS_PORT / REDIS_PASSWORD
 #   - CORS_ALLOWED_ORIGINS / FASTAPI_URL / JWT_SECRET
-#   - MAIL_* / GOOGLE_* / OAUTH_* / COOKIE_SECURE / GCP_*
+#   - MAIL_* / GOOGLE_* / OAUTH_* / COOKIE_SECURE / GCP_* / GOOGLE_APPLICATION_CREDENTIALS
 #
 # 활성화: .env 의 SPRING_PROFILES_ACTIVE=deploy
 #   (base 의 profiles.active=local 을 환경변수 우선순위로 override → local.yml 미로드)

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -268,6 +268,24 @@ class CourseServiceTest {
     }
 
     @Test
+    void deleteCourse_keepsCourseDeleted_whenThumbnailDeleteFails() {
+        Long courseId = 1L;
+        Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.ACTIVE);
+
+        given(courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)).willReturn(Optional.of(course));
+        doThrow(new RuntimeException("thumbnail delete failed"))
+                .when(courseThumbnailStoragePort)
+                .delete("java.png");
+
+        courseCommandService.deleteCourse(courseId);
+
+        assertEquals(CourseStatus.DELETED, course.getStatus());
+        assertNotNull(course.getDeletedAt());
+        verify(courseRepository).save(course);
+        verify(courseThumbnailStoragePort).delete("java.png");
+    }
+
+    @Test
     void publishCourse_activatesDraftCourse() {
         Long courseId = 1L;
         Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.DRAFT);

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.course.application.command.UpdateCourseCommand;
 import com.wanted.codebombalms.course.application.policy.CourseAuthorPolicy;
 import com.wanted.codebombalms.course.application.policy.CourseCategoryPolicy;
 import com.wanted.codebombalms.course.application.policy.CoursePublishPolicy;
+import com.wanted.codebombalms.course.application.port.CourseThumbnailStoragePort;
 import com.wanted.codebombalms.course.application.port.LectureManagementPort;
 import com.wanted.codebombalms.course.application.service.CourseCommandService;
 import com.wanted.codebombalms.course.application.service.CourseQueryService;
@@ -52,6 +53,9 @@ class CourseServiceTest {
 
     @Mock
     private LectureManagementPort lectureManagementPort;
+
+    @Mock
+    private CourseThumbnailStoragePort courseThumbnailStoragePort;
 
     @InjectMocks
     private CourseCommandService courseCommandService;
@@ -238,9 +242,10 @@ class CourseServiceTest {
 
         assertEquals(CourseStatus.DELETED, course.getStatus());
         assertNotNull(course.getDeletedAt());
-        var inOrder = inOrder(lectureManagementPort, courseRepository);
+        var inOrder = inOrder(lectureManagementPort, courseRepository, courseThumbnailStoragePort);
         inOrder.verify(lectureManagementPort).deleteLecturesByCourseId(courseId);
         inOrder.verify(courseRepository).save(course);
+        inOrder.verify(courseThumbnailStoragePort).delete("java.png");
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
@@ -1,0 +1,101 @@
+package com.wanted.codebombalms.course.infrastructure.lecture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
+import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
+import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LectureManagementAdapter unit test")
+class LectureManagementAdapterTest {
+
+    @Mock
+    private LectureRepository lectureRepository;
+
+    @Mock
+    private LectureMaterialRepository lectureMaterialRepository;
+
+    @Mock
+    private LectureMaterialStoragePort lectureMaterialStoragePort;
+
+    @InjectMocks
+    private LectureManagementAdapter lectureManagementAdapter;
+
+    @Test
+    void deleteLecturesByCourseId_deletesLectureMaterialsBeforeLectures() {
+        Long courseId = 1L;
+        Lecture lecture = createLecture(10L, courseId);
+        LectureMaterial material = createMaterial(100L, lecture.getLectureId());
+
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(lecture));
+        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lecture.getLectureId()))
+                .willReturn(List.of(material));
+
+        lectureManagementAdapter.deleteLecturesByCourseId(courseId);
+
+        assertNotNull(material.getDeletedAt());
+        assertEquals(LectureStatus.DELETED, lecture.getStatus());
+        assertNotNull(lecture.getDeletedAt());
+
+        InOrder inOrder = inOrder(
+                lectureMaterialRepository,
+                lectureMaterialStoragePort,
+                lectureRepository
+        );
+        inOrder.verify(lectureMaterialRepository).save(material);
+        inOrder.verify(lectureMaterialStoragePort).delete("lecture_materials/stored-guide.pdf");
+        inOrder.verify(lectureRepository).save(lecture);
+    }
+
+    private Lecture createLecture(Long lectureId, Long courseId) {
+        Course course = new Course();
+        course.setCourseId(courseId);
+
+        return Lecture.restore(
+                lectureId,
+                course,
+                "Java lecture",
+                "description",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "thumbnail.png",
+                null,
+                LectureStatus.ACTIVE,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null,
+                1
+        );
+    }
+
+    private LectureMaterial createMaterial(Long lectureMaterialId, Long lectureId) {
+        return LectureMaterial.restore(
+                lectureMaterialId,
+                lectureId,
+                "guide.pdf",
+                "stored-guide.pdf",
+                "lecture_materials/stored-guide.pdf",
+                "application/pdf",
+                1024L,
+                LocalDateTime.now(),
+                null
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/lecture/LectureManagementAdapterTest.java
@@ -3,7 +3,9 @@ package com.wanted.codebombalms.course.infrastructure.lecture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
@@ -46,7 +48,7 @@ class LectureManagementAdapterTest {
 
         given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
                 .willReturn(List.of(lecture));
-        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lecture.getLectureId()))
+        given(lectureMaterialRepository.findByLectureIdInAndDeletedAtIsNull(List.of(lecture.getLectureId())))
                 .willReturn(List.of(material));
 
         lectureManagementAdapter.deleteLecturesByCourseId(courseId);
@@ -63,6 +65,29 @@ class LectureManagementAdapterTest {
         inOrder.verify(lectureMaterialRepository).save(material);
         inOrder.verify(lectureMaterialStoragePort).delete("lecture_materials/stored-guide.pdf");
         inOrder.verify(lectureRepository).save(lecture);
+    }
+
+    @Test
+    void deleteLecturesByCourseId_keepsLectureDeleted_whenMaterialFileDeleteFails() {
+        Long courseId = 1L;
+        Lecture lecture = createLecture(10L, courseId);
+        LectureMaterial material = createMaterial(100L, lecture.getLectureId());
+
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(lecture));
+        given(lectureMaterialRepository.findByLectureIdInAndDeletedAtIsNull(List.of(lecture.getLectureId())))
+                .willReturn(List.of(material));
+        doThrow(new RuntimeException("material delete failed"))
+                .when(lectureMaterialStoragePort)
+                .delete("lecture_materials/stored-guide.pdf");
+
+        lectureManagementAdapter.deleteLecturesByCourseId(courseId);
+
+        assertNotNull(material.getDeletedAt());
+        assertEquals(LectureStatus.DELETED, lecture.getStatus());
+        assertNotNull(lecture.getDeletedAt());
+        verify(lectureMaterialRepository).save(material);
+        verify(lectureRepository).save(lecture);
     }
 
     private Lecture createLecture(Long lectureId, Long courseId) {

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
@@ -1,9 +1,17 @@
 package com.wanted.codebombalms.course.infrastructure.storage;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -50,5 +58,38 @@ class GcsCourseThumbnailStorageAdapterTest {
                 .isInstanceOf(ValidationException.class)
                 .extracting("errorCode")
                 .isEqualTo(CourseErrorCode.COURSE_THUMBNAIL_INVALID_FILE);
+    }
+
+    @Test
+    void delete_deletesGcsObject_whenUrlBelongsToConfiguredBucket() throws Exception {
+        Storage storage = mock(Storage.class);
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        when(storageClientFactory.create()).thenReturn(storage);
+
+        adapter.delete("https://storage.googleapis.com/codebombalms/course_thumbnail_images/java.png");
+
+        verify(storage).delete(BlobId.of("codebombalms", "course_thumbnail_images/java.png"));
+    }
+
+    @Test
+    void delete_ignoresUrl_whenUrlDoesNotBelongToConfiguredBucket() throws Exception {
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        adapter.delete("https://example.com/images/java.png");
+
+        verify(storageClientFactory, never()).create();
+    }
+
+    private GcpStorageProperties createProperties(String bucket) {
+        GcpStorageProperties properties = new GcpStorageProperties();
+        properties.getStorage().setBucket(bucket);
+        return properties;
     }
 }

--- a/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/infrastructure/storage/GcsCourseThumbnailStorageAdapterTest.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.course.infrastructure.storage;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
@@ -85,6 +87,47 @@ class GcsCourseThumbnailStorageAdapterTest {
         adapter.delete("https://example.com/images/java.png");
 
         verify(storageClientFactory, never()).create();
+    }
+
+    @Test
+    void delete_ignoresUrl_whenObjectIsOutsideCourseThumbnailPrefix() throws Exception {
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        adapter.delete("https://storage.googleapis.com/codebombalms/lecture_materials/guide.pdf");
+
+        verify(storageClientFactory, never()).create();
+    }
+
+    @Test
+    void delete_ignoresMalformedUrl() {
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+
+        assertThatCode(() -> adapter.delete("://not-a-url"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void delete_throwsExternalServiceException_whenStorageDeleteFails() throws Exception {
+        Storage storage = mock(Storage.class);
+        GcpStorageClientFactory storageClientFactory = mock(GcpStorageClientFactory.class);
+        GcpStorageProperties properties = createProperties("codebombalms");
+        GcsCourseThumbnailStorageAdapter adapter =
+                new GcsCourseThumbnailStorageAdapter(properties, storageClientFactory);
+        BlobId blobId = BlobId.of("codebombalms", "course_thumbnail_images/java.png");
+
+        when(storageClientFactory.create()).thenReturn(storage);
+        when(storage.delete(blobId)).thenThrow(new RuntimeException("delete failed"));
+
+        assertThatThrownBy(() -> adapter.delete("https://storage.googleapis.com/codebombalms/course_thumbnail_images/java.png"))
+                .isInstanceOf(ExternalServiceException.class)
+                .extracting("errorCode")
+                .isEqualTo(CourseErrorCode.COURSE_THUMBNAIL_DELETE_FAILED);
     }
 
     private GcpStorageProperties createProperties(String bucket) {

--- a/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -67,7 +68,8 @@ class PointRewardTaskServiceTest {
         assertThat(savedTask.getValue().status())
                 .isEqualTo(PointRewardTaskStatus.COMPLETED);
         verify(rewardMetrics).recordProcessed(ProcessResult.COMPLETED);
-        verify(rewardMetrics).recordProcess(anyLong());
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.COMPLETED), anyLong());
     }
 
     @Test
@@ -88,6 +90,8 @@ class PointRewardTaskServiceTest {
                 .isEqualTo(PointRewardTaskStatus.PENDING);
         assertThat(savedTask.getValue().retryCount()).isEqualTo(1);
         verify(rewardMetrics).recordProcessed(ProcessResult.RETRY);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.RETRY), anyLong());
     }
 
     @Test
@@ -108,6 +112,8 @@ class PointRewardTaskServiceTest {
                 .isEqualTo(PointRewardTaskStatus.FAILED);
         assertThat(savedTask.getValue().retryCount()).isEqualTo(5);
         verify(rewardMetrics).recordProcessed(ProcessResult.FAILED);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.FAILED), anyLong());
     }
 
     @Test
@@ -122,6 +128,8 @@ class PointRewardTaskServiceTest {
                 .grant(10L, 20L, 30L, 100);
         verify(pointRewardTaskRepository, never()).save(any(PointRewardTask.class));
         verify(rewardMetrics).recordProcessed(ProcessResult.SKIPPED);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.SKIPPED), anyLong());
     }
 
     private PointRewardTask task(

--- a/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/application/service/PointRewardTaskServiceTest.java
@@ -12,11 +12,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +30,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class PointRewardTaskServiceTest {
@@ -132,6 +136,50 @@ class PointRewardTaskServiceTest {
                 .recordProcess(eq(ProcessResult.SKIPPED), anyLong());
     }
 
+    @Test
+    void defersCompletedMetricsUntilTransactionCommits() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        initTransactionSynchronization();
+        try {
+            service.process(30L);
+
+            verifyNoInteractions(rewardMetrics);
+
+            completeTransaction(TransactionSynchronization.STATUS_COMMITTED);
+        } finally {
+            clearTransactionSynchronization();
+        }
+
+        verify(rewardMetrics).recordProcessed(ProcessResult.COMPLETED);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.COMPLETED), anyLong());
+    }
+
+    @Test
+    void recordsErrorMetricsWhenTransactionRollsBackAfterCompletedResult() {
+        PointRewardTask task = task(PointRewardTaskStatus.PENDING, 0);
+        given(pointRewardTaskRepository.findBySubmissionIdForUpdate(30L))
+                .willReturn(Optional.of(task));
+
+        initTransactionSynchronization();
+        try {
+            service.process(30L);
+
+            verifyNoInteractions(rewardMetrics);
+
+            completeTransaction(TransactionSynchronization.STATUS_ROLLED_BACK);
+        } finally {
+            clearTransactionSynchronization();
+        }
+
+        verify(rewardMetrics).recordProcessed(ProcessResult.ERROR);
+        verify(rewardMetrics)
+                .recordProcess(eq(ProcessResult.ERROR), anyLong());
+    }
+
     private PointRewardTask task(
             PointRewardTaskStatus status,
             int retryCount
@@ -150,5 +198,26 @@ class PointRewardTaskServiceTest {
                 now,
                 now
         );
+    }
+
+    private void initTransactionSynchronization() {
+        TransactionSynchronizationManager.initSynchronization();
+    }
+
+    private void completeTransaction(int status) {
+        List<TransactionSynchronization> synchronizations =
+                TransactionSynchronizationManager.getSynchronizations();
+
+        assertThat(synchronizations).hasSize(1);
+
+        synchronizations.forEach(
+                synchronization -> synchronization.afterCompletion(status)
+        );
+    }
+
+    private void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 }

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
@@ -16,33 +16,28 @@ class RewardMetricsTest {
         RewardMetrics metrics = new RewardMetrics(registry);
 
         metrics.recordScheduled();
-        metrics.recordProcessed(ProcessResult.COMPLETED);
-        metrics.recordProcessed(ProcessResult.RETRY);
-        metrics.recordProcessed(ProcessResult.FAILED);
-        metrics.recordProcess(
-                ProcessResult.COMPLETED,
-                TimeUnit.MILLISECONDS.toNanos(250)
-        );
+        for (ProcessResult result : ProcessResult.values()) {
+            metrics.recordProcessed(result);
+            metrics.recordProcess(
+                    result,
+                    TimeUnit.MILLISECONDS.toNanos(durationMillis(result))
+            );
+        }
         metrics.updatePending(7);
 
         assertThat(registry.get("reward_point_task_scheduled").counter().count())
                 .isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_processed")
-                .tag("result", "completed")
-                .counter()
-                .count()).isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_processed")
-                .tag("result", "retry")
-                .counter()
-                .count()).isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_processed")
-                .tag("result", "failed")
-                .counter()
-                .count()).isEqualTo(1.0);
-        assertThat(registry.get("reward_point_task_process_duration")
-                .tag("result", "completed")
-                .timer()
-                .totalTime(TimeUnit.MILLISECONDS)).isEqualTo(250.0);
+        for (ProcessResult result : ProcessResult.values()) {
+            assertThat(registry.get("reward_point_task_processed")
+                    .tag("result", result.tagValue())
+                    .counter()
+                    .count()).isEqualTo(1.0);
+            assertThat(registry.get("reward_point_task_process_duration")
+                    .tag("result", result.tagValue())
+                    .timer()
+                    .totalTime(TimeUnit.MILLISECONDS))
+                    .isEqualTo((double) durationMillis(result));
+        }
         assertThat(registry.get("reward_point_task_pending").gauge().value())
                 .isEqualTo(7.0);
     }
@@ -56,5 +51,9 @@ class RewardMetricsTest {
 
         assertThat(registry.get("reward_point_task_pending").gauge().value())
                 .isZero();
+    }
+
+    private long durationMillis(ProcessResult result) {
+        return 100L + result.ordinal();
     }
 }

--- a/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
+++ b/src/test/java/com/wanted/codebombalms/reward/point/infrastructure/metrics/RewardMetricsTest.java
@@ -19,7 +19,10 @@ class RewardMetricsTest {
         metrics.recordProcessed(ProcessResult.COMPLETED);
         metrics.recordProcessed(ProcessResult.RETRY);
         metrics.recordProcessed(ProcessResult.FAILED);
-        metrics.recordProcess(TimeUnit.MILLISECONDS.toNanos(250));
+        metrics.recordProcess(
+                ProcessResult.COMPLETED,
+                TimeUnit.MILLISECONDS.toNanos(250)
+        );
         metrics.updatePending(7);
 
         assertThat(registry.get("reward_point_task_scheduled").counter().count())
@@ -37,6 +40,7 @@ class RewardMetricsTest {
                 .counter()
                 .count()).isEqualTo(1.0);
         assertThat(registry.get("reward_point_task_process_duration")
+                .tag("result", "completed")
                 .timer()
                 .totalTime(TimeUnit.MILLISECONDS)).isEqualTo(250.0);
         assertThat(registry.get("reward_point_task_pending").gauge().value())

--- a/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
@@ -49,8 +49,18 @@ class WithdrawUserServiceTest {
         );
     }
 
+    private User socialUser() {
+        return User.restore(
+                2L, UserRole.STUDENT, "g01@gmail.com", null,     // 소셜은 비밀번호 없음
+                "김구글", "구글01", "010-2222-3333",
+                AuthProvider.GOOGLE, "google-sub-123",
+                true, false, null, null,
+                LocalDateTime.now(), LocalDateTime.now(), null
+        );
+    }
+
     @Test
-    @DisplayName("비밀번호가 일치하면 softDelete 후 저장하고 Refresh Token을 전부 삭제한다.")
+    @DisplayName("[LOCAL] 비밀번호가 일치하면 softDelete 후 저장하고 Refresh Token을 전부 삭제한다.")
     void 탈퇴_성공() {
         // given
         User user = activeUser();
@@ -58,7 +68,7 @@ class WithdrawUserServiceTest {
         given(passwordEncoder.matches("Test1234!", "ENCODED_PW")).willReturn(true);
 
         // when
-        withdrawUserService.withdraw(1L, "Test1234!");
+        withdrawUserService.withdraw(1L, "Test1234!", null);
 
         // then — softDelete 반영된 User가 저장되는지 캡처해서 검증
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
@@ -68,7 +78,7 @@ class WithdrawUserServiceTest {
     }
 
     @Test
-    @DisplayName("비밀번호가 불일치하면 ValidationException(AUTH_PASSWORD_MISMATCH)을 던지고, 저장/RT삭제는 일어나지 않는다.")
+    @DisplayName("[LOCAL] 비밀번호가 불일치하면 ValidationException(AUTH_PASSWORD_MISMATCH)을 던지고, 저장/RT삭제는 일어나지 않는다.")
     void 비밀번호_불일치_예외() {
         // given
         User user = activeUser();
@@ -78,9 +88,44 @@ class WithdrawUserServiceTest {
         // when & then
         ValidationException ex = assertThrows(
                 ValidationException.class,
-                () -> withdrawUserService.withdraw(1L, "wrong")
+                () -> withdrawUserService.withdraw(1L, "wrong", null)
         );
         assertEquals(AuthErrorCode.AUTH_PASSWORD_MISMATCH, ex.getErrorCode());
+
+        verify(userRepository, never()).save(any());
+        verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
+    }
+
+    @Test
+    @DisplayName("[소셜] 확인 문구가 '탈퇴하겠습니다' 와 일치하면 비밀번호 검증 없이 탈퇴에 성공한다.")
+    void 소셜_탈퇴_성공() {
+        // given
+        User user = socialUser();
+        given(userRepository.findByUserId(2L)).willReturn(Optional.of(user));
+
+        // when
+        withdrawUserService.withdraw(2L, null, "탈퇴하겠습니다");
+
+        // then
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertTrue(captor.getValue().isDeleted(), "deleted_at 이 채워져야 한다");
+        verify(refreshTokenRepository).deleteByUserId(2L);
+    }
+
+    @Test
+    @DisplayName("[소셜] 확인 문구가 불일치하면 ValidationException(USER_WITHDRAW_CONFIRM_MISMATCH)을 던지고, 저장/RT삭제는 일어나지 않는다.")
+    void 소셜_확인문구_불일치_예외() {
+        // given
+        User user = socialUser();
+        given(userRepository.findByUserId(2L)).willReturn(Optional.of(user));
+
+        // when & then
+        ValidationException ex = assertThrows(
+                ValidationException.class,
+                () -> withdrawUserService.withdraw(2L, null, "탈퇴할래요")
+        );
+        assertEquals(UserErrorCode.USER_WITHDRAW_CONFIRM_MISMATCH, ex.getErrorCode());
 
         verify(userRepository, never()).save(any());
         verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
@@ -95,7 +140,7 @@ class WithdrawUserServiceTest {
         // when & then
         NotFoundException ex = assertThrows(
                 NotFoundException.class,
-                () -> withdrawUserService.withdraw(99L, "Test1234!")
+                () -> withdrawUserService.withdraw(99L, "Test1234!", null)
         );
         assertEquals(UserErrorCode.USER_NOT_FOUND, ex.getErrorCode());
 


### PR DESCRIPTION
# 🚀 Backend Release Pull Request

> PR 제목은 반드시 `[Release] vX.Y.Z` 형식으로 작성해주세요.
>
> 예시: `[Release] v1.2.0`
>
> Release PR이 `main`에 머지되면 GitHub Actions가 PR 제목의 버전을 기준으로 태그와 GitHub Release를 생성합니다.

## 📌 릴리즈 정보

| 항목 | 내용 |
|------|------|
| **버전** | `v1.3.0 → v1.4.0` |
| **릴리즈 날짜** | 2026-07-01 |
| **기준 브랜치** | `develop` |
| **병합 브랜치** | `main` |
| **배포 환경** | `EC2 / Docker Compose / ECR / SSM / RDS / Redis / GCP Storage` |

---

# 📖 릴리즈 요약

> 이번 릴리즈에서 추가되거나 변경된 주요 백엔드 내용을 간략하게 작성해주세요.

- 소셜 계정 회원탈퇴 확인 문구 처리와 개인정보 수정 재인증 분기 로직을 보완했습니다.
- 강좌 삭제 시 강좌 썸네일 및 강의 자료 파일 정리 흐름을 추가했습니다.
- Google OAuth 오류 로깅, 보상 포인트 메트릭 result 태그, 운영 GCP 인증 경로 설정을 보완했습니다.
- 배포 환경 k6 부하 테스트 스크립트와 결과 리포트를 추가했습니다.

---

# 📋 릴리즈 노트

## Auth / User

### Added

- 소셜 계정 회원탈퇴 시 비밀번호 대신 확인 문구(`confirmText`)로 본인 확인하는 흐름을 추가했습니다.
- 회원탈퇴 확인 문구 불일치 에러 코드 `USR-013`을 추가했습니다.

### Changed

- 개인정보 수정 재인증 게이트를 LOCAL 계정에만 적용하도록 변경했습니다.
- Google OAuth 토큰 교환/사용자 정보 조회 실패 시 upstream 상태와 응답 본문을 로깅하도록 보완했습니다.
- `DELETE /api/v1/users/me` 요청 바디가 계정 유형별 확인값을 받을 수 있도록 변경되었습니다.

### Fixed

- 소셜 계정에서 비밀번호가 없어 개인정보 수정 또는 회원탈퇴가 막히는 문제를 보완했습니다.
- LOCAL 계정 회원탈퇴 시 비밀번호 누락/blank 입력이 500으로 번지지 않도록 검증을 보완했습니다.

---

## Course / Lecture / Enrollment / Learning

### Added

- 강좌 삭제 후 GCS 강좌 썸네일 파일 삭제 처리를 추가했습니다.
- 강좌 삭제 시 연결된 강의 자료 파일도 트랜잭션 커밋 후 정리하도록 보완했습니다.
- 강의 자료를 lectureId 목록으로 조회하는 repository 메서드를 추가했습니다.

### Changed

- 강좌 삭제 트랜잭션 커밋 이후 외부 스토리지 삭제를 수행하도록 처리 순서를 분리했습니다.
- JPA Auditing 기준 시간을 주입된 `Clock` 기반 `DateTimeProvider`로 변경했습니다.

### Fixed

- 강좌 삭제 후 썸네일/강의 자료 스토리지 파일이 남을 수 있는 문제를 보완했습니다.

---

## Problem / Submission / Ranking / Badge / Recommendation

### Added

- 없음

### Changed

- 보상 포인트 작업 처리 duration 메트릭에 `result` 태그를 추가했습니다.
- 트랜잭션 완료 상태에 따라 보상 포인트 처리 결과 메트릭이 기록되도록 변경했습니다.

### Fixed

- 보상 포인트 작업이 롤백된 경우에도 성공성 메트릭으로 기록될 수 있는 문제를 보완했습니다.

---

## Admin / Monitoring / Deploy

### Added

- 배포 환경 학습 진행률 k6 테스트 결과 리포트를 추가했습니다.
- 닉네임 중복 확인 k6 스크립트를 추가했습니다.
- Spring 컨테이너 기본 GCP 인증 경로 `GOOGLE_APPLICATION_CREDENTIALS` 설정을 추가했습니다.

### Changed

- `monitoring-deploy/k6/results/` 경로를 `.gitignore`에 추가했습니다.
- 배포용 `application-deploy.yml` 환경변수 주석에 `GOOGLE_APPLICATION_CREDENTIALS`를 추가했습니다.

### Fixed

- GCP Storage 인증 파일 경로가 컨테이너 내부에서 기본 ADC 경로로 잡히지 않을 수 있는 문제를 보완했습니다.

---

# 🔌 API / DB / 환경변수 변경 사항

## API 변경

- [ ] 없음
- [x] 있음

| 구분 | Method | URL | 변경 내용 | 프론트 영향 |
|------|--------|-----|----------|------------|
| 변경 | `DELETE` | `/api/v1/users/me` | 요청 바디가 `password` 단일 필수값에서 `password`, `confirmText` 계정 유형별 확인값 구조로 변경 | 있음 |
| 추가 | `DELETE` | `/api/v1/users/me` | 소셜 계정 탈퇴 확인 문구 불일치 에러 `USR-013` 추가 | 있음 |

## DB 변경

- [x] 없음
- [ ] 있음

변경 내용:

- Entity / schema / migration 파일 변경 없음
- 삭제 처리용 repository query 보완은 있으나 DB 스키마 변경은 없음

## 환경변수 / Secrets 변경

- [ ] 없음
- [x] 있음

변경 내용:

- `GOOGLE_APPLICATION_CREDENTIALS` 추가
- 기본값: `/app/secrets/gcp-storage-key.json`
- 실제 Secret 값은 PR 본문에 작성하지 않음

운영 반영 필요 여부:

- [ ] 없음
- [ ] GitHub Secrets 변경 필요
- [x] EC2 `.env` 변경 필요
- [ ] SSM Parameter Store 변경 필요

> Secret 값은 PR에 작성하지 않고, 키 이름과 반영 위치만 작성합니다.

---

# 🧪 릴리즈 체크리스트

- [x] `develop` 브랜치의 최신 코드가 반영되었습니다.
- [x] `develop → main` 방향의 Release PR입니다.
- [ ] GitHub Actions CI build가 통과했습니다.
- [ ] 로컬 또는 테스트 환경에서 `./gradlew build`를 확인했습니다.
- [ ] 주요 API 및 도메인 기능 테스트를 완료했습니다.
- [ ] 인증/인가가 필요한 API의 권한 검증을 확인했습니다.
- [ ] API 변경사항이 Swagger 또는 `.ai/API.md`에 반영되었습니다.
- [x] DB 스키마 / 시드 데이터 변경사항을 확인했습니다.
- [x] 운영 환경변수 또는 Secrets 변경사항을 확인했습니다.
- [x] 환경변수 / Secrets 키 추가·변경·삭제 여부를 확인했습니다.
- [x] 변경이 있는 경우 GitHub Secrets / EC2 `.env` / SSM Parameter Store 반영 대상을 확인했습니다.
- [x] Secret 값은 PR 본문에 노출하지 않았습니다.
- [x] Docker / EC2 배포 설정 변경사항을 확인했습니다.
- [ ] Merge Conflict가 없습니다.
- [x] 릴리즈 노트를 작성했습니다.
- [x] main 머지 후 생성할 Git Tag 버전을 확인했습니다.

---

# 🏷 버전 정보

| 이전 버전 | 변경 버전 | 버전 변경 유형 |
|----------|----------|----------------|
| `v1.3.0` | `v1.4.0` | `MINOR` |

### 버전 변경 사유

- **MINOR**: 소셜 계정 탈퇴 지원, 강좌/강의 자료 스토리지 정리, 운영 GCP 인증 경로, 모니터링/메트릭 개선이 포함되었습니다.
- 회원탈퇴 요청 바디 변경이 있으므로 프론트 연동 확인이 필요합니다.

---

# 📦 Git Tag

> 태그는 Release PR이 `main`에 머지된 후, `main` 브랜치 기준으로만 생성합니다.

```bash
git checkout main
git pull origin main

git tag v1.4.0
git push origin v1.4.0
```

---

# ✅ 배포 후 검증

```bash
curl http://<BACKEND_HOST>:8080/actuator/health
```

- [ ] `/actuator/health` 상태가 정상입니다.
- [ ] 로그인 / 회원가입이 정상 동작합니다.
- [ ] 주요 조회 API가 정상 동작합니다.
- [ ] DB / Redis / GCP Storage 연결이 정상입니다.
- [ ] EC2 Docker 컨테이너 로그를 확인했습니다.

---

# 💬 기타 사항

> 리뷰어가 확인해야 할 사항이나 배포 시 주의사항을 작성해주세요.

- `GOOGLE_APPLICATION_CREDENTIALS` 경로의 GCP 인증 파일이 EC2 컨테이너 내부 `/app/secrets/gcp-storage-key.json`에 마운트되는지 확인 필요
- `DELETE /api/v1/users/me` 프론트 요청 바디 변경 반영 필요
- CI build 및 운영 배포 전 smoke test 확인 필요