### PR TITLE
[Fix] 추천 후보 3개 미만이어도 있는 만큼 추천되도록 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
@@ -17,13 +17,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProblemRecommendationGenerationService implements GenerateProblemSetRecommendationsUseCase {
 
-    private static final int EXPECTED_RECOMMENDATION_COUNT = 3;
+    private static final int MAX_RECOMMENDATION_COUNT = 3;
 
     private final ProblemRecommendationGenerationClient generationClient;
     private final ProblemRecommendationCommandPort commandPort;
     private final RecommendationMetrics recommendationMetrics;
 
-    /** 사용자별 추천 3개 반환을 전제로 기존 추천 교체 저장을 수행합니다. */
+    /** 사용자별 추천 최대 3개(후보 부족 시 1~2개 가능) 반환을 전제로 기존 추천 교체 저장을 수행합니다. */
     @Override
     @Transactional
     public int generate() {
@@ -47,15 +47,15 @@ public class ProblemRecommendationGenerationService implements GenerateProblemSe
         }
     }
 
-    /** 추천 대상 사용자는 Python 서버에서 항상 3개의 문제 세트를 반환해야 합니다. */
+    /** 추천 대상 사용자는 Python 서버에서 1개 이상 {@value #MAX_RECOMMENDATION_COUNT}개 이하의 문제 세트를 반환해야 합니다. */
     private void validateRecommendationCount(GeneratedUserProblemSetRecommendations recommendations) {
         int actualCount = recommendations.problemSets() == null ? 0 : recommendations.problemSets().size();
 
-        if (actualCount != EXPECTED_RECOMMENDATION_COUNT) {
+        if (actualCount < 1 || actualCount > MAX_RECOMMENDATION_COUNT) {
             recommendationMetrics.incrementGenerationFailed("invalid_response");
             log.warn("event=recommendation_generation_failed reason=invalid_response exceptionType=IllegalStateException");
             throw new IllegalStateException(
-                    "Python 추천 서버는 추천 대상 사용자별 문제 세트 3개를 반환해야 합니다. userId="
+                    "Python 추천 서버는 추천 대상 사용자별로 1~" + MAX_RECOMMENDATION_COUNT + "개의 문제 세트를 반환해야 합니다. userId="
                             + recommendations.userId()
                             + ", actualCount="
                             + actualCount


### PR DESCRIPTION
해당하는 항목에 체크해주세요.
- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
---
## 📌 작업한 이슈
- Closes #557 
---
## 🛠️ 기능 관련 작업 내용
- `generate_apriori_recommendations()`에서 추천 후보 개수가 `recommendation_count`(기본 3)와 정확히 일치할 때만 응답에 포함하던 조건을 제거
- 후보가 1개 이상이면 있는 만큼(최대 `recommendation_count`개) 그대로 포함하도록 변경
- top-N 슬라이싱(`sorted_rules[:recommendation_count]`) 로직은 유지 — 최대 3개 제한은 그대로 동작
---
## ♻️ 패키지 변경 사항
- `app/recommendation/service/apriori.py`: 사용자별 추천 포함 조건을 `== recommendation_count` → `추천 후보 1개 이상 존재` 로 완화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 추천 결과 검증 기준이 더 유연해졌습니다. 이제 추천 서버 응답이 1~3개 범위면 정상으로 처리됩니다.
  * 응답 개수가 범위를 벗어나면 실패로 기록되고, 명확한 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->