### PR TITLE
[Feat] main 머지 시 AI 패치노트 Discord 자동 게시

### DIFF
--- a/.github/workflows/patch-note.yml
+++ b/.github/workflows/patch-note.yml
@@ -85,7 +85,7 @@ jobs:
             --arg body "$PR_BODY" \
             '{
               model: "claude-sonnet-5",
-              max_tokens: 512,
+              max_tokens: 1500,
               messages: [
                 {
                   role: "user",
@@ -109,7 +109,7 @@ jobs:
             exit 1
           fi
 
-          BULLETS=$(echo "$BODY_JSON" | jq -r '.content[0].text // empty')
+          BULLETS=$(echo "$BODY_JSON" | jq -r '[.content[] | select(.type == "text") | .text] | join("")')
 
           if [ -z "$BULLETS" ]; then
             echo "Claude 응답에서 요약 텍스트를 못 찾음"
@@ -117,9 +117,16 @@ jobs:
             exit 1
           fi
 
+          STOP_REASON=$(echo "$BODY_JSON" | jq -r '.stop_reason')
+          if [ "$STOP_REASON" = "max_tokens" ]; then
+            echo "Claude 응답이 max_tokens로 잘림 (요약 미완성) — 게시 중단"
+            echo "$BODY_JSON"
+            exit 1
+          fi
+
           # 제목은 AI에게 맡기지 않고 고정 포맷으로 조립 (KST 기준 날짜)
           DATE=$(TZ='Asia/Seoul' date +'%Y-%m-%d')
-          TITLE="백엔드팀 패치노트🦖 | $DATE"
+          TITLE="백엔드팀 패치노트🦖 | $DATE"   # 프론트 레포는 "프론트팀 패치노트🎨 | $DATE"
 
           printf '%s\n\n%s' "$TITLE" "$BULLETS" \
             | python3 -c "import sys; print(sys.stdin.read()[:1900])" > summary.txt


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #N (이슈 번호 확인 필요)

---

## 🛠️ 기능 관련 작업 내용
- develop→main PR merge 시 병합된 PR의 title/body를 자동 조회해 Claude로 비개발자용 패치노트 요약 생성 후 Discord에 자동 게시
- 패치노트 제목을 `팀명 패치노트 | 날짜(KST)` 형식으로 고정하고, 내용은 `✨ 개선사항` / `🐛 버그 해결` 두 섹션으로 구분해서 작성되도록 프롬프트 구성
- 게시 전 `patch-note-approval` Environment 승인 게이트를 적용해 담당자가 내용을 확인한 뒤 승인해야 실제 Discord 전송이 되도록 구성
- Claude API 호출 실패, 응답 파싱 실패(thinking 블록 오인식), max_tokens 부족으로 인한 응답 잘림, Discord 게시 실패 등 각 단계별 예외처리 보강

---

## ♻️ 패키지 변경 사항
- `.github/workflows/patch-note.yml`: 신규 생성 — `find-pr`(머지 PR 조회) → `generate-summary`(Claude 요약 생성 + 예외처리) → `post-to-discord`(승인 게이트 + Discord 게시) 3단계 job 구성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 요약 생성 시 더 많은 내용을 처리할 수 있도록 생성 한도가 확대되었습니다.
  * 응답의 여러 텍스트 조각을 통합해 요약 결과의 누락 가능성을 줄였습니다.
  * 요약이 중간에 잘린 경우 이를 감지해 불완전한 결과가 게시되지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->