### PR TITLE
[Fix] 보안 이벤트 IP 필드/추출 정합 (#549)

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -20,6 +20,7 @@ import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEventReco
 import com.wanted.codebombalms.auth.infrastructure.oauth.GoogleOAuthClient;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
@@ -89,7 +90,7 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
      * step-up(이메일 OTP)은 제외한다 (구글이 이미 인증을 보장).
      */
     private GoogleCallbackResult issueTokens(User user, HttpServletRequest request, String deviceFp) {
-        String ip = extractIpAddress(request);
+        String ip = ClientIpResolver.resolve(request);
         GeoLocation geo = geoIpResolver.resolve(ip);
 
         // 신뢰기기 1회 조회로 suspicious 판정 + upsert 모두 처리
@@ -160,10 +161,5 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
                     : (userAgent.contains("iPhone") || userAgent.contains("iPad")) ? "iOS"
                       : userAgent.contains("Linux") ? "Linux" : "Unknown";
         return browser + " · " + os;
-    }
-
-    /** 클라이언트 IP. XFF(위조 가능) 미신뢰, 실제 접속 IP 사용 (M-3) */
-    private String extractIpAddress(HttpServletRequest request) {
-        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -162,11 +162,8 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
         return browser + " · " + os;
     }
 
+    /** 클라이언트 IP. XFF(위조 가능) 미신뢰, 실제 접속 IP 사용 (M-3) */
     private String extractIpAddress(HttpServletRequest request) {
-        String forwarded = request.getHeader("X-Forwarded-For");
-        if (forwarded != null && !forwarded.isBlank()) {
-            return forwarded.split(",")[0].trim();
-        }
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -37,6 +37,8 @@ import java.security.SecureRandom;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -69,7 +71,7 @@ public class LoginService implements LoginUseCase {
         }
 
         // 4. 기기 지문 + 지역(GeoIP)
-        String ip = extractIpAddress(request);
+        String ip = ClientIpResolver.resolve(request);
         GeoLocation geo = geoIpResolver.resolve(ip);
 
         // 5. 적응형 판정 — 신뢰 기기 1차 + 위치 보조
@@ -155,11 +157,6 @@ public class LoginService implements LoginUseCase {
             return "***";
         }
         return email.charAt(0) + "***" + email.substring(at);
-    }
-
-    /** 클라이언트 IP. BE 직결 노출 환경이라 XFF(위조 가능)는 신뢰하지 않고 실제 접속 IP 사용 (M-3) */
-    private String extractIpAddress(HttpServletRequest request) {
-        return request.getRemoteAddr();
     }
 
     private final LockTokenRepository lockTokenRepository;

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -157,12 +157,8 @@ public class LoginService implements LoginUseCase {
         return email.charAt(0) + "***" + email.substring(at);
     }
 
-    /** 프록시 환경(X-Forwarded-For) 고려한 클라이언트 IP 추출 */
+    /** 클라이언트 IP. BE 직결 노출 환경이라 XFF(위조 가능)는 신뢰하지 않고 실제 접속 IP 사용 (M-3) */
     private String extractIpAddress(HttpServletRequest request) {
-        String forwarded = request.getHeader("X-Forwarded-For");
-        if (forwarded != null && !forwarded.isBlank()) {
-            return forwarded.split(",")[0].trim();
-        }
         return request.getRemoteAddr();
     }
 
@@ -170,4 +166,7 @@ public class LoginService implements LoginUseCase {
 
     @Value("${app.lock-url:http://localhost:8080/api/v1/auth/lock}")
     private String lockUrlBase;
+
+
 }
+

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
@@ -114,11 +114,8 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
         return browser + " · " + os;
     }
 
+    /** 클라이언트 IP. XFF(위조 가능) 미신뢰, 실제 접속 IP 사용 (M-3) */
     private String extractIpAddress(HttpServletRequest request) {
-        String forwarded = request.getHeader("X-Forwarded-For");
-        if (forwarded != null && !forwarded.isBlank()) {
-            return forwarded.split(",")[0].trim();
-        }
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
@@ -18,6 +18,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.TooManyReque
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -71,7 +72,7 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
 
         // 4. 신뢰 기기 등록 (옵션) — 이미 있으면 갱신, 없으면 신규 (유니크 (user_id, device_fp) 위반 방지)
         if (command.trustDevice()) {
-            GeoLocation geo = geoIpResolver.resolve(extractIpAddress(request));
+            GeoLocation geo = geoIpResolver.resolve(ClientIpResolver.resolve(request));
             TrustedDevice device = trustedDeviceRepository
                     .findByUserIdAndDeviceFp(user.getUserId(), challenge.deviceFp())
                     .map(existing -> {
@@ -112,10 +113,5 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
                     : (userAgent.contains("iPhone") || userAgent.contains("iPad")) ? "iOS"
                       : userAgent.contains("Linux") ? "Linux" : "Unknown";
         return browser + " · " + os;
-    }
-
-    /** 클라이언트 IP. XFF(위조 가능) 미신뢰, 실제 접속 IP 사용 (M-3) */
-    private String extractIpAddress(HttpServletRequest request) {
-        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
@@ -48,7 +48,7 @@ public class AuthSecurityEventRecorder implements SecurityEventReporter {
     /** 흐름 기반 이벤트(의심 로그인 등) 직접 기록. ip/uri 는 MDC(MdcLoggingFilter)에서 가져온다. */
     public void record(AuthSecurityEvent event, Long userId) {
         registry.counter(METRIC, "category", event.getCategory(), "type", event.getType()).increment();
-        log.warn("event=security_event category={} type={} userId={} ip={} uri={}",
+        log.warn("event=security_event category={} type={} userId={} clientIp={} uri={}",
                 event.getCategory(), event.getType(),
                 userId == null ? "-" : userId, mdc("clientIp"), mdc("requestURI"));
     }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.global.infrastructure.logging;
 
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
+import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.lang.NonNull;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -20,9 +22,9 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(
-            HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
 
         long startAt = System.nanoTime();
@@ -31,7 +33,7 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
             MDC.put("traceId", UUID.randomUUID().toString().substring(0, 8));
             MDC.put("requestURI", request.getRequestURI());
             MDC.put("method", request.getMethod());
-            MDC.put("clientIp", resolveClientIp(request));
+            MDC.put("clientIp", ClientIpResolver.resolve(request));
 
             log.info("event=request_started method={} uri={}",
                     request.getMethod(), request.getRequestURI());
@@ -52,7 +54,7 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
                     durationMs,
                     userId,
                     role,
-                    resolveClientIp(request));
+                    ClientIpResolver.resolve(request));
 
             MDC.clear();
         }
@@ -61,9 +63,5 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     private String resolveAttribute(HttpServletRequest request, String name) {
         Object value = request.getAttribute(name);
         return value == null ? ANONYMOUS : String.valueOf(value);
-    }
-
-    private String resolveClientIp(HttpServletRequest request) {
-        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/SecurityEventLogger.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/SecurityEventLogger.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.global.infrastructure.logging;
 
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
+import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +24,7 @@ public class SecurityEventLogger {
                 uri,
                 resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_USER_ID_ATTRIBUTE),
                 resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_ROLE_ATTRIBUTE),
-                resolveClientIp(request));
+                ClientIpResolver.resolve(request));
     }
 
     private String resolveAccessDeniedType(String uri) {
@@ -35,9 +36,5 @@ public class SecurityEventLogger {
     private String resolveAttribute(HttpServletRequest request, String name) {
         Object value = request.getAttribute(name);
         return value == null ? ANONYMOUS : String.valueOf(value);
-    }
-
-    private String resolveClientIp(HttpServletRequest request) {
-        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/web/ClientIpResolver.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/web/ClientIpResolver.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.global.infrastructure.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * 클라이언트 IP 해석 단일 지점.
+ * 현재 BE 직결 노출 환경이라 위조 가능한 X-Forwarded-For 를 신뢰하지 않고 실제 접속 IP 를 사용한다.
+ * 신뢰 프록시(RemoteIpValve 등) 도입으로 IP 정책이 바뀌면 이 메서드 한 곳만 수정한다. (M-3)
+ */
+public final class ClientIpResolver {
+
+    private ClientIpResolver() {}
+
+    public static String resolve(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [x] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #549

---

## 🛠️ 기능 관련 작업 내용
- 배포 그라파나 로그 패널 공백 해결: 대시보드 쿼리 `{job="lms"}`와 배포 Loki 수집 `{job="spring"}` 불일치를 spring으로 통일 (대시보드/수집 설정은 로컬 전용, 배포는 직접 import)
- 보안 이벤트 로그 IP 필드명 `ip=` → `clientIp=` 로 통일 — global `SecurityEventLogger`(admin)와 일치시켜 "공격자 IP Top 10" 패널이 auth·admin 이벤트를 모두 집계
- 직접 노출된 BE 환경에서 위조 가능한 `X-Forwarded-For` 원문 신뢰를 제거하고 실제 접속 IP만 사용 (IP 위조 차단)
- 클라이언트 IP 해석을 `ClientIpResolver` 단일 지점으로 통일 — 서비스 3곳·로거 2곳의 중복 IP 추출 제거 (CodeRabbit 리뷰 반영)

---

## ♻️ 패키지 변경 사항
- `codebombalms/global/infrastructure/web`: `ClientIpResolver` 신규 — `getRemoteAddr()` 직접 호출을 앱 전체 단일 지점으로 집약
- `codebombalms/auth/infrastructure/metrics`: `AuthSecurityEventRecorder` 로그 필드 `ip=` → `clientIp=`
- `codebombalms/auth/application/service`: `LoginService`·`GoogleCallbackService`·`StepUpVerifyService` IP 추출을 `ClientIpResolver` 경유로 교체 (자체 `extractIpAddress` 제거)
- `codebombalms/global/infrastructure/logging`: `MdcLoggingFilter`·`SecurityEventLogger` IP 추출을 `ClientIpResolver` 경유로 교체 (자체 `resolveClientIp` 제거)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->