### PR TITLE
[Fix] 삭제 강좌 수강목록 조회 500 오류 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentQueryService.java
@@ -43,6 +43,10 @@ public class EnrollmentQueryService implements EnrollmentQueryUseCase {
                 .flatMap(Optional::stream)
                 .toList();
 
+        if (visibleEnrollments.isEmpty()) {
+            return List.of();
+        }
+
         Map<EnrollmentLearningProgressKey, EnrollmentLearningProgress> progresses =
                 enrollmentLearningProgressPort.findProgresses(visibleEnrollments.stream()
                         .map(visibleEnrollment -> new EnrollmentLearningProgressKey(

--- a/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentQueryService.java
@@ -38,8 +38,19 @@ public class EnrollmentQueryService implements EnrollmentQueryUseCase {
         log.info("[EnrollmentQueryService] find my courses - userId: {}", userId);
 
         List<Enrollment> enrollments = enrollmentRepository.findByUserIdAndStatus(userId, EnrollmentStatus.ACTIVE);
+        return toMyCourseResults(enrollments);
+    }
+
+    @Override
+    public List<MyCourseResult> findAllEnrollmentCourses() {
+        log.info("[EnrollmentQueryService] find all enrollment courses");
+
+        return toMyCourseResults(enrollmentRepository.findByStatus(EnrollmentStatus.ACTIVE));
+    }
+
+    private List<MyCourseResult> toMyCourseResults(List<Enrollment> enrollments) {
         List<MyCourseEnrollment> visibleEnrollments = enrollments.stream()
-                .map(enrollment -> toVisibleEnrollment(userId, enrollment))
+                .map(this::toVisibleEnrollment)
                 .flatMap(Optional::stream)
                 .toList();
 
@@ -50,20 +61,17 @@ public class EnrollmentQueryService implements EnrollmentQueryUseCase {
         Map<EnrollmentLearningProgressKey, EnrollmentLearningProgress> progresses =
                 enrollmentLearningProgressPort.findProgresses(visibleEnrollments.stream()
                         .map(visibleEnrollment -> new EnrollmentLearningProgressKey(
-                                userId,
+                                visibleEnrollment.enrollment().getUserId(),
                                 visibleEnrollment.enrollment().getCourseId()
                         ))
                         .toList());
 
         return visibleEnrollments.stream()
-                .map(visibleEnrollment -> toMyCourseResult(userId, visibleEnrollment, progresses))
+                .map(visibleEnrollment -> toMyCourseResult(visibleEnrollment, progresses))
                 .toList();
     }
 
-    private Optional<MyCourseEnrollment> toVisibleEnrollment(
-            Long userId,
-            Enrollment enrollment
-    ) {
+    private Optional<MyCourseEnrollment> toVisibleEnrollment(Enrollment enrollment) {
         try {
             return Optional.of(new MyCourseEnrollment(
                     enrollment,
@@ -76,7 +84,7 @@ public class EnrollmentQueryService implements EnrollmentQueryUseCase {
 
             log.info(
                     "[EnrollmentQueryService] skip deleted course enrollment - userId: {}, enrollmentId: {}, courseId: {}",
-                    userId,
+                    enrollment.getUserId(),
                     enrollment.getEnrollmentId(),
                     enrollment.getCourseId()
             );
@@ -85,12 +93,14 @@ public class EnrollmentQueryService implements EnrollmentQueryUseCase {
     }
 
     private MyCourseResult toMyCourseResult(
-            Long userId,
             MyCourseEnrollment visibleEnrollment,
             Map<EnrollmentLearningProgressKey, EnrollmentLearningProgress> progresses
     ) {
         Enrollment enrollment = visibleEnrollment.enrollment();
-        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(userId, enrollment.getCourseId());
+        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(
+                enrollment.getUserId(),
+                enrollment.getCourseId()
+        );
 
         return MyCourseResult.from(
                 enrollment,

--- a/src/main/java/com/wanted/codebombalms/enrollment/application/usecase/EnrollmentQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/application/usecase/EnrollmentQueryUseCase.java
@@ -9,6 +9,8 @@ public interface EnrollmentQueryUseCase {
 
     List<MyCourseResult> findMyCourses(Long userId);
 
+    List<MyCourseResult> findAllEnrollmentCourses();
+
     List<Enrollment> findAllActiveEnrollments();
 
     List<Long> findActiveStudentIdsByCourse(Long courseId);

--- a/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/course/CourseAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/infrastructure/course/CourseAdapter.java
@@ -13,15 +13,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class CourseAdapter implements CourseCatalogPort {
 
     private final CourseRepository courseRepository;
 
     @Override
+    @Transactional(readOnly = true, noRollbackFor = NotFoundException.class)
     public CoursePublicationStatus getPublicationStatus(Long courseId) {
         Course course = courseRepository.findByCourseIdAndDeletedAtIsNull(courseId)
                 .orElseThrow(() -> new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
+        if (course.getStatus() == CourseStatus.DELETED) {
+            throw new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND);
+        }
 
         return new CoursePublicationStatus(
                 course.getCourseId(),

--- a/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
@@ -1,18 +1,11 @@
 package com.wanted.codebombalms.enrollment.presentation.api;
 
-import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.enrollment.application.command.CancelEnrollmentCommand;
 import com.wanted.codebombalms.enrollment.application.command.EnrollCourseCommand;
-import com.wanted.codebombalms.enrollment.application.port.CourseCatalogPort;
-import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort;
-import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgress;
-import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgressKey;
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentCommandUseCase;
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
-import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
 import com.wanted.codebombalms.enrollment.presentation.api.response.EnrollCourseResponse;
 import com.wanted.codebombalms.enrollment.presentation.api.response.MyCourseResponse;
-import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,9 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -39,8 +29,6 @@ public class EnrollmentController {
 
     private final EnrollmentCommandUseCase enrollmentCommandUseCase;
     private final EnrollmentQueryUseCase enrollmentQueryUseCase;
-    private final CourseCatalogPort courseCatalogPort;
-    private final EnrollmentLearningProgressPort enrollmentLearningProgressPort;
 
     @PostMapping("/courses/{courseId}/enrollments")
     @Operation(summary = "수강신청 생성")
@@ -96,21 +84,12 @@ public class EnrollmentController {
     public ResponseEntity<ApiResponse<?>> findAllEnrollments() {
         log.info("[EnrollmentController] find all active enrollments");
 
-        List<Enrollment> enrollments = enrollmentQueryUseCase.findAllActiveEnrollments();
-        Map<EnrollmentLearningProgressKey, EnrollmentLearningProgressPort.EnrollmentLearningProgress> progresses =
-                enrollmentLearningProgressPort.findProgresses(enrollments.stream()
-                        .map(enrollment -> new EnrollmentLearningProgressKey(
-                                enrollment.getUserId(),
-                                enrollment.getCourseId()
-                        ))
-                        .toList());
-
         return ResponseEntity.ok(ApiResponse.success(
                 EnrollmentResponseCode.RETRIEVED,
                 EnrollmentResponseMessage.RETRIEVED,
-                enrollments.stream()
-                        .map(enrollment -> toMyCourseResponse(enrollment, progresses))
-                        .flatMap(Optional::stream)
+                enrollmentQueryUseCase.findAllEnrollmentCourses()
+                        .stream()
+                        .map(MyCourseResponse::from)
                         .toList()
         ));
     }
@@ -153,34 +132,5 @@ public class EnrollmentController {
                         .map(MyCourseResponse::from)
                         .toList()
         ));
-    }
-
-    private Optional<MyCourseResponse> toMyCourseResponse(
-            Enrollment enrollment,
-            Map<EnrollmentLearningProgressKey, EnrollmentLearningProgress> progresses
-    ) {
-        try {
-            EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(
-                    enrollment.getUserId(),
-                    enrollment.getCourseId()
-            );
-            return Optional.of(MyCourseResponse.from(
-                    enrollment,
-                    courseCatalogPort.getPublicationStatus(enrollment.getCourseId()),
-                    progresses.getOrDefault(progressKey, EnrollmentLearningProgress.of(0, 0, 0, 0))
-            ));
-        } catch (NotFoundException e) {
-            if (e.getErrorCode() != CourseErrorCode.COURSE_NOT_FOUND) {
-                throw e;
-            }
-
-            log.info(
-                    "[EnrollmentController] skip deleted course enrollment - userId: {}, enrollmentId: {}, courseId: {}",
-                    enrollment.getUserId(),
-                    enrollment.getEnrollmentId(),
-                    enrollment.getCourseId()
-            );
-            return Optional.empty();
-        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentController.java
@@ -1,16 +1,20 @@
 package com.wanted.codebombalms.enrollment.presentation.api;
 
+import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.enrollment.application.command.CancelEnrollmentCommand;
 import com.wanted.codebombalms.enrollment.application.command.EnrollCourseCommand;
 import com.wanted.codebombalms.enrollment.application.port.CourseCatalogPort;
 import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort;
+import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgress;
 import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgressKey;
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentCommandUseCase;
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
 import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
 import com.wanted.codebombalms.enrollment.presentation.api.response.EnrollCourseResponse;
 import com.wanted.codebombalms.enrollment.presentation.api.response.MyCourseResponse;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -54,7 +59,7 @@ public class EnrollmentController {
                 ));
     }
 
-    @GetMapping({"/users/me/enrollments", "/users/me/enrollments/"})
+    @GetMapping("/users/me/enrollments")
     @Operation(summary = "내 수강 목록 조회")
     @PreAuthorize("hasRole('STUDENT')")
     public ResponseEntity<ApiResponse<?>> findMyCourses(
@@ -62,6 +67,15 @@ public class EnrollmentController {
     ) {
         log.info("[EnrollmentController] find my courses - userId: {}", userId);
 
+        return buildMyCoursesResponse(userId);
+    }
+
+    @Hidden
+    @GetMapping("/users/me/enrollments/")
+    @PreAuthorize("hasRole('STUDENT')")
+    public ResponseEntity<ApiResponse<?>> findMyCoursesWithTrailingSlash(
+            @AuthenticationPrincipal Long userId
+    ) {
         return buildMyCoursesResponse(userId);
     }
 
@@ -95,14 +109,8 @@ public class EnrollmentController {
                 EnrollmentResponseCode.RETRIEVED,
                 EnrollmentResponseMessage.RETRIEVED,
                 enrollments.stream()
-                        .map(enrollment -> MyCourseResponse.from(
-                                enrollment,
-                                courseCatalogPort.getPublicationStatus(enrollment.getCourseId()),
-                                progresses.get(new EnrollmentLearningProgressKey(
-                                        enrollment.getUserId(),
-                                        enrollment.getCourseId()
-                                ))
-                        ))
+                        .map(enrollment -> toMyCourseResponse(enrollment, progresses))
+                        .flatMap(Optional::stream)
                         .toList()
         ));
     }
@@ -145,5 +153,34 @@ public class EnrollmentController {
                         .map(MyCourseResponse::from)
                         .toList()
         ));
+    }
+
+    private Optional<MyCourseResponse> toMyCourseResponse(
+            Enrollment enrollment,
+            Map<EnrollmentLearningProgressKey, EnrollmentLearningProgress> progresses
+    ) {
+        try {
+            EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(
+                    enrollment.getUserId(),
+                    enrollment.getCourseId()
+            );
+            return Optional.of(MyCourseResponse.from(
+                    enrollment,
+                    courseCatalogPort.getPublicationStatus(enrollment.getCourseId()),
+                    progresses.getOrDefault(progressKey, EnrollmentLearningProgress.of(0, 0, 0, 0))
+            ));
+        } catch (NotFoundException e) {
+            if (e.getErrorCode() != CourseErrorCode.COURSE_NOT_FOUND) {
+                throw e;
+            }
+
+            log.info(
+                    "[EnrollmentController] skip deleted course enrollment - userId: {}, enrollmentId: {}, courseId: {}",
+                    enrollment.getUserId(),
+                    enrollment.getEnrollmentId(),
+                    enrollment.getCourseId()
+            );
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
@@ -1,8 +1,10 @@
 package com.wanted.codebombalms.lecture.application.policy;
 
+import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
@@ -19,6 +21,7 @@ public class LectureAccessPolicy {
     private final LectureProgressPort lectureProgressPort;
 
     public void validateLearningContentAccess(Lecture lecture, Long userId, boolean operator) {
+        validateCourseContentAccess(lecture.getCourse(), userId, operator);
         if (operator) {
             return;
         }
@@ -31,6 +34,9 @@ public class LectureAccessPolicy {
     }
 
     public void validateCourseContentAccess(Course course, Long userId, boolean operator) {
+        if (course == null || course.getDeletedAt() != null || course.getStatus() == CourseStatus.DELETED) {
+            throw new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND);
+        }
         if (operator) {
             return;
         }

--- a/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -175,6 +176,23 @@ class EnrollmentServiceTest {
         verify(courseCatalogPort).getPublicationStatus(1L);
         verify(courseCatalogPort).getPublicationStatus(2L);
         verify(enrollmentLearningProgressPort).findProgresses(List.of(activeProgressKey));
+    }
+
+    @Test
+    void findMyCourses_returnsEmptyList_whenAllEnrollmentsPointToDeletedCourses() {
+        Long userId = 10L;
+        Enrollment deletedCourseEnrollment = createEnrollment(1L, userId, 1L, EnrollmentStatus.ACTIVE);
+
+        given(enrollmentRepository.findByUserIdAndStatus(userId, EnrollmentStatus.ACTIVE))
+                .willReturn(List.of(deletedCourseEnrollment));
+        given(courseCatalogPort.getPublicationStatus(1L))
+                .willThrow(new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
+
+        List<MyCourseResult> results = enrollmentQueryService.findMyCourses(userId);
+
+        assertTrue(results.isEmpty());
+        verify(courseCatalogPort).getPublicationStatus(1L);
+        verify(enrollmentLearningProgressPort, never()).findProgresses(any());
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
@@ -237,6 +237,35 @@ class EnrollmentServiceTest {
     }
 
     @Test
+    void findAllEnrollmentCourses_skipsDeletedCourseEnrollments() {
+        Enrollment activeCourseEnrollment = createEnrollment(1L, 10L, 1L, EnrollmentStatus.ACTIVE);
+        Enrollment deletedCourseEnrollment = createEnrollment(2L, 11L, 2L, EnrollmentStatus.ACTIVE);
+
+        given(enrollmentRepository.findByStatus(EnrollmentStatus.ACTIVE))
+                .willReturn(List.of(activeCourseEnrollment, deletedCourseEnrollment));
+        given(courseCatalogPort.getPublicationStatus(1L)).willReturn(createCourseStatus(1L));
+        given(courseCatalogPort.getPublicationStatus(2L))
+                .willThrow(new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
+
+        EnrollmentLearningProgressKey activeProgressKey = new EnrollmentLearningProgressKey(10L, 1L);
+        given(enrollmentLearningProgressPort.findProgresses(List.of(activeProgressKey)))
+                .willReturn(Map.of(
+                        activeProgressKey,
+                        new EnrollmentLearningProgress(false, "IN_PROGRESS", 50, 1, 2, 0, 1)
+                ));
+
+        List<MyCourseResult> results = enrollmentQueryService.findAllEnrollmentCourses();
+
+        assertEquals(1, results.size());
+        assertEquals(10L, results.get(0).studentId());
+        assertEquals(1L, results.get(0).courseId());
+        assertEquals("Java", results.get(0).courseTitle());
+        verify(courseCatalogPort).getPublicationStatus(1L);
+        verify(courseCatalogPort).getPublicationStatus(2L);
+        verify(enrollmentLearningProgressPort).findProgresses(List.of(activeProgressKey));
+    }
+
+    @Test
     void findAllActiveEnrollments_returnsActiveEnrollments() {
         Enrollment enrollment = createEnrollment(1L, 10L, 1L, EnrollmentStatus.ACTIVE);
 

--- a/src/test/java/com/wanted/codebombalms/enrollment/infrastructure/course/CourseAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/infrastructure/course/CourseAdapterTest.java
@@ -1,0 +1,45 @@
+package com.wanted.codebombalms.enrollment.infrastructure.course;
+
+import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.course.domain.model.CourseStatus;
+import com.wanted.codebombalms.course.domain.repository.CourseRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CourseAdapterTest {
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @InjectMocks
+    private CourseAdapter courseAdapter;
+
+    @Test
+    void getPublicationStatus_throwsNotFound_whenCourseStatusIsDeleted() {
+        Long courseId = 1L;
+        Course course = new Course();
+        course.setCourseId(courseId);
+        course.setStatus(CourseStatus.DELETED);
+
+        given(courseRepository.findByCourseIdAndDeletedAtIsNull(courseId))
+                .willReturn(Optional.of(course));
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> courseAdapter.getPublicationStatus(courseId)
+        );
+
+        assertEquals(CourseErrorCode.COURSE_NOT_FOUND, exception.getErrorCode());
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.enrollment.presentation.api;
 
 import com.wanted.codebombalms.admin.permission.application.service.AdminPermissionCheckService;
+import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.enrollment.application.command.CancelEnrollmentCommand;
 import com.wanted.codebombalms.enrollment.application.command.EnrollCourseCommand;
 import com.wanted.codebombalms.enrollment.application.port.CourseCatalogPort;
@@ -13,6 +14,7 @@ import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentCommandU
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
 import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
 import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -192,6 +194,31 @@ class EnrollmentControllerTest {
                 .andExpect(jsonPath("$.code").value(EnrollmentResponseCode.RETRIEVED))
                 .andExpect(jsonPath("$.data[0].courseTitle").value("Java"))
                 .andExpect(jsonPath("$.data[0].displayStatus").value("COMPLETED"));
+    }
+
+    @Test
+    void findAllEnrollments_skipsDeletedCourseEnrollments() throws Exception {
+        Enrollment activeEnrollment = createEnrollment(1L, 10L, 1L, EnrollmentStatus.ACTIVE);
+        Enrollment deletedCourseEnrollment = createEnrollment(2L, 11L, 2L, EnrollmentStatus.ACTIVE);
+
+        given(enrollmentQueryUseCase.findAllActiveEnrollments())
+                .willReturn(List.of(activeEnrollment, deletedCourseEnrollment));
+        given(courseCatalogPort.getPublicationStatus(1L))
+                .willReturn(new CoursePublicationStatus(1L, 1L, "Java", "description", "java.png", true));
+        given(courseCatalogPort.getPublicationStatus(2L))
+                .willThrow(new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
+        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(10L, 1L);
+        given(enrollmentLearningProgressPort.findProgresses(List.of(
+                progressKey,
+                new EnrollmentLearningProgressKey(11L, 2L)
+        ))).willReturn(Map.of(progressKey, createCompletedProgress()));
+
+        mockMvc.perform(get("/api/v1/enrollments")
+                        .with(authentication(operatorPrincipal(1L)))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].courseId").value(1L));
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/presentation/api/EnrollmentControllerTest.java
@@ -1,20 +1,13 @@
 package com.wanted.codebombalms.enrollment.presentation.api;
 
 import com.wanted.codebombalms.admin.permission.application.service.AdminPermissionCheckService;
-import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.enrollment.application.command.CancelEnrollmentCommand;
 import com.wanted.codebombalms.enrollment.application.command.EnrollCourseCommand;
-import com.wanted.codebombalms.enrollment.application.port.CourseCatalogPort;
-import com.wanted.codebombalms.enrollment.application.port.CoursePublicationStatus;
-import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort;
-import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgress;
-import com.wanted.codebombalms.enrollment.application.port.EnrollmentLearningProgressPort.EnrollmentLearningProgressKey;
 import com.wanted.codebombalms.enrollment.application.query.MyCourseResult;
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentCommandUseCase;
 import com.wanted.codebombalms.enrollment.application.usecase.EnrollmentQueryUseCase;
 import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
 import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
-import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -35,7 +28,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,12 +55,6 @@ class EnrollmentControllerTest {
 
     @MockitoBean
     private EnrollmentQueryUseCase enrollmentQueryUseCase;
-
-    @MockitoBean
-    private CourseCatalogPort courseCatalogPort;
-
-    @MockitoBean
-    private EnrollmentLearningProgressPort enrollmentLearningProgressPort;
 
     @MockitoBean
     private AdminPermissionCheckService adminPermissionCheckService;
@@ -179,12 +165,8 @@ class EnrollmentControllerTest {
     void findAllEnrollments_returnsApiResponse() throws Exception {
         Enrollment enrollment = createEnrollment(1L, 10L, 1L, EnrollmentStatus.ACTIVE);
 
-        given(enrollmentQueryUseCase.findAllActiveEnrollments()).willReturn(List.of(enrollment));
-        given(courseCatalogPort.getPublicationStatus(1L))
-                .willReturn(new CoursePublicationStatus(1L, 1L, "Java", "description", "java.png", true));
-        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(10L, 1L);
-        given(enrollmentLearningProgressPort.findProgresses(List.of(progressKey)))
-                .willReturn(Map.of(progressKey, createCompletedProgress()));
+        given(enrollmentQueryUseCase.findAllEnrollmentCourses())
+                .willReturn(List.of(createMyCourseResult(enrollment)));
 
         mockMvc.perform(get("/api/v1/enrollments")
                         .with(authentication(operatorPrincipal(1L)))
@@ -197,21 +179,11 @@ class EnrollmentControllerTest {
     }
 
     @Test
-    void findAllEnrollments_skipsDeletedCourseEnrollments() throws Exception {
+    void findAllEnrollments_returnsFilteredResultsFromUseCase() throws Exception {
         Enrollment activeEnrollment = createEnrollment(1L, 10L, 1L, EnrollmentStatus.ACTIVE);
-        Enrollment deletedCourseEnrollment = createEnrollment(2L, 11L, 2L, EnrollmentStatus.ACTIVE);
 
-        given(enrollmentQueryUseCase.findAllActiveEnrollments())
-                .willReturn(List.of(activeEnrollment, deletedCourseEnrollment));
-        given(courseCatalogPort.getPublicationStatus(1L))
-                .willReturn(new CoursePublicationStatus(1L, 1L, "Java", "description", "java.png", true));
-        given(courseCatalogPort.getPublicationStatus(2L))
-                .willThrow(new NotFoundException(CourseErrorCode.COURSE_NOT_FOUND));
-        EnrollmentLearningProgressKey progressKey = new EnrollmentLearningProgressKey(10L, 1L);
-        given(enrollmentLearningProgressPort.findProgresses(List.of(
-                progressKey,
-                new EnrollmentLearningProgressKey(11L, 2L)
-        ))).willReturn(Map.of(progressKey, createCompletedProgress()));
+        given(enrollmentQueryUseCase.findAllEnrollmentCourses())
+                .willReturn(List.of(createMyCourseResult(activeEnrollment)));
 
         mockMvc.perform(get("/api/v1/enrollments")
                         .with(authentication(operatorPrincipal(1L)))
@@ -323,7 +295,4 @@ class EnrollmentControllerTest {
         );
     }
 
-    private EnrollmentLearningProgress createCompletedProgress() {
-        return new EnrollmentLearningProgress(true, "COMPLETED", 100, 2, 2, 1, 1);
-    }
 }

--- a/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
@@ -1,8 +1,10 @@
 package com.wanted.codebombalms.lecture.application.policy;
 
+import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
@@ -84,6 +86,20 @@ class LectureAccessPolicyTest {
     }
 
     @Test
+    void validateLearningContentAccess_throwsNotFoundForDeletedCourseWithoutEnrollmentCheck() {
+        Lecture lecture = new Lecture();
+        lecture.setCourse(course(1L, CourseStatus.DELETED));
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> lectureAccessPolicy.validateLearningContentAccess(lecture, 10L, false)
+        );
+
+        assertEquals(CourseErrorCode.COURSE_NOT_FOUND, exception.getErrorCode());
+        verifyNoInteractions(lectureEnrollmentPort);
+    }
+
+    @Test
     void validateCourseContentAccess_allowsActiveCourseWithoutEnrollmentCheck() {
         Course course = course(1L, CourseStatus.ACTIVE);
 
@@ -133,15 +149,15 @@ class LectureAccessPolicyTest {
     }
 
     @Test
-    void validateCourseContentAccess_throwsForbiddenForDeletedCourseWithoutEnrollmentCheck() {
+    void validateCourseContentAccess_throwsNotFoundForDeletedCourseWithoutEnrollmentCheck() {
         Course course = course(1L, CourseStatus.DELETED);
 
-        ForbiddenException exception = assertThrows(
-                ForbiddenException.class,
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
                 () -> lectureAccessPolicy.validateCourseContentAccess(course, 10L, false)
         );
 
-        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
+        assertEquals(CourseErrorCode.COURSE_NOT_FOUND, exception.getErrorCode());
         verifyNoInteractions(lectureEnrollmentPort);
     }
 


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #591

---

## 🛠️ 기능 관련 작업 내용

- 삭제된 강좌가 수강목록에 남아 있어도 내 수강목록 조회가 500으로 실패하지 않고 해당 강좌를 skip하도록 수정
- 삭제 강좌 조회 중 발생한 `NotFoundException`이 트랜잭션 rollback-only로 전파되어 `UnexpectedRollbackException`이 발생하지 않도록 처리
- 전체 수강신청 목록 조회에서도 삭제 강좌와 누락된 progress 데이터를 안전하게 처리
- Swagger에는 `/api/v1/users/me/enrollments`만 노출하고 trailing slash 호환 매핑은 숨김 처리

---

## ♻️ 패키지 변경 사항

- `project/enrollment`: 삭제 강좌 수강목록 skip, progress 기본값 처리, Swagger 중복 노출 정리
- `project/lecture`: 삭제 강좌 하위 강의 접근 시 `CRS-001`로 차단하도록 접근 정책 보완
- `project/test`: 삭제 강좌 수강목록/전체 수강목록/강의 접근 정책 회귀 테스트 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 삭제된 강의/강의 상품이 조회될 때 더 일관되게 “찾을 수 없음”으로 처리되도록 개선했습니다.
  * 수강 목록 조회에서 삭제된 강의는 결과에서 제외되며, 관련 추가 조회는 불필요하게 수행하지 않습니다.
  * 일부 접근 검증에서 삭제된 강의는 권한 오류 대신 “찾을 수 없음”으로 응답합니다.

* **Tests**
  * 삭제된 강의, 빈 수강 목록, 접근 정책 변경을 검증하는 테스트를 추가하고 기존 기대값을 갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->