### PR TITLE
[Fix] 정답 제출 문제 해설 조회 흐름 개선

### DIFF
--- a/src/main/java/com/wanted/codebombalms/problems/explanation/application/port/ProblemExplanationSolvedQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/explanation/application/port/ProblemExplanationSolvedQueryPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.explanation.application.port;
+
+public interface ProblemExplanationSolvedQueryPort {
+
+    boolean existsCorrectSubmission(Long userId, Long problemId);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/explanation/application/service/ProblemExplanationViewService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/explanation/application/service/ProblemExplanationViewService.java
@@ -1,6 +1,8 @@
 package com.wanted.codebombalms.problems.explanation.application.service;
 
+import com.wanted.codebombalms.problems.explanation.application.port.ProblemExplanationSolvedQueryPort;
 import com.wanted.codebombalms.problems.explanation.application.port.ProblemExplanationViewCommandPort;
+import com.wanted.codebombalms.problems.explanation.application.port.ProblemExplanationViewQueryPort;
 import com.wanted.codebombalms.problems.explanation.application.usecase.ViewProblemExplanationUseCase;
 import com.wanted.codebombalms.problems.progress.enums.ProblemProgressStatus;
 import com.wanted.codebombalms.submission.application.port.LoadProblemForSubmissionPort;
@@ -17,11 +19,27 @@ public class ProblemExplanationViewService implements ViewProblemExplanationUseC
     private final LoadProblemForSubmissionPort loadProblemForSubmissionPort;
     private final ProblemProgressPort problemProgressPort;
     private final ProblemExplanationViewCommandPort commandPort;
+    private final ProblemExplanationViewQueryPort queryPort;
+    private final ProblemExplanationSolvedQueryPort solvedQueryPort;
 
     @Override
     @Transactional
     public ViewProblemExplanationUseCase.ExplanationView viewExplanation(Long userId, Long problemId) {
         var problem = loadProblemForSubmissionPort.loadProblemForSubmission(problemId);
+
+        if (solvedQueryPort.existsCorrectSubmission(userId, problem.problemId())) {
+            return readOnlyExplanation(
+                    problem,
+                    ProblemProgressStatus.CORRECT
+            );
+        }
+
+        if (queryPort.existsViewed(userId, problem.problemId())) {
+            return readOnlyExplanation(
+                    problem,
+                    ProblemProgressStatus.EXPLANATION_VIEWED
+            );
+        }
 
         problemProgressPort.validateCurrentProblem(
                 userId,
@@ -64,6 +82,22 @@ public class ProblemExplanationViewService implements ViewProblemExplanationUseC
                 problem.explanation(),
                 nextProblemId,
                 problemSetCompleted,
+                0,
+                false
+        );
+    }
+
+    private ViewProblemExplanationUseCase.ExplanationView readOnlyExplanation(
+            LoadProblemForSubmissionPort.ProblemForSubmission problem,
+            ProblemProgressStatus status
+    ) {
+        return new ViewProblemExplanationUseCase.ExplanationView(
+                problem.problemId(),
+                status,
+                ProblemProgressStatus.CORRECT,
+                problem.explanation(),
+                null,
+                false,
                 0,
                 false
         );

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/ProblemExplanationSolvedQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/ProblemExplanationSolvedQueryAdapter.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.submission.infrastructure.persistence;
+
+import com.wanted.codebombalms.problems.explanation.application.port.ProblemExplanationSolvedQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemExplanationSolvedQueryAdapter implements ProblemExplanationSolvedQueryPort {
+
+    private final SpringDataSubmissionRepository submissionRepository;
+
+    @Override
+    public boolean existsCorrectSubmission(Long userId, Long problemId) {
+        return submissionRepository.existsByUserIdAndProblem_ProblemIdAndIsCorrectTrue(
+                userId,
+                problemId
+        );
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 🛠️ 기능 관련 작업 내용
- 이미 정답 제출한 문제는 현재 진행 문제 검증 없이 해설을 조회할 수 있도록 수정했습니다.
- 이미 해설 조회한 문제는 진행도 변경 없이 해설만 다시 반환하도록 처리했습니다.
- 아직 풀지 않은 현재 문제에서 해설을 조회하는 경우에는 기존처럼 `EXPLANATION_VIEWED` 처리 후 다음 문제를 열도록 유지했습니다.
- 정답 제출 여부를 확인하기 위한 `ProblemExplanationSolvedQueryPort`와 Adapter를 추가했습니다.

---

## ♻️ 패키지 변경 사항
- `project/problems/explanation/application/port`: 해설 조회 시 정답 제출 여부를 확인하는 Port 추가
- `project/problems/explanation/application/service`: 정답 제출/해설 조회 이력 여부에 따라 해설 조회 흐름 분기 처리
- `project/submission/infrastructure/persistence`: 제출 이력을 기반으로 정답 제출 여부를 조회하는 Adapter 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
  - 문제를 이미 정답 제출했거나 해설을 본 경우, 해설을 다시 조회할 수 있습니다.
  - 이 경우 문제 상태 변경이나 다음 문제 해금 없이 읽기 전용으로 표시됩니다.
- **버그 수정**
  - 해설 재조회 시 불필요하게 열람 기록이 저장되거나 문제 진행 상태가 변경되는 문제를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->