### PR TITLE
[Fix] stateless AT 세션·잠금 하드닝 — Redis sid로 P0 3종

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/service/AuthSessionManager.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/AuthSessionManager.java
@@ -1,0 +1,39 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.domain.repository.AuthSessionRepository;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AuthSessionManager {
+
+    private final AuthSessionRepository authSessionRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 새 세션 오픈 — sid 발급 + Redis 저장(단일세션: 기존 세션 덮어씀).
+     * 반환된 sid 를 AT 에 심는다. TTL = RT 만료(세션 최대 수명).
+     */
+    public String open(Long userId) {
+        String sid = UUID.randomUUID().toString();
+        authSessionRepository.save(userId, sid,
+                Duration.ofMillis(jwtTokenProvider.getRefreshExpiration()));
+        return sid;
+    }
+
+    /** 현재 세션 sid 반환 — 없으면 새로 오픈. 세션 유지형 AT 재발급용(예: 닉네임 변경). */
+    public String currentSid(Long userId) {
+        return authSessionRepository.findSid(userId)
+                .orElseGet(() -> open(userId));
+    }
+
+    /** 세션 종료 — 잠금·탈퇴 시 호출 → 발급된 전 AT 즉시 무효 */
+    public void close(Long userId) {
+        authSessionRepository.delete(userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/AuthSessionManager.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/AuthSessionManager.java
@@ -1,19 +1,24 @@
 package com.wanted.codebombalms.auth.application.service;
 
 import com.wanted.codebombalms.auth.domain.repository.AuthSessionRepository;
-import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.UUID;
 
 @Service
-@RequiredArgsConstructor
 public class AuthSessionManager {
 
     private final AuthSessionRepository authSessionRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final long refreshExpirationMillis;
+
+    public AuthSessionManager(
+            AuthSessionRepository authSessionRepository,
+            @Value("${jwt.refresh-expiration}") long refreshExpirationMillis) {
+        this.authSessionRepository = authSessionRepository;
+        this.refreshExpirationMillis = refreshExpirationMillis;
+    }
 
     /**
      * 새 세션 오픈 — sid 발급 + Redis 저장(단일세션: 기존 세션 덮어씀).
@@ -21,8 +26,7 @@ public class AuthSessionManager {
      */
     public String open(Long userId) {
         String sid = UUID.randomUUID().toString();
-        authSessionRepository.save(userId, sid,
-                Duration.ofMillis(jwtTokenProvider.getRefreshExpiration()));
+        authSessionRepository.save(userId, sid, Duration.ofMillis(refreshExpirationMillis));
         return sid;
     }
 

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/CompleteSocialSignupService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/CompleteSocialSignupService.java
@@ -27,6 +27,7 @@ public class CompleteSocialSignupService implements CompleteSocialSignupUseCase 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public TokenPair complete(String tempToken, String nickname, String phone) {
@@ -54,8 +55,9 @@ public class CompleteSocialSignupService implements CompleteSocialSignupUseCase 
         tempTokenRepository.findAndDelete(tempToken);
 
         // 6. 토큰 발급 (가입 직후 바로 로그인)
+        String sid = authSessionManager.open(saved.getUserId());
         String accessToken = jwtTokenProvider.generateAccessToken(
-                saved.getUserId(), saved.getNickname(), saved.getRole());
+                saved.getUserId(), saved.getNickname(), saved.getRole(), sid);
         String refreshToken = jwtTokenProvider.generateRefreshToken(saved.getUserId());
 
         refreshTokenRepository.save(

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackService.java
@@ -32,6 +32,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -47,6 +50,7 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
     private final LoginHistoryRepository loginHistoryRepository;
     private final TrustedDeviceRepository trustedDeviceRepository;
     private final AuthSecurityEventRecorder securityEventRecorder;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public GoogleCallbackResult handleCallback(String code, String state, HttpServletRequest request, String deviceFp) {
@@ -90,6 +94,11 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
      * step-up(이메일 OTP)은 제외한다 (구글이 이미 인증을 보장).
      */
     private GoogleCallbackResult issueTokens(User user, HttpServletRequest request, String deviceFp) {
+        // P0-3: 잠긴 소셜 계정 로그인 차단 (LOCAL 로그인과 동일 가드)
+        if (user.isLocked()) {
+            throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
+        }
+
         String ip = ClientIpResolver.resolve(request);
         GeoLocation geo = geoIpResolver.resolve(ip);
 
@@ -129,8 +138,9 @@ public class GoogleCallbackService implements GoogleCallbackUseCase {
 
         // 단일 세션 강제 후 AT/RT 발급
         refreshTokenRepository.deleteByUserId(user.getUserId());
+        String sid = authSessionManager.open(user.getUserId());
         String token = jwtTokenProvider.generateAccessToken(
-                user.getUserId(), user.getNickname(), user.getRole());
+                user.getUserId(), user.getNickname(), user.getRole(), sid);
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
         refreshTokenRepository.save(
                 RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration())

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LockAccountService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LockAccountService.java
@@ -19,6 +19,7 @@ public class LockAccountService implements LockAccountUseCase {
     private final LockTokenRepository lockTokenRepository;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public void lock(String token) {
@@ -35,7 +36,8 @@ public class LockAccountService implements LockAccountUseCase {
         user.lock();
         userRepository.save(user);
 
-        // 3. 강제 로그아웃 (RT 전체 삭제)
+        // 3. 강제 로그아웃 (RT 전체 삭제 + AT 세션 무효화 → 발급된 전 AT 즉시 만료)
         refreshTokenRepository.deleteByUserId(userId);
+        authSessionManager.close(userId);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LoginService.java
@@ -59,6 +59,7 @@ public class LoginService implements LoginUseCase {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthSecurityEventRecorder securityEventRecorder;
     private final AuthMetricsPort authMetrics;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public LoginResult login(LoginCommand command, HttpServletRequest request, String deviceFp) {
@@ -144,7 +145,9 @@ public class LoginService implements LoginUseCase {
 
     private LoginResult issueTokens(User user) {
         refreshTokenRepository.deleteByUserId(user.getUserId());
-        String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getNickname(), user.getRole());
+        String sid = authSessionManager.open(user.getUserId());
+        String accessToken = jwtTokenProvider.generateAccessToken(
+                user.getUserId(), user.getNickname(), user.getRole(), sid);
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
         refreshTokenRepository.save(
                 RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration()));

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
@@ -25,6 +25,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +42,7 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
     private final GeoIpResolver geoIpResolver;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthSecurityEventRecorder securityEventRecorder;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public LoginResult verify(StepUpVerifyCommand command, HttpServletRequest request) {
@@ -70,6 +73,9 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
         User user = userRepository.findByUserId(challenge.userId())
                 .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_LOGIN_FAIL));
 
+        if (user.isLocked()) {
+            throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
+        }
         // 4. 신뢰 기기 등록 (옵션) — 이미 있으면 갱신, 없으면 신규 (유니크 (user_id, device_fp) 위반 방지)
         if (command.trustDevice()) {
             GeoLocation geo = geoIpResolver.resolve(ClientIpResolver.resolve(request));
@@ -90,8 +96,11 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
         }
 
         // 5. 정식 토큰 발급 (단일 세션 강제)
+        // 5. 정식 토큰 발급 (단일 세션 강제)
         refreshTokenRepository.deleteByUserId(user.getUserId());
-        String accessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getNickname(), user.getRole());
+        String sid = authSessionManager.open(user.getUserId());
+        String accessToken = jwtTokenProvider.generateAccessToken(
+                user.getUserId(), user.getNickname(), user.getRole(), sid);
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
         refreshTokenRepository.save(
                 RefreshToken.issue(user.getUserId(), refreshToken, jwtTokenProvider.getRefreshExpiration()));

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/StepUpVerifyService.java
@@ -96,7 +96,6 @@ public class StepUpVerifyService implements StepUpVerifyUseCase {
         }
 
         // 5. 정식 토큰 발급 (단일 세션 강제)
-        // 5. 정식 토큰 발급 (단일 세션 강제)
         refreshTokenRepository.deleteByUserId(user.getUserId());
         String sid = authSessionManager.open(user.getUserId());
         String accessToken = jwtTokenProvider.generateAccessToken(

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/TokenReissueService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/TokenReissueService.java
@@ -24,6 +24,7 @@ public class TokenReissueService implements TokenReissueUseCase {
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public TokenPair reissue(String refreshToken) {
@@ -49,8 +50,10 @@ public class TokenReissueService implements TokenReissueUseCase {
             throw new ForbiddenException(UserErrorCode.USER_ACCOUNT_LOCKED);
         }
 
-        // 5. 새 토큰 발급
-        String newAccessToken = jwtTokenProvider.generateAccessToken(user.getUserId(), user.getNickname(),user.getRole());
+        // 5. 새 토큰 발급 (sid 회전 — 이전 AT 무효화)
+        String sid = authSessionManager.open(user.getUserId());
+        String newAccessToken = jwtTokenProvider.generateAccessToken(
+                user.getUserId(), user.getNickname(), user.getRole(), sid);
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
 
         // 6. RTR — 기존 RT 삭제 + 새 RT 저장 (1회용)

--- a/src/main/java/com/wanted/codebombalms/auth/domain/repository/AuthSessionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/domain/repository/AuthSessionRepository.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.auth.domain.repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface AuthSessionRepository {
+
+    /** 로그인 시 단일 세션 저장 (userId → sid). 기존 값 덮어씀 = 이전 세션(옛 AT) 축출. */
+    void save(Long userId, String sid, Duration ttl);
+
+    /** 현재 유효 세션 sid 조회 — 필터가 AT 의 sid 와 대조. */
+    Optional<String> findSid(Long userId);
+
+    /** 세션 무효화 — 잠금·탈퇴 시 호출 → 발급된 전 AT 즉시 무효. */
+    void delete(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisAuthSessionAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/RedisAuthSessionAdapter.java
@@ -1,0 +1,33 @@
+package com.wanted.codebombalms.auth.infrastructure.persistence;
+
+import com.wanted.codebombalms.auth.domain.repository.AuthSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class RedisAuthSessionAdapter implements AuthSessionRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String KEY_SESSION = "auth:session:"; // + {userId}
+
+    @Override
+    public void save(Long userId, String sid, Duration ttl) {
+        redisTemplate.opsForValue().set(KEY_SESSION + userId, sid, ttl);
+    }
+
+    @Override
+    public Optional<String> findSid(Long userId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(KEY_SESSION + userId));
+    }
+
+    @Override
+    public void delete(Long userId) {
+        redisTemplate.delete(KEY_SESSION + userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.global.infrastructure.config.security;
 
+import com.wanted.codebombalms.auth.domain.repository.AuthSessionRepository;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import jakarta.servlet.DispatcherType;
@@ -28,6 +29,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthSessionRepository authSessionRepository;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final CustomAccessDeniedHandler accessDeniedHandler;
 
@@ -74,7 +76,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        new JwtAuthenticationFilter(jwtTokenProvider, authSessionRepository),
                         UsernamePasswordAuthenticationFilter.class
                 ).exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint)

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -7,16 +7,19 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
+import com.wanted.codebombalms.auth.domain.repository.AuthSessionRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -24,6 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public static final String AUTHENTICATED_ROLE_ATTRIBUTE = "authenticatedRole";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthSessionRepository authSessionRepository;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -43,6 +47,24 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 // 3. claims에서 userId, role 꺼내기
                 Claims claims = jwtTokenProvider.getClaims(token);
                 Long userId = Long.parseLong(claims.getSubject());
+
+                // 3-1. 세션(sid) 검증 — 단일세션(P0-2) + 실시간 잠금/탈퇴 반영(P0-1)
+                //      Redis 장애 시 fail-closed(안전측): 검증 불가 → 미인증 처리(401)
+                String sid = jwtTokenProvider.getSid(claims);
+                boolean sessionValid;
+                try {
+                    sessionValid = sid != null
+                            && authSessionRepository.findSid(userId).map(sid::equals).orElse(false);
+                } catch (RuntimeException redisDown) {
+                    sessionValid = false;
+                    log.warn("세션(sid) 검증 실패 — Redis 접근 오류로 fail-closed 처리. userId={}", userId, redisDown);
+                }
+                if (!sessionValid) {
+                    SecurityContextHolder.clearContext();
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 String role = claims.get("role", String.class);
                 request.setAttribute(AUTHENTICATED_USER_ID_ATTRIBUTE, userId);
                 request.setAttribute(AUTHENTICATED_ROLE_ATTRIBUTE, role);

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtTokenProvider.java
@@ -37,16 +37,23 @@ public class JwtTokenProvider {
         this.refreshExpiration = refreshExpiration;
     }
 
-    public String generateAccessToken(Long userId, String nickname, UserRole role) {
+    /** sid(세션ID) 포함 AT 발급 — 단일세션 + 실시간 잠금 검증용. */
+    public String generateAccessToken(Long userId, String nickname, UserRole role, String sid) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim("typ", TYPE_ACCESS)
                 .claim("nickname", nickname)
                 .claim("role", role.name())
+                .claim("sid", sid)
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + accessExpiration))
                 .signWith(key)
                 .compact();
+    }
+
+    /** AT claims 에서 sid 추출 — 필터가 Redis 세션과 대조. */
+    public String getSid(Claims claims) {
+        return claims.get("sid", String.class);
     }
 
     public String generateRefreshToken(Long userId) {

--- a/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.auth.application.service.AuthSessionManager;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.user.application.usecase.ChangeStudentLockUseCase;
@@ -17,6 +18,7 @@ public class ChangeStudentLockService implements ChangeStudentLockUseCase {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public void changeLock(Long userId, boolean locked) {
@@ -26,6 +28,7 @@ public class ChangeStudentLockService implements ChangeStudentLockUseCase {
         if (locked) {
             user.lock();
             refreshTokenRepository.deleteByUserId(userId);
+            authSessionManager.close(userId);
         } else {
             user.unlock();
         }

--- a/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/WithdrawUserService.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.auth.application.service.AuthSessionManager;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
@@ -26,6 +27,7 @@ public class WithdrawUserService implements WithdrawUserUseCase {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public void withdraw(Long userId, String rawPassword, String confirmText) {
@@ -52,8 +54,9 @@ public class WithdrawUserService implements WithdrawUserUseCase {
         user.softDelete();
         userRepository.save(user);
 
-        // 4. Refresh Token 전체 삭제 (강제 로그아웃)
+        // 4. Refresh Token 전체 삭제 + AT 세션 무효화 (강제 로그아웃)
         refreshTokenRepository.deleteByUserId(userId);
+        authSessionManager.close(userId);
 
         // 5. 감사 추적 로깅
         log.info("회원 탈퇴 처리 완료 - userId={}, social={}, deletedAt={}",

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/UpdateMyInfoController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/UpdateMyInfoController.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.user.presentation.api;
 
+import com.wanted.codebombalms.auth.application.service.AuthSessionManager;
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import com.wanted.codebombalms.user.application.query.UpdateMyInfoResult;
@@ -28,6 +29,7 @@ public class UpdateMyInfoController {
     private final UpdateMyInfoUseCase updateMyInfoUseCase;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthCookieFactory authCookieFactory;
+    private final AuthSessionManager authSessionManager;
 
     @Operation(
             summary = "개인정보 수정",
@@ -48,8 +50,9 @@ public class UpdateMyInfoController {
 
         // 2. 닉네임 변경 시에만 accessToken 재발급 (JWT nickname claim 최신화)
         if (result.nicknameChanged()) {
+            String sid = authSessionManager.currentSid(userId);
             String newAccessToken = jwtTokenProvider.generateAccessToken(
-                    userId, result.nickname(), result.role()
+                    userId, result.nickname(), result.role(), sid
             );
             response.addCookie(authCookieFactory.create(
                     "accessToken",

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/GoogleCallbackServiceTest.java
@@ -57,6 +57,7 @@ class GoogleCallbackServiceTest {
     @Mock private TrustedDeviceRepository trustedDeviceRepository;
     @Mock private HttpServletRequest request;
     @Mock private AuthSecurityEventRecorder securityEventRecorder;
+    @Mock private AuthSessionManager authSessionManager;
 
     @InjectMocks
     private GoogleCallbackService service;
@@ -78,7 +79,8 @@ class GoogleCallbackServiceTest {
         given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
         given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
         given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.empty());
-        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("AT");
+        given(authSessionManager.open(1L)).willReturn("SID");
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "SID")).willReturn("AT");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("RT");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
@@ -118,7 +120,8 @@ class GoogleCallbackServiceTest {
         given(userRepository.findByEmail(EMAIL)).willReturn(Optional.of(user));
         given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
         given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP)).willReturn(Optional.of(existing));
-        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("AT");
+        given(authSessionManager.open(1L)).willReturn("SID");
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "SID")).willReturn("AT");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("RT");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LoginServiceTest.java
@@ -61,6 +61,7 @@ class LoginServiceTest {
     @Mock private HttpServletRequest httpRequest;
     @Mock private AuthSecurityEventRecorder securityEventRecorder;
     @Mock private AuthMetricsPort authMetrics;
+    @Mock private AuthSessionManager authSessionManager;
 
     @InjectMocks
     private LoginService loginService;
@@ -82,7 +83,8 @@ class LoginServiceTest {
         given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
         given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP))
                 .willReturn(Optional.of(TrustedDevice.register(1L, DEVICE_FP, "Chrome", null, null)));
-        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
+        given(authSessionManager.open(1L)).willReturn("SID");
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "SID")).willReturn("ACCESS_TOKEN");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 
@@ -119,7 +121,7 @@ class LoginServiceTest {
         assertNull(result.accessToken());
         verify(emailSender).sendStepUpCode(eq("test@example.com"), anyString(), anyString());        verify(stepUpTokenRepository).save(anyString(), any());
         verify(loginHistoryRepository).save(any(LoginHistory.class));
-        verify(jwtTokenProvider, never()).generateAccessToken(anyLong(), anyString(), any());
+        verify(jwtTokenProvider, never()).generateAccessToken(anyLong(), anyString(), any(), any());
         verify(refreshTokenRepository, never()).save(any());
     }
 
@@ -185,7 +187,8 @@ class LoginServiceTest {
         given(geoIpResolver.resolve(any())).willReturn(GeoLocation.unknown());
         given(trustedDeviceRepository.findByUserIdAndDeviceFp(1L, DEVICE_FP))
                 .willReturn(Optional.of(TrustedDevice.register(1L, DEVICE_FP, "Chrome", null, null)));
-        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("ACCESS_TOKEN");
+        given(authSessionManager.open(1L)).willReturn("SID");
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "SID")).willReturn("ACCESS_TOKEN");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("REFRESH_TOKEN");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/TokenReissueServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/TokenReissueServiceTest.java
@@ -36,6 +36,7 @@ class TokenReissueServiceTest {
     @Mock private RefreshTokenRepository refreshTokenRepository;
     @Mock private UserRepository userRepository;
     @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private AuthSessionManager authSessionManager;
 
     @InjectMocks
     private TokenReissueService tokenReissueService;
@@ -56,7 +57,8 @@ class TokenReissueServiceTest {
 
         given(refreshTokenRepository.findByToken(OLD_TOKEN)).willReturn(Optional.of(stored));
         given(userRepository.findByUserId(1L)).willReturn(Optional.of(user));
-        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT)).willReturn("NEW_ACCESS");
+        given(authSessionManager.open(1L)).willReturn("SID");
+        given(jwtTokenProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "SID")).willReturn("NEW_ACCESS");
         given(jwtTokenProvider.generateRefreshToken(1L)).willReturn("NEW_REFRESH");
         given(jwtTokenProvider.getRefreshExpiration()).willReturn(1209600000L);
 

--- a/src/test/java/com/wanted/codebombalms/course/controller/CourseCategorySecurityTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/controller/CourseCategorySecurityTest.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.course.application.usecase.CourseCategoryQueryUse
 import com.wanted.codebombalms.course.domain.model.CourseCategory;
 import com.wanted.codebombalms.course.domain.model.CourseCategoryStatus;
 import com.wanted.codebombalms.course.presentation.api.CourseCategoryController;
+import com.wanted.codebombalms.auth.domain.repository.AuthSessionRepository;
 import com.wanted.codebombalms.global.infrastructure.config.security.CustomAccessDeniedHandler;
 import com.wanted.codebombalms.global.infrastructure.config.security.CustomAuthenticationEntryPoint;
 import com.wanted.codebombalms.global.infrastructure.config.security.SecurityConfig;
@@ -43,6 +44,9 @@ class CourseCategorySecurityTest {
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private AuthSessionRepository authSessionRepository;
 
     @MockitoBean
     private CustomAccessDeniedHandler accessDeniedHandler;

--- a/src/test/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/wanted/codebombalms/global/infrastructure/jwt/JwtTokenProviderTest.java
@@ -23,7 +23,7 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("정상 access token은 검증을 통과하고 typ/role claim을 담는다.")
     void access_token_정상() {
-        String token = provider.generateAccessToken(1L, "길동이", UserRole.STUDENT);
+        String token = provider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "sid-1");
 
         assertDoesNotThrow(() -> provider.validateAccessToken(token));
 
@@ -57,7 +57,7 @@ class JwtTokenProviderTest {
     @Test
     @DisplayName("access token을 refresh로 검증하면 AUTH_REFRESH_TOKEN_INVALID로 차단한다. (역방향 오용 방지)")
     void access를_refresh로_쓰면_차단() {
-        String accessToken = provider.generateAccessToken(1L, "길동이", UserRole.STUDENT);
+        String accessToken = provider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "sid-1");
 
         UnauthorizedException ex = assertThrows(
                 UnauthorizedException.class,
@@ -71,7 +71,7 @@ class JwtTokenProviderTest {
     void 만료된_access_token() {
         JwtTokenProvider expiredProvider =
                 new JwtTokenProvider(SECRET, -1000L, REFRESH_EXP); // 발급 즉시 만료
-        String expired = expiredProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT);
+        String expired = expiredProvider.generateAccessToken(1L, "길동이", UserRole.STUDENT, "sid-1");
 
         UnauthorizedException ex = assertThrows(
                 UnauthorizedException.class,

--- a/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.auth.application.service.AuthSessionManager;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
@@ -28,6 +29,7 @@ class ChangeStudentLockServiceTest {
 
     @Mock private UserRepository userRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock private AuthSessionManager authSessionManager;
 
     @InjectMocks
     private ChangeStudentLockService changeStudentLockService;

--- a/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
@@ -47,6 +47,7 @@ class ChangeStudentLockServiceTest {
         // then
         assertTrue(user.isLocked());
         verify(refreshTokenRepository).deleteByUserId(1L);
+        verify(authSessionManager).close(1L);
         verify(userRepository).save(user);
     }
 
@@ -63,6 +64,7 @@ class ChangeStudentLockServiceTest {
         // then
         assertFalse(user.isLocked());
         verify(refreshTokenRepository, never()).deleteByUserId(any());
+        verify(authSessionManager, never()).close(any());
         verify(userRepository).save(user);
     }
 
@@ -79,6 +81,7 @@ class ChangeStudentLockServiceTest {
         );
         assertEquals(UserErrorCode.USER_NOT_FOUND, ex.getErrorCode());
         verify(refreshTokenRepository, never()).deleteByUserId(any());
+        verify(authSessionManager, never()).close(any());
         verify(userRepository, never()).save(any());
     }
 

--- a/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.auth.application.service.AuthSessionManager;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
@@ -35,6 +36,7 @@ class WithdrawUserServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
     @Mock private PasswordEncoder passwordEncoder;
+    @Mock private AuthSessionManager authSessionManager;
 
     @InjectMocks
     private WithdrawUserService withdrawUserService;

--- a/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/WithdrawUserServiceTest.java
@@ -77,6 +77,7 @@ class WithdrawUserServiceTest {
         verify(userRepository).save(captor.capture());
         assertTrue(captor.getValue().isDeleted(), "deleted_at 이 채워져야 한다");
         verify(refreshTokenRepository).deleteByUserId(1L);
+        verify(authSessionManager).close(1L);
     }
 
     @Test
@@ -96,6 +97,7 @@ class WithdrawUserServiceTest {
 
         verify(userRepository, never()).save(any());
         verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
+        verify(authSessionManager, never()).close(anyLong());
     }
 
     @Test
@@ -113,6 +115,7 @@ class WithdrawUserServiceTest {
         verify(userRepository).save(captor.capture());
         assertTrue(captor.getValue().isDeleted(), "deleted_at 이 채워져야 한다");
         verify(refreshTokenRepository).deleteByUserId(2L);
+        verify(authSessionManager).close(2L);
     }
 
     @Test
@@ -131,6 +134,7 @@ class WithdrawUserServiceTest {
 
         verify(userRepository, never()).save(any());
         verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
+        verify(authSessionManager, never()).close(anyLong());
     }
 
     @Test
@@ -148,5 +152,6 @@ class WithdrawUserServiceTest {
 
         verify(userRepository, never()).save(any());
         verify(refreshTokenRepository, never()).deleteByUserId(anyLong());
+        verify(authSessionManager, never()).close(anyLong());
     }
 }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- 

---

## 🛠️ 기능 관련 작업 내용
- Redis 세션ID(`sid`) 도입 — 필터가 매 요청 AT의 sid를 `auth:session:{userId}`와 대조
- P0-1: 잠금/탈퇴 시 세션 삭제 → 발급된 전 AT 즉시 무효 (기존 1h 무검증 창 제거)
- P0-2: 로그인·재발급 sid 단일세션 강제 → 옛 기기 AT 자동 축출
- P0-3: 소셜 로그인·step-up 에 `isLocked` 잠금 가드 추가

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/domain/repository`·`auth/infrastructure/persistence`: `AuthSessionRepository` + Redis 어댑터 신규
- `codebombalms/auth/application/service`: `AuthSessionManager` 신규 + 발급/잠금 sid 연동
- `codebombalms/global/infrastructure/jwt`·`.../config/security`: AT `sid` claim + 필터 enforcement
- `codebombalms/user/application/service`·`presentation/api`: 탈퇴·잠금·내정보수정 sid 연동

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 로그인, 소셜 로그인, 재발급, 닉네임 변경 시 세션 식별자를 반영한 토큰 발급이 지원됩니다.
  * 사용자별 세션을 조회·생성·종료하는 흐름이 추가되었습니다.
* **Bug Fixes**
  * 잠긴 계정은 인증 토큰 발급이 차단됩니다.
  * 계정 잠금, 탈퇴 시 기존 세션이 함께 종료되어 이후 토큰 사용이 제한됩니다.
* **Security**
  * JWT 인증 시 세션 일치 여부를 확인해 무효화된 토큰은 인증되지 않도록 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->