### PR TITLE
[Feat] 문제세트 인기순 정렬 및 count 응답 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemSetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/port/LoadProblemSetPort.java
@@ -6,10 +6,18 @@ import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummaryPage;
 import java.util.Optional;
 
 public interface LoadProblemSetPort {
+    ProblemSetSummaryPage loadActiveProblemSetsByCategory(
+            Long categoryId,
+            int page,
+            int size,
+            boolean popularSort
+    );
 
-    ProblemSetSummaryPage loadActiveProblemSetsByCategory(Long categoryId, int page, int size);
-
-    ProblemSetSummaryPage loadActiveProblemSets(int page, int size);
+    ProblemSetSummaryPage loadActiveProblemSets(
+            int page,
+            int size,
+            boolean popularSort
+    );
 
     // 챗봇 adapter용 단건 조회
     Optional<ProblemSetBrief> loadById(Long problemSetId);

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/query/GetProblemSetsQuery.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/query/GetProblemSetsQuery.java
@@ -4,24 +4,10 @@ public record GetProblemSetsQuery(
         Long categoryId,
         int page,
         int size,
-        String sort
+        ProblemSetSort sort
 ) {
-    private static final String DEFAULT_SORT = "default";
-    private static final String POPULAR_SORT = "popular";
-
-    public String normalizedSort() {
-        if (sort == null || sort.isBlank()) {
-            return DEFAULT_SORT;
-        }
-
-        return sort.trim().toLowerCase();
-    }
-
-    public boolean isDefaultSort() {
-        return DEFAULT_SORT.equals(normalizedSort());
-    }
 
     public boolean isPopularSort() {
-        return POPULAR_SORT.equals(normalizedSort());
+        return sort != null && sort.isPopular();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/query/GetProblemSetsQuery.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/query/GetProblemSetsQuery.java
@@ -3,6 +3,25 @@ package com.wanted.codebombalms.problems.set.application.query;
 public record GetProblemSetsQuery(
         Long categoryId,
         int page,
-        int size
+        int size,
+        String sort
 ) {
+    private static final String DEFAULT_SORT = "default";
+    private static final String POPULAR_SORT = "popular";
+
+    public String normalizedSort() {
+        if (sort == null || sort.isBlank()) {
+            return DEFAULT_SORT;
+        }
+
+        return sort.trim().toLowerCase();
+    }
+
+    public boolean isDefaultSort() {
+        return DEFAULT_SORT.equals(normalizedSort());
+    }
+
+    public boolean isPopularSort() {
+        return POPULAR_SORT.equals(normalizedSort());
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/query/ProblemSetSort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/query/ProblemSetSort.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.problems.set.application.query;
+
+public enum ProblemSetSort {
+    DEFAULT,
+    POPULAR;
+
+    public boolean isPopular() {
+        return this == POPULAR;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
@@ -26,7 +26,7 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
     public ProblemSetPageView handle(GetProblemSetsQuery query) {
         validatePageRequest(query.page(), query.size());
 
-        boolean popularSort = validateAndCheckPopularSort(query);
+        boolean popularSort = query.isPopularSort();
 
         ProblemSetSummaryPage problemSets;
 
@@ -51,19 +51,6 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
         );
         return toPageView(problemSets);
     }
-
-    private boolean validateAndCheckPopularSort(GetProblemSetsQuery query) {
-        if (query.isDefaultSort()) {
-            return false;
-        }
-
-        if (query.isPopularSort()) {
-            return true;
-        }
-
-        throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
-    }
-
     private static final int MAX_PAGE_SIZE = 100;
     private static final long MAX_PAGE_OFFSET = 100_000L;
 

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetQueryService.java
@@ -20,15 +20,22 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
     private final CheckProblemSetCategoryPort checkProblemSetCategoryPort;
     private final LoadProblemSetPort loadProblemSetPort;
 
+
     @Override
     @Transactional(readOnly = true)
     public ProblemSetPageView handle(GetProblemSetsQuery query) {
         validatePageRequest(query.page(), query.size());
 
+        boolean popularSort = validateAndCheckPopularSort(query);
+
         ProblemSetSummaryPage problemSets;
 
         if (query.categoryId() == null) {
-            problemSets = loadProblemSetPort.loadActiveProblemSets(query.page(), query.size());
+            problemSets = loadProblemSetPort.loadActiveProblemSets(
+                    query.page(),
+                    query.size(),
+                    popularSort
+            );
             return toPageView(problemSets);
         }
 
@@ -39,9 +46,22 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
         problemSets = loadProblemSetPort.loadActiveProblemSetsByCategory(
                 query.categoryId(),
                 query.page(),
-                query.size()
+                query.size(),
+                popularSort
         );
         return toPageView(problemSets);
+    }
+
+    private boolean validateAndCheckPopularSort(GetProblemSetsQuery query) {
+        if (query.isDefaultSort()) {
+            return false;
+        }
+
+        if (query.isPopularSort()) {
+            return true;
+        }
+
+        throw new ValidationException(ProblemErrorCode.PROBLEM_INVALID_INPUT);
     }
 
     private static final int MAX_PAGE_SIZE = 100;
@@ -99,6 +119,8 @@ public class ProblemSetQueryService implements GetProblemSetsUseCase {
                 problemSet.getDescription(),
                 problemSet.getDifficulty(),
                 problemSet.getAccuracyRate(),
+                problemSet.getCompletedUserCount(),
+                problemSet.getStartedUserCount(),
                 problemSet.getCreatedAt()
         );
     }

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/GetProblemSetsUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/GetProblemSetsUseCase.java
@@ -26,6 +26,8 @@ public interface GetProblemSetsUseCase {
             String description,
             String difficulty,
             Double accuracyRate,
+            Integer completedUserCount,
+            Integer startedUserCount,
             LocalDateTime createdAt
     ) {
     }

--- a/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetSummary.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/domain/model/ProblemSetSummary.java
@@ -11,6 +11,8 @@ public class ProblemSetSummary {
     private final String difficulty;
     private final Double accuracyRate;
     private final LocalDateTime createdAt;
+    private final Integer completedUserCount;
+    private final Integer startedUserCount;
 
     private ProblemSetSummary(
             Long problemSetId,
@@ -19,6 +21,8 @@ public class ProblemSetSummary {
             String description,
             String difficulty,
             Double accuracyRate,
+            Integer completedUserCount,
+            Integer startedUserCount,
             LocalDateTime createdAt
     ) {
         this.problemSetId = problemSetId;
@@ -27,6 +31,8 @@ public class ProblemSetSummary {
         this.description = description;
         this.difficulty = difficulty;
         this.accuracyRate = accuracyRate;
+        this.completedUserCount = completedUserCount;
+        this.startedUserCount = startedUserCount;
         this.createdAt = createdAt;
     }
 
@@ -47,6 +53,8 @@ public class ProblemSetSummary {
                 description,
                 difficulty,
                 calculateAccuracyRate(completedUserCount, startedUserCount),
+                toZeroIfNull(completedUserCount),
+                toZeroIfNull(startedUserCount),
                 createdAt
         );
     }
@@ -97,5 +105,13 @@ public class ProblemSetSummary {
 
     public LocalDateTime getCreatedAt() {
         return createdAt;
+    }
+
+    public Integer getCompletedUserCount() {
+        return completedUserCount;
+    }
+
+    public Integer getStartedUserCount() {
+        return startedUserCount;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetPersistenceAdapter.java
@@ -29,12 +29,27 @@ public class ProblemSetPersistenceAdapter implements
     private final SpringDataProblemSetRepository problemSetRepository;
 
     @Override
-    public ProblemSetSummaryPage loadActiveProblemSetsByCategory(Long categoryId, int page, int size) {
-        var problemSets = problemSetRepository.findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(
-                categoryId,
-                ProblemSetStatus.ACTIVE,
-                PageRequest.of(page, size)
-        );
+    public ProblemSetSummaryPage loadActiveProblemSetsByCategory(
+            Long categoryId,
+            int page,
+            int size,
+            boolean popularSort
+    ) {
+        Page<ProblemSetJpaEntity> problemSets;
+
+        if (popularSort) {
+            problemSets = problemSetRepository.findByCategory_CategoryIdAndStatusOrderByStartedUserCountDescProblemSetIdDesc(
+                    categoryId,
+                    ProblemSetStatus.ACTIVE,
+                    PageRequest.of(page, size)
+            );
+        } else {
+            problemSets = problemSetRepository.findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(
+                    categoryId,
+                    ProblemSetStatus.ACTIVE,
+                    PageRequest.of(page, size)
+            );
+        }
 
         return toSummaryPage(problemSets, page, size);
     }
@@ -67,11 +82,24 @@ public class ProblemSetPersistenceAdapter implements
     }
 
     @Override
-    public ProblemSetSummaryPage loadActiveProblemSets(int page, int size) {
-        var problemSets = problemSetRepository.findByStatusOrderByProblemSetIdAsc(
-                ProblemSetStatus.ACTIVE,
-                PageRequest.of(page, size)
-        );
+    public ProblemSetSummaryPage loadActiveProblemSets(
+            int page,
+            int size,
+            boolean popularSort
+    ) {
+        Page<ProblemSetJpaEntity> problemSets;
+
+        if (popularSort) {
+            problemSets = problemSetRepository.findByStatusOrderByStartedUserCountDescProblemSetIdDesc(
+                    ProblemSetStatus.ACTIVE,
+                    PageRequest.of(page, size)
+            );
+        } else {
+            problemSets = problemSetRepository.findByStatusOrderByProblemSetIdAsc(
+                    ProblemSetStatus.ACTIVE,
+                    PageRequest.of(page, size)
+            );
+        }
 
         return toSummaryPage(problemSets, page, size);
     }

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
@@ -35,6 +35,17 @@ public interface SpringDataProblemSetRepository extends JpaRepository<ProblemSet
             Pageable pageable
     );
 
+    Page<ProblemSetJpaEntity> findByStatusOrderByStartedUserCountDescProblemSetIdDesc(
+            ProblemSetStatus status,
+            Pageable pageable
+    );
+
+    Page<ProblemSetJpaEntity> findByCategory_CategoryIdAndStatusOrderByStartedUserCountDescProblemSetIdDesc(
+            Long categoryId,
+            ProblemSetStatus status,
+            Pageable pageable
+    );
+
     @Transactional
     default int hardDeleteByDeletedAtBefore(LocalDateTime threshold) {
         List<Long> problemSetIds = findHardDeleteTargetIds(threshold);

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
@@ -143,9 +143,11 @@ public class ProblemSetController {
             @Parameter(description = "페이지 번호(0부터 시작)", example = "0")
             @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "20")
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "정렬 기준(default, popular)", example = "popular")
+            @RequestParam(defaultValue = "default") String sort
     ) {
-        var query = new GetProblemSetsQuery(categoryId, page, size);
+        var query = new GetProblemSetsQuery(categoryId, page, size,sort);
         var response = ProblemSetPageResponse.from(getProblemSetsUseCase.handle(query));
 
         return ResponseEntity.ok(ApiResponse.success(

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemSetController.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
 import com.wanted.codebombalms.problems.set.application.query.EnterProblemSetQuery;
 import com.wanted.codebombalms.problems.set.application.query.GetProblemSetsQuery;
+import com.wanted.codebombalms.problems.set.application.query.ProblemSetSort;
 import com.wanted.codebombalms.problems.set.application.usecase.EnterProblemSetUseCase;
 import com.wanted.codebombalms.problems.set.application.usecase.GetProblemSetsUseCase;
 import com.wanted.codebombalms.problems.set.presentation.response.ProblemSetEnterResponse;
@@ -144,8 +145,8 @@ public class ProblemSetController {
             @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "20")
             @RequestParam(defaultValue = "20") int size,
-            @Parameter(description = "정렬 기준(default, popular)", example = "popular")
-            @RequestParam(defaultValue = "default") String sort
+            @Parameter(description = "정렬 기준(DEFAULT, POPULAR)", example = "POPULAR")
+            @RequestParam(defaultValue = "DEFAULT") ProblemSetSort sort
     ) {
         var query = new GetProblemSetsQuery(categoryId, page, size,sort);
         var response = ProblemSetPageResponse.from(getProblemSetsUseCase.handle(query));

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemSetListResponse.java
@@ -24,6 +24,11 @@ public record ProblemSetListResponse(
         @Schema(description = "문제 세트 정답률", example = "75.5", nullable = true)
         Double accuracyRate,
 
+        @Schema(description = "문제세트를 완료한 사용자 수", example = "18")
+        Integer completedUserCount,
+
+        @Schema(description = "문제세트에 진입한 사용자 수", example = "42")
+        Integer startedUserCount,
         @Schema(description = "문제 세트 생성일", example = "2026-05-27T10:00:00")
         LocalDateTime createdAt
 ) {
@@ -35,6 +40,8 @@ public record ProblemSetListResponse(
                 problemSet.description(),
                 problemSet.difficulty(),
                 problemSet.accuracyRate(),
+                problemSet.completedUserCount(),
+                problemSet.startedUserCount(),
                 problemSet.createdAt()
         );
     }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #540 

---

## 🛠️ 기능 관련 작업 내용
- 문제세트 목록 조회 API에 `sort=popular` 정렬 옵션을 추가했습니다.
- 인기순 정렬 시 `startedUserCount DESC`, `problemSetId DESC` 기준으로 DB에서 정렬되도록 수정했습니다.
- 문제세트 목록 응답에 `completedUserCount`, `startedUserCount` 값을 추가했습니다.
- 잘못된 `sort` 값은 입력값 오류로 처리하도록 검증 로직을 추가했습니다.

---

## ♻️ 패키지 변경 사항
- `project/problems/set/presentation`: 문제세트 목록 조회 요청에 `sort` 파라미터를 추가하고 count 응답 필드를 확장했습니다.
- `project/problems/set/application`: 목록 조회 쿼리와 유스케이스 응답에 정렬 기준 및 count 값을 반영했습니다.
- `project/problems/set/domain`: `ProblemSetSummary`에서 완료 사용자 수와 시작 사용자 수를 보관하도록 수정했습니다.
- `project/problems/set/infrastructure`: 인기순 조회용 Repository 메서드와 PersistenceAdapter 분기 로직을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 문제세트 목록 조회에 정렬 옵션이 추가되어, 기본 순서와 인기 순서로 볼 수 있게 되었습니다.
  * 문제세트 목록 응답에 완료/진입 사용자 수가 함께 표시됩니다.
* **Bug Fixes**
  * 목록 조회 시 정렬 값이 잘못 들어오면 오류로 처리되도록 개선했습니다.
  * 인기 순서 조회에서 사용자 참여 수를 기준으로 더 관련성 높은 결과를 보여줍니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->