### PR TITLE
[Feat] CSV 메타데이터 추출 및 RDS 저장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,7 @@ jobs:
           GOOGLE_REDIRECT_URI: ${{ vars.GOOGLE_REDIRECT_URI }}
           OAUTH_ADDITIONAL_INFO_URI: ${{ vars.OAUTH_ADDITIONAL_INFO_URI }}
           OAUTH_SUCCESS_URI: ${{ vars.OAUTH_SUCCESS_URI }}
+          OAUTH_ERROR_URI: ${{ vars.OAUTH_ERROR_URI }}
           COOKIE_SECURE: ${{ vars.COOKIE_SECURE }}
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_STORAGE_BUCKET: ${{ vars.GCP_STORAGE_BUCKET }}
@@ -86,13 +87,28 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
+          # ── 필수 값 검증 (재발방지 가드) ──
+          # 누락 시 앱이 application.yml의 localhost/빈 기본값으로 "조용히" 떨어져
+          # 챗봇(FASTAPI_URL)·로그수집(LOKI_HOST)·OAuth 리다이렉트가 런타임에 깨진다.
+          # → 배포 자체를 여기서 크게 실패시켜 잘못된 기동을 막는다.
+          missing=""
+          for k in DB_URL DB_USERNAME DB_PASSWORD JWT_SECRET REDIS_HOST REDIS_PASSWORD \
+                   FASTAPI_URL LOKI_HOST CORS_ALLOWED_ORIGINS COOKIE_SECURE \
+                   GOOGLE_REDIRECT_URI OAUTH_SUCCESS_URI OAUTH_ADDITIONAL_INFO_URI OAUTH_ERROR_URI; do
+            [ -z "${!k:-}" ] && missing="$missing $k"
+          done
+          if [ -n "$missing" ]; then
+            echo "❌ 필수 GitHub Secret/Variable 누락:$missing"
+            echo "   → 레포 Settings → Secrets and variables → Actions 에 등록 후 재실행."
+            exit 1
+          fi
           : > deploy.env
           # 빈 값은 건너뜀 → application.yml 기본값 유지 (빈값 override 방지)
           for k in ECR_REGISTRY SPRING_PROFILES_ACTIVE GOOGLE_APPLICATION_CREDENTIALS DDL_AUTO \
                    DB_URL DB_USERNAME DB_PASSWORD REDIS_HOST REDIS_PORT REDIS_PASSWORD LOKI_HOST \
                    CORS_ALLOWED_ORIGINS FASTAPI_URL JWT_SECRET MAIL_USERNAME MAIL_PASSWORD \
                    GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_REDIRECT_URI \
-                   OAUTH_ADDITIONAL_INFO_URI OAUTH_SUCCESS_URI COOKIE_SECURE \
+                   OAUTH_ADDITIONAL_INFO_URI OAUTH_SUCCESS_URI OAUTH_ERROR_URI COOKIE_SECURE \
                    GCP_PROJECT_ID GCP_STORAGE_BUCKET; do
             v="${!k}"
             [ -n "$v" ] && printf '%s=%s\n' "$k" "$v" >> deploy.env

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ application-*.yaml
 .env*
 /secrets/
 /src/main/resources/gcs/
+# GCP 서비스 계정 키(로컬 배치) — 절대 커밋 금지
+gcp-storage-key.json
+*-storage-key.json
 
 ### Logs ###
 *.log

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     //구글 클라우드
     implementation 'com.google.cloud:google-cloud-storage:2.68.0'
 
+    //CSV 파싱 (데이터셋 metadata 추출 #544)
+    implementation 'org.apache.commons:commons-csv:1.11.0'
+
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     //mail

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/application/service/DatasetMetadataExtractor.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/application/service/DatasetMetadataExtractor.java
@@ -1,0 +1,146 @@
+package com.wanted.codebombalms.problems.dataset.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.springframework.stereotype.Component;
+
+import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 업로드된 CSV bytes에서 컬럼명 + 예시값을 추출해 metadata JSON을 만든다.
+ * 계약: {"columns":[{"name":..,"examples":[..]}]} (dtype 추론 없음)
+ * 부가정보이므로 어떤 실패에도 예외를 던지지 않고 null을 반환한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DatasetMetadataExtractor {
+
+    private static final int MAX_COLUMNS = 100;
+    private static final int MAX_EXAMPLES = 5;
+    private static final int MAX_EXAMPLE_LENGTH = 100;
+    private static final int MAX_SCAN_ROWS = 200;
+    private static final Charset MS949 = Charset.forName("MS949");
+
+    private final ObjectMapper objectMapper;
+
+    public String extract(byte[] content) {
+        if (content == null || content.length == 0) {
+            return null;
+        }
+
+        String text = decode(content);
+        if (text == null) {
+            log.warn("데이터셋 metadata 추출 실패: UTF-8/MS949 디코딩 불가 (mojibake 차단)");
+            return null;
+        }
+
+        try {
+            return parse(text);
+        } catch (Exception e) {
+            log.warn("데이터셋 metadata 추출 실패: CSV 파싱 오류", e);
+            return null;
+        }
+    }
+
+    private String parse(String text) throws Exception {
+        try (CSVParser parser = CSVParser.parse(new StringReader(text), CSVFormat.DEFAULT)) {
+            Iterator<CSVRecord> it = parser.iterator();
+            if (!it.hasNext()) {
+                return null; // 빈 파일
+            }
+
+            CSVRecord header = it.next();
+            int columnCount = Math.min(header.size(), MAX_COLUMNS);
+            if (columnCount == 0) {
+                return null;
+            }
+
+            List<String> names = new ArrayList<>(columnCount);
+            List<LinkedHashSet<String>> examples = new ArrayList<>(columnCount);
+            for (int i = 0; i < columnCount; i++) {
+                names.add(header.get(i) == null ? "" : header.get(i).trim());
+                examples.add(new LinkedHashSet<>());
+            }
+
+            int scanned = 0;
+            while (it.hasNext() && scanned < MAX_SCAN_ROWS) {
+                CSVRecord row = it.next();
+                for (int i = 0; i < columnCount; i++) {
+                    if (i >= row.size()) {
+                        continue;
+                    }
+                    String value = row.get(i);
+                    if (value == null || value.isBlank()) {
+                        continue;
+                    }
+                    LinkedHashSet<String> bucket = examples.get(i);
+                    if (bucket.size() >= MAX_EXAMPLES) {
+                        continue;
+                    }
+                    bucket.add(truncate(value.trim()));
+                }
+                scanned++;
+            }
+
+            List<ColumnMeta> columns = new ArrayList<>(columnCount);
+            for (int i = 0; i < columnCount; i++) {
+                columns.add(new ColumnMeta(names.get(i), new ArrayList<>(examples.get(i))));
+            }
+
+            return objectMapper.writeValueAsString(new DatasetMeta(columns));
+        }
+    }
+
+    private String decode(byte[] content) {
+        String utf8 = decodeStrict(content, StandardCharsets.UTF_8);
+        if (utf8 != null) {
+            return stripBom(utf8);
+        }
+        return decodeStrict(content, MS949);
+    }
+
+    private String decodeStrict(byte[] content, Charset charset) {
+        CharsetDecoder decoder = charset.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+        try {
+            return decoder.decode(ByteBuffer.wrap(content)).toString();
+        } catch (CharacterCodingException e) {
+            return null;
+        }
+    }
+
+    private String stripBom(String text) {
+        if (!text.isEmpty() && text.charAt(0) == '\uFEFF') {
+            return text.substring(1);
+        }
+        return text;
+    }
+
+    private String truncate(String value) {
+        return value.length() <= MAX_EXAMPLE_LENGTH
+                ? value
+                : value.substring(0, MAX_EXAMPLE_LENGTH);
+    }
+
+    // 클래스 하단에 nested record 2개 추가 (JSON 계약 shape)
+    private record ColumnMeta(String name, List<String> examples) {}
+    private record DatasetMeta(List<ColumnMeta> columns) {}
+}

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/domain/model/StoredDatasetFile.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/domain/model/StoredDatasetFile.java
@@ -10,13 +10,15 @@ public class StoredDatasetFile {
     private final String fileUrl;
     private final String filePath;
     private final Long fileSize;
+    private final String metadata;
 
     private StoredDatasetFile(
             String originalFileName,
             String storedFileName,
             String fileUrl,
             String filePath,
-            Long fileSize
+            Long fileSize,
+            String metadata
     ) {
         if (originalFileName == null || originalFileName.isBlank()) {
             throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE);
@@ -36,6 +38,7 @@ public class StoredDatasetFile {
         this.fileUrl = fileUrl;
         this.filePath = filePath;
         this.fileSize = fileSize;
+        this.metadata = metadata;
     }
 
     public static StoredDatasetFile create(
@@ -43,14 +46,16 @@ public class StoredDatasetFile {
             String storedFileName,
             String fileUrl,
             String filePath,
-            Long fileSize
+            Long fileSize,
+            String metadata
     ) {
         return new StoredDatasetFile(
                 originalFileName,
                 storedFileName,
                 fileUrl,
                 filePath,
-                fileSize
+                fileSize,
+                metadata
         );
     }
 
@@ -72,5 +77,9 @@ public class StoredDatasetFile {
 
     public Long getFileSize() {
         return fileSize;
+    }
+
+    public String getMetadata() {
+        return metadata;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetJpaEntity.java
@@ -53,7 +53,8 @@ public class ProblemDatasetJpaEntity {
             String storedFileName,
             String fileUrl,
             String filePath,
-            Long fileSize
+            Long fileSize,
+            String metadata
     ) {
         ProblemDatasetJpaEntity dataset = new ProblemDatasetJpaEntity();
         dataset.originalFileName = originalFileName;
@@ -61,6 +62,7 @@ public class ProblemDatasetJpaEntity {
         dataset.fileUrl = fileUrl;
         dataset.filePath = filePath;
         dataset.fileSize = fileSize;
+        dataset.metadata = metadata;
         dataset.status = "ACTIVE";
         dataset.createdAt = LocalDateTime.now();
         dataset.updatedAt = dataset.createdAt;

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/persistence/ProblemDatasetPersistenceAdapter.java
@@ -32,7 +32,8 @@ public class ProblemDatasetPersistenceAdapter implements
                 storedFile.getStoredFileName(),
                 storedFile.getFileUrl(),
                 storedFile.getFilePath(),
-                storedFile.getFileSize()
+                storedFile.getFileSize(),
+                storedFile.getMetadata()
         );
 
         ProblemDatasetJpaEntity savedDataset = problemDatasetRepository.save(dataset);
@@ -67,7 +68,8 @@ public class ProblemDatasetPersistenceAdapter implements
                 storedFile.getStoredFileName(),
                 storedFile.getFileUrl(),
                 storedFile.getFilePath(),
-                storedFile.getFileSize()
+                storedFile.getFileSize(),
+                storedFile.getMetadata()
         );
 
         dataset.connectProblemSet(problemSet);

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/GcsDatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/GcsDatasetFileStorage.java
@@ -7,6 +7,7 @@ import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFac
 import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
 import com.wanted.codebombalms.problems.dataset.application.command.UploadProblemDatasetCommand;
 import com.wanted.codebombalms.problems.dataset.application.port.StoreDatasetFilePort;
+import com.wanted.codebombalms.problems.dataset.application.service.DatasetMetadataExtractor;
 import com.wanted.codebombalms.problems.dataset.domain.model.StoredDatasetFile;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
@@ -25,13 +26,16 @@ public class GcsDatasetFileStorage implements StoreDatasetFilePort {
 
     private final GcpStorageProperties properties;
     private final GcpStorageClientFactory storageClientFactory;
+    private final DatasetMetadataExtractor metadataExtractor;
 
     public GcsDatasetFileStorage(
             GcpStorageProperties properties,
-            GcpStorageClientFactory storageClientFactory
+            GcpStorageClientFactory storageClientFactory,
+            DatasetMetadataExtractor metadataExtractor
     ) {
         this.properties = properties;
         this.storageClientFactory = storageClientFactory;
+        this.metadataExtractor = metadataExtractor;
     }
 
     @Override
@@ -48,12 +52,15 @@ public class GcsDatasetFileStorage implements StoreDatasetFilePort {
 
         createStorage().create(blobInfo, command.content());
 
+        String metadata = metadataExtractor.extract(command.content());
+
         return StoredDatasetFile.create(
                 originalFileName,
                 storedFileName,
                 buildFileUrl(objectName),
                 objectName,
-                command.fileSize()
+                command.fileSize(),
+                metadata
         );
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/LocalDatasetFileStorage.java
+++ b/src/main/java/com/wanted/codebombalms/problems/dataset/infrastructure/storage/LocalDatasetFileStorage.java
@@ -2,7 +2,9 @@ package com.wanted.codebombalms.problems.dataset.infrastructure.storage;
 
 import com.wanted.codebombalms.problems.dataset.application.command.UploadProblemDatasetCommand;
 import com.wanted.codebombalms.problems.dataset.application.port.StoreDatasetFilePort;
+import com.wanted.codebombalms.problems.dataset.application.service.DatasetMetadataExtractor;
 import com.wanted.codebombalms.problems.dataset.domain.model.StoredDatasetFile;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -13,9 +15,12 @@ import java.util.UUID;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class LocalDatasetFileStorage implements StoreDatasetFilePort {
 
     private static final String UPLOAD_DIR = "uploads/datasets";
+
+    private final DatasetMetadataExtractor metadataExtractor;
 
     @Override
     public StoredDatasetFile store(UploadProblemDatasetCommand command) throws IOException {
@@ -31,12 +36,15 @@ public class LocalDatasetFileStorage implements StoreDatasetFilePort {
         String fileUrl = "/" + UPLOAD_DIR + "/" + storedFileName;
         String filePath = UPLOAD_DIR + "/" + storedFileName;
 
+        String metadata = metadataExtractor.extract(command.content());
+
         return StoredDatasetFile.create(
                 originalFileName,
                 storedFileName,
                 fileUrl,
                 filePath,
-                command.fileSize()
+                command.fileSize(),
+                metadata
         );
     }
 

--- a/src/test/java/com/wanted/codebombalms/problems/dataset/application/service/DatasetMetadataExtractorTest.java
+++ b/src/test/java/com/wanted/codebombalms/problems/dataset/application/service/DatasetMetadataExtractorTest.java
@@ -1,0 +1,133 @@
+package com.wanted.codebombalms.problems.dataset.application.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DatasetMetadataExtractorTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final DatasetMetadataExtractor extractor = new DatasetMetadataExtractor(objectMapper);
+
+    private JsonNode extractAsJson(byte[] content) throws Exception {
+        String json = extractor.extract(content);
+        return json == null ? null : objectMapper.readTree(json);
+    }
+
+    @Test
+    @DisplayName("정상 UTF-8 CSV → 컬럼명과 distinct 예시값이 추출된다")
+    void extract_normalCsv() throws Exception {
+        byte[] content = ("user_id,country\n"
+                + "1,KR\n"
+                + "2,US\n"
+                + "3,KR\n").getBytes(StandardCharsets.UTF_8);
+
+        JsonNode root = extractAsJson(content);
+
+        assertEquals(2, root.get("columns").size());
+        assertEquals("user_id", root.get("columns").get(0).get("name").asText());
+        assertEquals("country", root.get("columns").get(1).get("name").asText());
+        // country: distinct 유지 (KR, US) — 중복 KR 하나만
+        JsonNode countryExamples = root.get("columns").get(1).get("examples");
+        assertEquals(2, countryExamples.size());
+        assertEquals("KR", countryExamples.get(0).asText());
+        assertEquals("US", countryExamples.get(1).asText());
+    }
+
+    @Test
+    @DisplayName("따옴표 안 콤마/개행이 있어도 컬럼이 밀리지 않는다")
+    void extract_quotedFieldWithCommaAndNewline() throws Exception {
+        byte[] content = ("name,note\n"
+                + "\"Kim, D\",\"line1\nline2\"\n").getBytes(StandardCharsets.UTF_8);
+
+        JsonNode root = extractAsJson(content);
+
+        assertEquals(2, root.get("columns").size());
+        assertEquals("Kim, D", root.get("columns").get(0).get("examples").get(0).asText());
+        assertEquals("line1\nline2", root.get("columns").get(1).get("examples").get(0).asText());
+    }
+
+    @Test
+    @DisplayName("MS949(CP949) 한글 CSV도 정상 디코드된다")
+    void extract_ms949Korean() throws Exception {
+        byte[] content = ("이름,지역\n홍길동,서울\n").getBytes(Charset.forName("MS949"));
+
+        JsonNode root = extractAsJson(content);
+
+        assertEquals("이름", root.get("columns").get(0).get("name").asText());
+        assertEquals("홍길동", root.get("columns").get(0).get("examples").get(0).asText());
+        assertEquals("서울", root.get("columns").get(1).get("examples").get(0).asText());
+    }
+
+    @Test
+    @DisplayName("UTF-8/MS949 둘 다 디코드 불가한 바이트 → null")
+    void extract_undecodable_returnsNull() throws Exception {
+        byte[] content = {(byte) 0xC3, (byte) 0x28, (byte) 0xA0, (byte) 0xA1};
+
+        assertNull(extractAsJson(content));
+    }
+
+    @Test
+    @DisplayName("빈 파일 → null")
+    void extract_empty_returnsNull() throws Exception {
+        assertNull(extractAsJson(new byte[0]));
+        assertNull(extractAsJson(null));
+    }
+
+    @Test
+    @DisplayName("헤더만 있는 파일 → 컬럼명은 나오되 examples는 빈 배열")
+    void extract_headerOnly() throws Exception {
+        byte[] content = "col_a,col_b".getBytes(StandardCharsets.UTF_8);
+
+        JsonNode root = extractAsJson(content);
+
+        assertEquals(2, root.get("columns").size());
+        assertTrue(root.get("columns").get(0).get("examples").isEmpty());
+    }
+
+    @Test
+    @DisplayName("distinct 예시값은 최대 5개로 절단되고 공백값은 스킵된다")
+    void extract_distinctCappedAndBlankSkipped() throws Exception {
+        StringBuilder sb = new StringBuilder("v\n");
+        sb.append("\n");        // 공백 → 스킵
+        sb.append("   \n");     // 공백 → 스킵
+        for (int i = 1; i <= 8; i++) {
+            sb.append(i).append("\n");
+        }
+        byte[] content = sb.toString().getBytes(StandardCharsets.UTF_8);
+
+        JsonNode root = extractAsJson(content);
+        JsonNode examples = root.get("columns").get(0).get("examples");
+
+        assertEquals(5, examples.size());
+        assertEquals("1", examples.get(0).asText());
+        assertEquals("5", examples.get(4).asText());
+    }
+
+    @Test
+    @DisplayName("컬럼 수가 상한(100)을 넘으면 앞 100개로 절단된다")
+    void extract_columnCap() throws Exception {
+        StringBuilder header = new StringBuilder();
+        StringBuilder rowValues = new StringBuilder();
+        for (int i = 0; i < 150; i++) {
+            if (i > 0) {
+                header.append(",");
+                rowValues.append(",");
+            }
+            header.append("c").append(i);
+            rowValues.append("v").append(i);
+        }
+        byte[] content = (header + "\n" + rowValues + "\n").getBytes(StandardCharsets.UTF_8);
+
+        JsonNode root = extractAsJson(content);
+
+        assertEquals(100, root.get("columns").size());
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #544

---

## 🛠️ 기능 관련 작업 내용

- 데이터셋 업로드 시 CSV 컬럼명 + 예시값을 metadata로 추출 후 RDS `problem_dataset.meta_data` 컬럼에 저장
- 3개 업로드 경로(GCS, Local, 기타)를 `StoreDatasetFilePort.store()` 단일 진입점으로 통합하여 순수 `DatasetMetadataExtractor` 호출
- 챗봇 컨텍스트 빌더의 데이터셋 배관 활성화 (그동안 metadata가 항상 null이라 비활성 상태)
- 단위테스트 8케이스 추가 (메타데이터 추출 로직 검증)
- **부수 작업**: GCS 서비스계정 키 파일 gitignore 처리(보안), CI/CD 배포 설정 변경 포함

**E2E 검증**: 실 CSV(36컬럼) 업로드 → RDS 저장 → 문제방 챗봇 컨텍스트에 metadata 유입 확인 완료

---

## ♻️ 패키지 변경 사항

- `problems/dataset/application/service/DatasetMetadataExtractor` : commons-csv 기반 메타데이터 추출 로직 구현
- `problems/dataset/domain/model/StoredDatasetFile` : 메타데이터 필드 추가
- `problems/dataset/infrastructure/persistence/ProblemDatasetJpaEntity` : meta_data 컬럼 매핑 추가
- `problems/dataset/infrastructure/persistence/ProblemDatasetPersistenceAdapter` : 저장 기능 확대
- `problems/dataset/infrastructure/storage/GcsDatasetFileStorage` / `LocalDatasetFileStorage` : 메타데이터 추출 포트 호출 통합
- `problems/dataset/application/service/DatasetMetadataExtractorTest` : 8개 단위테스트 케이스

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.