### PR TITLE
[Feat] 로그인·회원가입 KPI 카운터 계측 (#550)

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/port/AuthMetricsPort.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/port/AuthMetricsPort.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.auth.application.port;
+
+/**
+ * Auth 도메인 KPI 계측 포트 — application 이 infrastructure(AuthMetrics)에
+ * 직접 의존하지 않도록 의존 방향을 역전한다(헥사고날). AuthMetrics 가 구현한다.
+ */
+public interface AuthMetricsPort {
+
+    /** 정식 로그인 성공(신뢰기기 즉시 발급). */
+    void recordLoginSuccess();
+
+    /** 추가 인증(step-up) 챌린지 발생 — 로그인 미완료. */
+    void recordLoginStepUp();
+
+    /** 로그인 실패(자격 불일치/계정 잠금). */
+    void recordLoginFail();
+
+    /** 회원가입 완료. */
+    void recordSignupSuccess();
+
+    /** 회원가입 실패(검증/중복/DB 제약). */
+    void recordSignupFail();
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 
 import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
 
-import com.wanted.codebombalms.auth.infrastructure.metrics.AuthMetrics;
+import com.wanted.codebombalms.auth.application.port.AuthMetricsPort;
 
 @Service
 @RequiredArgsConstructor
@@ -58,7 +58,7 @@ public class LoginService implements LoginUseCase {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthSecurityEventRecorder securityEventRecorder;
-    private final AuthMetrics authMetrics;
+    private final AuthMetricsPort authMetrics;
 
     @Override
     public LoginResult login(LoginCommand command, HttpServletRequest request, String deviceFp) {

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -39,6 +39,8 @@ import java.util.UUID;
 
 import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
 
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthMetrics;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -56,18 +58,25 @@ public class LoginService implements LoginUseCase {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthSecurityEventRecorder securityEventRecorder;
+    private final AuthMetrics authMetrics;
 
     @Override
     public LoginResult login(LoginCommand command, HttpServletRequest request, String deviceFp) {
 
         // 1~3. 인증 (이메일 / 비밀번호 / 계정 잠금)
-        User user = userRepository.findByEmail(command.email())
-                .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
-        if (!passwordEncoder.matches(command.rawpassword(), user.getPassword())) {
-            throw new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL);
-        }
-        if (user.isLocked()) {
-            throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
+        User user;
+        try {
+            user = userRepository.findByEmail(command.email())
+                    .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
+            if (!passwordEncoder.matches(command.rawpassword(), user.getPassword())) {
+                throw new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL);
+            }
+            if (user.isLocked()) {
+                throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
+            }
+        } catch (UnauthorizedException | ForbiddenException e) {
+            authMetrics.recordLoginFail();
+            throw e;
         }
 
         // 4. 기기 지문 + 지역(GeoIP)
@@ -108,6 +117,7 @@ public class LoginService implements LoginUseCase {
     }
 
     private LoginResult issueStepUp(User user, String deviceFp, GeoLocation geo) {
+        authMetrics.recordLoginStepUp();   // ← KPI: 이 로그인은 추가 인증으로 분기
         String stepUpToken = UUID.randomUUID().toString();
         String code = generateCode();
 
@@ -138,6 +148,7 @@ public class LoginService implements LoginUseCase {
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
         refreshTokenRepository.save(
                 RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration()));
+        authMetrics.recordLoginSuccess();   // ← KPI: 정식 로그인 성공
         return LoginResult.success(accessToken, refreshToken, user.getNickname(), user.getRole());
     }
 

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
@@ -1,15 +1,16 @@
 package com.wanted.codebombalms.auth.application.service;
 
 import com.wanted.codebombalms.auth.application.command.SignupCommand;
+import com.wanted.codebombalms.auth.application.port.AuthMetricsPort;
 import com.wanted.codebombalms.auth.application.usecase.SignupUseCase;
 import com.wanted.codebombalms.auth.domain.repository.EmailVerificationRepository;
-import com.wanted.codebombalms.auth.infrastructure.metrics.AuthMetrics;
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +23,7 @@ public class SignupService implements SignupUseCase {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final EmailVerificationRepository emailVerificationRepository;
-    private final AuthMetrics authMetrics;
+    private final AuthMetricsPort authMetrics;
 
     @Override
     public Long signup(SignupCommand command) {
@@ -69,6 +70,9 @@ public class SignupService implements SignupUseCase {
             return saved.getUserId();
         } catch (ValidationException | ConflictException e) {
             authMetrics.recordSignupFail();       // ← KPI: 검증/중복 실패
+            throw e;
+        } catch (DataIntegrityViolationException e) {
+            authMetrics.recordSignupFail();       // ← KPI: 동시 가입 경쟁으로 DB 유니크 위반
             throw e;
         }
     }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.auth.application.service;
 import com.wanted.codebombalms.auth.application.command.SignupCommand;
 import com.wanted.codebombalms.auth.application.usecase.SignupUseCase;
 import com.wanted.codebombalms.auth.domain.repository.EmailVerificationRepository;
+import com.wanted.codebombalms.auth.infrastructure.metrics.AuthMetrics;
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
@@ -21,48 +22,54 @@ public class SignupService implements SignupUseCase {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final EmailVerificationRepository emailVerificationRepository;
+    private final AuthMetrics authMetrics;
 
     @Override
     public Long signup(SignupCommand command) {
+        try {
+            // 1. 이메일 인증 완료 여부 확인 (보안 — 인증 우회 차단)
+            if (!emailVerificationRepository.isVerified(command.email())) {
+                throw new ValidationException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
+            }
 
-        // 1. 이메일 인증 완료 여부 확인 (보안 — 인증 우회 차단)
-        if (!emailVerificationRepository.isVerified(command.email())) {
-            throw new ValidationException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
+            // 2. 비밀번호 / 비밀번호 확인 일치 검증
+            if (!command.rawpassword().equals(command.passwordConfirm())) {
+                throw new ValidationException(UserErrorCode.USER_PASSWORD_CONFIRM_MISMATCH);
+            }
+
+            // 3. 이메일 중복 체크
+            if (userRepository.existsByEmail(command.email())) {
+                throw new ConflictException(UserErrorCode.USER_EMAIL_DUPLICATED);
+            }
+
+            // 4. 닉네임 중복 체크
+            if (userRepository.existsByNickname(command.nickname())) {
+                throw new ConflictException(UserErrorCode.USER_NICKNAME_DUPLICATED);
+            }
+
+            // 5. 비밀번호 인코딩
+            String encodedPassword = passwordEncoder.encode(command.rawpassword());
+
+            // 6. 도메인 객체 생성
+            User user = User.createLocalUser(
+                    command.email(),
+                    encodedPassword,
+                    command.name(),
+                    command.nickname(),
+                    command.phone()
+            );
+
+            // 7. 저장
+            User saved = userRepository.save(user);
+
+            // 8. 회원가입 완료 — 인증 플래그 정리
+            emailVerificationRepository.clearVerified(command.email());
+
+            authMetrics.recordSignupSuccess();   // ← KPI: 회원가입 완료
+            return saved.getUserId();
+        } catch (ValidationException | ConflictException e) {
+            authMetrics.recordSignupFail();       // ← KPI: 검증/중복 실패
+            throw e;
         }
-
-        // 2. 비밀번호 / 비밀번호 확인 일치 검증
-        if (!command.rawpassword().equals(command.passwordConfirm())) {
-            throw new ValidationException(UserErrorCode.USER_PASSWORD_CONFIRM_MISMATCH);
-        }
-
-        // 3. 이메일 중복 체크
-        if (userRepository.existsByEmail(command.email())) {
-            throw new ConflictException(UserErrorCode.USER_EMAIL_DUPLICATED);
-        }
-
-        // 4. 닉네임 중복 체크
-        if (userRepository.existsByNickname(command.nickname())) {
-            throw new ConflictException(UserErrorCode.USER_NICKNAME_DUPLICATED);
-        }
-
-        // 5. 비밀번호 인코딩
-        String encodedPassword = passwordEncoder.encode(command.rawpassword());
-
-        // 6. 도메인 객체 생성
-        User user = User.createLocalUser(
-                command.email(),
-                encodedPassword,
-                command.name(),
-                command.nickname(),
-                command.phone()
-        );
-
-        // 7. 저장
-        User saved = userRepository.save(user);
-
-        // 8. 회원가입 완료 — 인증 플래그 정리
-        emailVerificationRepository.clearVerified(command.email());
-
-        return saved.getUserId();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthMetrics.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.auth.infrastructure.metrics;
 
+import com.wanted.codebombalms.auth.application.port.AuthMetricsPort;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -15,7 +16,7 @@ import java.util.concurrent.TimeUnit;
  * 구분 못 한다. 비즈니스 outcome 차원({@code auth_login_total} / {@code auth_signup_total})을 채운다.
  */
 @Component
-public class AuthMetrics {
+public class AuthMetrics implements AuthMetricsPort {
 
     private final Timer loginHistoryQueryTimer;
 
@@ -62,26 +63,31 @@ public class AuthMetrics {
     }
 
     /** 정식 로그인 성공(신뢰기기 즉시 발급). */
+    @Override
     public void recordLoginSuccess() {
         loginSuccess.increment();
     }
 
     /** 추가 인증(step-up) 챌린지 발생 — 로그인 미완료. */
+    @Override
     public void recordLoginStepUp() {
         loginStepUp.increment();
     }
 
     /** 로그인 실패(자격 불일치/계정 잠금). */
+    @Override
     public void recordLoginFail() {
         loginFail.increment();
     }
 
     /** 회원가입 완료. */
+    @Override
     public void recordSignupSuccess() {
         signupSuccess.increment();
     }
 
     /** 회원가입 실패(검증/중복). */
+    @Override
     public void recordSignupFail() {
         signupFail.increment();
     }

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthMetrics.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthMetrics.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.auth.infrastructure.metrics;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.springframework.stereotype.Component;
@@ -9,15 +10,21 @@ import java.util.concurrent.TimeUnit;
 /**
  * Auth 도메인 커스텀 메트릭 (관측 Layer 3).
  *
- * <p>HTTP 메트릭({@code http_server_requests})은 요청 전체(컨트롤러~직렬화) 시간만 안다.
- * 이 Timer 는 "로그인 이력 조회 내부 구간(login_history 페이지 쿼리)"만 분리 측정한다.
- * 부하 중 HTTP p95 ↑ 와 이 timer ↑ 가 함께 움직이면 병목 = 이력 조회 쿼리(인덱스
- * 부재 풀스캔/filesort)로 좁힐 수 있다. 인덱스 반영 후 이 timer 가 떨어지면 효과를 증명한다.
+ * <p>Timer: 로그인 이력 조회 내부 구간 측정.
+ * <p>Counter(KPI): {@code http_server_requests} 는 200이 "로그인 성공"인지 "step-up 필요"인지
+ * 구분 못 한다. 비즈니스 outcome 차원({@code auth_login_total} / {@code auth_signup_total})을 채운다.
  */
 @Component
 public class AuthMetrics {
 
     private final Timer loginHistoryQueryTimer;
+
+    // KPI 카운터 — outcome 태그로 분해. 시작 시 0으로 사전 등록(이벤트 없어도 패널에 0 표시).
+    private final Counter loginSuccess;
+    private final Counter loginStepUp;
+    private final Counter loginFail;
+    private final Counter signupSuccess;
+    private final Counter signupFail;
 
     public AuthMetrics(MeterRegistry registry) {
         // 등록명엔 _seconds 를 붙이지 않는다. Timer 라서 Prometheus 가
@@ -25,10 +32,57 @@ public class AuthMetrics {
         this.loginHistoryQueryTimer = Timer.builder("auth_login_history_query_duration")
                 .description("로그인 이력 조회 구간 시간(login_history 페이지 쿼리)")
                 .register(registry);
+
+        // 등록명엔 _total 을 붙이지 않는다. Counter 라서 Prometheus 가
+        // auth_login_total{outcome} / auth_signup_total{outcome} 로 변환한다.
+        this.loginSuccess = loginCounter(registry, "success");
+        this.loginStepUp  = loginCounter(registry, "stepup");
+        this.loginFail    = loginCounter(registry, "fail");
+        this.signupSuccess = signupCounter(registry, "success");
+        this.signupFail    = signupCounter(registry, "fail");
+    }
+
+    private Counter loginCounter(MeterRegistry registry, String outcome) {
+        return Counter.builder("auth_login")
+                .tag("outcome", outcome)
+                .description("로그인 시도 결과 (success/stepup/fail)")
+                .register(registry);
+    }
+
+    private Counter signupCounter(MeterRegistry registry, String outcome) {
+        return Counter.builder("auth_signup")
+                .tag("outcome", outcome)
+                .description("회원가입 결과 (success/fail)")
+                .register(registry);
     }
 
     /** 로그인 이력 조회(login_history 페이지) 구간 소요 시간 기록. */
     public void recordLoginHistoryQuery(long elapsedNanos) {
         loginHistoryQueryTimer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+    }
+
+    /** 정식 로그인 성공(신뢰기기 즉시 발급). */
+    public void recordLoginSuccess() {
+        loginSuccess.increment();
+    }
+
+    /** 추가 인증(step-up) 챌린지 발생 — 로그인 미완료. */
+    public void recordLoginStepUp() {
+        loginStepUp.increment();
+    }
+
+    /** 로그인 실패(자격 불일치/계정 잠금). */
+    public void recordLoginFail() {
+        loginFail.increment();
+    }
+
+    /** 회원가입 완료. */
+    public void recordSignupSuccess() {
+        signupSuccess.increment();
+    }
+
+    /** 회원가입 실패(검증/중복). */
+    public void recordSignupFail() {
+        signupFail.increment();
     }
 }

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -22,6 +22,7 @@ import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import com.wanted.codebombalms.auth.application.port.AuthMetricsPort;
 import com.wanted.codebombalms.auth.infrastructure.metrics.AuthSecurityEventRecorder;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +60,7 @@ class LoginServiceTest {
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private HttpServletRequest httpRequest;
     @Mock private AuthSecurityEventRecorder securityEventRecorder;
+    @Mock private AuthMetricsPort authMetrics;
 
     @InjectMocks
     private LoginService loginService;

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.auth.application.service;
 
 import com.wanted.codebombalms.auth.application.command.SignupCommand;
+import com.wanted.codebombalms.auth.application.port.AuthMetricsPort;
 import com.wanted.codebombalms.auth.domain.repository.EmailVerificationRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
@@ -29,6 +30,7 @@ class SignupServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private EmailVerificationRepository emailVerificationRepository;
+    @Mock private AuthMetricsPort authMetrics;
 
     @InjectMocks
     private SignupService signupService;


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #550 

---

## 🛠️ 기능 관련 작업 내용
- `auth_login_total{outcome}` 카운터 추가 — 로그인 결과를 success/stepup/fail로 분해 (HTTP 200이 성공인지 step-up인지 구분 못 하는 한계 보강)
- `auth_signup_total{outcome}` 카운터 추가 — 회원가입 완료/실패 집계 → 가입 완료율 KPI
- `AuthMetrics`에 outcome 카운터 5종 사전 등록 → 이벤트 0건에도 대시보드에 0 노출
- `domain` 태그 전 컨트롤러 점검 — 14개 도메인 전부 유효 매핑, `unknown` 없음 확인

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/infrastructure/metrics`: `AuthMetrics`에 KPI 카운터 5종 + record 메서드 추가
- `codebombalms/auth/application/service`: `LoginService`(success/stepup/fail)·`SignupService`(success/fail) 계측 호출 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 로그인과 회원가입의 처리 상태를 더 세밀하게 기록하도록 개선했습니다.
* **버그 수정**
  * 인증 실패, 계정 잠금, 입력 검증, 중복 가입 상황에서 처리 흐름을 안정적으로 정리했습니다.
  * 성공/실패 및 단계 전환이 더 정확히 반영되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->