### PR TITLE
[Feat] 문제 카테고리 관리 API 추가 및 자동 생성 제거

### DIFF
--- a/src/main/java/com/wanted/codebombalms/problems/category/application/port/CheckProblemCategoryUsagePort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/application/port/CheckProblemCategoryUsagePort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.category.application.port;
+
+public interface CheckProblemCategoryUsagePort {
+
+    boolean existsActiveProblemSet(Long categoryId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/category/application/port/ManageProblemCategoryPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/application/port/ManageProblemCategoryPort.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.problems.category.application.port;
+
+import com.wanted.codebombalms.problems.category.domain.model.ProblemCategory;
+
+import java.util.List;
+
+public interface ManageProblemCategoryPort {
+
+    List<ProblemCategory> loadAllCategories();
+
+    boolean existsByCategoryName(String categoryName);
+
+    boolean existsByCategoryNameAndCategoryIdNot(String categoryName, Long categoryId);
+
+    ProblemCategory create(String categoryName);
+
+    ProblemCategory updateName(Long categoryId, String categoryName);
+
+    ProblemCategory deactivate(Long categoryId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/category/application/port/ManageProblemCategoryPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/application/port/ManageProblemCategoryPort.java
@@ -8,9 +8,9 @@ public interface ManageProblemCategoryPort {
 
     List<ProblemCategory> loadAllCategories();
 
-    boolean existsByCategoryName(String categoryName);
+    boolean existsActiveByCategoryName(String categoryName);
 
-    boolean existsByCategoryNameAndCategoryIdNot(String categoryName, Long categoryId);
+    boolean existsActiveByCategoryNameAndCategoryIdNot(String categoryName, Long categoryId);
 
     ProblemCategory create(String categoryName);
 

--- a/src/main/java/com/wanted/codebombalms/problems/category/application/service/ProblemCategoryManagementService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/application/service/ProblemCategoryManagementService.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.problems.category.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.category.application.port.CheckProblemCategoryUsagePort;
 import com.wanted.codebombalms.problems.category.application.port.ManageProblemCategoryPort;
 import com.wanted.codebombalms.problems.category.application.usecase.ManageProblemCategoriesUseCase;
 import com.wanted.codebombalms.problems.category.domain.model.ProblemCategory;
@@ -18,6 +19,7 @@ import java.util.List;
 public class ProblemCategoryManagementService implements ManageProblemCategoriesUseCase {
 
     private final ManageProblemCategoryPort manageProblemCategoryPort;
+    private final CheckProblemCategoryUsagePort checkProblemCategoryUsagePort;
 
     @Override
     public List<ProblemCategoryAdminView> findCategories() {
@@ -32,7 +34,7 @@ public class ProblemCategoryManagementService implements ManageProblemCategories
     public ProblemCategoryAdminView create(String categoryName) {
         String normalizedCategoryName = normalizeCategoryName(categoryName);
 
-        if (manageProblemCategoryPort.existsByCategoryName(normalizedCategoryName)) {
+        if (manageProblemCategoryPort.existsActiveByCategoryName(normalizedCategoryName)) {
             throw new ConflictException(ProblemErrorCode.CATEGORY_ALREADY_EXISTS);
         }
 
@@ -44,7 +46,7 @@ public class ProblemCategoryManagementService implements ManageProblemCategories
     public ProblemCategoryAdminView updateName(Long categoryId, String categoryName) {
         String normalizedCategoryName = normalizeCategoryName(categoryName);
 
-        if (manageProblemCategoryPort.existsByCategoryNameAndCategoryIdNot(
+        if (manageProblemCategoryPort.existsActiveByCategoryNameAndCategoryIdNot(
                 normalizedCategoryName,
                 categoryId
         )) {
@@ -57,6 +59,10 @@ public class ProblemCategoryManagementService implements ManageProblemCategories
     @Override
     @Transactional
     public ProblemCategoryAdminView deactivate(Long categoryId) {
+        if (checkProblemCategoryUsagePort.existsActiveProblemSet(categoryId)) {
+            throw new ConflictException(ProblemErrorCode.INVALID_CATEGORY);
+        }
+
         return toView(manageProblemCategoryPort.deactivate(categoryId));
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/category/application/service/ProblemCategoryManagementService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/application/service/ProblemCategoryManagementService.java
@@ -1,0 +1,78 @@
+package com.wanted.codebombalms.problems.category.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.category.application.port.ManageProblemCategoryPort;
+import com.wanted.codebombalms.problems.category.application.usecase.ManageProblemCategoriesUseCase;
+import com.wanted.codebombalms.problems.category.domain.model.ProblemCategory;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemCategoryManagementService implements ManageProblemCategoriesUseCase {
+
+    private final ManageProblemCategoryPort manageProblemCategoryPort;
+
+    @Override
+    public List<ProblemCategoryAdminView> findCategories() {
+        return manageProblemCategoryPort.loadAllCategories()
+                .stream()
+                .map(this::toView)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public ProblemCategoryAdminView create(String categoryName) {
+        String normalizedCategoryName = normalizeCategoryName(categoryName);
+
+        if (manageProblemCategoryPort.existsByCategoryName(normalizedCategoryName)) {
+            throw new ConflictException(ProblemErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
+
+        return toView(manageProblemCategoryPort.create(normalizedCategoryName));
+    }
+
+    @Override
+    @Transactional
+    public ProblemCategoryAdminView updateName(Long categoryId, String categoryName) {
+        String normalizedCategoryName = normalizeCategoryName(categoryName);
+
+        if (manageProblemCategoryPort.existsByCategoryNameAndCategoryIdNot(
+                normalizedCategoryName,
+                categoryId
+        )) {
+            throw new ConflictException(ProblemErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
+
+        return toView(manageProblemCategoryPort.updateName(categoryId, normalizedCategoryName));
+    }
+
+    @Override
+    @Transactional
+    public ProblemCategoryAdminView deactivate(Long categoryId) {
+        return toView(manageProblemCategoryPort.deactivate(categoryId));
+    }
+
+    private String normalizeCategoryName(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) {
+            throw new ValidationException(ProblemErrorCode.PROBLEM_CATEGORY_REQUIRED);
+        }
+
+        return categoryName.trim();
+    }
+
+    private ProblemCategoryAdminView toView(ProblemCategory category) {
+        return new ProblemCategoryAdminView(
+                category.getCategoryId(),
+                category.getCategoryName(),
+                category.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/category/application/usecase/ManageProblemCategoriesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/application/usecase/ManageProblemCategoriesUseCase.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.problems.category.application.usecase;
+
+import java.util.List;
+
+public interface ManageProblemCategoriesUseCase {
+
+    List<ProblemCategoryAdminView> findCategories();
+
+    ProblemCategoryAdminView create(String categoryName);
+
+    ProblemCategoryAdminView updateName(Long categoryId, String categoryName);
+
+    ProblemCategoryAdminView deactivate(Long categoryId);
+
+    record ProblemCategoryAdminView(
+            Long categoryId,
+            String categoryName,
+            String status
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/ProblemCategoryJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/ProblemCategoryJpaEntity.java
@@ -45,4 +45,12 @@ public class ProblemCategoryJpaEntity {
     public ProblemCategoryStatus getStatus() {
         return status;
     }
+
+    public void updateName(String categoryName) {
+        this.categoryName = categoryName;
+    }
+
+    public void deactivate() {
+        this.status = ProblemCategoryStatus.INACTIVE;
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/ProblemCategoryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/ProblemCategoryPersistenceAdapter.java
@@ -1,10 +1,13 @@
 package com.wanted.codebombalms.problems.category.infrastructure.persistence;
 
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.problems.category.application.port.LoadProblemCategoryPort;
+import com.wanted.codebombalms.problems.category.application.port.ManageProblemCategoryPort;
 import com.wanted.codebombalms.problems.category.domain.model.ProblemCategory;
 import com.wanted.codebombalms.problems.category.domain.model.ProblemCategoryStatus;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
 import com.wanted.codebombalms.problems.set.application.port.CheckProblemSetCategoryPort;
-import com.wanted.codebombalms.problems.set.application.port.FindOrCreateProblemSetCategoryPort;
+import com.wanted.codebombalms.problems.set.application.port.FindActiveProblemSetCategoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,7 +18,8 @@ import java.util.List;
 public class ProblemCategoryPersistenceAdapter implements
         LoadProblemCategoryPort,
         CheckProblemSetCategoryPort,
-        FindOrCreateProblemSetCategoryPort {
+        FindActiveProblemSetCategoryPort,
+        ManageProblemCategoryPort {
 
     private final SpringDataProblemCategoryRepository springDataProblemCategoryRepository;
 
@@ -35,16 +39,64 @@ public class ProblemCategoryPersistenceAdapter implements
         );
     }
     @Override
-    public Long findOrCreateActiveCategoryId(String categoryName) {
+    public Long findActiveCategoryId(String categoryName) {
         ProblemCategory category = ProblemCategory.create(categoryName);
 
         return springDataProblemCategoryRepository.findByCategoryNameAndStatus(
                         category.getCategoryName(),
                         category.getStatus()
                 )
-                .orElseGet(() -> springDataProblemCategoryRepository.save(
-                        ProblemCategoryMapper.toEntity(category)
-                ))
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.CATEGORY_NOT_FOUND))
                 .getCategoryId();
+    }
+
+    @Override
+    public List<ProblemCategory> loadAllCategories() {
+        return springDataProblemCategoryRepository.findAllByOrderByCategoryIdAsc()
+                .stream()
+                .map(ProblemCategoryMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public boolean existsByCategoryName(String categoryName) {
+        return springDataProblemCategoryRepository.existsByCategoryName(categoryName);
+    }
+
+    @Override
+    public boolean existsByCategoryNameAndCategoryIdNot(String categoryName, Long categoryId) {
+        return springDataProblemCategoryRepository.existsByCategoryNameAndCategoryIdNot(
+                categoryName,
+                categoryId
+        );
+    }
+
+    @Override
+    public ProblemCategory create(String categoryName) {
+        ProblemCategory category = ProblemCategory.create(categoryName);
+        ProblemCategoryJpaEntity savedCategory =
+                springDataProblemCategoryRepository.save(ProblemCategoryMapper.toEntity(category));
+
+        return ProblemCategoryMapper.toDomain(savedCategory);
+    }
+
+    @Override
+    public ProblemCategory updateName(Long categoryId, String categoryName) {
+        ProblemCategoryJpaEntity category = springDataProblemCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.CATEGORY_NOT_FOUND));
+
+        category.updateName(categoryName);
+
+        return ProblemCategoryMapper.toDomain(category);
+    }
+
+    @Override
+    public ProblemCategory deactivate(Long categoryId) {
+        ProblemCategoryJpaEntity category = springDataProblemCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException(ProblemErrorCode.CATEGORY_NOT_FOUND));
+
+        category.deactivate();
+
+        return ProblemCategoryMapper.toDomain(category);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/ProblemCategoryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/ProblemCategoryPersistenceAdapter.java
@@ -40,11 +40,11 @@ public class ProblemCategoryPersistenceAdapter implements
     }
     @Override
     public Long findActiveCategoryId(String categoryName) {
-        ProblemCategory category = ProblemCategory.create(categoryName);
+        String normalizedCategoryName = categoryName == null ? "" : categoryName.trim();
 
         return springDataProblemCategoryRepository.findByCategoryNameAndStatus(
-                        category.getCategoryName(),
-                        category.getStatus()
+                        normalizedCategoryName,
+                        ProblemCategoryStatus.ACTIVE
                 )
                 .orElseThrow(() -> new NotFoundException(ProblemErrorCode.CATEGORY_NOT_FOUND))
                 .getCategoryId();
@@ -59,14 +59,18 @@ public class ProblemCategoryPersistenceAdapter implements
     }
 
     @Override
-    public boolean existsByCategoryName(String categoryName) {
-        return springDataProblemCategoryRepository.existsByCategoryName(categoryName);
+    public boolean existsActiveByCategoryName(String categoryName) {
+        return springDataProblemCategoryRepository.existsByCategoryNameAndStatus(
+                categoryName,
+                ProblemCategoryStatus.ACTIVE
+        );
     }
 
     @Override
-    public boolean existsByCategoryNameAndCategoryIdNot(String categoryName, Long categoryId) {
-        return springDataProblemCategoryRepository.existsByCategoryNameAndCategoryIdNot(
+    public boolean existsActiveByCategoryNameAndCategoryIdNot(String categoryName, Long categoryId) {
+        return springDataProblemCategoryRepository.existsByCategoryNameAndStatusAndCategoryIdNot(
                 categoryName,
+                ProblemCategoryStatus.ACTIVE,
                 categoryId
         );
     }

--- a/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/SpringDataProblemCategoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/SpringDataProblemCategoryRepository.java
@@ -21,10 +21,14 @@ public interface SpringDataProblemCategoryRepository extends JpaRepository<Probl
 
     List<ProblemCategoryJpaEntity> findAllByOrderByCategoryIdAsc();
 
-    boolean existsByCategoryName(String categoryName);
-
-    boolean existsByCategoryNameAndCategoryIdNot(
+    boolean existsByCategoryNameAndStatus(
             String categoryName,
+            ProblemCategoryStatus status
+    );
+
+    boolean existsByCategoryNameAndStatusAndCategoryIdNot(
+            String categoryName,
+            ProblemCategoryStatus status,
             Long categoryId
     );
 

--- a/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/SpringDataProblemCategoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/infrastructure/persistence/SpringDataProblemCategoryRepository.java
@@ -18,4 +18,14 @@ public interface SpringDataProblemCategoryRepository extends JpaRepository<Probl
             String categoryName,
             ProblemCategoryStatus status
     );
+
+    List<ProblemCategoryJpaEntity> findAllByOrderByCategoryIdAsc();
+
+    boolean existsByCategoryName(String categoryName);
+
+    boolean existsByCategoryNameAndCategoryIdNot(
+            String categoryName,
+            Long categoryId
+    );
+
 }

--- a/src/main/java/com/wanted/codebombalms/problems/category/presentation/ProblemCategoryAdminController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/presentation/ProblemCategoryAdminController.java
@@ -1,0 +1,83 @@
+package com.wanted.codebombalms.problems.category.presentation;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.problems.category.application.usecase.ManageProblemCategoriesUseCase;
+import com.wanted.codebombalms.problems.category.presentation.request.ProblemCategoryCreateRequest;
+import com.wanted.codebombalms.problems.category.presentation.request.ProblemCategoryUpdateRequest;
+import com.wanted.codebombalms.problems.category.presentation.response.ProblemCategoryAdminResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/problem-categories")
+@RequiredArgsConstructor
+public class ProblemCategoryAdminController {
+
+    private final ManageProblemCategoriesUseCase manageProblemCategoriesUseCase;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ProblemCategoryAdminResponse>>> findCategories() {
+        List<ProblemCategoryAdminResponse> response = manageProblemCategoriesUseCase.findCategories()
+                .stream()
+                .map(ProblemCategoryAdminResponse::new)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ProblemCategoryAdminResponse>> create(
+            @RequestBody @Valid ProblemCategoryCreateRequest request
+    ) {
+        ProblemCategoryAdminResponse response = new ProblemCategoryAdminResponse(
+                manageProblemCategoriesUseCase.create(request.categoryName())
+        );
+
+        return ResponseEntity.status(201).body(ApiResponse.created(
+                ApiResponseCode.CREATED,
+                ApiResponseMessage.CREATED,
+                response
+        ));
+    }
+
+    @PatchMapping("/{categoryId}")
+    public ResponseEntity<ApiResponse<ProblemCategoryAdminResponse>> updateName(
+            @PathVariable Long categoryId,
+            @RequestBody @Valid ProblemCategoryUpdateRequest request
+    ) {
+        ProblemCategoryAdminResponse response = new ProblemCategoryAdminResponse(
+                manageProblemCategoriesUseCase.updateName(categoryId, request.categoryName())
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<ApiResponse<ProblemCategoryAdminResponse>> deactivate(
+            @PathVariable Long categoryId
+    ) {
+        ProblemCategoryAdminResponse response = new ProblemCategoryAdminResponse(
+                manageProblemCategoriesUseCase.deactivate(categoryId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                response
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryCreateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryCreateRequest.java
@@ -2,10 +2,12 @@ package com.wanted.codebombalms.problems.category.presentation.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record ProblemCategoryCreateRequest(
         @Schema(description = "문제 카테고리 이름", example = "알고리즘")
         @NotBlank(message = "카테고리 이름은 필수입니다.")
+        @Size(max = 255, message = "카테고리 이름은 255자 이하여야 합니다.")
         String categoryName
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryCreateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryCreateRequest.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.category.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ProblemCategoryCreateRequest(
+        @Schema(description = "문제 카테고리 이름", example = "알고리즘")
+        @NotBlank(message = "카테고리 이름은 필수입니다.")
+        String categoryName
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryUpdateRequest.java
@@ -2,10 +2,12 @@ package com.wanted.codebombalms.problems.category.presentation.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record ProblemCategoryUpdateRequest(
         @Schema(description = "수정할 문제 카테고리 이름", example = "Python 기초")
         @NotBlank(message = "카테고리 이름은 필수입니다.")
+        @Size(max = 255, message = "카테고리 이름은 255자 이하여야 합니다.")
         String categoryName
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/presentation/request/ProblemCategoryUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.category.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ProblemCategoryUpdateRequest(
+        @Schema(description = "수정할 문제 카테고리 이름", example = "Python 기초")
+        @NotBlank(message = "카테고리 이름은 필수입니다.")
+        String categoryName
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/category/presentation/response/ProblemCategoryAdminResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/category/presentation/response/ProblemCategoryAdminResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.problems.category.presentation.response;
+
+import com.wanted.codebombalms.problems.category.application.usecase.ManageProblemCategoriesUseCase.ProblemCategoryAdminView;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ProblemCategoryAdminResponse(
+        @Schema(description = "카테고리 ID", example = "1")
+        Long categoryId,
+
+        @Schema(description = "카테고리 이름", example = "알고리즘")
+        String categoryName,
+
+        @Schema(description = "카테고리 상태", example = "ACTIVE")
+        String status
+) {
+    public ProblemCategoryAdminResponse(ProblemCategoryAdminView view) {
+        this(
+                view.categoryId(),
+                view.categoryName(),
+                view.status()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
@@ -32,6 +32,7 @@ public enum ProblemErrorCode implements ErrorCode {
     CATEGORY_NOT_FOUND("PRB-CAT-001", "문제 분야를 찾을 수 없습니다."),
     INVALID_CATEGORY("PRB-CAT-002", "잘못된 문제 분야입니다."),
     PROBLEM_CATEGORY_REQUIRED("PRB-CAT-003", "카테고리는 필수입니다."),
+    CATEGORY_ALREADY_EXISTS("PRB-CAT-004", "이미 존재하는 문제 카테고리입니다."),
 
     // 힌트 (PRB-HNT)
     HINT_NOT_FOUND("PRB-HNT-001", "존재하지 않는 힌트입니다."),

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/port/FindActiveProblemSetCategoryPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/port/FindActiveProblemSetCategoryPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.set.application.port;
+
+public interface FindActiveProblemSetCategoryPort {
+
+    Long findActiveCategoryId(String categoryName);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/port/FindOrCreateProblemSetCategoryPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/port/FindOrCreateProblemSetCategoryPort.java
@@ -1,6 +1,0 @@
-package com.wanted.codebombalms.problems.set.application.port;
-
-public interface FindOrCreateProblemSetCategoryPort {
-
-    Long findOrCreateActiveCategoryId(String categoryName);
-}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemCategoryUsagePersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemCategoryUsagePersistenceAdapter.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.problems.set.infrastructure.persistence;
+
+import com.wanted.codebombalms.problems.category.application.port.CheckProblemCategoryUsagePort;
+import com.wanted.codebombalms.problems.set.domain.model.ProblemSetStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProblemCategoryUsagePersistenceAdapter implements CheckProblemCategoryUsagePort {
+
+    private final SpringDataProblemSetRepository problemSetRepository;
+
+    @Override
+    public boolean existsActiveProblemSet(Long categoryId) {
+        return problemSetRepository.existsByCategory_CategoryIdAndStatus(
+                categoryId,
+                ProblemSetStatus.ACTIVE
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetManagementPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/ProblemSetManagementPersistenceAdapter.java
@@ -3,7 +3,7 @@ package com.wanted.codebombalms.problems.set.infrastructure.persistence;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.problems.category.infrastructure.persistence.ProblemCategoryJpaEntity;
 import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
-import com.wanted.codebombalms.problems.set.application.port.FindOrCreateProblemSetCategoryPort;
+import com.wanted.codebombalms.problems.set.application.port.FindActiveProblemSetCategoryPort;
 import com.wanted.codebombalms.problems.set.application.port.ManageProblemSetHintsPort;
 import com.wanted.codebombalms.problems.set.application.port.ManageProblemSetProblemsPort;
 import com.wanted.codebombalms.problems.set.application.port.ManageProblemSetTestCasesPort;
@@ -30,7 +30,7 @@ import java.util.Set;
 public class ProblemSetManagementPersistenceAdapter implements ProblemSetManagementRepository {
 
     private final SpringDataProblemSetRepository problemSetRepository;
-    private final FindOrCreateProblemSetCategoryPort findOrCreateProblemSetCategoryPort;
+    private final FindActiveProblemSetCategoryPort findActiveProblemSetCategoryPort;
     private final ManageProblemSetProblemsPort manageProblemSetProblemsPort;
     private final ManageProblemSetHintsPort manageProblemSetHintsPort;
     private final ManageProblemSetTestCasesPort manageProblemSetTestCasesPort;
@@ -39,7 +39,7 @@ public class ProblemSetManagementPersistenceAdapter implements ProblemSetManagem
     @Override
     public ProblemSetRegistrationResult createProblemSet(ProblemSetRegistration registration, Long createdBy) {
         ProblemCategoryJpaEntity category = getCategoryReference(
-                findOrCreateProblemSetCategoryPort.findOrCreateActiveCategoryId(registration.categoryName())
+                findActiveProblemSetCategoryPort.findActiveCategoryId(registration.categoryName())
         );
 
         ProblemSetJpaEntity problemSet = new ProblemSetJpaEntity(
@@ -90,7 +90,7 @@ public class ProblemSetManagementPersistenceAdapter implements ProblemSetManagem
         ProblemSetJpaEntity problemSet = problemSetRepository.findById(modification.problemSetId())
                 .orElseThrow(() -> new NotFoundException(ProblemErrorCode.PROBLEM_SET_NOT_FOUND));
         ProblemCategoryJpaEntity category = getCategoryReference(
-                findOrCreateProblemSetCategoryPort.findOrCreateActiveCategoryId(modification.categoryName())
+                findActiveProblemSetCategoryPort.findActiveCategoryId(modification.categoryName())
         );
 
         problemSet.update(

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
@@ -20,6 +20,11 @@ public interface SpringDataProblemSetRepository extends JpaRepository<ProblemSet
             ProblemSetStatus status
     );
 
+    boolean existsByCategory_CategoryIdAndStatus(
+            Long categoryId,
+            ProblemSetStatus status
+    );
+
     Page<ProblemSetJpaEntity> findByCategory_CategoryIdAndStatusOrderByProblemSetIdAsc(
             Long categoryId,
             ProblemSetStatus status,


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #603 

---

## 🛠️ 기능 관련 작업 내용
- 관리자용 문제 카테고리 전체 조회, 생성, 이름 수정, 비활성화 API를 추가했습니다.
- 문제세트 등록/수정 시 존재하지 않는 카테고리를 자동 생성하던 흐름을 제거했습니다.
- 문제세트 등록/수정에서는 기존 ACTIVE 상태의 카테고리만 사용할 수 있도록 변경했습니다.
- 카테고리 관리 API와 문제세트 카테고리 정책 변경 내용을 API 문서에 반영했습니다.

---

## ♻️ 패키지 변경 사항
- `project/problems/category/presentation`: 관리자용 문제 카테고리 관리 컨트롤러 및 요청/응답 DTO 추가
- `project/problems/category/application`: 카테고리 관리 UseCase, Service, Port 추가
- `project/problems/category/infrastructure`: 카테고리 전체 조회, 생성, 이름 수정, 비활성화 저장 로직 추가
- `project/problems/set/application`: 문제세트에서 ACTIVE 카테고리만 찾는 Port 추가
- `project/problems/set/infrastructure`: 문제세트 등록/수정 시 카테고리 자동 생성 대신 ACTIVE 카테고리 조회만 수행하도록 변경
- `project/problems/exception`: 카테고리 중복 에러 코드 추가
- `project/ai`: 문제세트 등록/수정 카테고리 정책 변경 문서화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 관리자용 문제 카테고리 목록 조회, 생성, 이름 수정, 비활성화 기능을 추가했습니다.
  - 카테고리 이름의 필수 입력 및 중복 검증을 지원합니다.
  - 카테고리 상태와 식별자를 포함한 관리 화면용 응답을 제공합니다.

- **변경 사항**
  - 비활성 카테고리는 문제 세트 생성 및 수정 시 자동으로 사용되지 않습니다.
  - 존재하지 않는 활성 카테고리 선택 시 명확한 오류를 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->