### PR TITLE
[Feat] main 머지 시 AI 패치노트 Discord 자동 게시

### DIFF
--- a/.github/workflows/patch-note.yml
+++ b/.github/workflows/patch-note.yml
@@ -80,15 +80,47 @@ jobs:
 
           PR_BODY=$(cat pr_body.txt)
 
-          PROMPT=$(jq -n --arg title "$PR_TITLE" --arg body "$PR_BODY" \
-            '"다음 PR을 비개발자도 이해할 수 있게 패치노트로 요약해줘.\n- 개발 용어 최소화\n- 한줄 요약 + 상세 bullet 2~4개\n- 이모지 적절히 사용\n\n제목: \($title)\n본문:\n\($body)"')
+          # 요청 JSON을 jq 하나로 통째로 생성 (수정 3)
+          REQUEST=$(jq -n \
+            --arg title "$PR_TITLE" \
+            --arg body "$PR_BODY" \
+            '{
+              model: "claude-sonnet-5",
+              max_tokens: 512,
+              messages: [
+                {
+                  role: "user",
+                  content: ("다음 PR을 비개발자도 이해할 수 있게 패치노트로 요약해줘.\n- 개발 용어 최소화\n- 한줄 요약 + 상세 bullet 2~4개\n- 이모지 적절히 사용\n\n제목: " + $title + "\n본문:\n" + $body)
+                }
+              ]
+            }')
 
-          curl -s https://api.anthropic.com/v1/messages \
+          RESPONSE=$(curl -s -w "\n%{http_code}" https://api.anthropic.com/v1/messages \
             -H "x-api-key: $ANTHROPIC_API_KEY" \
             -H "anthropic-version: 2023-06-01" \
             -H "content-type: application/json" \
-            -d "{\"model\": \"claude-sonnet-5\", \"max_tokens\": 512, \"messages\": [{\"role\": \"user\", \"content\": $PROMPT}]}" \
-            | jq -r '.content[0].text' > summary.txt
+            -d "$REQUEST")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+          BODY_JSON=$(echo "$RESPONSE" | sed '$d')
+
+          # API 호출 실패 시 명확히 실패 처리 (수정 1)
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Claude API 호출 실패 (HTTP $HTTP_CODE)"
+            echo "$BODY_JSON"
+            exit 1
+          fi
+
+          SUMMARY=$(echo "$BODY_JSON" | jq -r '.content[0].text // empty')
+
+          if [ -z "$SUMMARY" ]; then
+            echo "Claude 응답에서 요약 텍스트를 못 찾음"
+            echo "$BODY_JSON"
+            exit 1
+          fi
+
+          # Discord 2000자 제한 대응 (수정 2)
+          echo "$SUMMARY" | cut -c1-1900 > summary.txt
 
           cat summary.txt >> "$GITHUB_STEP_SUMMARY"
 
@@ -99,10 +131,10 @@ jobs:
           path: summary.txt
 
   post-to-discord:
-    needs: [find-pr, generate-summary]
+    needs: [ find-pr, generate-summary ]
     if: needs.find-pr.outputs.should_post == 'true'
     runs-on: ubuntu-latest
-    environment: patch-note-approval   # 4단계에서 만든 Environment 이름 (승인 게이트 필요 없으면 이 줄 삭제)
+    environment: patch-note-approval
     steps:
       - name: Download summary
         uses: actions/download-artifact@v4
@@ -114,6 +146,16 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           set -euo pipefail
+
           SUMMARY=$(cat summary.txt)
           PAYLOAD=$(jq -n --arg content "$SUMMARY" '{content: $content}')
-          curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          # Discord 게시 실패도 명확히 실패 처리 (수정 1과 동일한 이유)
+          if [ "$HTTP_CODE" -ge 300 ]; then
+            echo "Discord 게시 실패 (HTTP $HTTP_CODE)"
+            exit 1
+          fi

--- a/.github/workflows/patch-note.yml
+++ b/.github/workflows/patch-note.yml
@@ -37,8 +37,8 @@ jobs:
           PR_JSON=$(gh api \
             -H "Accept: application/vnd.github+json" \
             "/repos/$REPO/commits/$SHA/pulls")
-
-          PR=$(echo "$PR_JSON" | jq -c 'map(select(.base.ref == "main")) | .[0] // null')
+          
+          PR=$(echo "$PR_JSON" | jq -c 'map(select(.base.ref == "main" and .head.ref == "develop)) | .[0] // null')
 
           if [ "$PR" = "null" ]; then
             echo "should_post=false" >> "$GITHUB_OUTPUT"
@@ -80,7 +80,6 @@ jobs:
 
           PR_BODY=$(cat pr_body.txt)
 
-          # 요청 JSON을 jq 하나로 통째로 생성 (수정 3)
           REQUEST=$(jq -n \
             --arg title "$PR_TITLE" \
             --arg body "$PR_BODY" \
@@ -90,7 +89,7 @@ jobs:
               messages: [
                 {
                   role: "user",
-                  content: ("다음 PR을 비개발자도 이해할 수 있게 패치노트로 요약해줘.\n- 개발 용어 최소화\n- 한줄 요약 + 상세 bullet 2~4개\n- 이모지 적절히 사용\n\n제목: " + $title + "\n본문:\n" + $body)
+                  content: ("다음 PR 변경사항을 비개발자도 이해할 수 있게 요약해줘.\n- 개발 용어 최소화\n- 아래 두 섹션으로 구분해서 작성:\n  ✨ 개선사항\n  🐛 버그 해결\n- 해당 내용이 없는 섹션은 통째로 생략\n- 각 섹션 안에는 \"* \"로 시작하는 bullet 2~4개\n- 이모지를 적극적으로 활용해서 눈에 잘 띄게 작성\n- 섹션 제목/bullet 외의 인사말, 마무리 문구 등은 절대 포함하지 말 것\n\n제목: " + $title + "\n본문:\n" + $body)
                 }
               ]
             }')
@@ -104,23 +103,26 @@ jobs:
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY_JSON=$(echo "$RESPONSE" | sed '$d')
 
-          # API 호출 실패 시 명확히 실패 처리 (수정 1)
           if [ "$HTTP_CODE" != "200" ]; then
             echo "Claude API 호출 실패 (HTTP $HTTP_CODE)"
             echo "$BODY_JSON"
             exit 1
           fi
 
-          SUMMARY=$(echo "$BODY_JSON" | jq -r '.content[0].text // empty')
+          BULLETS=$(echo "$BODY_JSON" | jq -r '.content[0].text // empty')
 
-          if [ -z "$SUMMARY" ]; then
+          if [ -z "$BULLETS" ]; then
             echo "Claude 응답에서 요약 텍스트를 못 찾음"
             echo "$BODY_JSON"
             exit 1
           fi
 
-          # Discord 2000자 제한 대응 (수정 2)
-          echo "$SUMMARY" | cut -c1-1900 > summary.txt
+          # 제목은 AI에게 맡기지 않고 고정 포맷으로 조립 (KST 기준 날짜)
+          DATE=$(TZ='Asia/Seoul' date +'%Y-%m-%d')
+          TITLE="백엔드팀 패치노트🦖 | $DATE"
+
+          printf '%s\n\n%s' "$TITLE" "$BULLETS" \
+            | python3 -c "import sys; print(sys.stdin.read()[:1900])" > summary.txt
 
           cat summary.txt >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/patch-note.yml
+++ b/.github/workflows/patch-note.yml
@@ -38,7 +38,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "/repos/$REPO/commits/$SHA/pulls")
           
-          PR=$(echo "$PR_JSON" | jq -c 'map(select(.base.ref == "main" and .head.ref == "develop)) | .[0] // null')
+          PR=$(echo "$PR_JSON" | jq -c 'map(select(.base.ref == "main" and .head.ref == "develop")) | .[0] // null')
 
           if [ "$PR" = "null" ]; then
             echo "should_post=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/patch-note.yml
+++ b/.github/workflows/patch-note.yml
@@ -1,0 +1,119 @@
+name: Post Patch Note to Discord
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: patch-note-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  find-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      should_post: ${{ steps.pr.outputs.should_post }}
+      pr_title: ${{ steps.pr.outputs.pr_title }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find merged PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          PR_JSON=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/commits/$SHA/pulls")
+
+          PR=$(echo "$PR_JSON" | jq -c 'map(select(.base.ref == "main")) | .[0] // null')
+
+          if [ "$PR" = "null" ]; then
+            echo "should_post=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TITLE=$(echo "$PR" | jq -r '.title')
+          NUMBER=$(echo "$PR" | jq -r '.number')
+          BODY=$(echo "$PR" | jq -r '.body // ""')
+
+          echo "should_post=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$TITLE" >> "$GITHUB_OUTPUT"
+          printf "%s" "$BODY" > pr_body.txt
+
+      - name: Upload PR body
+        if: steps.pr.outputs.should_post == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_body
+          path: pr_body.txt
+
+  generate-summary:
+    needs: find-pr
+    if: needs.find-pr.outputs.should_post == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR body
+        uses: actions/download-artifact@v4
+        with:
+          name: pr_body
+
+      - name: Ask Claude for a friendly summary
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_TITLE: ${{ needs.find-pr.outputs.pr_title }}
+        run: |
+          set -euo pipefail
+
+          PR_BODY=$(cat pr_body.txt)
+
+          PROMPT=$(jq -n --arg title "$PR_TITLE" --arg body "$PR_BODY" \
+            '"다음 PR을 비개발자도 이해할 수 있게 패치노트로 요약해줘.\n- 개발 용어 최소화\n- 한줄 요약 + 상세 bullet 2~4개\n- 이모지 적절히 사용\n\n제목: \($title)\n본문:\n\($body)"')
+
+          curl -s https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "{\"model\": \"claude-sonnet-5\", \"max_tokens\": 512, \"messages\": [{\"role\": \"user\", \"content\": $PROMPT}]}" \
+            | jq -r '.content[0].text' > summary.txt
+
+          cat summary.txt >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: patch_note_summary
+          path: summary.txt
+
+  post-to-discord:
+    needs: [find-pr, generate-summary]
+    if: needs.find-pr.outputs.should_post == 'true'
+    runs-on: ubuntu-latest
+    environment: patch-note-approval   # 4단계에서 만든 Environment 이름 (승인 게이트 필요 없으면 이 줄 삭제)
+    steps:
+      - name: Download summary
+        uses: actions/download-artifact@v4
+        with:
+          name: patch_note_summary
+
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          SUMMARY=$(cat summary.txt)
+          PAYLOAD=$(jq -n --arg content "$SUMMARY" '{content: $content}')
+          curl -s -X POST "$DISCORD_WEBHOOK_URL" -H "Content-Type: application/json" -d "$PAYLOAD"


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #581 

---

## 🛠️ 기능 관련 작업 내용
- main 브랜치에 push(develop→main PR merge) 발생 시, 병합된 PR의 title/body를 자동 조회
- Claude API 호출로 비개발자도 이해할 수 있는 패치노트 요약 생성 (개발 용어 최소화, 한줄 요약 + bullet 형식)
- Discord Webhook으로 패치노트 채널에 자동 게시, 게시 전 `patch-note-approval` Environment 승인 게이트 적용
- Claude API 호출 실패 / Discord 게시 실패 시 job이 명시적으로 실패하도록 예외처리 추가, Discord 2000자 제한에 맞춰 요약 자동 truncate 처리

---

## ♻️ 패키지 변경 사항
- `.github/workflows/patch-note.yml`: 신규 생성 — `find-pr`(머지 PR 조회) → `generate-summary`(Claude 요약 생성) → `post-to-discord`(승인 게이트 + Discord 게시) 3단계 job 구성