### PR TITLE
[Update] Ranking Grafana 대시보드 오류 해석 기준 개선

### DIFF
--- a/monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json
@@ -1,7 +1,7 @@
 {
   "uid": "lms-ranking-domain",
   "title": "[LMS][도메인 상세] 랭킹",
-  "description": "공용 대시보드에서 랭킹 이상을 발견한 뒤, 랭킹 데이터 정합성, 내 랭킹 없음, 대표 뱃지 URL 비용 후보를 확인합니다.",
+  "description": "공용 대시보드에서 랭킹 이상을 발견한 뒤, 랭킹 5xx, 4xx, 내 랭킹 없음 404, 예상 밖 404를 분리해서 확인합니다.",
   "tags": [
     "lms",
     "domain-detail",
@@ -11,7 +11,7 @@
   ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 5,
+  "version": 6,
   "refresh": "10s",
   "time": {
     "from": "now-30m",
@@ -30,7 +30,7 @@
       "id": 1,
       "options": {
         "mode": "markdown",
-        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `ranking` 도메인의 지연이나 4xx/5xx 증가를 먼저 확인합니다.\n- 현재 랭킹 도메인은 전용 내부 처리 시간 지표가 없으므로, 이 화면은 요청 로그와 정합성 후보를 중심으로 봅니다.\n- 내 랭킹 404가 늘면 포인트 이력/랭킹 조회 모델/시드 데이터 정합성을 먼저 확인합니다."
+        "content": "### 이 화면의 역할\n- 공용 대시보드에서 `ranking` 도메인의 지연이나 오류 증가를 먼저 확인합니다.\n- 이 화면에서는 랭킹 요청의 5xx, 4xx, 내 랭킹 없음 404, 예상 밖 404를 분리해서 봅니다.\n- `/points/me`, `/points/weekly/me`의 404는 아직 랭킹 데이터가 없는 정상 후보일 수 있으므로 서버 오류와 따로 해석합니다."
       }
     },
     {
@@ -47,8 +47,8 @@
     },
     {
       "type": "stat",
-      "title": "랭킹 오류 로그(5분)",
-      "description": "랭킹 요청 중 실패 상태 로그입니다.",
+      "title": "랭킹 서버 오류(5xx, 5분)",
+      "description": "랭킹 요청 완료 로그 중 서버 오류만 집계합니다.",
       "datasource": {
         "type": "loki",
         "uid": "loki"
@@ -99,15 +99,15 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "sum(count_over_time({job=\"lms\"} |= \"/api/v1/rankings/\" |~ \"status=4..|status=5..\" [5m]))",
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=request_completed\" |= \"/api/v1/rankings/\" |~ \"status=5..\" [5m]))",
           "queryType": "range"
         }
       ]
     },
     {
       "type": "stat",
-      "title": "내 랭킹 없음(5분)",
-      "description": "내 랭킹 404는 데이터 정합성 문제일 수 있습니다.",
+      "title": "랭킹 요청 오류(4xx, 404 제외)",
+      "description": "인증/권한/잘못된 요청처럼 404가 아닌 클라이언트 오류만 집계합니다.",
       "datasource": {
         "type": "loki",
         "uid": "loki"
@@ -131,12 +131,8 @@
                 "value": null
               },
               {
-                "color": "orange",
-                "value": 1
-              },
-              {
                 "color": "red",
-                "value": 5
+                "value": 1
               }
             ]
           }
@@ -162,7 +158,129 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "sum(count_over_time({job=\"lms\"} |= \"/api/v1/rankings/points/me\" |= \"status=404\" [5m]))",
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=request_completed\" |= \"/api/v1/rankings/\" |~ \"status=4..\" != \"status=404\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "내 랭킹 없음(404, 5분)",
+      "description": "`/points/me`, `/points/weekly/me`에서 발생한 404입니다. 아직 랭킹 데이터가 없는 정상 후보일 수 있어 서버 오류와 분리합니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 6
+      },
+      "id": 5,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=request_completed\" |~ \"uri=/api/v1/rankings/points/(weekly/)?me\" |= \"status=404\" [5m]))",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "예상 밖 랭킹 404(5분)",
+      "description": "내 랭킹 조회가 아닌 랭킹 API에서 발생한 404입니다. 라우팅, URI, 조회 모델 정합성을 확인합니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 6
+      },
+      "id": 6,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({job=\"lms\"} |= \"event=request_completed\" |= \"/api/v1/rankings/\" |= \"status=404\" !~ \"uri=/api/v1/rankings/points/(weekly/)?me\" [5m]))",
           "queryType": "range"
         }
       ]
@@ -178,10 +296,10 @@
       "gridPos": {
         "h": 5,
         "w": 6,
-        "x": 12,
-        "y": 6
+        "x": 0,
+        "y": 11
       },
-      "id": 5,
+      "id": 10,
       "fieldConfig": {
         "defaults": {
           "unit": "short",
@@ -230,15 +348,15 @@
       "type": "text",
       "title": "추가 계측 판단",
       "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 18,
-        "y": 6
+        "h": 5,
+        "w": 18,
+        "x": 6,
+        "y": 11
       },
-      "id": 6,
+      "id": 11,
       "options": {
         "mode": "markdown",
-        "content": "### 아직 공용 지표만으로 부족할 때\n- 전체/주간/내 랭킹 중 어느 조회가 느린지는 공용 대시보드의 URI별 지연에서 확인합니다.\n- 그 다음 원인이 DB 집계인지 대표 뱃지 URL 생성인지 구분이 필요해질 때만 `ranking_query_duration`, `ranking_badge_url_duration`을 추가합니다.\n- 사용자 ID를 메트릭 태그로 넣으면 시계열이 폭증하므로 로그에서만 봅니다."
+        "content": "### 404 해석 기준\n- `/api/v1/rankings/points/me`, `/api/v1/rankings/points/weekly/me`의 404는 아직 포인트/주간 포인트가 없어 내 랭킹이 없는 상태일 수 있습니다.\n- 내 랭킹 조회가 아닌 랭킹 API의 404는 라우팅, URI, 조회 모델 정합성을 먼저 확인합니다.\n- 지연 원인이 DB 집계인지 대표 뱃지 URL 생성인지 구분이 필요해질 때만 `ranking_query_duration`, `ranking_badge_url_duration`을 추가합니다."
       }
     },
     {
@@ -248,7 +366,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 16
       },
       "id": 7,
       "collapsed": false
@@ -265,7 +383,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 17
       },
       "id": 8,
       "options": {
@@ -298,7 +416,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 15
+        "y": 17
       },
       "id": 9,
       "options": {


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #537 
---

## 🛠️ 기능 관련 작업 내용

이번 PR에서 어떤 기능을 구현하거나 수정했는지 작성해주세요.

- Ranking 상세 Grafana 대시보드에서 4xx와 5xx 오류 카운트를 분리했습니다.
- 서버 장애로 봐야 하는 오류는 5xx만 별도 집계하도록 수정했습니다.
- `/api/v1/rankings/points/me`, `/api/v1/rankings/points/weekly/me`의 404를 “내 랭킹 없음” 상태로 분리해 서버 장애와 구분했습니다.
- 실제 Loki 로그 라벨에 맞춰 Ranking 대시보드의 `job` selector를 `spring`으로 수정했습니다.
- 내 랭킹 조회 외 Ranking API에서 발생한 404는 “예상 밖 랭킹 404”로 별도 확인할 수 있게 했습니다.

---

## ♻️ 패키지 변경 사항

변경된 패키지, 클래스, HTML 파일 등을 작성해주세요.

- `monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json` : Ranking 5xx 서버 오류 패널 추가 및 5xx만 집계하도록 수정
- `monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json` : 4xx 오류 패널에서 404를 제외하도록 수정
- `monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json` : 내 랭킹 없음 404와 예상 밖 랭킹 404를 별도 패널로 분리
- `monitoring-local/grafana/provisioning/dashboards/lms-ranking-domain-dashboard.json` : Loki selector를 `job="spring"` 기준으로 수정

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.