### PR TITLE
[Feat] 약관 동의 + 개인정보 보관·파기(소프트딜리트 1년 후 익명화)

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/command/SignupCommand.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/command/SignupCommand.java
@@ -6,7 +6,9 @@ public record SignupCommand(
         String passwordConfirm,
         String name,
         String nickname,
-        String phone
+        String phone,
+        boolean termsOfServiceAgreed,
+        boolean privacyPolicyAgreed
 ) {
 
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/CompleteSocialSignupService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/CompleteSocialSignupService.java
@@ -12,7 +12,6 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ValidationEx
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
-import com.wanted.codebombalms.user.domain.model.TermsType;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserAgreement;
 import com.wanted.codebombalms.user.domain.repository.UserAgreementRepository;
@@ -20,8 +19,6 @@ import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -62,11 +59,8 @@ public class CompleteSocialSignupService implements CompleteSocialSignupUseCase 
                 User.createSocialUser(data.email(), data.name(), nickname, phone, AuthProvider.GOOGLE)
         );
 
-        // 6. 약관 동의 이력 저장 (SERVICE·PRIVACY 2건 — 버전은 서버가 스탬프)
-        userAgreementRepository.saveAll(List.of(
-                UserAgreement.agree(saved.getUserId(), TermsType.SERVICE),
-                UserAgreement.agree(saved.getUserId(), TermsType.PRIVACY)
-        ));
+        // 6. 약관 동의 이력 저장 (필수 2종 — 버전은 서버가 스탬프)
+        userAgreementRepository.saveAll(UserAgreement.requiredAgreements(saved.getUserId()));
 
         // 7. 가입 성공 후 TEMP_TOKEN 소비 (단일 사용 — 이 시점에 삭제)
         tempTokenRepository.findAndDelete(tempToken);

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/CompleteSocialSignupService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/CompleteSocialSignupService.java
@@ -12,11 +12,16 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ValidationEx
 import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
+import com.wanted.codebombalms.user.domain.model.TermsType;
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserAgreement;
+import com.wanted.codebombalms.user.domain.repository.UserAgreementRepository;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,35 +30,48 @@ public class CompleteSocialSignupService implements CompleteSocialSignupUseCase 
 
     private final TempTokenRepository tempTokenRepository;
     private final UserRepository userRepository;
+    private final UserAgreementRepository userAgreementRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public TokenPair complete(String tempToken, String nickname, String phone) {
+    public TokenPair complete(String tempToken, String nickname, String phone,
+                              boolean termsOfServiceAgreed, boolean privacyPolicyAgreed) {
 
         // 1. TEMP_TOKEN 조회 (삭제 X — 검증 실패 시 재시도 가능하게). 없으면 401
         OAuthTempData data = tempTokenRepository.find(tempToken)
                 .orElseThrow(() -> new UnauthorizedException(AuthErrorCode.AUTH_TEMP_TOKEN_INVALID));
 
-        // 2. 닉네임 중복 검사 (USR-003)
+        // 2. 필수 약관 동의 확인 (이용약관 + 개인정보 수집·이용)
+        if (!termsOfServiceAgreed || !privacyPolicyAgreed) {
+            throw new ValidationException(UserErrorCode.USER_TERMS_NOT_AGREED);
+        }
+
+        // 3. 닉네임 중복 검사 (USR-003)
         if (userRepository.existsByNickname(nickname)) {
             throw new ValidationException(UserErrorCode.USER_NICKNAME_DUPLICATED);
         }
 
-        // 3. 이메일 중복 방어 (중복 제출 등 — USR-002)
+        // 4. 이메일 중복 방어 (중복 제출 등 — USR-002)
         if (userRepository.existsByEmail(data.email())) {
             throw new ValidationException(UserErrorCode.USER_EMAIL_DUPLICATED);
         }
 
-        // 4. 소셜 회원 생성 (GOOGLE, STUDENT)
+        // 5. 소셜 회원 생성 (GOOGLE, STUDENT)
         User saved = userRepository.save(
                 User.createSocialUser(data.email(), data.name(), nickname, phone, AuthProvider.GOOGLE)
         );
 
-        // 5. 가입 성공 후 TEMP_TOKEN 소비 (단일 사용 — 이 시점에 삭제)
+        // 6. 약관 동의 이력 저장 (SERVICE·PRIVACY 2건 — 버전은 서버가 스탬프)
+        userAgreementRepository.saveAll(List.of(
+                UserAgreement.agree(saved.getUserId(), TermsType.SERVICE),
+                UserAgreement.agree(saved.getUserId(), TermsType.PRIVACY)
+        ));
+
+        // 7. 가입 성공 후 TEMP_TOKEN 소비 (단일 사용 — 이 시점에 삭제)
         tempTokenRepository.findAndDelete(tempToken);
 
-        // 6. 토큰 발급 (가입 직후 바로 로그인)
+        // 8. 토큰 발급 (가입 직후 바로 로그인)
         String accessToken = jwtTokenProvider.generateAccessToken(
                 saved.getUserId(), saved.getNickname(), saved.getRole());
         String refreshToken = jwtTokenProvider.generateRefreshToken(saved.getUserId());

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
@@ -7,7 +7,6 @@ import com.wanted.codebombalms.auth.domain.repository.EmailVerificationRepositor
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
-import com.wanted.codebombalms.user.domain.model.TermsType;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserAgreement;
 import com.wanted.codebombalms.user.domain.repository.UserAgreementRepository;
@@ -17,8 +16,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -74,11 +71,8 @@ public class SignupService implements SignupUseCase {
             // 8. 저장
             User saved = userRepository.save(user);
 
-            // 9. 약관 동의 이력 저장 (SERVICE·PRIVACY 2건 — 버전은 서버가 스탬프)
-            userAgreementRepository.saveAll(List.of(
-                    UserAgreement.agree(saved.getUserId(), TermsType.SERVICE),
-                    UserAgreement.agree(saved.getUserId(), TermsType.PRIVACY)
-            ));
+            // 9. 약관 동의 이력 저장 (필수 2종 — 버전은 서버가 스탬프)
+            userAgreementRepository.saveAll(UserAgreement.requiredAgreements(saved.getUserId()));
 
             // 10. 회원가입 완료 — 인증 플래그 정리
             emailVerificationRepository.clearVerified(command.email());

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SignupService.java
@@ -7,13 +7,18 @@ import com.wanted.codebombalms.auth.domain.repository.EmailVerificationRepositor
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.TermsType;
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.model.UserAgreement;
+import com.wanted.codebombalms.user.domain.repository.UserAgreementRepository;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +28,7 @@ public class SignupService implements SignupUseCase {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final EmailVerificationRepository emailVerificationRepository;
+    private final UserAgreementRepository userAgreementRepository;
     private final AuthMetricsPort authMetrics;
 
     @Override
@@ -38,20 +44,25 @@ public class SignupService implements SignupUseCase {
                 throw new ValidationException(UserErrorCode.USER_PASSWORD_CONFIRM_MISMATCH);
             }
 
-            // 3. 이메일 중복 체크
+            // 3. 필수 약관 동의 확인 (이용약관 + 개인정보 수집·이용)
+            if (!command.termsOfServiceAgreed() || !command.privacyPolicyAgreed()) {
+                throw new ValidationException(UserErrorCode.USER_TERMS_NOT_AGREED);
+            }
+
+            // 4. 이메일 중복 체크
             if (userRepository.existsByEmail(command.email())) {
                 throw new ConflictException(UserErrorCode.USER_EMAIL_DUPLICATED);
             }
 
-            // 4. 닉네임 중복 체크
+            // 5. 닉네임 중복 체크
             if (userRepository.existsByNickname(command.nickname())) {
                 throw new ConflictException(UserErrorCode.USER_NICKNAME_DUPLICATED);
             }
 
-            // 5. 비밀번호 인코딩
+            // 6. 비밀번호 인코딩
             String encodedPassword = passwordEncoder.encode(command.rawpassword());
 
-            // 6. 도메인 객체 생성
+            // 7. 도메인 객체 생성
             User user = User.createLocalUser(
                     command.email(),
                     encodedPassword,
@@ -60,10 +71,16 @@ public class SignupService implements SignupUseCase {
                     command.phone()
             );
 
-            // 7. 저장
+            // 8. 저장
             User saved = userRepository.save(user);
 
-            // 8. 회원가입 완료 — 인증 플래그 정리
+            // 9. 약관 동의 이력 저장 (SERVICE·PRIVACY 2건 — 버전은 서버가 스탬프)
+            userAgreementRepository.saveAll(List.of(
+                    UserAgreement.agree(saved.getUserId(), TermsType.SERVICE),
+                    UserAgreement.agree(saved.getUserId(), TermsType.PRIVACY)
+            ));
+
+            // 10. 회원가입 완료 — 인증 플래그 정리
             emailVerificationRepository.clearVerified(command.email());
 
             authMetrics.recordSignupSuccess();   // ← KPI: 회원가입 완료

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/CompleteSocialSignupUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/CompleteSocialSignupUseCase.java
@@ -4,5 +4,6 @@ import com.wanted.codebombalms.auth.application.dto.TokenPair;
 
 public interface CompleteSocialSignupUseCase {
 
-    TokenPair complete(String tempToken, String nickname, String phone);
+    TokenPair complete(String tempToken, String nickname, String phone,
+                       boolean termsOfServiceAgreed, boolean privacyPolicyAgreed);
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/OAuthCompleteController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/OAuthCompleteController.java
@@ -32,8 +32,12 @@ public class OAuthCompleteController {
 
     @Operation(
             summary = "소셜 추가 정보 제출",
-            description = "TEMP_TOKEN 검증 후 닉네임/전화번호로 가입 완료. 토큰 쿠키 발급 + TEMP_TOKEN 제거."
+            description = "TEMP_TOKEN 검증 후 닉네임/전화번호 + 약관 동의(둘 다 필수)로 가입 완료. "
+                       + "토큰 쿠키 발급 + TEMP_TOKEN 제거."
     )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "소셜 가입 완료")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "USR-003 닉네임 중복 / USR-005 전화번호 형식 / USR-014 필수 약관 미동의")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-006 유효하지 않은 임시 토큰")
     @PostMapping("/complete")
     public ResponseEntity<ApiResponse<Void>> complete(
             @CookieValue(name = "tempToken", required = false) String tempToken,
@@ -46,7 +50,8 @@ public class OAuthCompleteController {
         }
 
         TokenPair tokens = completeSocialSignupUseCase.complete(
-                tempToken, request.nickname(), request.phone());
+                tempToken, request.nickname(), request.phone(),
+                request.termsOfServiceAgreed(), request.privacyPolicyAgreed());
 
         // AT/RT 쿠키 발급 + TEMP_TOKEN 제거
         response.addCookie(authCookieFactory.create(

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/SignupController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/SignupController.java
@@ -23,10 +23,11 @@ public class SignupController {
 
     @Operation(
             summary = "회원가입",
-            description = "이메일/비밀번호로 신규 회원가입. 사전에 이메일 인증 완료 필수."
+            description = "이메일/비밀번호로 신규 회원가입. 사전에 이메일 인증 완료 필수. "
+                    + "이용약관·개인정보 수집·이용 동의(둘 다 필수) 포함."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "USR-009 이메일 미인증 / USR-006 비밀번호 확인 불일치 / 형식 오류")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "USR-009 이메일 미인증 / USR-006 비밀번호 확인 불일치 / USR-014 필수 약관 미동의 / 형식 오류")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "USR-002 이메일 중복 / USR-003 닉네임 중복")
 
     @PostMapping("/signup")

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/OAuthCompleteRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/OAuthCompleteRequest.java
@@ -1,20 +1,29 @@
 package com.wanted.codebombalms.auth.presentation.api.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record OAuthCompleteRequest(
 
+        @Schema(description = "닉네임", example = "gildong", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = 30, message = "닉네임은 30자 이하여야 합니다.")
         String nickname,
 
+        @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "전화번호는 필수입니다.")
         @Pattern(
                 regexp = "^01[0-9]-\\d{3,4}-\\d{4}$",
                 message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
         )
-        String phone
+        String phone,
+
+        @Schema(description = "이용약관 동의 (필수, 반드시 true)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean termsOfServiceAgreed,
+
+        @Schema(description = "개인정보 수집·이용 동의 (필수, 반드시 true)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean privacyPolicyAgreed
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/SignupRequest.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/request/SignupRequest.java
@@ -1,16 +1,19 @@
 package com.wanted.codebombalms.auth.presentation.api.dto.request;
 
 import com.wanted.codebombalms.auth.application.command.SignupCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record SignupRequest(
 
+        @Schema(description = "이메일", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
         String email,
 
+        @Schema(description = "비밀번호 (8자 이상, 영문+숫자+특수문자)", example = "Passw0rd!", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Pattern(
                 regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+={}\\[\\]:;\"'<>,.?/~`\\\\|-]).{8,}$",
@@ -18,24 +21,37 @@ public record SignupRequest(
         )
         String password,
 
+        @Schema(description = "비밀번호 확인", example = "Passw0rd!", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "비밀번호 확인은 필수입니다.")
         String passwordConfirm,
 
+        @Schema(description = "실명", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "이름은 필수입니다.")
         String name,
 
+        @Schema(description = "닉네임", example = "gildong", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "닉네임은 필수입니다.")
         String nickname,
 
+        @Schema(description = "전화번호", example = "010-1234-5678", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "전화번호는 필수입니다.")
         @Pattern(
                 regexp = "^01[0-9]-\\d{3,4}-\\d{4}$",
                 message = "전화번호 형식이 올바르지 않습니다. (예: 010-1234-5678)"
         )
-        String phone
+        String phone,
+
+        @Schema(description = "이용약관 동의 (필수, 반드시 true)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean termsOfServiceAgreed,
+
+        @Schema(description = "개인정보 수집·이용 동의 (필수, 반드시 true)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean privacyPolicyAgreed
 ) {
 
     public SignupCommand toCommand() {
-        return new SignupCommand(email, password, passwordConfirm, name, nickname, phone);
+        return new SignupCommand(
+                email, password, passwordConfirm, name, nickname, phone,
+                termsOfServiceAgreed, privacyPolicyAgreed
+        );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/port/UserHardDeletePort.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/port/UserHardDeletePort.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.user.application.port;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserHardDeletePort {
+
+    // 소프트딜리트 후 기준 시각을 지난 회원 ID 목록 (@SQLRestriction 우회 — 네이티브)
+    List<Long> findDeletedUserIdsBefore(LocalDateTime threshold);
+
+    // 해당 회원의 PII 물리 삭제 (users + 인증·기기·동의 이력). 활동데이터는 익명화(유지)
+    void purgeByUserId(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UserHardDeleteProcessor.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UserHardDeleteProcessor.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.user.application.port.UserHardDeletePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserHardDeleteProcessor {
+
+    private final UserHardDeletePort userHardDeletePort;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean hardDelete(Long userId) {
+        try {
+            userHardDeletePort.purgeByUserId(userId);
+            return true;
+        } catch (RuntimeException e) {
+            log.atError()
+                    .setCause(e)
+                    .log("회원 하드 딜리트 실패로 건너뜁니다. userId={}", userId);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/UserHardDeleteService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/UserHardDeleteService.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.user.application.service;
+
+import com.wanted.codebombalms.user.application.port.UserHardDeletePort;
+import com.wanted.codebombalms.user.application.usecase.HardDeleteUsersUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserHardDeleteService implements HardDeleteUsersUseCase {
+
+    private final UserHardDeletePort userHardDeletePort;
+    private final UserHardDeleteProcessor userHardDeleteProcessor;
+
+    @Override
+    @Transactional(readOnly = true)
+    public int hardDeleteBefore(LocalDateTime threshold) {
+        List<Long> targetUserIds = userHardDeletePort.findDeletedUserIdsBefore(threshold);
+
+        int deletedCount = 0;
+        for (Long userId : targetUserIds) {
+            if (userHardDeleteProcessor.hardDelete(userId)) {
+                deletedCount++;
+            }
+        }
+
+        log.info("회원 하드 딜리트 완료. 대상={}건, 삭제={}건, 기준시각={}",
+                targetUserIds.size(), deletedCount, threshold);
+        return deletedCount;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/HardDeleteUsersUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/HardDeleteUsersUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.user.application.usecase;
+
+import java.time.LocalDateTime;
+
+public interface HardDeleteUsersUseCase {
+
+    int hardDeleteBefore(LocalDateTime threshold);
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/exception/UserErrorCode.java
@@ -31,7 +31,10 @@ public enum UserErrorCode implements ErrorCode {
 
     TRUSTED_DEVICE_NOT_FOUND("USR-012", "신뢰 기기를 찾을 수 없습니다."),
 
-    USER_WITHDRAW_CONFIRM_MISMATCH("USR-013", "탈퇴 확인 문구가 일치하지 않습니다.");
+    USER_WITHDRAW_CONFIRM_MISMATCH("USR-013", "탈퇴 확인 문구가 일치하지 않습니다."),
+
+    // 약관 동의
+    USER_TERMS_NOT_AGREED("USR-014", "필수 약관에 동의해야 합니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/user/domain/model/TermsType.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/model/TermsType.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.user.domain.model;
+
+public enum TermsType {
+
+    SERVICE("v1.0"),   // 이용약관 (필수)
+    PRIVACY("v1.0");   // 개인정보 수집·이용 (필수)
+
+    private final String currentVersion;
+
+    TermsType(String currentVersion) {
+        this.currentVersion = currentVersion;
+    }
+
+    public String currentVersion() {
+        return currentVersion;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/model/UserAgreement.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/model/UserAgreement.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.user.domain.model;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class UserAgreement {
 
@@ -30,6 +31,14 @@ public class UserAgreement {
         a.agreed       = true;
         a.agreedAt     = LocalDateTime.now();
         return a;
+    }
+
+    // ===== 필수 약관(이용약관 + 개인정보 수집·이용) 동의 일괄 생성 — "무엇이 필수인가"를 여기 한 곳에서 정의 =====
+    public static List<UserAgreement> requiredAgreements(Long userId) {
+        return List.of(
+                agree(userId, TermsType.SERVICE),
+                agree(userId, TermsType.PRIVACY)
+        );
     }
 
     // ===== 영속성 복원 — Adapter 전용 =====

--- a/src/main/java/com/wanted/codebombalms/user/domain/model/UserAgreement.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/model/UserAgreement.java
@@ -1,0 +1,49 @@
+package com.wanted.codebombalms.user.domain.model;
+
+import java.time.LocalDateTime;
+
+public class UserAgreement {
+
+    private Long userAgreementId;
+    private Long userId;
+    private TermsType termsType;
+    private String termsVersion;
+    private boolean agreed;
+    private LocalDateTime agreedAt;
+
+    private UserAgreement() {}
+
+    // ===== Getter =====
+    public Long getUserAgreementId()   { return userAgreementId; }
+    public Long getUserId()            { return userId; }
+    public TermsType getTermsType()    { return termsType; }
+    public String getTermsVersion()    { return termsVersion; }
+    public boolean isAgreed()          { return agreed; }
+    public LocalDateTime getAgreedAt() { return agreedAt; }
+
+    // ===== 신규 동의 생성 — 현재 약관 버전을 서버가 스탬프 =====
+    public static UserAgreement agree(Long userId, TermsType termsType) {
+        UserAgreement a = new UserAgreement();
+        a.userId       = userId;
+        a.termsType    = termsType;
+        a.termsVersion = termsType.currentVersion();
+        a.agreed       = true;
+        a.agreedAt     = LocalDateTime.now();
+        return a;
+    }
+
+    // ===== 영속성 복원 — Adapter 전용 =====
+    public static UserAgreement restore(
+            Long userAgreementId, Long userId, TermsType termsType,
+            String termsVersion, boolean agreed, LocalDateTime agreedAt
+    ) {
+        UserAgreement a = new UserAgreement();
+        a.userAgreementId = userAgreementId;
+        a.userId          = userId;
+        a.termsType       = termsType;
+        a.termsVersion    = termsVersion;
+        a.agreed          = agreed;
+        a.agreedAt        = agreedAt;
+        return a;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/UserAgreementRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/UserAgreementRepository.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.user.domain.repository;
+
+import com.wanted.codebombalms.user.domain.model.UserAgreement;
+
+import java.util.List;
+
+public interface UserAgreementRepository {
+
+    List<UserAgreement> saveAll(List<UserAgreement> agreements);
+}

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/cleanup/UserCleanupConfig.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/cleanup/UserCleanupConfig.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.user.infrastructure.cleanup;
+
+import com.wanted.codebombalms.global.application.cleanup.DefaultHardDeleteTarget;
+import com.wanted.codebombalms.global.application.cleanup.port.HardDeleteTarget;
+import com.wanted.codebombalms.user.application.usecase.HardDeleteUsersUseCase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Period;
+
+@Configuration
+public class UserCleanupConfig {
+
+    @Bean
+    public HardDeleteTarget userHardDeleteTarget(
+            HardDeleteUsersUseCase hardDeleteUsersUseCase
+    ) {
+        return new DefaultHardDeleteTarget(
+                "user",
+                Period.ofYears(1),                       // 탈퇴 후 1년 보관 → 파기
+                hardDeleteUsersUseCase::hardDeleteBefore
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserAgreementRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserAgreementRepository.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.user.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataUserAgreementRepository
+        extends JpaRepository<UserAgreementJpaEntity, Long> {
+}

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserAgreementJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserAgreementJpaEntity.java
@@ -1,0 +1,62 @@
+package com.wanted.codebombalms.user.infrastructure.persistence;
+
+import com.wanted.codebombalms.user.domain.model.TermsType;
+import com.wanted.codebombalms.user.domain.model.UserAgreement;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "user_agreement",
+        indexes = {
+                @Index(name = "idx_user_agreement_user_type_time",
+                        columnList = "user_id, terms_type, agreed_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAgreementJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_agreement_id")
+    private Long userAgreementId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "terms_type", nullable = false, length = 20)
+    private TermsType termsType;
+
+    @Column(name = "terms_version", nullable = false, length = 20)
+    private String termsVersion;
+
+    @Column(name = "agreed", nullable = false)
+    private boolean agreed;
+
+    @Column(name = "agreed_at", nullable = false)
+    private LocalDateTime agreedAt;
+
+    public static UserAgreementJpaEntity from(UserAgreement agreement) {
+        UserAgreementJpaEntity e = new UserAgreementJpaEntity();
+        e.userAgreementId = agreement.getUserAgreementId();
+        e.userId          = agreement.getUserId();
+        e.termsType       = agreement.getTermsType();
+        e.termsVersion    = agreement.getTermsVersion();
+        e.agreed          = agreement.isAgreed();
+        e.agreedAt        = agreement.getAgreedAt();
+        return e;
+    }
+
+    public UserAgreement toDomain() {
+        return UserAgreement.restore(
+                userAgreementId, userId, termsType,
+                termsVersion, agreed, agreedAt
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserAgreementRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserAgreementRepositoryAdapter.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.user.infrastructure.persistence;
+
+import com.wanted.codebombalms.user.domain.model.UserAgreement;
+import com.wanted.codebombalms.user.domain.repository.UserAgreementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class UserAgreementRepositoryAdapter implements UserAgreementRepository {
+
+    private final SpringDataUserAgreementRepository springDataUserAgreementRepository;
+
+    @Override
+    public List<UserAgreement> saveAll(List<UserAgreement> agreements) {
+        List<UserAgreementJpaEntity> entities = agreements.stream()
+                .map(UserAgreementJpaEntity::from)
+                .toList();
+
+        return springDataUserAgreementRepository.saveAll(entities).stream()
+                .map(UserAgreementJpaEntity::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserHardDeleteAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserHardDeleteAdapter.java
@@ -3,41 +3,69 @@ package com.wanted.codebombalms.user.infrastructure.persistence;
 import com.wanted.codebombalms.user.application.port.UserHardDeletePort;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Component
 public class UserHardDeleteAdapter implements UserHardDeletePort {
+
+    // 1회 실행당 파기 대상 상한 — ID 목록 OOM 방지. 초과분은 익일 실행에서 처리
+    private static final int MAX_BATCH = 1000;
 
     @PersistenceContext
     private EntityManager em;
 
     @Override
     public List<Long> findDeletedUserIdsBefore(LocalDateTime threshold) {
+        // 소프트딜리트 1년 경과 + 아직 익명화 안 된 회원. @SQLRestriction(deleted_at IS NULL) 우회 위해 네이티브.
+        // MAX_BATCH 는 코드 상수(int) — 문자열 결합해도 인젝션 없음. LIMIT 바인드 드라이버 이슈도 회피
         @SuppressWarnings("unchecked")
-        List<Object> rows = em.createNativeQuery("""
-                        SELECT user_id FROM users
-                        WHERE deleted_at IS NOT NULL AND deleted_at < :threshold
-                        """)
+        List<Object> rows = em.createNativeQuery(
+                        "SELECT user_id FROM users "
+                      + "WHERE deleted_at IS NOT NULL AND deleted_at < :threshold AND anonymized_at IS NULL "
+                      + "ORDER BY user_id LIMIT " + MAX_BATCH)
                 .setParameter("threshold", threshold)
                 .getResultList();
 
-        return rows.stream()
+        List<Long> ids = rows.stream()
                 .map(id -> ((Number) id).longValue())
                 .toList();
+
+        if (ids.size() == MAX_BATCH) {
+            log.warn("회원 파기 대상이 배치 상한({})에 도달 — 잔여분은 다음 실행(익일 03시)에서 처리됩니다.", MAX_BATCH);
+        }
+        return ids;
     }
 
     @Override
     public void purgeByUserId(Long userId) {
-        // 활동데이터(submissions·progress·points·badge·enrollment·chat)는 A안 = 익명화(유지).
-        // users 행이 사라지면 user_id 는 식별 불가 → 사실상 익명화됨.
+        // 1) PII 자식 테이블 물리 삭제
+        //    users 를 지우지 않으므로 CASCADE 가 안 걸림 → 명시적으로 삭제
         deleteFrom("login_history", userId);
         deleteFrom("trusted_devices", userId);
         deleteFrom("refresh_tokens", userId);
         deleteFrom("user_agreement", userId);
-        deleteFrom("users", userId);          // PII 앵커 — 마지막에 삭제
+
+        // 2) users 본체는 '삭제' 대신 '익명화'
+        //    활동데이터(submission·enrollment 등)의 RESTRICT FK 와 충돌 회피 +
+        //    직접 식별정보 제거 + 재처리 방지 마커(anonymized_at) 기록
+        em.createNativeQuery("""
+                        UPDATE users SET
+                            name          = '탈퇴회원',
+                            phone         = NULL,
+                            email         = CONCAT('#anonymized#', user_id),
+                            password      = NULL,
+                            bio           = NULL,
+                            career        = NULL,
+                            anonymized_at = NOW()
+                        WHERE user_id = :userId
+                        """)
+                .setParameter("userId", userId)
+                .executeUpdate();
     }
 
     // 고정 테이블명만 사용 (사용자 입력 아님 — 인젝션 없음)

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserHardDeleteAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserHardDeleteAdapter.java
@@ -1,0 +1,49 @@
+package com.wanted.codebombalms.user.infrastructure.persistence;
+
+import com.wanted.codebombalms.user.application.port.UserHardDeletePort;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class UserHardDeleteAdapter implements UserHardDeletePort {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<Long> findDeletedUserIdsBefore(LocalDateTime threshold) {
+        @SuppressWarnings("unchecked")
+        List<Object> rows = em.createNativeQuery("""
+                        SELECT user_id FROM users
+                        WHERE deleted_at IS NOT NULL AND deleted_at < :threshold
+                        """)
+                .setParameter("threshold", threshold)
+                .getResultList();
+
+        return rows.stream()
+                .map(id -> ((Number) id).longValue())
+                .toList();
+    }
+
+    @Override
+    public void purgeByUserId(Long userId) {
+        // 활동데이터(submissions·progress·points·badge·enrollment·chat)는 A안 = 익명화(유지).
+        // users 행이 사라지면 user_id 는 식별 불가 → 사실상 익명화됨.
+        deleteFrom("login_history", userId);
+        deleteFrom("trusted_devices", userId);
+        deleteFrom("refresh_tokens", userId);
+        deleteFrom("user_agreement", userId);
+        deleteFrom("users", userId);          // PII 앵커 — 마지막에 삭제
+    }
+
+    // 고정 테이블명만 사용 (사용자 입력 아님 — 인젝션 없음)
+    private void deleteFrom(String table, Long userId) {
+        em.createNativeQuery("DELETE FROM " + table + " WHERE user_id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.auth.domain.repository.EmailVerificationRepositor
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
+import com.wanted.codebombalms.user.domain.model.TermsType;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.repository.UserAgreementRepository;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -77,7 +80,11 @@ class SignupServiceTest {
         // then
         assertEquals(1L, userId);
         verify(userRepository).save(any(User.class));
-        verify(userAgreementRepository).saveAll(argThat(list -> list.size() == 2));
+        verify(userAgreementRepository).saveAll(argThat(list ->
+                list.size() == 2
+                && list.stream().anyMatch(a -> a.getTermsType() == TermsType.SERVICE)
+                && list.stream().anyMatch(a -> a.getTermsType() == TermsType.PRIVACY)
+        ));
         verify(emailVerificationRepository).clearVerified("test@example.com");
     }
 
@@ -121,9 +128,14 @@ class SignupServiceTest {
         verify(userRepository, never()).save(any(User.class));
     }
 
-    @Test
-    @DisplayName("필수 약관에 동의하지 않으면 ValidationException(USER_TERMS_NOT_AGREED)을 던진다.")
-    void 약관_미동의_예외() {
+    @ParameterizedTest(name = "이용약관={0}, 개인정보={1} → USR-014")
+    @CsvSource({
+            "false, true",   // 이용약관만 미동의
+            "true,  false",  // 개인정보만 미동의
+            "false, false"   // 둘 다 미동의
+    })
+    @DisplayName("필수 약관에 하나라도 동의하지 않으면 ValidationException(USER_TERMS_NOT_AGREED)을 던진다.")
+    void 약관_미동의_예외(boolean termsOfServiceAgreed, boolean privacyPolicyAgreed) {
         // given
         SignupCommand notAgreed = new SignupCommand(
                 "test@example.com",
@@ -132,8 +144,8 @@ class SignupServiceTest {
                 "홍길동",
                 "길동이",
                 "010-1234-5678",
-                false,   // 이용약관 미동의
-                true
+                termsOfServiceAgreed,
+                privacyPolicyAgreed
         );
         given(emailVerificationRepository.isVerified("test@example.com")).willReturn(true);
 
@@ -144,6 +156,7 @@ class SignupServiceTest {
         );
         assertEquals(UserErrorCode.USER_TERMS_NOT_AGREED, ex.getErrorCode());
         verify(userRepository, never()).save(any(User.class));
+        verify(userAgreementRepository, never()).saveAll(any());
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/SignupServiceTest.java
@@ -7,6 +7,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ConflictExce
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.user.domain.exception.UserErrorCode;
 import com.wanted.codebombalms.user.domain.model.User;
+import com.wanted.codebombalms.user.domain.repository.UserAgreementRepository;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +31,7 @@ class SignupServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private EmailVerificationRepository emailVerificationRepository;
+    @Mock private UserAgreementRepository userAgreementRepository;
     @Mock private AuthMetricsPort authMetrics;
 
     @InjectMocks
@@ -45,7 +47,9 @@ class SignupServiceTest {
                 "Test1234!",
                 "홍길동",
                 "길동이",
-                "010-1234-5678"
+                "010-1234-5678",
+                true,   // 이용약관 동의
+                true    // 개인정보 수집·이용 동의
         );
     }
 
@@ -73,6 +77,7 @@ class SignupServiceTest {
         // then
         assertEquals(1L, userId);
         verify(userRepository).save(any(User.class));
+        verify(userAgreementRepository).saveAll(argThat(list -> list.size() == 2));
         verify(emailVerificationRepository).clearVerified("test@example.com");
     }
 
@@ -101,7 +106,9 @@ class SignupServiceTest {
                 "DifferentPassword5!",     // 일치하지 않음
                 "홍길동",
                 "길동이",
-                "010-1234-5678"
+                "010-1234-5678",
+                true,
+                true
         );
         given(emailVerificationRepository.isVerified("test@example.com")).willReturn(true);
 
@@ -111,6 +118,31 @@ class SignupServiceTest {
                 () -> signupService.signup(mismatch)
         );
         assertEquals(UserErrorCode.USER_PASSWORD_CONFIRM_MISMATCH, ex.getErrorCode());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("필수 약관에 동의하지 않으면 ValidationException(USER_TERMS_NOT_AGREED)을 던진다.")
+    void 약관_미동의_예외() {
+        // given
+        SignupCommand notAgreed = new SignupCommand(
+                "test@example.com",
+                "Test1234!",
+                "Test1234!",
+                "홍길동",
+                "길동이",
+                "010-1234-5678",
+                false,   // 이용약관 미동의
+                true
+        );
+        given(emailVerificationRepository.isVerified("test@example.com")).willReturn(true);
+
+        // when & then
+        ValidationException ex = assertThrows(
+                ValidationException.class,
+                () -> signupService.signup(notAgreed)
+        );
+        assertEquals(UserErrorCode.USER_TERMS_NOT_AGREED, ex.getErrorCode());
         verify(userRepository, never()).save(any(User.class));
     }
 


### PR DESCRIPTION


## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #598

---

## 🛠️ 기능 관련 작업 내용
- 회원가입 2경로(일반·소셜)에 이용약관(SERVICE)·개인정보 수집·이용(PRIVACY) 필수 동의 추가 — 미동의 시 `USR-014`, 동의 이력을 `user_agreement`에 버전과 함께 append 저장(서버가 버전 스탬프)
- 소프트딜리트 1년 경과 회원 파기 — 기존 `HardDeleteTarget` 프레임워크에 대상 등록(매일 3시)
- 파기 방식은 **익명화**: 활동데이터가 users를 RESTRICT FK로 참조해 물리삭제 불가 → PII 자식 삭제 + users 본체 PII 스크럽 + `anonymized_at` 재처리 마커. 활동데이터는 익명 유저로 유지
- 동의문 초안(이용약관·개인정보 수집이용 v1.0) 작성 + API.md 반영

---

## ♻️ 패키지 변경 사항
- `codebombalms/user/domain`: `TermsType`·`UserAgreement` 도메인, `UserAgreementRepository` 포트, `UserErrorCode`(USR-014)
- `codebombalms/user/infrastructure`: 동의 영속성(Entity·SpringData·Adapter), 파기 어댑터(`UserHardDeleteAdapter`, 네이티브·익명화), `UserCleanupConfig`
- `codebombalms/user/application`: 파기 유스케이스/서비스/프로세서(REQUIRES_NEW), `UserHardDeletePort`
- `codebombalms/auth`: 회원가입·소셜 complete DTO/서비스/컨트롤러에 동의 필드 + 검증 + 저장 + Swagger
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회원가입 및 소셜 회원가입 시 이용약관과 개인정보 수집·이용 동의가 필수로 적용됩니다.
  * 동의 이력이 저장되어 동의한 약관과 버전을 확인할 수 있습니다.
  * 탈퇴 후 1년이 지난 사용자 정보를 영구 삭제하는 정리 기능이 추가되었습니다.

* **버그 수정**
  * 필수 약관에 동의하지 않은 가입 요청이 명확한 오류로 거부됩니다.

* **문서화**
  * 회원가입 API 문서에 입력 항목과 필수 동의 조건이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->