### PR TITLE
[Update] 비활성 강좌 접근 및 강의자료 삭제 정책 보완

### DIFF
--- a/src/main/java/com/wanted/codebombalms/course/application/port/CourseEnrollmentPort.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/port/CourseEnrollmentPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.course.application.port;
+
+public interface CourseEnrollmentPort {
+
+    boolean isActiveStudentOfCourse(Long courseId, Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseQueryService.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.course.application.service;
 
+import com.wanted.codebombalms.course.application.port.CourseEnrollmentPort;
 import com.wanted.codebombalms.course.application.usecase.CourseQueryUseCase;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class CourseQueryService implements CourseQueryUseCase {
     private static final Logger log = LoggerFactory.getLogger(CourseQueryService.class);
 
     private final CourseRepository courseRepository;
+    private final CourseEnrollmentPort courseEnrollmentPort;
 
     @LogBusiness
     @LogPerformance
@@ -83,6 +86,15 @@ public class CourseQueryService implements CourseQueryUseCase {
     }
 
     @Override
+    public Course findCourseByIdForStudent(Long courseId, Long userId) {
+        log.info("[CourseQueryService] find student course - courseId: {}, userId: {}", courseId, userId);
+
+        return courseRepository.findByCourseIdAndStatusAndDeletedAtIsNull(courseId, CourseStatus.ACTIVE)
+                .or(() -> findInactiveCourseForEnrolledStudent(courseId, userId))
+                .orElseThrow(() -> new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
+    }
+
+    @Override
     public Course findCourseByIdForOperator(Long courseId) {
         log.info("[CourseQueryService] find operator course - courseId: {}", courseId);
 
@@ -92,5 +104,15 @@ public class CourseQueryService implements CourseQueryUseCase {
         log.info("[CourseQueryService] found operator course - courseId: {}", courseId);
 
         return course;
+    }
+
+    private Optional<Course> findInactiveCourseForEnrolledStudent(Long courseId, Long userId) {
+        if (userId == null) {
+            return Optional.empty();
+        }
+
+        return courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)
+                .filter(course -> course.getStatus() == CourseStatus.INACTIVE)
+                .filter(course -> courseEnrollmentPort.isActiveStudentOfCourse(courseId, userId));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/course/application/usecase/CourseQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/usecase/CourseQueryUseCase.java
@@ -14,5 +14,7 @@ public interface CourseQueryUseCase {
 
     Course findCourseById(Long courseId);
 
+    Course findCourseByIdForStudent(Long courseId, Long userId);
+
     Course findCourseByIdForOperator(Long courseId);
 }

--- a/src/main/java/com/wanted/codebombalms/course/infrastructure/enrollment/CourseEnrollmentAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/course/infrastructure/enrollment/CourseEnrollmentAdapter.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.course.infrastructure.enrollment;
+
+import com.wanted.codebombalms.course.application.port.CourseEnrollmentPort;
+import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseEnrollmentAdapter implements CourseEnrollmentPort {
+
+    private final EnrollmentQueryUseCase enrollmentQueryUseCase;
+
+    @Override
+    public boolean isActiveStudentOfCourse(Long courseId, Long userId) {
+        return enrollmentQueryUseCase.isActiveStudentOfCourse(courseId, userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseController.java
+++ b/src/main/java/com/wanted/codebombalms/course/presentation/api/CourseController.java
@@ -90,6 +90,7 @@ public class CourseController {
     @GetMapping("/courses/{courseId}")
     public ResponseEntity<ApiResponse<?>> findCourseById(
             @PathVariable Long courseId,
+            @AuthenticationPrincipal Long userId,
             Authentication authentication
     ) {
         log.info("[CourseController] find course - courseId: {}", courseId);
@@ -99,7 +100,7 @@ public class CourseController {
                 CourseResponseMessage.RETRIEVED,
                 CourseDetailResponse.from(isOperator(authentication)
                         ? courseQueryUseCase.findCourseByIdForOperator(courseId)
-                        : courseQueryUseCase.findCourseById(courseId))
+                        : courseQueryUseCase.findCourseByIdForStudent(courseId, userId))
         ));
     }
 

--- a/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
@@ -1,5 +1,7 @@
 package com.wanted.codebombalms.lecture.application.policy;
 
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
@@ -22,6 +24,21 @@ public class LectureAccessPolicy {
         }
         if (userId == null || !lectureEnrollmentPort.isActiveStudentOfCourse(
                 lecture.getCourse().getCourseId(),
+                userId
+        )) {
+            throw new ForbiddenException(LectureErrorCode.LECTURE_ACCESS_DENIED);
+        }
+    }
+
+    public void validateCourseContentAccess(Course course, Long userId, boolean operator) {
+        if (operator) {
+            return;
+        }
+        if (course.getStatus() == CourseStatus.ACTIVE) {
+            return;
+        }
+        if (userId == null || !lectureEnrollmentPort.isActiveStudentOfCourse(
+                course.getCourseId(),
                 userId
         )) {
             throw new ForbiddenException(LectureErrorCode.LECTURE_ACCESS_DENIED);

--- a/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
@@ -37,6 +37,9 @@ public class LectureAccessPolicy {
         if (course.getStatus() == CourseStatus.ACTIVE) {
             return;
         }
+        if (course.getStatus() != CourseStatus.INACTIVE) {
+            throw new ForbiddenException(LectureErrorCode.LECTURE_ACCESS_DENIED);
+        }
         if (userId == null || !lectureEnrollmentPort.isActiveStudentOfCourse(
                 course.getCourseId(),
                 userId

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
@@ -8,8 +8,11 @@ import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
 import com.wanted.codebombalms.lecture.application.usecase.LectureCommandUseCase;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -18,6 +21,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,6 +40,8 @@ public class LectureCommandService implements LectureCommandUseCase {
     private final LectureRepository lectureRepository;
     private final CourseCatalogPort courseCatalogPort;
     private final LectureCreationPolicy lectureCreationPolicy;
+    private final LectureMaterialRepository lectureMaterialRepository;
+    private final LectureMaterialStoragePort lectureMaterialStoragePort;
 
     @Override
     public Lecture createLecture(CreateLectureCommand command) {
@@ -96,8 +103,39 @@ public class LectureCommandService implements LectureCommandUseCase {
         Lecture lecture = lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
                 .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_NOT_FOUND));
 
+        lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
+                .forEach(this::deleteMaterial);
         lecture.delete();
         lectureRepository.save(lecture);
+    }
+
+    private void deleteMaterial(LectureMaterial material) {
+        String filePath = material.getFilePath();
+        material.delete();
+        lectureMaterialRepository.save(material);
+        runAfterCommit(() -> deleteMaterialFileQuietly(filePath));
+    }
+
+    private void deleteMaterialFileQuietly(String filePath) {
+        try {
+            lectureMaterialStoragePort.delete(filePath);
+        } catch (RuntimeException e) {
+            log.warn("Failed to delete lecture material file after lecture deletion. filePath={}", filePath, e);
+        }
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            task.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                task.run();
+            }
+        });
     }
 
     private void validateLectureOrder(Long courseId, Long lectureId, Integer lectureOrder) {

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialService.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundExce
 import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
 import com.wanted.codebombalms.lecture.application.usecase.LectureMaterialUseCase;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
@@ -16,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +30,7 @@ public class LectureMaterialService implements LectureMaterialUseCase {
     private final LectureRepository lectureRepository;
     private final LectureMaterialStoragePort lectureMaterialStoragePort;
     private final LectureEnrollmentPort lectureEnrollmentPort;
+    private final LectureAccessPolicy lectureAccessPolicy;
 
     @Override
     public LectureMaterial uploadMaterial(UploadLectureMaterialCommand command) {
@@ -65,6 +69,14 @@ public class LectureMaterialService implements LectureMaterialUseCase {
 
     @Override
     @Transactional(readOnly = true)
+    public List<LectureMaterial> findMaterialsForAccess(Long lectureId, Long userId, boolean operator) {
+        Lecture lecture = validateLecture(lectureId);
+        lectureAccessPolicy.validateCourseContentAccess(lecture.getCourse(), userId, operator);
+        return lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public String issueDownloadUrl(Long lectureMaterialId, Long userId, boolean operator) {
         LectureMaterial material = findMaterial(lectureMaterialId);
 
@@ -91,7 +103,7 @@ public class LectureMaterialService implements LectureMaterialUseCase {
         LectureMaterial material = findMaterial(lectureMaterialId);
         material.delete();
         lectureMaterialRepository.save(material);
-        lectureMaterialStoragePort.delete(material.getFilePath());
+        deleteMaterialFileAfterCommit(material.getFilePath());
     }
 
     private Lecture validateLecture(Long lectureId) {
@@ -111,5 +123,29 @@ public class LectureMaterialService implements LectureMaterialUseCase {
             originalException.addSuppressed(deleteException);
             log.warn("Failed to delete uploaded lecture material after DB save failure. filePath={}", filePath, deleteException);
         }
+    }
+
+    private void deleteMaterialFileAfterCommit(String filePath) {
+        runAfterCommit(() -> {
+            try {
+                lectureMaterialStoragePort.delete(filePath);
+            } catch (RuntimeException e) {
+                log.warn("Failed to delete lecture material file after material deletion. filePath={}", filePath, e);
+            }
+        });
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            task.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                task.run();
+            }
+        });
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureProblemSetQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureProblemSetQueryService.java
@@ -1,10 +1,14 @@
 package com.wanted.codebombalms.lecture.application.service;
 
+import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
+import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
 import com.wanted.codebombalms.lecture.application.usecase.LectureProblemSetQueryUseCase;
 import com.wanted.codebombalms.lecture.domain.exception.LectureProblemSetErrorCode;
 import com.wanted.codebombalms.lecture.domain.model.LectureProblemSet;
 import com.wanted.codebombalms.lecture.domain.model.LectureProblemSetRole;
+import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureProblemSetRepository;
+import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +20,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class LectureProblemSetQueryService implements LectureProblemSetQueryUseCase {
 
     private final LectureProblemSetRepository lectureProblemSetRepository;
+    private final CourseCatalogPort courseCatalogPort;
+    private final LectureRepository lectureRepository;
+    private final LectureAccessPolicy lectureAccessPolicy;
 
     @Override
     @Transactional(readOnly = true)
     public List<LectureProblemSet> findProblemSetsByCourse(Long courseId) {
+        return lectureProblemSetRepository.findByCourseId(courseId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LectureProblemSet> findProblemSetsByCourseForAccess(Long courseId, Long userId, boolean operator) {
+        var course = courseCatalogPort.findCourse(courseId);
+        lectureAccessPolicy.validateCourseContentAccess(course, userId, operator);
         return lectureProblemSetRepository.findByCourseId(courseId);
     }
 
@@ -32,6 +47,15 @@ public class LectureProblemSetQueryService implements LectureProblemSetQueryUseC
     @Override
     @Transactional(readOnly = true)
     public List<LectureProblemSet> findProblemSetsByLecture(Long lectureId) {
+        return lectureProblemSetRepository.findByLectureId(lectureId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LectureProblemSet> findProblemSetsByLectureForAccess(Long lectureId, Long userId, boolean operator) {
+        var lecture = lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)
+                .orElseThrow(() -> new NotFoundException(LectureErrorCode.LECTURE_NOT_FOUND));
+        lectureAccessPolicy.validateCourseContentAccess(lecture.getCourse(), userId, operator);
         return lectureProblemSetRepository.findByLectureId(lectureId);
     }
 

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureQueryService.java
@@ -39,6 +39,18 @@ public class LectureQueryService implements LectureQueryUseCase {
     }
 
     @Override
+    public List<Lecture> findLecturesByCourseIdForAccess(Long courseId, Long userId, boolean operator) {
+        log.info("[LectureQueryService] find lectures for access - courseId: {}, userId: {}", courseId, userId);
+
+        var course = courseCatalogPort.findCourse(courseId);
+        lectureAccessPolicy.validateCourseContentAccess(course, userId, operator);
+
+        return lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId)
+                .stream()
+                .toList();
+    }
+
+    @Override
     public Lecture findLectureById(Long lectureId) {
         log.info("[LectureQueryService] find lecture - lectureId: {}", lectureId);
 

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureMaterialUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureMaterialUseCase.java
@@ -10,6 +10,8 @@ public interface LectureMaterialUseCase {
 
     List<LectureMaterial> findMaterials(Long lectureId);
 
+    List<LectureMaterial> findMaterialsForAccess(Long lectureId, Long userId, boolean operator);
+
     String issueDownloadUrl(Long lectureMaterialId, Long userId, boolean operator);
 
     void deleteMaterial(Long lectureMaterialId);

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureProblemSetQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureProblemSetQueryUseCase.java
@@ -8,9 +8,13 @@ public interface LectureProblemSetQueryUseCase {
 
     List<LectureProblemSet> findProblemSetsByCourse(Long courseId);
 
+    List<LectureProblemSet> findProblemSetsByCourseForAccess(Long courseId, Long userId, boolean operator);
+
     List<LectureProblemSet> findProblemSetsByCourseAndRole(Long courseId, LectureProblemSetRole role);
 
     List<LectureProblemSet> findProblemSetsByLecture(Long lectureId);
+
+    List<LectureProblemSet> findProblemSetsByLectureForAccess(Long lectureId, Long userId, boolean operator);
 
     LectureProblemSet findProblemSetById(Long lectureProblemSetId);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureQueryUseCase.java
@@ -8,6 +8,8 @@ public interface LectureQueryUseCase {
 
     List<Lecture> findLecturesByCourseId(Long courseId);
 
+    List<Lecture> findLecturesByCourseIdForAccess(Long courseId, Long userId, boolean operator);
+
     Lecture findLectureById(Long lectureId);
 
     Lecture findLectureByIdForLearning(Long lectureId, Long userId, boolean operator);

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
@@ -48,13 +48,17 @@ public class LectureController {
 
     @GetMapping("/courses/{courseId}/lectures")
     @Operation(summary = "강좌별 강의 목록 조회")
-    public ResponseEntity<ApiResponse<?>> findLecturesByCourseId(@PathVariable Long courseId) {
+    public ResponseEntity<ApiResponse<?>> findLecturesByCourseId(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal Long userId,
+            Authentication authentication
+    ) {
         log.info("[LectureController] find lectures - courseId: {}", courseId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 LectureResponseCode.RETRIEVED,
                 LectureResponseMessage.RETRIEVED,
-                lectureQueryUseCase.findLecturesByCourseId(courseId)
+                lectureQueryUseCase.findLecturesByCourseIdForAccess(courseId, userId, isOperator(authentication))
                         .stream()
                         .map(LectureResponse::from)
                         .toList()
@@ -194,11 +198,15 @@ public class LectureController {
 
     @GetMapping("/lectures/{lectureId}/materials")
     @Operation(summary = "강의자료 목록 조회")
-    public ResponseEntity<ApiResponse<?>> findMaterials(@PathVariable Long lectureId) {
+    public ResponseEntity<ApiResponse<?>> findMaterials(
+            @PathVariable Long lectureId,
+            @AuthenticationPrincipal Long userId,
+            Authentication authentication
+    ) {
         return ResponseEntity.ok(ApiResponse.success(
                 LectureResponseCode.RETRIEVED,
                 LectureResponseMessage.RETRIEVED,
-                lectureMaterialUseCase.findMaterials(lectureId)
+                lectureMaterialUseCase.findMaterialsForAccess(lectureId, userId, isOperator(authentication))
                         .stream()
                         .map(LectureMaterialResponse::from)
                         .toList()

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureProblemSetController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureProblemSetController.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -35,13 +37,21 @@ public class LectureProblemSetController {
 
     @GetMapping("/courses/{courseId}/lecture-problem-sets")
     @Operation(summary = "Find lecture problem sets by course")
-    public ResponseEntity<ApiResponse<?>> findProblemSetsByCourse(@PathVariable Long courseId) {
+    public ResponseEntity<ApiResponse<?>> findProblemSetsByCourse(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal Long userId,
+            Authentication authentication
+    ) {
         log.info("[LectureProblemSetController] find course lecture problem sets - courseId: {}", courseId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 CourseResponseCode.RETRIEVED,
                 CourseResponseMessage.RETRIEVED,
-                lectureProblemSetQueryUseCase.findProblemSetsByCourse(courseId)
+                lectureProblemSetQueryUseCase.findProblemSetsByCourseForAccess(
+                                courseId,
+                                userId,
+                                isOperator(authentication)
+                        )
                         .stream()
                         .map(LectureProblemSetResponse::from)
                         .toList()
@@ -50,13 +60,21 @@ public class LectureProblemSetController {
 
     @GetMapping("/lectures/{lectureId}/lecture-problem-sets")
     @Operation(summary = "Find lecture problem sets by lecture")
-    public ResponseEntity<ApiResponse<?>> findProblemSetsByLecture(@PathVariable Long lectureId) {
+    public ResponseEntity<ApiResponse<?>> findProblemSetsByLecture(
+            @PathVariable Long lectureId,
+            @AuthenticationPrincipal Long userId,
+            Authentication authentication
+    ) {
         log.info("[LectureProblemSetController] find lecture problem sets - lectureId: {}", lectureId);
 
         return ResponseEntity.ok(ApiResponse.success(
                 CourseResponseCode.RETRIEVED,
                 CourseResponseMessage.RETRIEVED,
-                lectureProblemSetQueryUseCase.findProblemSetsByLecture(lectureId)
+                lectureProblemSetQueryUseCase.findProblemSetsByLectureForAccess(
+                                lectureId,
+                                userId,
+                                isOperator(authentication)
+                        )
                         .stream()
                         .map(LectureProblemSetResponse::from)
                         .toList()
@@ -80,5 +98,11 @@ public class LectureProblemSetController {
                         .map(LectureProblemSetResponse::from)
                         .toList()
         ));
+    }
+
+    private boolean isOperator(Authentication authentication) {
+        return authentication != null
+                && authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_OPERATOR".equals(authority.getAuthority()));
     }
 }

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.course.application.command.UpdateCourseCommand;
 import com.wanted.codebombalms.course.application.policy.CourseAuthorPolicy;
 import com.wanted.codebombalms.course.application.policy.CourseCategoryPolicy;
 import com.wanted.codebombalms.course.application.policy.CoursePublishPolicy;
+import com.wanted.codebombalms.course.application.port.CourseEnrollmentPort;
 import com.wanted.codebombalms.course.application.port.CourseThumbnailStoragePort;
 import com.wanted.codebombalms.course.application.port.LectureManagementPort;
 import com.wanted.codebombalms.course.application.service.CourseCommandService;
@@ -56,6 +57,9 @@ class CourseServiceTest {
 
     @Mock
     private CourseThumbnailStoragePort courseThumbnailStoragePort;
+
+    @Mock
+    private CourseEnrollmentPort courseEnrollmentPort;
 
     @InjectMocks
     private CourseCommandService courseCommandService;
@@ -156,6 +160,94 @@ class CourseServiceTest {
         );
 
         assertEquals(CourseErrorCode.COURSE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findCourseByIdForStudent_returnsActiveCourse() {
+        Long courseId = 1L;
+        Long userId = 10L;
+        Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.ACTIVE);
+
+        given(courseRepository.findByCourseIdAndStatusAndDeletedAtIsNull(courseId, CourseStatus.ACTIVE))
+                .willReturn(Optional.of(course));
+
+        Course result = courseQueryService.findCourseByIdForStudent(courseId, userId);
+
+        assertEquals(courseId, result.getCourseId());
+        assertEquals(CourseStatus.ACTIVE, result.getStatus());
+        verify(courseEnrollmentPort, never()).isActiveStudentOfCourse(any(), any());
+    }
+
+    @Test
+    void findCourseByIdForStudent_returnsInactiveCourse_whenStudentEnrolled() {
+        Long courseId = 1L;
+        Long userId = 10L;
+        Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.INACTIVE);
+
+        given(courseRepository.findByCourseIdAndStatusAndDeletedAtIsNull(courseId, CourseStatus.ACTIVE))
+                .willReturn(Optional.empty());
+        given(courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)).willReturn(Optional.of(course));
+        given(courseEnrollmentPort.isActiveStudentOfCourse(courseId, userId)).willReturn(true);
+
+        Course result = courseQueryService.findCourseByIdForStudent(courseId, userId);
+
+        assertEquals(courseId, result.getCourseId());
+        assertEquals(CourseStatus.INACTIVE, result.getStatus());
+    }
+
+    @Test
+    void findCourseByIdForStudent_throwsNotFound_whenInactiveCourseAndStudentNotEnrolled() {
+        Long courseId = 1L;
+        Long userId = 10L;
+        Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.INACTIVE);
+
+        given(courseRepository.findByCourseIdAndStatusAndDeletedAtIsNull(courseId, CourseStatus.ACTIVE))
+                .willReturn(Optional.empty());
+        given(courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)).willReturn(Optional.of(course));
+        given(courseEnrollmentPort.isActiveStudentOfCourse(courseId, userId)).willReturn(false);
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> courseQueryService.findCourseByIdForStudent(courseId, userId)
+        );
+
+        assertEquals(CourseErrorCode.COURSE_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findCourseByIdForStudent_throwsNotFound_whenInactiveCourseAndAnonymousUser() {
+        Long courseId = 1L;
+
+        given(courseRepository.findByCourseIdAndStatusAndDeletedAtIsNull(courseId, CourseStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> courseQueryService.findCourseByIdForStudent(courseId, null)
+        );
+
+        assertEquals(CourseErrorCode.COURSE_NOT_FOUND, exception.getErrorCode());
+        verify(courseRepository, never()).findByCourseIdAndDeletedAtIsNull(courseId);
+        verify(courseEnrollmentPort, never()).isActiveStudentOfCourse(any(), any());
+    }
+
+    @Test
+    void findCourseByIdForStudent_throwsNotFound_whenDraftCourseEvenIfStudentEnrolled() {
+        Long courseId = 1L;
+        Long userId = 10L;
+        Course course = createCourse(courseId, 10L, "Java", "description", "java.png", CourseStatus.DRAFT);
+
+        given(courseRepository.findByCourseIdAndStatusAndDeletedAtIsNull(courseId, CourseStatus.ACTIVE))
+                .willReturn(Optional.empty());
+        given(courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)).willReturn(Optional.of(course));
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> courseQueryService.findCourseByIdForStudent(courseId, userId)
+        );
+
+        assertEquals(CourseErrorCode.COURSE_NOT_FOUND, exception.getErrorCode());
+        verify(courseEnrollmentPort, never()).isActiveStudentOfCourse(any(), any());
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/course/controller/CourseControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/controller/CourseControllerTest.java
@@ -95,7 +95,8 @@ class CourseControllerTest {
     @Test
     void findCourseById_returnsApiResponse() throws Exception {
         Long courseId = 1L;
-        given(courseQueryUseCase.findCourseById(courseId)).willReturn(createDetailResult(courseId, "Java"));
+        given(courseQueryUseCase.findCourseByIdForStudent(courseId, null))
+                .willReturn(createDetailResult(courseId, "Java"));
 
         mockMvc.perform(get("/api/v1/courses/{courseId}", courseId).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.lecture.application.policy;
 
 import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
@@ -83,6 +84,79 @@ class LectureAccessPolicyTest {
     }
 
     @Test
+    void validateCourseContentAccess_allowsActiveCourseWithoutEnrollmentCheck() {
+        Course course = course(1L, CourseStatus.ACTIVE);
+
+        assertDoesNotThrow(
+                () -> lectureAccessPolicy.validateCourseContentAccess(course, null, false)
+        );
+
+        verifyNoInteractions(lectureEnrollmentPort);
+    }
+
+    @Test
+    void validateCourseContentAccess_allowsInactiveCourse_whenStudentIsEnrolled() {
+        Long userId = 10L;
+        Course course = course(1L, CourseStatus.INACTIVE);
+        given(lectureEnrollmentPort.isActiveStudentOfCourse(1L, userId)).willReturn(true);
+
+        assertDoesNotThrow(
+                () -> lectureAccessPolicy.validateCourseContentAccess(course, userId, false)
+        );
+    }
+
+    @Test
+    void validateCourseContentAccess_throwsForbiddenForInactiveCourse_whenStudentIsNotEnrolled() {
+        Long userId = 10L;
+        Course course = course(1L, CourseStatus.INACTIVE);
+        given(lectureEnrollmentPort.isActiveStudentOfCourse(1L, userId)).willReturn(false);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureAccessPolicy.validateCourseContentAccess(course, userId, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
+    }
+
+    @Test
+    void validateCourseContentAccess_throwsForbiddenForDraftCourseWithoutEnrollmentCheck() {
+        Course course = course(1L, CourseStatus.DRAFT);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureAccessPolicy.validateCourseContentAccess(course, 10L, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
+        verifyNoInteractions(lectureEnrollmentPort);
+    }
+
+    @Test
+    void validateCourseContentAccess_throwsForbiddenForDeletedCourseWithoutEnrollmentCheck() {
+        Course course = course(1L, CourseStatus.DELETED);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureAccessPolicy.validateCourseContentAccess(course, 10L, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
+        verifyNoInteractions(lectureEnrollmentPort);
+    }
+
+    @Test
+    void validateCourseContentAccess_allowsOperatorForDraftCourse() {
+        Course course = course(1L, CourseStatus.DRAFT);
+
+        assertDoesNotThrow(
+                () -> lectureAccessPolicy.validateCourseContentAccess(course, null, true)
+        );
+
+        verifyNoInteractions(lectureEnrollmentPort);
+    }
+
+    @Test
     void validatePreviousLecturesCompleted_allowsFirstLecture() {
         lectureAccessPolicy.validatePreviousLecturesCompleted(10L, List.of());
 
@@ -115,10 +189,16 @@ class LectureAccessPolicyTest {
     }
 
     private Lecture lecture(Long courseId) {
-        Course course = new Course();
-        course.setCourseId(courseId);
+        Course course = course(courseId, CourseStatus.ACTIVE);
         Lecture lecture = new Lecture();
         lecture.setCourse(course);
         return lecture;
+    }
+
+    private Course course(Long courseId, CourseStatus status) {
+        Course course = new Course();
+        course.setCourseId(courseId);
+        course.setStatus(status);
+        return course;
     }
 }

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
@@ -13,6 +13,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundExce
 import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
+import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
@@ -41,6 +42,9 @@ class LectureMaterialServiceTest {
 
     @Mock
     private LectureEnrollmentPort lectureEnrollmentPort;
+
+    @Mock
+    private LectureAccessPolicy lectureAccessPolicy;
 
     @InjectMocks
     private LectureMaterialService lectureMaterialService;

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureMaterialServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -19,6 +20,7 @@ import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -169,6 +171,44 @@ class LectureMaterialServiceTest {
 
         assertEquals(1, result.size());
         assertEquals(10L, result.get(0).getLectureMaterialId());
+    }
+
+    @Test
+    void findMaterialsForAccess_validatesCourseContentAccess() {
+        Long lectureId = 1L;
+        Long userId = 20L;
+        Lecture lecture = createLecture(lectureId, 100L);
+        LectureMaterial material = createMaterial(10L, lectureId);
+
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(Optional.of(lecture));
+        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(List.of(material));
+
+        var result = lectureMaterialService.findMaterialsForAccess(lectureId, userId, false);
+
+        assertEquals(1, result.size());
+        verify(lectureAccessPolicy).validateCourseContentAccess(lecture.getCourse(), userId, false);
+    }
+
+    @Test
+    void findMaterialsForAccess_propagatesForbidden_whenAccessDenied() {
+        Long lectureId = 1L;
+        Long userId = 20L;
+        Lecture lecture = createLecture(lectureId, 100L);
+
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId))
+                .willReturn(Optional.of(lecture));
+        doThrow(new ForbiddenException(LectureErrorCode.LECTURE_ACCESS_DENIED))
+                .when(lectureAccessPolicy).validateCourseContentAccess(lecture.getCourse(), userId, false);
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> lectureMaterialService.findMaterialsForAccess(lectureId, userId, false)
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
+        verify(lectureMaterialRepository, never()).findByLectureIdAndDeletedAtIsNull(lectureId);
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
@@ -459,6 +459,38 @@ class LectureServiceTest {
     }
 
     @Test
+    void deleteLecture_completesSoftDelete_whenMaterialFileDeleteFails() {
+        Long lectureId = 1L;
+        Lecture lecture = createLecture(lectureId, createCourse(1L, 10L, "Java"), "Java 1", LectureStatus.ACTIVE, 1);
+        LectureMaterial material = LectureMaterial.restore(
+                10L,
+                lectureId,
+                "guide.pdf",
+                "stored-guide.pdf",
+                "lecture_materials/stored-guide.pdf",
+                "application/pdf",
+                3L,
+                LocalDateTime.now(),
+                null
+        );
+
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)).willReturn(Optional.of(lecture));
+        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId)).willReturn(List.of(material));
+        given(lectureRepository.save(lecture)).willReturn(lecture);
+        given(lectureMaterialRepository.save(material)).willReturn(material);
+        doThrow(new RuntimeException("gcs unavailable"))
+                .when(lectureMaterialStoragePort).delete("lecture_materials/stored-guide.pdf");
+
+        assertDoesNotThrow(() -> lectureCommandService.deleteLecture(lectureId));
+
+        assertEquals(LectureStatus.DELETED, lecture.getStatus());
+        assertNotNull(lecture.getDeletedAt());
+        assertNotNull(material.getDeletedAt());
+        verify(lectureMaterialRepository).save(material);
+        verify(lectureRepository).save(lecture);
+    }
+
+    @Test
     void updateLecture_throwsValidation_whenVideoUrlIsNotYoutube() {
         Long lectureId = 1L;
         Lecture lecture = createLecture(lectureId, createCourse(1L, 10L, "Java"), "Java 1", LectureStatus.ACTIVE, 1);

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
@@ -8,11 +8,14 @@ import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
 import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
 import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
+import com.wanted.codebombalms.lecture.application.port.LectureMaterialStoragePort;
 import com.wanted.codebombalms.lecture.application.service.LectureCommandService;
 import com.wanted.codebombalms.lecture.application.service.LectureQueryService;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
+import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -50,6 +53,12 @@ class LectureServiceTest {
 
     @Mock
     private LectureAccessPolicy lectureAccessPolicy;
+
+    @Mock
+    private LectureMaterialRepository lectureMaterialRepository;
+
+    @Mock
+    private LectureMaterialStoragePort lectureMaterialStoragePort;
 
     @InjectMocks
     private LectureCommandService lectureCommandService;
@@ -419,6 +428,34 @@ class LectureServiceTest {
         assertEquals("Updated Java", result.getTitle());
         assertEquals(LectureStatus.INACTIVE, result.getStatus());
         verify(lectureRepository).save(lecture);
+    }
+
+    @Test
+    void deleteLecture_softDeletesMaterialsAndDeletesFiles() {
+        Long lectureId = 1L;
+        Lecture lecture = createLecture(lectureId, createCourse(1L, 10L, "Java"), "Java 1", LectureStatus.ACTIVE, 1);
+        LectureMaterial material = LectureMaterial.restore(
+                10L,
+                lectureId,
+                "guide.pdf",
+                "stored-guide.pdf",
+                "lecture_materials/stored-guide.pdf",
+                "application/pdf",
+                3L,
+                LocalDateTime.now(),
+                null
+        );
+
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(lectureId)).willReturn(Optional.of(lecture));
+        given(lectureMaterialRepository.findByLectureIdAndDeletedAtIsNull(lectureId)).willReturn(List.of(material));
+        given(lectureRepository.save(lecture)).willReturn(lecture);
+        given(lectureMaterialRepository.save(material)).willReturn(material);
+
+        lectureCommandService.deleteLecture(lectureId);
+
+        assertNotNull(material.getDeletedAt());
+        verify(lectureMaterialRepository).save(material);
+        verify(lectureMaterialStoragePort).delete("lecture_materials/stored-guide.pdf");
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
@@ -74,7 +74,7 @@ class LectureControllerTest {
     @Test
     void findLecturesByCourseId_returnsApiResponse() throws Exception {
         Long courseId = 1L;
-        given(lectureQueryUseCase.findLecturesByCourseId(courseId)).willReturn(List.of(
+        given(lectureQueryUseCase.findLecturesByCourseIdForAccess(eq(courseId), isNull(), eq(false))).willReturn(List.of(
                 createLecture(1L, createCourse(courseId), "Java 1")
         ));
 
@@ -296,7 +296,7 @@ class LectureControllerTest {
     @Test
     void findMaterials_returnsApiResponse() throws Exception {
         Long lectureId = 1L;
-        given(lectureMaterialUseCase.findMaterials(lectureId))
+        given(lectureMaterialUseCase.findMaterialsForAccess(eq(lectureId), isNull(), eq(false)))
                 .willReturn(List.of(createMaterial(10L, lectureId)));
 
         mockMvc.perform(get("/api/v1/lectures/{lectureId}/materials", lectureId))

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureProblemSetControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureProblemSetControllerTest.java
@@ -77,7 +77,7 @@ class LectureProblemSetControllerTest {
 
     @Test
     void findProblemSetsByCourseReturnsApiResponse() throws Exception {
-        given(lectureProblemSetQueryUseCase.findProblemSetsByCourse(101L)).willReturn(List.of(
+        given(lectureProblemSetQueryUseCase.findProblemSetsByCourseForAccess(101L, null, false)).willReturn(List.of(
                 LectureProblemSet.restore(6001L, 101L, 1001L, 2002L, LectureProblemSetRole.MAIN, 1),
                 LectureProblemSet.restore(6002L, 101L, null, 2003L, LectureProblemSetRole.FINAL, 1)
         ));
@@ -93,7 +93,7 @@ class LectureProblemSetControllerTest {
 
     @Test
     void findProblemSetsByLectureReturnsApiResponse() throws Exception {
-        given(lectureProblemSetQueryUseCase.findProblemSetsByLecture(101L)).willReturn(List.of(
+        given(lectureProblemSetQueryUseCase.findProblemSetsByLectureForAccess(101L, null, false)).willReturn(List.of(
                 LectureProblemSet.restore(6001L, 101L, 101L, 2002L, LectureProblemSetRole.MAIN, 1)
         ));
 


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #556 
- Closes #571 

---

## 🛠️ 기능 관련 작업 내용

- 비활성화된 강좌도 기존 수강생은 내 강의실/학습 흐름에서 접근할 수 있도록 강좌 조회 정책을 보완했습니다.
- 강좌/강의 하위 리소스 조회 시 operator, 공개 강좌, 기존 수강생 조건을 분리해 접근 정책을 적용했습니다.
- 강의 삭제 시 연결된 강의자료를 소프트 딜리트하고, 트랜잭션 커밋 후 GCS 파일 삭제를 시도하도록 보완했습니다.
- 강좌 비활성 접근 정책과 강의자료 삭제 생명주기에 대한 서비스/컨트롤러 테스트를 수정 및 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `project/course`: 비활성 강좌 조회 시 기존 수강생 여부를 확인하는 enrollment 포트/어댑터 및 조회 정책을 추가했습니다.
- `project/lecture`: 비활성 강좌 하위 강의/문제세트/강의자료 접근 정책과 강의자료 삭제 처리를 보완했습니다.
- `project/test`: course, lecture 정책 변경에 맞춰 서비스/컨트롤러 테스트를 보완했습니다.

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 학생/운영자 권한에 따라 코스, 강의, 자료, 문제 세트를 조회할 수 있게 되었습니다.
  * 비활성 코스도 해당 학생이 활성 수강자인 경우 정상 조회됩니다.

* **Bug Fixes**
  * 강의 조회 시 접근 권한이 더 정확하게 적용됩니다.
  * 강의 삭제 시 연관 자료와 파일 정리가 함께 처리되며, 저장이 확정된 뒤에만 파일이 삭제됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->