### PR TITLE
[Update] 문제 상세 응답에 문제세트 정보 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetEntryService.java
@@ -85,6 +85,7 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
                     .stream()
                     .map(problem -> toDetailItemView(
                             problem,
+                            problemSet,
                             progressItemMap.get(problem.getProblemId()),
                             startCode
                     ))
@@ -157,11 +158,15 @@ public class ProblemSetEntryService implements EnterProblemSetUseCase {
 
     private ProblemDetailItemView toDetailItemView(
             ProblemDetail problem,
+            ProblemSetEntry problemSet,
             ProblemProgressItem progressItem,
             String startCode
     ) {
         return new ProblemDetailItemView(
                 problem.getProblemId(),
+                problemSet.getProblemSetId(),
+                problemSet.getTitle(),
+                problemSet.getDescription(),
                 problem.getProblemNumber(),
                 problem.getTitle(),
                 problem.getContent(),

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/EnterProblemSetUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/usecase/EnterProblemSetUseCase.java
@@ -23,6 +23,9 @@ public interface EnterProblemSetUseCase {
 
     record ProblemDetailItemView(
             Long problemId,
+            Long problemSetId,
+            String problemSetTitle,
+            String problemSetDescription,
             Integer problemNumber,
             String title,
             String content,

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemDetailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/response/ProblemDetailResponse.java
@@ -31,6 +31,12 @@ public record ProblemDetailResponse(
                 allowableValues = {"LOCKED", "UNSOLVED", "CORRECT", "WRONG"}
         )
         String status,
+        @Schema(description = "문제가 속한 문제세트 ID", example = "3001")
+        Long problemSetId,
+        @Schema(description = "문제가 속한 문제세트 제목", example = "pandas 기초 분석 문제 세트")
+        String problemSetTitle,
+        @Schema(description = "문제가 속한 문제세트 설명", example = "CSV 데이터를 사용한 코드 실행 문제 세트입니다.")
+        String problemSetDescription,
 
         @Schema(description = "가장 최근 제출 ID", example = "3021", nullable = true)
         Long latestSubmissionId
@@ -45,6 +51,9 @@ public record ProblemDetailResponse(
                 problem.point(),
                 problem.startCode(),
                 problem.status(),
+                problem.problemSetId(),
+                problem.problemSetTitle(),
+                problem.problemSetDescription(),
                 problem.latestSubmissionId()
         );
     }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #541 

---

## 🛠️ 기능 관련 작업 내용
- 문제세트 진입 응답의 각 소문제 항목에 `problemSetId`, `problemSetTitle`, `problemSetDescription`을 추가했습니다.
- 프론트가 문제 상세 또는 제출 화면으로 이동한 뒤에도 문제세트 제목과 설명을 표시할 수 있도록 응답 구조를 보완했습니다.
- 기존 문제세트 진입 조회 흐름에서 이미 조회한 문제세트 정보를 재사용하여 추가 DB 조회 없이 응답을 구성했습니다.

---

## ♻️ 패키지 변경 사항
- `project/problems/set/application`: `ProblemDetailItemView`에 문제세트 메타 필드를 추가하고 응답 구성 로직에 반영했습니다.
- `project/problems/set/presentation`: `ProblemDetailResponse`에 문제세트 ID, 제목, 설명 응답 필드와 Swagger 설명을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 문제 상세 응답에 소속 문제 세트의 ID, 제목, 설명 정보가 추가되었습니다.
  * 문제 정보와 함께 해당 문제 세트의 메타데이터를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->