### PR TITLE
[Fix] 내 수강목록 및 카테고리 공개 조회 오류 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentQueryService.java
@@ -2,7 +2,9 @@ package com.wanted.codebombalms.enrollment.application.service;
 
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.enrollment.application.port.CourseCatalogPort;
+import com.wanted.codebombalms.enrollment.application.port.CoursePublicationStatus;
 import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort;
+import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgress;
 import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgressKey;
 import com.wanted.codebombalms.enrollment.application.query.MyCourseResult;
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
@@ -36,27 +38,32 @@ public class EnrollmentQueryService implements EnrollmentQueryUseCase {
         log.info("[EnrollmentQueryService] find my courses - userId: {}", userId);
 
         List<Enrollment> enrollments = enrollmentRepository.findByUserIdAndStatus(userId, EnrollmentStatus.ACTIVE);
-        Map<EnrollmentLearningProgressKey, EnrollmentLearningProgressPort.EnrollmentLearningProgress> progresses =
-                enrollmentLearningProgressPort.findProgresses(enrollments.stream()
-                        .map(enrollment -> new EnrollmentLearningProgressKey(userId, enrollment.getCourseId()))
+        List<MyCourseEnrollment> visibleEnrollments = enrollments.stream()
+                .map(enrollment -> toVisibleEnrollment(userId, enrollment))
+                .flatMap(Optional::stream)
+                .toList();
+
+        Map<EnrollmentLearningProgressKey, EnrollmentLearningProgress> progresses =
+                enrollmentLearningProgressPort.findProgresses(visibleEnrollments.stream()
+                        .map(visibleEnrollment -> new EnrollmentLearningProgressKey(
+                                userId,
+                                visibleEnrollment.enrollment().getCourseId()
+                        ))
                         .toList());
 
-        return enrollments.stream()
-                .map(enrollment -> toMyCourseResult(userId, enrollment, progresses))
-                .flatMap(Optional::stream)
+        return visibleEnrollments.stream()
+                .map(visibleEnrollment -> toMyCourseResult(userId, visibleEnrollment, progresses))
                 .toList();
     }
 
-    private Optional<MyCourseResult> toMyCourseResult(
+    private Optional<MyCourseEnrollment> toVisibleEnrollment(
             Long userId,
-            Enrollment enrollment,
-            Map<EnrollmentLearningProgressKey, EnrollmentLearningProgressPort.EnrollmentLearningProgress> progresses
+            Enrollment enrollment
     ) {
         try {
-            return Optional.of(MyCourseResult.from(
+            return Optional.of(new MyCourseEnrollment(
                     enrollment,
-                    courseCatalogPort.getPublicationStatus(enrollment.getCourseId()),
-                    progresses.get(new EnrollmentLearningProgressKey(userId, enrollment.getCourseId()))
+                    courseCatalogPort.getPublicationStatus(enrollment.getCourseId())
             ));
         } catch (NotFoundException e) {
             if (e.getErrorCode() != CourseErrorCode.COURSE_NOT_FOUND) {
@@ -71,6 +78,27 @@ public class EnrollmentQueryService implements EnrollmentQueryUseCase {
             );
             return Optional.empty();
         }
+    }
+
+    private MyCourseResult toMyCourseResult(
+            Long userId,
+            MyCourseEnrollment visibleEnrollment,
+            Map<EnrollmentLearningProgressKey, EnrollmentLearningProgress> progresses
+    ) {
+        Enrollment enrollment = visibleEnrollment.enrollment();
+        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(userId, enrollment.getCourseId());
+
+        return MyCourseResult.from(
+                enrollment,
+                visibleEnrollment.course(),
+                progresses.getOrDefault(progressKey, EnrollmentLearningProgress.of(0, 0, 0, 0))
+        );
+    }
+
+    private record MyCourseEnrollment(
+            Enrollment enrollment,
+            CoursePublicationStatus course
+    ) {
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -65,9 +65,9 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/users/find-email").permitAll()
                         // 강의/코스 브라우징
-                        .requestMatchers("/api/v1/courses/**").permitAll()
-                        .requestMatchers("/api/v1/course-categories/**").permitAll()
-                        .requestMatchers("/api/v1/lectures/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/courses/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/course-categories/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/lectures/**").permitAll()
                         // 운영/관리자 전용 (권한 경계 확정 전까지 둘 다 허용)
                         .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN", "OPERATOR", "MASTER")
                         // 그 외 모두 인증 필요

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/users/find-email").permitAll()
                         // 강의/코스 브라우징
                         .requestMatchers("/api/v1/courses/**").permitAll()
+                        .requestMatchers("/api/v1/course-categories/**").permitAll()
                         .requestMatchers("/api/v1/lectures/**").permitAll()
                         // 운영/관리자 전용 (권한 경계 확정 전까지 둘 다 허용)
                         .requestMatchers("/api/v1/admin/**").hasAnyRole("ADMIN", "OPERATOR", "MASTER")

--- a/src/test/java/com/wanted/codebombalms/course/controller/CourseCategorySecurityTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/controller/CourseCategorySecurityTest.java
@@ -1,0 +1,71 @@
+package com.wanted.codebombalms.course.controller;
+
+import com.wanted.codebombalms.admin.permission.application.service.AdminPermissionCheckService;
+import com.wanted.codebombalms.course.application.usecase.CourseCategoryQueryUseCase;
+import com.wanted.codebombalms.course.domain.model.CourseCategory;
+import com.wanted.codebombalms.course.domain.model.CourseCategoryStatus;
+import com.wanted.codebombalms.course.presentation.api.CourseCategoryController;
+import com.wanted.codebombalms.global.infrastructure.config.security.CustomAccessDeniedHandler;
+import com.wanted.codebombalms.global.infrastructure.config.security.CustomAuthenticationEntryPoint;
+import com.wanted.codebombalms.global.infrastructure.config.security.SecurityConfig;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CourseCategoryController.class)
+@Import({
+        SecurityConfig.class,
+        CustomAuthenticationEntryPoint.class
+})
+@DisplayName("CourseCategory security test")
+class CourseCategorySecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CourseCategoryQueryUseCase courseCategoryQueryUseCase;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private CustomAccessDeniedHandler accessDeniedHandler;
+
+    @MockitoBean
+    private AdminPermissionCheckService adminPermissionCheckService;
+
+    @Test
+    void findCourseCategories_isPublicBeforeLogin() throws Exception {
+        given(courseCategoryQueryUseCase.findCourseCategories()).willReturn(List.of(
+                CourseCategory.restore(
+                        1L,
+                        "Python",
+                        CourseCategoryStatus.ACTIVE,
+                        1,
+                        LocalDateTime.now()
+                )
+        ));
+
+        mockMvc.perform(get("/api/v1/course-categories")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data[0].courseCategoryId").value(1L))
+                .andExpect(jsonPath("$.data[0].name").value("Python"));
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/course/controller/CourseCategorySecurityTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/controller/CourseCategorySecurityTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -67,5 +68,12 @@ class CourseCategorySecurityTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data[0].courseCategoryId").value(1L))
                 .andExpect(jsonPath("$.data[0].name").value("Python"));
+    }
+
+    @Test
+    void writeMethodToCourseCategories_requiresAuthenticationBeforeLogin() throws Exception {
+        mockMvc.perform(post("/api/v1/course-categories")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
@@ -161,13 +161,10 @@ class EnrollmentServiceTest {
                 .willThrow(new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
 
         EnrollmentLearningProgressKey activeProgressKey = new EnrollmentLearningProgressKey(userId, 1L);
-        EnrollmentLearningProgressKey deletedProgressKey = new EnrollmentLearningProgressKey(userId, 2L);
-        given(enrollmentLearningProgressPort.findProgresses(List.of(activeProgressKey, deletedProgressKey)))
+        given(enrollmentLearningProgressPort.findProgresses(List.of(activeProgressKey)))
                 .willReturn(Map.of(
                         activeProgressKey,
-                        new EnrollmentLearningProgress(false, "IN_PROGRESS", 50, 1, 2, 0, 1),
-                        deletedProgressKey,
-                        new EnrollmentLearningProgress(false, "IN_PROGRESS", 0, 0, 1, 0, 1)
+                        new EnrollmentLearningProgress(false, "IN_PROGRESS", 50, 1, 2, 0, 1)
                 ));
 
         List<MyCourseResult> results = enrollmentQueryService.findMyCourses(userId);
@@ -177,21 +174,16 @@ class EnrollmentServiceTest {
         assertEquals("Java", results.get(0).courseTitle());
         verify(courseCatalogPort).getPublicationStatus(1L);
         verify(courseCatalogPort).getPublicationStatus(2L);
+        verify(enrollmentLearningProgressPort).findProgresses(List.of(activeProgressKey));
     }
 
     @Test
     void findMyCourses_rethrowsNotFound_whenErrorCodeIsNotCourseNotFound() {
         Long userId = 10L;
         Enrollment enrollment = createEnrollment(1L, userId, 1L, EnrollmentStatus.ACTIVE);
-        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(userId, 1L);
 
         given(enrollmentRepository.findByUserIdAndStatus(userId, EnrollmentStatus.ACTIVE))
                 .willReturn(List.of(enrollment));
-        given(enrollmentLearningProgressPort.findProgresses(List.of(progressKey)))
-                .willReturn(Map.of(
-                        progressKey,
-                        new EnrollmentLearningProgress(false, "IN_PROGRESS", 50, 1, 2, 0, 1)
-                ));
         given(courseCatalogPort.getPublicationStatus(1L))
                 .willThrow(new NotFoundException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND));
 
@@ -201,6 +193,29 @@ class EnrollmentServiceTest {
         );
 
         assertEquals(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void findMyCourses_returnsDefaultProgress_whenProgressIsMissing() {
+        Long userId = 10L;
+        Enrollment enrollment = createEnrollment(1L, userId, 1L, EnrollmentStatus.ACTIVE);
+        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(userId, 1L);
+
+        given(enrollmentRepository.findByUserIdAndStatus(userId, EnrollmentStatus.ACTIVE))
+                .willReturn(List.of(enrollment));
+        given(courseCatalogPort.getPublicationStatus(1L)).willReturn(createCourseStatus(1L));
+        given(enrollmentLearningProgressPort.findProgresses(List.of(progressKey))).willReturn(Map.of());
+
+        List<MyCourseResult> results = enrollmentQueryService.findMyCourses(userId);
+
+        assertEquals(1, results.size());
+        assertFalse(results.get(0).learningCompleted());
+        assertEquals("IN_PROGRESS", results.get(0).displayStatus());
+        assertEquals(0, results.get(0).lectureProgressRate());
+        assertEquals(0, results.get(0).completedLectureCount());
+        assertEquals(0, results.get(0).totalLectureCount());
+        assertEquals(0, results.get(0).completedProblemCount());
+        assertEquals(0, results.get(0).totalProblemCount());
     }
 
     @Test


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #588

---

## 🛠️ 기능 관련 작업 내용

- 내 수강목록 조회 시 삭제된 강좌를 먼저 제외한 뒤 정상 강좌만 학습 진행률 집계 대상으로 처리
- 학습 진행률 집계 결과가 누락되어도 기본 진행률(`IN_PROGRESS`, 0%)로 응답하도록 보완
- 비로그인 상태에서도 강좌 카테고리 목록을 조회할 수 있도록 `/api/v1/course-categories/**` 공개 허용
- 삭제 강좌 제외, progress 누락 기본값, 비로그인 카테고리 조회 보안 테스트 추가

---

## ♻️ 패키지 변경 사항

- `project/enrollment/application/service`: 내 수강목록 조회 시 삭제 강좌 제외 및 progress 누락 기본값 처리
- `project/enrollment/application/service/test`: 삭제 강좌 progress 제외 및 progress 누락 기본값 테스트 추가
- `project/global/infrastructure/config/security`: 강좌 카테고리 API 공개 허용 경로 추가
- `project/course/controller/test`: 비로그인 강좌 카테고리 조회 보안 테스트 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 강의 카테고리 조회 API가 로그인 없이도 이용 가능해졌습니다.

* **Bug Fixes**
  * 내 강의 목록에서 삭제된 강의는 더 이상 표시되지 않도록 개선했습니다.
  * 진행 정보가 없더라도 기본 진행 상태와 수치가 정상적으로 표시되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->