### PR TITLE
[Feat] traceId 로그 드릴다운 + Loki Derived Field (#551)

### DIFF
--- a/monitoring-local/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring-local/grafana/provisioning/datasources/datasources.yml
@@ -13,3 +13,13 @@ datasources:
     uid: loki                  # 대시보드 JSON 이 고정 uid 로 참조
     access: proxy
     url: http://loki:3100
+    jsonData:
+      derivedFields:
+        # 로그 라인의 [xxxxxxxx] 브라켓(8자리 traceId)을 클릭 가능한 링크로 만든다.
+        # 브라켓 기반이라 traceId 필드가 없던 옛 로그도 그대로 드릴다운된다.
+        # $$ 는 Grafana provisioning 의 환경변수 확장을 피하기 위한 이스케이프(로드 후 ${__value.raw}).
+        - name: TraceID
+          matcherRegex: '\[([0-9a-f]{8})\]'
+          url: '{job="spring"} |= "[$${__value.raw}]"'
+          datasourceUid: loki
+          urlDisplayLabel: 'traceId 전체 로그 →'

--- a/monitoring-local/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring-local/grafana/provisioning/datasources/datasources.yml
@@ -1,5 +1,6 @@
 apiVersion: 1
 
+
 datasources:
   - name: Prometheus
     type: prometheus

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
@@ -48,7 +48,8 @@ public class AuthSecurityEventRecorder implements SecurityEventReporter {
     /** 흐름 기반 이벤트(의심 로그인 등) 직접 기록. ip/uri 는 MDC(MdcLoggingFilter)에서 가져온다. */
     public void record(AuthSecurityEvent event, Long userId) {
         registry.counter(METRIC, "category", event.getCategory(), "type", event.getType()).increment();
-        log.warn("event=security_event category={} type={} userId={} clientIp={} uri={}",
+        log.warn("event=security_event traceId={} category={} type={} userId={} clientIp={} uri={}",
+                mdc("traceId"),
                 event.getCategory(), event.getType(),
                 userId == null ? "-" : userId, mdc("clientIp"), mdc("requestURI"));
     }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -28,9 +28,11 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         long startAt = System.nanoTime();
+        // traceId 는 로컬 변수로 잡아둔다 — doFilter 내부 필터가 MDC.clear() 해도 완료 로그에 안전.
+        String traceId = UUID.randomUUID().toString().substring(0, 8);
 
         try {
-            MDC.put("traceId", UUID.randomUUID().toString().substring(0, 8));
+            MDC.put("traceId", traceId);
             MDC.put("requestURI", request.getRequestURI());
             MDC.put("method", request.getMethod());
             MDC.put("clientIp", ClientIpResolver.resolve(request));
@@ -40,7 +42,6 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
         } finally {
-            // MDC.clear() 전에 남겨야 완료 로그에도 traceId 가 붙는다.
             long durationMs = (System.nanoTime() - startAt) / 1_000_000;
             String userId = resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_USER_ID_ATTRIBUTE);
             String role = resolveAttribute(request, JwtAuthenticationFilter.AUTHENTICATED_ROLE_ATTRIBUTE);
@@ -48,7 +49,7 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
             MDC.put("role", role);
 
             log.info("event=request_completed traceId={} method={} uri={} status={} durationMs={} userId={} role={} clientIp={}",
-                    MDC.get("traceId"),
+                    traceId,
                     request.getMethod(),
                     request.getRequestURI(),
                     response.getStatus(),

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -47,7 +47,8 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
             MDC.put("userId", userId);
             MDC.put("role", role);
 
-            log.info("event=request_completed method={} uri={} status={} durationMs={} userId={} role={} clientIp={}",
+            log.info("event=request_completed traceId={} method={} uri={} status={} durationMs={} userId={} role={} clientIp={}",
+                    MDC.get("traceId"),
                     request.getMethod(),
                     request.getRequestURI(),
                     response.getStatus(),


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #551

---

## 🛠️ 기능 관련 작업 내용
- `request_completed`·`security_event` 로그 본문에 `traceId` 필드 추가 (logfmt 파싱 → Loki 트레이스 드릴다운 기반)
- Loki Derived Field(브라켓 `[xxxxxxxx]` 기반) 설정으로 traceId 클릭 드릴다운 — 옛 로그도 매칭돼 재배포 불필요
- 대시보드 D1/D2에 `$userId`·`$traceId` 변수 + 유저/트레이스 드릴다운 패널 (로컬 provisioning)

---

## ♻️ 패키지 변경 사항
- `codebombalms/global/infrastructure/logging`: `MdcLoggingFilter` — `request_completed` 로그에 traceId 필드
- `codebombalms/auth/infrastructure/metrics`: `AuthSecurityEventRecorder` — `security_event` 로그에 traceId 필드
- `monitoring-local/grafana`: Loki Derived Field (`datasources.yml`) — traceId 브라켓 → 클릭 링크
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 요청 완료 로그와 인증 보안 이벤트 로그에 `traceId`가 추가되어, 요청 추적과 장애 분석이 더 쉬워졌습니다.
  * 기존 로그 항목들은 유지하면서 식별 정보가 더 풍부해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->