### PR TITLE
[Feat] 추천 오늘 하루 숨김 metric 추가

### DIFF
--- a/monitoring-local/docs/domains/recommendation/metrics.md
+++ b/monitoring-local/docs/domains/recommendation/metrics.md
@@ -56,6 +56,7 @@ event=recommendation_generation_failed reason=<reason> exceptionType=<type>
 | Prometheus 노출명 | 종류 | 코드 등록명 | 의미 | 코드 위치 |
 |---|---|---|---|---|
 | `recommendation_problem_set_exposed_total` | Counter | `recommendation_problem_set_exposed_total` | 추천 목록에서 사용자에게 노출된 추천 카드 수 | [`ProblemRecommendationQueryService.getRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java) |
+| `recommendation_hide_today_total` | Counter | `recommendation_hide_today_total` | 사용자가 추천 영역을 오늘 하루 숨김 처리한 횟수 | [`RecommendationMetrics`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java), [`RecommendationHideService.hideToday`](../../../../src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java) |
 | `recommendation_score_confidence_{count,sum,max}` | DistributionSummary | `recommendation_score_confidence` | 생성된 추천 confidence 분포 | [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) |
 | `recommendation_score_lift_{count,sum,max}` | DistributionSummary | `recommendation_score_lift` | 생성된 추천 lift 분포 | [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) |
 | `recommendation_score_support_{count,sum,max}` | DistributionSummary | `recommendation_score_support` | 생성된 추천 support 분포 | [`ProblemRecommendationCommandAdapter.replaceActiveRecommendations`](../../../../src/main/java/com/wanted/codebombalms/recommendation/infrastructure/persistence/ProblemRecommendationCommandAdapter.java) |
@@ -100,6 +101,12 @@ sum by (reason) (increase(recommendation_generation_failed_total[5m]))
 
 ```promql
 sum(increase(recommendation_problem_set_exposed_total[5m]))
+```
+
+### 오늘 하루 보지 않음 수
+
+```promql
+sum(increase(recommendation_hide_today_total[1d]))
 ```
 
 ### 배치 실패 로그

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/port/RecommendationMetricPort.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/port/RecommendationMetricPort.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.recommendation.application.port;
+
+/** Recommendation 도메인 metric 기록 port입니다. */
+public interface RecommendationMetricPort {
+
+    void recordProblemSetList(long elapsedNanos);
+
+    void recordGenerationBatch(long elapsedNanos);
+
+    void incrementGenerationUsers(int userCount);
+
+    void incrementGenerationFailed(String reason);
+
+    void incrementExposed(int exposedCount);
+
+    void incrementHideToday();
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationGenerationService.java
@@ -3,8 +3,8 @@ package com.wanted.codebombalms.recommendation.application.service;
 import com.wanted.codebombalms.recommendation.application.command.GeneratedUserProblemSetRecommendations;
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationCommandPort;
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationGenerationClient;
+import com.wanted.codebombalms.recommendation.application.port.RecommendationMetricPort;
 import com.wanted.codebombalms.recommendation.application.usecase.GenerateProblemSetRecommendationsUseCase;
-import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +21,7 @@ public class ProblemRecommendationGenerationService implements GenerateProblemSe
 
     private final ProblemRecommendationGenerationClient generationClient;
     private final ProblemRecommendationCommandPort commandPort;
-    private final RecommendationMetrics recommendationMetrics;
+    private final RecommendationMetricPort recommendationMetrics;
 
     /** 사용자별 추천 최대 3개(후보 부족 시 1~2개 가능) 반환을 전제로 기존 추천 교체 저장을 수행합니다. */
     @Override

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/ProblemRecommendationQueryService.java
@@ -2,10 +2,10 @@ package com.wanted.codebombalms.recommendation.application.service;
 
 import com.wanted.codebombalms.recommendation.application.port.ProblemRecommendationQueryPort;
 import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
+import com.wanted.codebombalms.recommendation.application.port.RecommendationMetricPort;
 import com.wanted.codebombalms.recommendation.application.query.ProblemSetRecommendationResult;
 import com.wanted.codebombalms.recommendation.application.usecase.GetMyProblemSetRecommendationsUseCase;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
-import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -27,7 +27,7 @@ public class ProblemRecommendationQueryService implements GetMyProblemSetRecomme
 
     private final ProblemRecommendationQueryPort problemRecommendationQueryPort;
     private final RecommendationHidePort recommendationHidePort;
-    private final RecommendationMetrics recommendationMetrics;
+    private final RecommendationMetricPort recommendationMetrics;
 
     /** 숨김 상태를 먼저 확인한 뒤 활성 추천 목록을 최대 3개까지 조회합니다. */
     @Override

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java
@@ -2,10 +2,10 @@ package com.wanted.codebombalms.recommendation.application.service;
 
 import com.wanted.codebombalms.recommendation.application.command.RecommendationHideResult;
 import com.wanted.codebombalms.recommendation.application.port.RecommendationHidePort;
+import com.wanted.codebombalms.recommendation.application.port.RecommendationMetricPort;
 import com.wanted.codebombalms.recommendation.application.usecase.HideProblemSetRecommendationsTodayUseCase;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
-import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -23,7 +23,7 @@ public class RecommendationHideService implements HideProblemSetRecommendationsT
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     private final RecommendationHidePort recommendationHidePort;
-    private final RecommendationMetrics recommendationMetrics;
+    private final RecommendationMetricPort recommendationMetrics;
 
     /** Asia/Seoul 기준 오늘 23:59:59까지 숨김 만료 시간을 저장합니다. */
     @Override

--- a/src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/application/service/RecommendationHideService.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.recommendation.application.port.RecommendationHid
 import com.wanted.codebombalms.recommendation.application.usecase.HideProblemSetRecommendationsTodayUseCase;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHide;
 import com.wanted.codebombalms.recommendation.domain.model.RecommendationHideType;
+import com.wanted.codebombalms.recommendation.infrastructure.metrics.RecommendationMetrics;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -22,6 +23,7 @@ public class RecommendationHideService implements HideProblemSetRecommendationsT
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     private final RecommendationHidePort recommendationHidePort;
+    private final RecommendationMetrics recommendationMetrics;
 
     /** Asia/Seoul 기준 오늘 23:59:59까지 숨김 만료 시간을 저장합니다. */
     @Override
@@ -32,6 +34,7 @@ public class RecommendationHideService implements HideProblemSetRecommendationsT
                 RecommendationHideType.PROBLEM_SET_RECOMMENDATION,
                 hiddenUntil
         );
+        recommendationMetrics.incrementHideToday();
 
         return new RecommendationHideResult(true, hide.hiddenUntil());
     }

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java
@@ -20,6 +20,7 @@ public class RecommendationMetrics {
     private final Timer generationExternalTimer;
     private final Counter generationUserCounter;
     private final Counter exposedCounter;
+    private final Counter hideTodayCounter;
     private final DistributionSummary confidenceSummary;
     private final DistributionSummary liftSummary;
     private final DistributionSummary supportSummary;
@@ -61,6 +62,11 @@ public class RecommendationMetrics {
         // 추천 생성 대상 사용자 수 누적
         this.exposedCounter = Counter.builder("recommendation_problem_set_exposed_total")
                 .description("추천 목록에서 사용자에게 노출된 추천 카드 수")
+                .register(registry);
+
+        // 추천 영역 오늘 하루 숨김 처리 수 누적
+        this.hideTodayCounter = Counter.builder("recommendation_hide_today_total")
+                .description("추천 영역을 오늘 하루 숨김 처리한 횟수")
                 .register(registry);
 
         // 추천 생성 실패 수를 reason 별로 기록
@@ -120,6 +126,10 @@ public class RecommendationMetrics {
         if (exposedCount > 0) {
             exposedCounter.increment(exposedCount);
         }
+    }
+
+    public void incrementHideToday() {
+        hideTodayCounter.increment();
     }
 
     // 추천 score인 confidence/lift/support 분포 기록

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/metrics/RecommendationMetrics.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.recommendation.infrastructure.metrics;
 
+import com.wanted.codebombalms.recommendation.application.port.RecommendationMetricPort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 /** Recommendation 도메인 커스텀 메트릭을 기록합니다. */
 @Component
-public class RecommendationMetrics {
+public class RecommendationMetrics implements RecommendationMetricPort {
 
     private final MeterRegistry registry;
     private final Timer problemSetListTimer;
@@ -83,6 +84,7 @@ public class RecommendationMetrics {
                 .register(registry);
     }
 
+    @Override
     public void recordProblemSetList(long elapsedNanos) {
         problemSetListTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
@@ -95,6 +97,7 @@ public class RecommendationMetrics {
         problemSetListQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
 
+    @Override
     public void recordGenerationBatch(long elapsedNanos) {
         generationBatchTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
@@ -108,12 +111,14 @@ public class RecommendationMetrics {
                 .record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
 
+    @Override
     public void incrementGenerationUsers(int userCount) {
         if (userCount > 0) {
             generationUserCounter.increment(userCount);
         }
     }
 
+    @Override
     public void incrementGenerationFailed(String reason) {
         Counter.builder("recommendation_generation_failed_total")
                 .description("추천 생성 실패 수")
@@ -122,12 +127,14 @@ public class RecommendationMetrics {
                 .increment();
     }
 
+    @Override
     public void incrementExposed(int exposedCount) {
         if (exposedCount > 0) {
             exposedCounter.increment(exposedCount);
         }
     }
 
+    @Override
     public void incrementHideToday() {
         hideTodayCounter.increment();
     }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #575 

---

## 🛠️ 기능 관련 작업 내용
- 추천 영역 `오늘 하루 보지 않음` 클릭 수를 집계하는 `recommendation_hide_today_total` Counter metric 추가
- 추천 숨김 처리 성공 시 metric이 증가하도록 `RecommendationHideService`에 계측 연결
- Grafana 패널 구성을 위한 추천 도메인 metric 문서 업데이트

---

## ♻️ 패키지 변경 사항
- `project/recommendation/infrastructure/metrics`: 추천 숨김 Counter metric 등록 및 증가 메서드 추가
- `project/recommendation/application/service`: 오늘 하루 숨김 처리 성공 시 metric 기록
- `project/monitoring-local/docs/domains/recommendation`: 신규 metric 및 PromQL 문서화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 오늘 하루 추천 영역을 숨긴 횟수가 집계되도록 추가되었습니다.
  * 추천 숨김 동작이 발생할 때 관련 사용량이 자동으로 기록됩니다.
* **Bug Fixes**
  * 숨김 처리 흐름은 그대로 유지하면서, 집계 기능만 보강되어 기존 동작에 영향을 최소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->