### PR TITLE
[Feat] 서비스 이벤트 수집 P3 — 전 도메인 비즈니스 이벤트 연결

### DIFF
--- a/src/main/java/com/wanted/codebombalms/admin/permission/application/service/AdminPermissionManagementService.java
+++ b/src/main/java/com/wanted/codebombalms/admin/permission/application/service/AdminPermissionManagementService.java
@@ -21,6 +21,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 import java.util.List;
 
 // master 전용 admin 계정 목록 조회와 권한 부여/회수 정책을 처리한다.
@@ -33,6 +37,8 @@ public class AdminPermissionManagementService implements GetAdminAccountsUseCase
     private final UserRepository userRepository;
     private final AdminPermissionRepository adminPermissionRepository;
     private final AdminAccountQueryRepository adminAccountQueryRepository;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     // 검색어와 페이지 조건을 검증한 뒤 admin 계정 목록을 조회한다.
     @Override
@@ -62,6 +68,12 @@ public class AdminPermissionManagementService implements GetAdminAccountsUseCase
                     command.permissionType()
             );
         }
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.PERMISSION_TOGGLED, command.adminUserId(), null,
+                "type=" + command.permissionType()
+                        + " granted=" + command.granted()
+                        + " by=" + command.grantedBy()));
 
         AdminPermissionStates permissionStates = getPermissionStates(command.adminUserId());
 

--- a/src/main/java/com/wanted/codebombalms/badge/application/service/MyBadgeService.java
+++ b/src/main/java/com/wanted/codebombalms/badge/application/service/MyBadgeService.java
@@ -20,6 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +42,8 @@ public class MyBadgeService implements MyBadgeUseCase , SyncUserBadgesUseCase {
     private final LoadUserTotalPointPort loadUserTotalPointPort;
     private final LoadMyBadgesPort loadMyBadgesPort;
     private final BadgeMetrics badgeMetrics;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     @Override
     @Transactional(readOnly = true)
@@ -159,6 +165,10 @@ public class MyBadgeService implements MyBadgeUseCase , SyncUserBadgesUseCase {
         );
         long saveNanos = System.nanoTime() - saveStartNanos;
         badgeMetrics.recordSave(saveNanos);
+
+        savedUserBadges.forEach(userBadge -> serviceEventRecorder.record(
+                ServiceEventEnvelope.business(
+                        ServiceEventType.BADGE_ACQUIRED, userId, userBadge.getBadgeId())));
 
         Map<Long, UserBadge> savedByBadgeId = savedUserBadges.stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageTransactionService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageTransactionService.java
@@ -11,6 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 import java.time.Instant;
 
 /**
@@ -25,6 +29,8 @@ public class ChatMessageTransactionService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatContextBuilder chatContextBuilder;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     /** 스트림 전 동기 구간: 방 검증 + USER 메시지 저장 + 컨텍스트 조립(타 BC 포트 호출 포함). */
     @Transactional
@@ -53,5 +59,9 @@ public class ChatMessageTransactionService {
         ChatRoom chatRoom = chatRoomRepository.getById(roomId);
         chatRoom.updateTimestamp(Instant.now());
         chatRoomRepository.save(chatRoom);
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.AI_ANSWERED, chatRoom.getUserId(), roomId,
+                "totalTokens=" + usage.totalTokens()));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomProvisionService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatRoomProvisionService.java
@@ -8,6 +8,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 import java.util.Optional;
 
 /**
@@ -20,6 +24,8 @@ public class ChatRoomProvisionService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatContextPort chatContextPort;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     @Transactional
     public ChatRoom getOrCreate(SendFirstMessageCommand command) {
@@ -39,7 +45,10 @@ public class ChatRoomProvisionService {
     private ChatRoom createRoom(Long userId, Long problemSetId, Long problemId, String userMessage) {
         String title = resolveTitle(problemSetId, problemId, userMessage);
         ChatRoom newRoom = ChatRoom.create(userId, problemSetId, problemId, title);
-        return chatRoomRepository.save(newRoom);
+        ChatRoom savedRoom = chatRoomRepository.save(newRoom);
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.ROOM_CREATED, userId, savedRoom.getId()));
+        return savedRoom;
     }
 
     private String resolveTitle(Long problemSetId, Long problemId, String userMessage) {

--- a/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/course/application/service/CourseCommandService.java
@@ -25,6 +25,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -38,6 +42,8 @@ public class CourseCommandService implements CourseCommandUseCase {
     private final CoursePublishPolicy coursePublishPolicy;
     private final LectureManagementPort lectureManagementPort;
     private final CourseThumbnailStoragePort courseThumbnailStoragePort;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     @LogBusiness
     @LogPerformance
@@ -58,6 +64,9 @@ public class CourseCommandService implements CourseCommandUseCase {
 
         Course savedCourse = courseRepository.save(course);
         log.info("[CourseCommandService] created course - courseId: {}", savedCourse.getCourseId());
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.COURSE_CREATED, command.instructorId(), savedCourse.getCourseId()));
 
         return savedCourse;
     }
@@ -104,6 +113,9 @@ public class CourseCommandService implements CourseCommandUseCase {
         Course savedCourse = courseRepository.save(course);
         log.info("[CourseCommandService] published course - courseId: {}", command.courseId());
 
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.COURSE_PUBLISHED, course.getInstructorId(), command.courseId()));
+
         return savedCourse;
     }
 
@@ -117,6 +129,10 @@ public class CourseCommandService implements CourseCommandUseCase {
         lectureManagementPort.deleteLecturesByCourseId(courseId);
         course.delete();
         courseRepository.save(course);
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.COURSE_DELETED, course.getInstructorId(), courseId));
+
         deleteThumbnailAfterCommit(course.getThumbnailUrl());
 
         log.info("[CourseCommandService] deleted course - courseId: {}", courseId);

--- a/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentCommandService.java
@@ -45,10 +45,7 @@ public class EnrollmentCommandService implements EnrollmentCommandUseCase {
         CoursePublicationStatus course = courseCatalogPort.getPublicationStatus(command.courseId());
         enrollmentEligibilityPolicy.validate(command.userId(), course);
 
-        serviceEventRecorder.record(ServiceEventEnvelope.business(
-                ServiceEventType.ENROLL_CREATED, command.userId(), course.courseId()));
-
-        return enrollmentRepository.findByCourseIdAndUserIdAndStatus(
+        Enrollment savedEnrollment = enrollmentRepository.findByCourseIdAndUserIdAndStatus(
                         course.courseId(),
                         command.userId(),
                         EnrollmentStatus.CANCELED
@@ -61,6 +58,11 @@ public class EnrollmentCommandService implements EnrollmentCommandUseCase {
                         command.userId(),
                         course.courseId()
                 )));
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.ENROLL_CREATED, command.userId(), course.courseId()));
+
+        return savedEnrollment;
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentCommandService.java
@@ -17,6 +17,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -28,6 +33,8 @@ public class EnrollmentCommandService implements EnrollmentCommandUseCase {
     private final CourseCatalogPort courseCatalogPort;
     private final EnrollmentEligibilityPolicy enrollmentEligibilityPolicy;
 
+    private final ServiceEventRecorder serviceEventRecorder;
+
     @Override
     public Enrollment createEnrollment(EnrollCourseCommand command) {
         log.info("[EnrollmentCommandService] create enrollment - courseId: {}, userId: {}",
@@ -37,6 +44,9 @@ public class EnrollmentCommandService implements EnrollmentCommandUseCase {
 
         CoursePublicationStatus course = courseCatalogPort.getPublicationStatus(command.courseId());
         enrollmentEligibilityPolicy.validate(command.userId(), course);
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.ENROLL_CREATED, command.userId(), course.courseId()));
 
         return enrollmentRepository.findByCourseIdAndUserIdAndStatus(
                         course.courseId(),
@@ -66,5 +76,8 @@ public class EnrollmentCommandService implements EnrollmentCommandUseCase {
 
         enrollment.cancel();
         enrollmentRepository.save(enrollment);
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.ENROLL_CANCELLED, command.userId(), enrollment.getCourseId()));
     }
 }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -6,6 +6,7 @@ import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
 import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
 import com.wanted.codebombalms.serviceevent.infrastructure.persistence.ServiceEventWriter;
 import com.wanted.codebombalms.serviceevent.infrastructure.web.HttpAnomalyGuard;
+import com.wanted.codebombalms.serviceevent.infrastructure.web.HttpRequestAnomalySupport;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,7 +15,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.lang.NonNull;
 
 import java.io.IOException;
@@ -97,8 +97,8 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
             long durationMs, String userIdAttribute, String traceId) {
         try {
             int status = response.getStatus();
-            String route = normalizedRoute(request);
-            Long userId = parseUserId(userIdAttribute);
+            String route = HttpRequestAnomalySupport.normalizedRoute(request);
+            Long userId = HttpRequestAnomalySupport.parseUserId(userIdAttribute);
             String clientIp = ClientIpResolver.resolve(request);
 
             if (durationMs >= slowThresholdMs && anomalyGuard.tryAcquire("slow:" + route)) {
@@ -132,26 +132,6 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
             }
         } catch (Exception e) {
             log.warn("event=http_anomaly_record_failed reason={}", e.toString());
-        }
-    }
-
-    /**
-     * 정규화된 라우트 키 — raw URI 금지(경로변수·스캔 경로로 카디널리티 폭발).
-     * DispatcherServlet 도달 전 차단된 요청(401 등)은 패턴이 없어 "unmatched".
-     */
-    private String normalizedRoute(HttpServletRequest request) {
-        Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-        return request.getMethod() + " " + (pattern == null ? "unmatched" : pattern.toString());
-    }
-
-    private Long parseUserId(String attribute) {
-        if (attribute == null || ANONYMOUS.equals(attribute)) {
-            return null;
-        }
-        try {
-            return Long.parseLong(attribute);
-        } catch (NumberFormatException e) {
-            return null;
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/HttpAnomalyReporter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/HttpAnomalyReporter.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.global.infrastructure.metrics;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * 5xx 상세 기록 포트 (#607 리뷰 반영).
+ * SecurityEventReporter 와 동일한 패턴 — presentation(GlobalExceptionHandler)은
+ * 이 인터페이스만 알고, 구현(service_event 적재)은 serviceevent infra 에 둔다.
+ */
+public interface HttpAnomalyReporter {
+
+    /**
+     * 서버 오류(500·502)를 원인 예외와 함께 기록한다.
+     * 구현은 절대 예외를 던지지 않아야 한다 (에러 응답 보호).
+     */
+    void reportServerError(HttpServletRequest request, int httpStatus, Exception cause);
+}

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -2,19 +2,12 @@ package com.wanted.codebombalms.global.presentation.api.common;
 
 import com.wanted.codebombalms.global.domain.common.error.DomainException;
 import com.wanted.codebombalms.global.domain.common.error.exception.*;
-import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
-import com.wanted.codebombalms.global.infrastructure.logging.MdcLoggingFilter;
+import com.wanted.codebombalms.global.infrastructure.metrics.HttpAnomalyReporter;
 import com.wanted.codebombalms.global.infrastructure.metrics.SecurityEventReporter;
-import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
-import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
-import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
-import com.wanted.codebombalms.serviceevent.infrastructure.persistence.ServiceEventWriter;
-import com.wanted.codebombalms.serviceevent.infrastructure.web.HttpAnomalyGuard;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +25,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
-import org.springframework.web.servlet.HandlerMapping;
 
 import java.util.Arrays;
 
@@ -43,8 +35,7 @@ public class GlobalExceptionHandler {
 
     private final Environment env;
     private final ObjectProvider<SecurityEventReporter> securityEventReporter;
-    private final ObjectProvider<ServiceEventWriter> serviceEventWriter;
-    private final ObjectProvider<HttpAnomalyGuard> anomalyGuard;
+    private final ObjectProvider<HttpAnomalyReporter> httpAnomalyReporter;
 
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<ApiErrorResponse> handleDomainException(
@@ -58,7 +49,7 @@ public class GlobalExceptionHandler {
         }
         // 외부 서비스 예외(502)는 원인 클래스명까지 상세 기록 — 필터의 상태코드 기록보다 정보가 많다 (#606)
         if (e instanceof ExternalServiceException) {
-            recordServerError(request, ServiceEventType.HTTP_502_EXTERNAL, e.getHttpStatus(), e);
+            reportServerErrorQuietly(request, e.getHttpStatus(), e);
         }
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ApiErrorResponse.of(e.getHttpStatus(), e.getErrorCode(), request.getRequestURI()));
@@ -100,8 +91,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleException(
             Exception e, HttpServletRequest request) {
         log.error("[500] 예상치 못한 예외 - path: {}", request.getRequestURI(), e);
-        // unhandled 500 — 예외 클래스명을 detail 로 남긴다. 필터는 원인 정보를 알 수 없다 (#606)
-        recordServerError(request, ServiceEventType.HTTP_5XX, 500, e);
+        // unhandled 500 — 예외 클래스명 상세는 HttpAnomalyReporter 구현이 기록한다 (#606)
+        reportServerErrorQuietly(request, 500, e);
         String message = isDev() ? e.getMessage() : "서버 오류가 발생했습니다.";
         return ResponseEntity.status(500)
                 .body(ApiErrorResponse.of(500, "INTERNAL_ERROR", message, request.getRequestURI()));
@@ -131,47 +122,12 @@ public class GlobalExceptionHandler {
         }
     }
 
-    /**
-     * 5xx 상세 기록 (#606). 예외 클래스명을 detail 로 남기고, 중복 방지 마커를 세워
-     * MdcLoggingFilter 의 상태코드 기반 기록이 같은 요청을 다시 적재하지 않게 한다.
-     * ObjectProvider 주입 — @WebMvcTest 슬라이스 컨텍스트에는 빈이 없어도 부팅되게 한다.
-     * 기록 실패는 전부 삼킨다 — 에러 응답 자체를 절대 깨지 않는다.
-     */
-    private void recordServerError(
-            HttpServletRequest request, ServiceEventType type, int status, Exception cause) {
+    /** 5xx 상세 기록 위임 — SecurityEventReporter 와 동일한 ifAvailable+삼킴 패턴 (#607 리뷰 반영) */
+    private void reportServerErrorQuietly(HttpServletRequest request, int httpStatus, Exception cause) {
         try {
-            request.setAttribute(MdcLoggingFilter.ANOMALY_RECORDED_ATTRIBUTE, Boolean.TRUE);
-
-            ServiceEventWriter writer = serviceEventWriter.getIfAvailable();
-            HttpAnomalyGuard guard = anomalyGuard.getIfAvailable();
-            if (writer == null || guard == null) {
-                return;
-            }
-
-            Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-            String route = request.getMethod() + " " + (pattern == null ? "unmatched" : pattern.toString());
-            if (!guard.tryAcquire("5xx:" + route)) {
-                return;
-            }
-
-            Long userId = parseUserId(request.getAttribute(JwtAuthenticationFilter.AUTHENTICATED_USER_ID_ATTRIBUTE));
-            writer.write(ServiceEventEnvelope.httpAnomaly(
-                    type, route, status, null,
-                    ClientIpResolver.resolve(request), userId, MDC.get("traceId"),
-                    "exception=" + cause.getClass().getSimpleName()));
+            httpAnomalyReporter.ifAvailable(r -> r.reportServerError(request, httpStatus, cause));
         } catch (Exception ignored) {
             log.warn("event=server_error_record_failed reason={}", ignored.toString());
-        }
-    }
-
-    private Long parseUserId(Object attribute) {
-        if (attribute == null) {
-            return null;
-        }
-        try {
-            return Long.parseLong(String.valueOf(attribute));
-        } catch (NumberFormatException e) {
-            return null;
         }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
@@ -27,6 +27,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 @Service
 @RequiredArgsConstructor
 public class LectureProblemSetService implements LectureProblemSetQueryUseCase, LectureProblemSubmissionUseCase {
@@ -38,6 +42,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
     private final LectureProblemProgressRepository lectureProblemProgressRepository;
     private final LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
     private final LearningAccessPolicy learningAccessPolicy;
+    private final ServiceEventRecorder serviceEventRecorder;
 
     @Override
     @Transactional
@@ -203,6 +208,12 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
                     nextProblemNumber,
                     completed
             );
+            if (completed) {
+                serviceEventRecorder.record(ServiceEventEnvelope.business(
+                        ServiceEventType.PROBLEM_SET_COMPLETED, command.userId(),
+                        lectureProblemSet.problemSetId(),
+                        "source=lecture lectureProblemSetId=" + lectureProblemSetId));
+            }
         }
 
         Integer remainingAttemptCount = calculateRemainingAttempts(problem.attemptLimit(), attemptNo);

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProgressService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProgressService.java
@@ -15,6 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 @Service
 @RequiredArgsConstructor
 public class LectureProgressService implements LectureProgressCommandUseCase, LectureProgressQueryUseCase {
@@ -22,6 +26,8 @@ public class LectureProgressService implements LectureProgressCommandUseCase, Le
     private final LectureProgressRepository lectureProgressRepository;
     private final LearningLecturePort learningLecturePort;
     private final LearningEnrollmentPort learningEnrollmentPort;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     @Override
     @Transactional
@@ -49,6 +55,8 @@ public class LectureProgressService implements LectureProgressCommandUseCase, Le
                 .orElseGet(() -> LectureProgress.create(userId, lectureId));
 
         progress.complete();
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.LESSON_COMPLETED, userId, lectureId));
         return lectureProgressRepository.save(progress);
     }
 

--- a/src/main/java/com/wanted/codebombalms/problems/explanation/application/service/ProblemExplanationViewService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/explanation/application/service/ProblemExplanationViewService.java
@@ -9,6 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +21,8 @@ public class ProblemExplanationViewService implements ViewProblemExplanationUseC
     private final LoadProblemForSubmissionPort loadProblemForSubmissionPort;
     private final ProblemProgressPort problemProgressPort;
     private final ProblemExplanationViewCommandPort commandPort;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     @Override
     @Transactional
@@ -34,6 +40,10 @@ public class ProblemExplanationViewService implements ViewProblemExplanationUseC
                 problem.problemId(),
                 problem.problemSetId()
         );
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.EXPLANATION_VIEWED, userId, problem.problemId(),
+                "problemSetId=" + problem.problemSetId()));
 
         Long nextProblemId = loadProblemForSubmissionPort
                 .findNextProblemId(

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventRecorder.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.serviceevent.application.port;
+
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+
+/**
+ * 도메인 서비스가 비즈니스 이벤트를 기록할 때 쓰는 발행 포트
+ * 사용법 (도메인 코드에 1줄):
+ *   serviceEventRecorder.record(ServiceEventEnvelope.business(ENROLL_CREATED, userId, courseId));
+ * 트랜잭션 커밋 후(AFTER_COMMIT)에만 기록되므로 롤백된 행위는 남지 않는다.
+ */
+public interface ServiceEventRecorder {
+
+    void record(ServiceEventEnvelope envelope);
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/ServiceEventListener.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/ServiceEventListener.java
@@ -1,0 +1,70 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.event;
+
+import com.wanted.codebombalms.reward.point.domain.event.PointGrantedEvent;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+import com.wanted.codebombalms.serviceevent.infrastructure.persistence.ServiceEventWriter;
+import com.wanted.codebombalms.submission.domain.event.ProblemSetCompletedEvent;
+import com.wanted.codebombalms.submission.domain.event.ProblemSolvedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 갈래 A 수집 리스너
+ *
+ * ① 신규 발행 경로: 도메인이 ServiceEventRecorder 로 발행한 envelope 을 커밋 후 적재.
+ * ② 기존 이벤트 경로: submission·reward 가 이미 발행 중인 이벤트 3종을 구독만 한다
+ *    — 발행측 코드 0줄, 기존 리스너(포인트 지급·뱃지 동기화)와 완전 독립.
+ *
+ * 모든 예외는 여기서 삼킨다 — 같은 이벤트를 구독하는 다른 리스너에 절대 전파하지 않는다.
+ * 무거운 작업(INSERT)은 writer 의 @Async 풀에서 실행되므로 이 리스너 자체는
+ * 큐 등록만 하고 즉시 반환한다 (발행 스레드 부담 = 마이크로초 단위).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ServiceEventListener {
+
+    private final ServiceEventWriter serviceEventWriter;
+
+    /** 신규 발행 경로 — fallbackExecution: 트랜잭션 밖 발행(리액티브 흐름 등)도 수집 */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onServiceEvent(ServiceEventEnvelope envelope) {
+        forward(envelope);
+    }
+
+    /** 기존 이벤트 구독 — 문제 정답 (submission 발행, 코드 무변경) */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onProblemSolved(ProblemSolvedEvent event) {
+        forward(ServiceEventEnvelope.business(
+                ServiceEventType.PROBLEM_SOLVED, event.userId(), event.problemId(),
+                "submissionId=" + event.submissionId() + " point=" + event.point()));
+    }
+
+    /** 기존 이벤트 구독 — 문제집 완료 (submission 발행, 코드 무변경) */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onProblemSetCompleted(ProblemSetCompletedEvent event) {
+        forward(ServiceEventEnvelope.business(
+                ServiceEventType.PROBLEM_SET_COMPLETED, event.userId(), event.problemSetId(), null));
+    }
+
+    /** 기존 이벤트 구독 — 포인트 지급 (reward.point 발행, 코드 무변경) */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onPointGranted(PointGrantedEvent event) {
+        forward(ServiceEventEnvelope.business(
+                ServiceEventType.POINT_GRANTED, event.userId(), null,
+                "totalPoint=" + event.totalPoint()));
+    }
+
+    private void forward(ServiceEventEnvelope envelope) {
+        try {
+            serviceEventWriter.write(envelope);
+        } catch (Exception e) {
+            log.warn("event=service_event_listener_failed type={}",
+                    envelope == null ? "-" : envelope.type().code(), e);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/SpringServiceEventAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/SpringServiceEventAdapter.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.event;
+
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+/**
+ * 발행 어댑터 — envelope 를 Spring ApplicationEvent 로 발행
+ * 기존 SpringProblemSolvedEventAdapter 등과 동일한 패턴.
+ */
+@Component
+@RequiredArgsConstructor
+public class SpringServiceEventAdapter implements ServiceEventRecorder {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void record(ServiceEventEnvelope envelope) {
+        eventPublisher.publishEvent(envelope);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/HttpRequestAnomalySupport.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/HttpRequestAnomalySupport.java
@@ -1,0 +1,35 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * HTTP 예외 신호 수집 공용 유틸 (#607 리뷰 반영).
+ * MdcLoggingFilter 와 ServerErrorEventRecorder 가 같은 정규화 규칙을 쓰도록 단일화한다.
+ */
+public final class HttpRequestAnomalySupport {
+
+    private HttpRequestAnomalySupport() {
+    }
+
+    /**
+     * 정규화된 라우트 키 — raw URI 금지(경로변수·스캔 경로로 카디널리티 폭발).
+     * DispatcherServlet 도달 전 차단된 요청(401 등)은 패턴이 없어 "unmatched".
+     */
+    public static String normalizedRoute(HttpServletRequest request) {
+        Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        return request.getMethod() + " " + (pattern == null ? "unmatched" : pattern.toString());
+    }
+
+    /** JwtAuthenticationFilter 가 심은 userId attribute 값을 Long 으로 변환 ("anonymous"·비숫자는 null) */
+    public static Long parseUserId(Object attributeValue) {
+        if (attributeValue == null) {
+            return null;
+        }
+        try {
+            return Long.parseLong(String.valueOf(attributeValue));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/ServerErrorEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/ServerErrorEventRecorder.java
@@ -1,0 +1,54 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.web;
+
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtAuthenticationFilter;
+import com.wanted.codebombalms.global.infrastructure.logging.MdcLoggingFilter;
+import com.wanted.codebombalms.global.infrastructure.metrics.HttpAnomalyReporter;
+import com.wanted.codebombalms.global.infrastructure.web.ClientIpResolver;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+import com.wanted.codebombalms.serviceevent.infrastructure.persistence.ServiceEventWriter;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+/**
+ * 5xx 상세 기록 구현 (#606, #607 리뷰로 GlobalExceptionHandler 에서 이관).
+ * 예외 클래스명을 detail 로 남기고, 중복 방지 마커를 세워 MdcLoggingFilter 의
+ * 상태코드 기반 기록이 같은 요청을 다시 적재하지 않게 한다.
+ * 기록 실패는 전부 삼킨다 — 에러 응답을 절대 깨지 않는다 (best-effort).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ServerErrorEventRecorder implements HttpAnomalyReporter {
+
+    private final ServiceEventWriter serviceEventWriter;
+    private final HttpAnomalyGuard anomalyGuard;
+
+    @Override
+    public void reportServerError(HttpServletRequest request, int httpStatus, Exception cause) {
+        try {
+            request.setAttribute(MdcLoggingFilter.ANOMALY_RECORDED_ATTRIBUTE, Boolean.TRUE);
+
+            String route = HttpRequestAnomalySupport.normalizedRoute(request);
+            if (!anomalyGuard.tryAcquire("5xx:" + route)) {
+                return;
+            }
+
+            ServiceEventType type = httpStatus == 502
+                    ? ServiceEventType.HTTP_502_EXTERNAL
+                    : ServiceEventType.HTTP_5XX;
+            Long userId = HttpRequestAnomalySupport.parseUserId(
+                    request.getAttribute(JwtAuthenticationFilter.AUTHENTICATED_USER_ID_ATTRIBUTE));
+
+            serviceEventWriter.write(ServiceEventEnvelope.httpAnomaly(
+                    type, route, httpStatus, null,
+                    ClientIpResolver.resolve(request), userId, MDC.get("traceId"),
+                    "exception=" + cause.getClass().getSimpleName()));
+        } catch (Exception ignored) {
+            log.warn("event=server_error_record_failed reason={}", ignored.toString());
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
@@ -11,6 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -19,6 +23,8 @@ public class ChangeStudentLockService implements ChangeStudentLockUseCase {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AuthSessionManager authSessionManager;
+
+    private final ServiceEventRecorder serviceEventRecorder;
 
     @Override
     public void changeLock(Long userId, boolean locked) {
@@ -34,5 +40,9 @@ public class ChangeStudentLockService implements ChangeStudentLockUseCase {
         }
 
         userRepository.save(user);
+
+        serviceEventRecorder.record(ServiceEventEnvelope.business(
+                ServiceEventType.ACCOUNT_LOCKED, userId, null,
+                "locked=" + locked));
     }
 }

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -18,6 +18,7 @@ import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,6 +88,7 @@ class CourseServiceTest {
         verify(courseAuthorPolicy).validateOperator(command.instructorId());
         verify(courseCategoryPolicy).validateActiveCategory(command.courseCategoryId());
         verify(courseRepository).save(any(Course.class));
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test
@@ -342,6 +344,7 @@ class CourseServiceTest {
         inOrder.verify(lectureManagementPort).deleteLecturesByCourseId(courseId);
         inOrder.verify(courseRepository).save(course);
         inOrder.verify(courseThumbnailStoragePort).delete("java.png");
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test
@@ -379,6 +382,7 @@ class CourseServiceTest {
         assertNotNull(course.getDeletedAt());
         verify(courseRepository).save(course);
         verify(courseThumbnailStoragePort).delete("java.png");
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test
@@ -394,6 +398,7 @@ class CourseServiceTest {
         assertEquals(CourseStatus.ACTIVE, result.getStatus());
         verify(coursePublishPolicy).validate(course);
         verify(courseRepository).save(course);
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     private Course createCourse(

--- a/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/course/application/service/CourseServiceTest.java
@@ -17,6 +17,7 @@ import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.course.domain.repository.CourseRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,6 +61,9 @@ class CourseServiceTest {
 
     @Mock
     private CourseEnrollmentPort courseEnrollmentPort;
+
+    @Mock
+    private ServiceEventRecorder serviceEventRecorder;
 
     @InjectMocks
     private CourseCommandService courseCommandService;

--- a/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
@@ -15,6 +15,7 @@ import com.wanted.codebombalms.enrollment.domain.model.Enrollment;
 import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
 import com.wanted.codebombalms.enrollment.domain.repository.EnrollmentRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +49,9 @@ class EnrollmentServiceTest {
 
     @Mock
     private EnrollmentLearningProgressPort enrollmentLearningProgressPort;
+
+    @Mock
+    private ServiceEventRecorder serviceEventRecorder;
 
     @InjectMocks
     private EnrollmentCommandService enrollmentCommandService;

--- a/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/enrollment/application/service/EnrollmentServiceTest.java
@@ -16,6 +16,7 @@ import com.wanted.codebombalms.enrollment.domain.model.EnrollmentStatus;
 import com.wanted.codebombalms.enrollment.domain.repository.EnrollmentRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +83,7 @@ class EnrollmentServiceTest {
         assertEquals(EnrollmentStatus.ACTIVE, result.getStatus());
         verify(enrollmentEligibilityPolicy).validate(userId, course);
         verify(enrollmentRepository).save(any(Enrollment.class));
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test
@@ -108,6 +110,7 @@ class EnrollmentServiceTest {
         assertNotNull(result.getEnrolledAt());
         verify(enrollmentEligibilityPolicy).validate(userId, course);
         verify(enrollmentRepository).save(canceledEnrollment);
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test
@@ -300,6 +303,7 @@ class EnrollmentServiceTest {
         assertEquals(EnrollmentStatus.CANCELED, enrollment.getStatus());
         assertNotNull(enrollment.getCanceledAt());
         verify(enrollmentRepository).save(enrollment);
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
@@ -22,6 +22,7 @@ import com.wanted.codebombalms.learning.domain.model.StudentLearningProgress;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemProgressRepository;
 import com.wanted.codebombalms.learning.domain.repository.LectureProgressRepository;
 import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -395,6 +396,7 @@ class LearningServiceTest {
         assertTrue(result.isCompleted());
         assertNotNull(result.getCompletedAt());
         verify(lectureProgressRepository).save(any(LectureProgress.class));
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test
@@ -427,6 +429,7 @@ class LearningServiceTest {
         assertTrue(result.isCompleted());
         assertEquals(completedAt, result.getCompletedAt());
         verify(lectureProgressRepository).save(any(LectureProgress.class));
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LearningServiceTest.java
@@ -21,6 +21,7 @@ import com.wanted.codebombalms.learning.domain.model.LectureProgress;
 import com.wanted.codebombalms.learning.domain.model.StudentLearningProgress;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemProgressRepository;
 import com.wanted.codebombalms.learning.domain.repository.LectureProgressRepository;
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +85,9 @@ class LearningServiceTest {
 
     @Mock
     private LearningProgressMetricsPort learningMetrics;
+
+    @Mock
+    private ServiceEventRecorder serviceEventRecorder;
 
     @InjectMocks
     private LectureProgressService lectureProgressService;

--- a/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
@@ -8,6 +8,7 @@ import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +31,7 @@ class ChangeStudentLockServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
     @Mock private AuthSessionManager authSessionManager;
+    @Mock private ServiceEventRecorder serviceEventRecorder;
 
     @InjectMocks
     private ChangeStudentLockService changeStudentLockService;

--- a/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockServiceTest.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +52,7 @@ class ChangeStudentLockServiceTest {
         verify(refreshTokenRepository).deleteByUserId(1L);
         verify(authSessionManager).close(1L);
         verify(userRepository).save(user);
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test
@@ -68,6 +70,7 @@ class ChangeStudentLockServiceTest {
         verify(refreshTokenRepository, never()).deleteByUserId(any());
         verify(authSessionManager, never()).close(any());
         verify(userRepository).save(user);
+        verify(serviceEventRecorder).record(any(ServiceEventEnvelope.class));
     }
 
     @Test


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #607

---

## 🛠️ 기능 관련 작업 내용
- 도메인용 발행 포트(ServiceEventRecorder) + AFTER_COMMIT 수집 리스너 — 롤백된 행위 미기록, 예외 자기소화로 기존 리스너와 완전 격리
- submission·reward 기존 이벤트 3종(문제정답·문제집완료·포인트지급)은 구독만으로 수집 — 해당 도메인 코드 무변경
- 8개 도메인 서비스에 기록 1줄 연결 (사전 공지 및 #607 명시 목록 그대로): 수강신청/취소, 코스 개설/게시/삭제, 레슨·문제집 완료, 뱃지 획득, 챗봇 방 생성/AI 응답, 해설 열람, 관리자 권한 변경, 계정 잠금
- 각 도메인 침습 = import 3줄 + 필드 1줄 + record() 1개 — 비즈니스 로직·트랜잭션 무변경

---

## ♻️ 패키지 변경 사항
- `codebombalms/serviceevent`: 발행 포트·어댑터·수집 리스너 신규 (3파일)
- `codebombalms/enrollment`·`course`·`learning`·`badge`·`chatbot`·`problems`·`admin`·`user`: 각 서비스에 이벤트 기록 1줄 (본인 도메인 부분 리뷰 부탁드립니다 🙏)
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 권한 변경, 배지 획득, AI 답변, 채팅방·강의·수강신청 관련 주요 활동이 이벤트로 기록됩니다.
  * 강의 완료, 문제 세트 완료, 해설 조회, 계정 잠금 및 서버 오류 기록이 추가되었습니다.
  * 주요 이벤트는 작업이 성공적으로 완료된 후 수집됩니다.

* **개선 사항**
  * 서버 오류 및 외부 서비스 오류 기록이 안정화되어, 기록 실패가 오류 응답에 영향을 주지 않습니다.
  * HTTP 요청 정보와 사용자 식별 정보 처리가 일관되게 개선되었습니다.

* **테스트**
  * 주요 작업의 이벤트 기록 여부를 검증하는 테스트가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->