### PR TITLE
[Update] 데이터셋 업로드 실패 원인 추적 로그 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetWithDatasetRegistrationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetWithDatasetRegistrationService.java
@@ -68,21 +68,21 @@ public class ProblemSetWithDatasetRegistrationService implements RegisterProblem
 
             throw e;
         } catch (Exception e) {
-        if (storedFile != null) {
-            storeDatasetFilePort.delete(storedFile.getFilePath());
+            if (storedFile != null) {
+                storeDatasetFilePort.delete(storedFile.getFilePath());
+            }
+
+            log.error(
+                    "event=problem_set_dataset_upload_failed originalFilename={} contentType={} fileSize={} exceptionType={}",
+                    datasetCommand.originalFileName(),
+                    datasetCommand.contentType(),
+                    datasetCommand.fileSize(),
+                    e.getClass().getSimpleName(),
+                    e
+            );
+
+            throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED, e);
         }
-
-        log.error(
-                "event=problem_set_dataset_upload_failed originalFilename={} contentType={} fileSize={} exceptionType={}",
-                datasetCommand.originalFileName(),
-                datasetCommand.contentType(),
-                datasetCommand.fileSize(),
-                e.getClass().getSimpleName(),
-                e
-        );
-
-        throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED);
-    }
     }
 
     private void validateDatasetFile(UploadProblemDatasetCommand command) {

--- a/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetWithDatasetRegistrationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/application/service/ProblemSetWithDatasetRegistrationService.java
@@ -13,10 +13,12 @@ import com.wanted.codebombalms.problems.set.application.policy.DatasetStartCodeP
 import com.wanted.codebombalms.problems.set.application.usecase.RegisterProblemSetUseCase;
 import com.wanted.codebombalms.problems.set.application.usecase.RegisterProblemSetWithDatasetUseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ProblemSetWithDatasetRegistrationService implements RegisterProblemSetWithDatasetUseCase {
 
@@ -66,12 +68,21 @@ public class ProblemSetWithDatasetRegistrationService implements RegisterProblem
 
             throw e;
         } catch (Exception e) {
-            if (storedFile != null) {
-                storeDatasetFilePort.delete(storedFile.getFilePath());
-            }
-
-            throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED);
+        if (storedFile != null) {
+            storeDatasetFilePort.delete(storedFile.getFilePath());
         }
+
+        log.error(
+                "event=problem_set_dataset_upload_failed originalFilename={} contentType={} fileSize={} exceptionType={}",
+                datasetCommand.originalFileName(),
+                datasetCommand.contentType(),
+                datasetCommand.fileSize(),
+                e.getClass().getSimpleName(),
+                e
+        );
+
+        throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED);
+    }
     }
 
     private void validateDatasetFile(UploadProblemDatasetCommand command) {
@@ -95,7 +106,7 @@ public class ProblemSetWithDatasetRegistrationService implements RegisterProblem
                 && !contentType.equals("text/csv")
                 && !contentType.equals("application/vnd.ms-excel")) {
             throw new ValidationException(ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE);
-        }
+       }
     }
 
 

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
@@ -33,6 +33,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -55,6 +56,7 @@ import java.util.List;
 @Tag(name = "문제 관리", description = "운영자가 문제 세트와 소문제를 등록, 수정, 삭제하는 API")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class ProblemManageController {
 
     private final GetProblemSetForUpdateUseCase getProblemSetForUpdateUseCase;
@@ -319,7 +321,13 @@ public class ProblemManageController {
                 result.datasetFileName(),
                 result.startCode()
         );
-
+        log.info(
+                "event=dataset_file_received originalFilename={} contentType={} size={} empty={}",
+                datasetFile.getOriginalFilename(),
+                datasetFile.getContentType(),
+                datasetFile.getSize(),
+                datasetFile.isEmpty()
+        );
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(
                         ApiResponseCode.CREATED,

--- a/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/presentation/ProblemManageController.java
@@ -304,6 +304,14 @@ public class ProblemManageController {
             @Parameter(description = "문제 세트에 연결할 CSV 데이터셋 파일", required = true)
             @RequestPart("datasetFile") MultipartFile datasetFile
     ) {
+        log.info(
+                "event=dataset_file_received originalFilename={} contentType={} size={} empty={}",
+                datasetFile.getOriginalFilename(),
+                datasetFile.getContentType(),
+                datasetFile.getSize(),
+                datasetFile.isEmpty()
+        );
+
         var result = registerProblemSetWithDatasetUseCase.handle(
                 toCommand(createdBy, request),
                 toDatasetCommand(datasetFile)
@@ -321,13 +329,7 @@ public class ProblemManageController {
                 result.datasetFileName(),
                 result.startCode()
         );
-        log.info(
-                "event=dataset_file_received originalFilename={} contentType={} size={} empty={}",
-                datasetFile.getOriginalFilename(),
-                datasetFile.getContentType(),
-                datasetFile.getSize(),
-                datasetFile.isEmpty()
-        );
+
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(
                         ApiResponseCode.CREATED,


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---


## 🛠️ 기능 관련 작업 내용
- 문제세트와 데이터셋을 함께 등록할 때 데이터셋 업로드 실패 원인을 추적할 수 있도록 로그를 추가했습니다.
- 서버가 실제로 수신한 데이터셋 파일명, Content-Type, 파일 크기, 빈 파일 여부를 확인할 수 있도록 했습니다.
- 데이터셋 저장 실패 시 예외 타입과 stack trace를 남겨 GCS 인증/권한 문제, DB 저장 문제, 파일 전송 문제를 구분할 수 있도록 했습니다.
- 민감 정보나 CSV 본문은 로그에 남기지 않도록 했습니다.

---

## ♻️ 패키지 변경 사항
- `project/problems/set/presentation`: `/api/v1/problems/with-dataset` 요청에서 수신한 datasetFile 기본 정보를 로그로 확인할 수 있도록 보완
- `project/problems/set/application/service`: 데이터셋 저장 실패 시 실제 예외 타입과 stack trace를 로깅하도록 보완

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 문제 데이터셋 업로드 중 오류가 발생하면 저장된 파일을 정리하고, 일관된 업로드 실패 오류로 안내하도록 개선했습니다.
  * 업로드 처리 중 예외 상황에서도 안정적으로 오류가 반환됩니다.

* **운영 개선**
  * 데이터셋 업로드 상태와 파일 정보를 기록해 문제 원인 파악과 장애 대응이 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->