### PR TITLE
[Fix] 강의 중간 삽입 및 순서 변경 중복 오류 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/lecture/application/command/UpdateLectureOrdersCommand.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/command/UpdateLectureOrdersCommand.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.lecture.application.command;
+
+import java.util.List;
+
+public record UpdateLectureOrdersCommand(
+        Long courseId,
+        List<LectureOrderItem> lectures
+) {
+
+    public record LectureOrderItem(
+            Long lectureId,
+            Integer lectureOrder
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
@@ -120,17 +120,7 @@ public class LectureCommandService implements LectureCommandUseCase {
                         UpdateLectureOrdersCommand.LectureOrderItem::lectureOrder
                 ));
 
-        for (int index = 0; index < currentLectures.size(); index++) {
-            Lecture lecture = currentLectures.get(index);
-            lecture.updateOrder(-(index + 1));
-            lectureRepository.save(lecture);
-        }
-        lectureRepository.flush();
-
-        currentLectures.forEach(lecture -> {
-            lecture.updateOrder(requestedOrders.get(lecture.getLectureId()));
-            lectureRepository.save(lecture);
-        });
+        lectureRepository.updateLectureOrders(currentLectures, requestedOrders);
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/LectureCommandService.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.lecture.application.service;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
+import com.wanted.codebombalms.lecture.application.command.UpdateLectureOrdersCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
 import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
 import com.wanted.codebombalms.lecture.application.usecase.LectureCommandUseCase;
@@ -28,6 +29,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -49,6 +54,7 @@ public class LectureCommandService implements LectureCommandUseCase {
 
         Course course = courseCatalogPort.findCourse(command.courseId());
         lectureCreationPolicy.validate(course);
+        clearDeletedLectureOrders(command.courseId(), java.util.Collections.singletonList(command.lectureOrder()));
         validateLectureOrder(command.courseId(), null, command.lectureOrder());
         validateYoutubeVideoUrl(command.videoUrl());
 
@@ -94,6 +100,37 @@ public class LectureCommandService implements LectureCommandUseCase {
         );
 
         return lectureRepository.save(lecture);
+    }
+
+    @Override
+    public void updateLectureOrders(UpdateLectureOrdersCommand command) {
+        log.info("[LectureCommandService] update lecture orders - courseId: {}, lectureCount: {}",
+                command.courseId(), command.lectures().size());
+
+        List<Lecture> currentLectures = lectureRepository
+                .findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(command.courseId());
+        validateLectureOrderRequest(currentLectures, command.lectures());
+        clearDeletedLectureOrders(command.courseId(), command.lectures().stream()
+                .map(UpdateLectureOrdersCommand.LectureOrderItem::lectureOrder)
+                .toList());
+
+        Map<Long, Integer> requestedOrders = command.lectures().stream()
+                .collect(Collectors.toMap(
+                        UpdateLectureOrdersCommand.LectureOrderItem::lectureId,
+                        UpdateLectureOrdersCommand.LectureOrderItem::lectureOrder
+                ));
+
+        for (int index = 0; index < currentLectures.size(); index++) {
+            Lecture lecture = currentLectures.get(index);
+            lecture.updateOrder(-(index + 1));
+            lectureRepository.save(lecture);
+        }
+        lectureRepository.flush();
+
+        currentLectures.forEach(lecture -> {
+            lecture.updateOrder(requestedOrders.get(lecture.getLectureId()));
+            lectureRepository.save(lecture);
+        });
     }
 
     @Override
@@ -150,6 +187,42 @@ public class LectureCommandService implements LectureCommandUseCase {
 
         if (duplicated) {
             throw new ConflictException(LectureErrorCode.LECTURE_ORDER_DUPLICATED);
+        }
+    }
+
+    private void clearDeletedLectureOrders(Long courseId, List<Integer> lectureOrders) {
+        List<Integer> nonNullOrders = lectureOrders.stream()
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (!nonNullOrders.isEmpty()) {
+            lectureRepository.clearDeletedLectureOrders(courseId, nonNullOrders);
+        }
+    }
+
+    private void validateLectureOrderRequest(
+            List<Lecture> currentLectures,
+            List<UpdateLectureOrdersCommand.LectureOrderItem> requestedLectures
+    ) {
+        Set<Long> requestedLectureIds = requestedLectures.stream()
+                .map(UpdateLectureOrdersCommand.LectureOrderItem::lectureId)
+                .collect(Collectors.toSet());
+        Set<Integer> requestedOrders = requestedLectures.stream()
+                .map(UpdateLectureOrdersCommand.LectureOrderItem::lectureOrder)
+                .collect(Collectors.toSet());
+        Set<Long> currentLectureIds = currentLectures.stream()
+                .map(Lecture::getLectureId)
+                .collect(Collectors.toSet());
+
+        boolean duplicatedLectureId = requestedLectureIds.size() != requestedLectures.size();
+        boolean duplicatedOrder = requestedOrders.size() != requestedLectures.size();
+        boolean incompleteCourseLectureSet = !requestedLectureIds.equals(currentLectureIds);
+
+        if (duplicatedOrder) {
+            throw new ConflictException(LectureErrorCode.LECTURE_ORDER_DUPLICATED);
+        }
+        if (duplicatedLectureId || incompleteCourseLectureSet) {
+            throw new ValidationException(LectureErrorCode.INVALID_LECTURE_ORDER_REQUEST);
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureCommandUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/LectureCommandUseCase.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.lecture.application.usecase;
 
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
+import com.wanted.codebombalms.lecture.application.command.UpdateLectureOrdersCommand;
 import com.wanted.codebombalms.lecture.domain.model.Lecture;
 
 public interface LectureCommandUseCase {
@@ -9,6 +10,8 @@ public interface LectureCommandUseCase {
     Lecture createLecture(CreateLectureCommand command);
 
     Lecture updateLecture(UpdateLectureCommand command);
+
+    void updateLectureOrders(UpdateLectureOrdersCommand command);
 
     void deleteLecture(Long lectureId);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
@@ -20,7 +20,8 @@ public enum LectureErrorCode implements ErrorCode {
     LECTURE_MATERIAL_DELETE_FAILED("LCT-010", "Lecture material delete failed."),
     LECTURE_ACCESS_DENIED("LCT-011", "Only enrolled students can access lecture content."),
     PREVIOUS_LECTURE_NOT_COMPLETED("LCT-012", "Previous lectures must be completed before accessing this lecture."),
-    FINAL_PROBLEM_SET_NOT_AVAILABLE("LCT-013", "Final problem set recommendations are available after completing the last lecture.");
+    FINAL_PROBLEM_SET_NOT_AVAILABLE("LCT-013", "Final problem set recommendations are available after completing the last lecture."),
+    INVALID_LECTURE_ORDER_REQUEST("LCT-014", "Lecture order request must include every active lecture exactly once.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/model/Lecture.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/model/Lecture.java
@@ -23,6 +23,7 @@ public class Lecture {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
+    @Setter(AccessLevel.NONE)
     private Integer lectureOrder;
 
     public static Lecture create(
@@ -42,7 +43,7 @@ public class Lecture {
         lecture.setVideoUrl(videoUrl);
         lecture.setThumbnailUrl(thumbnailUrl);
         lecture.setProblemCategoryId(problemCategoryId);
-        lecture.setLectureOrder(lectureOrder);
+        lecture.updateOrder(lectureOrder);
         lecture.setStatus(status == null ? LectureStatus.ACTIVE : status);
 
         return lecture;

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/model/Lecture.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/model/Lecture.java
@@ -119,5 +119,10 @@ public class Lecture {
     public void delete() {
         this.status = LectureStatus.DELETED;
         this.deletedAt = LocalDateTime.now();
+        this.lectureOrder = null;
+    }
+
+    public void updateOrder(Integer lectureOrder) {
+        this.lectureOrder = lectureOrder;
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureRepository.java
@@ -11,6 +11,10 @@ public interface LectureRepository {
 
     Lecture save(Lecture lecture);
 
+    void flush();
+
+    int clearDeletedLectureOrders(Long courseId, Collection<Integer> lectureOrders);
+
     List<Lecture> findByDeletedAtIsNull();
 
     Optional<Lecture> findByLectureIdAndDeletedAtIsNull(Long lectureId);

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/repository/LectureRepository.java
@@ -11,9 +11,9 @@ public interface LectureRepository {
 
     Lecture save(Lecture lecture);
 
-    void flush();
-
     int clearDeletedLectureOrders(Long courseId, Collection<Integer> lectureOrders);
+
+    void updateLectureOrders(List<Lecture> lectures, Map<Long, Integer> requestedOrders);
 
     List<Lecture> findByDeletedAtIsNull();
 

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -36,6 +36,19 @@ public class LectureRepositoryAdapter implements LectureRepository {
     }
 
     @Override
+    public void flush() {
+        springDataLectureRepository.flush();
+    }
+
+    @Override
+    public int clearDeletedLectureOrders(Long courseId, Collection<Integer> lectureOrders) {
+        if (lectureOrders.isEmpty()) {
+            return 0;
+        }
+        return springDataLectureRepository.clearDeletedLectureOrders(courseId, lectureOrders);
+    }
+
+    @Override
     public List<Lecture> findByDeletedAtIsNull() {
         List<LectureJpaEntity> entities = springDataLectureRepository.findByDeletedAtIsNull();
         if (entities.isEmpty()) {

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapter.java
@@ -36,16 +36,26 @@ public class LectureRepositoryAdapter implements LectureRepository {
     }
 
     @Override
-    public void flush() {
-        springDataLectureRepository.flush();
-    }
-
-    @Override
     public int clearDeletedLectureOrders(Long courseId, Collection<Integer> lectureOrders) {
         if (lectureOrders.isEmpty()) {
             return 0;
         }
         return springDataLectureRepository.clearDeletedLectureOrders(courseId, lectureOrders);
+    }
+
+    @Override
+    public void updateLectureOrders(List<Lecture> lectures, Map<Long, Integer> requestedOrders) {
+        for (int index = 0; index < lectures.size(); index++) {
+            Lecture lecture = lectures.get(index);
+            lecture.updateOrder(-(index + 1));
+            save(lecture);
+        }
+        springDataLectureRepository.flush();
+
+        lectures.forEach(lecture -> {
+            lecture.updateOrder(requestedOrders.get(lecture.getLectureId()));
+            save(lecture);
+        });
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/persistence/SpringDataLectureRepository.java
@@ -26,6 +26,19 @@ public interface SpringDataLectureRepository extends JpaRepository<LectureJpaEnt
 
     List<LectureJpaEntity> findByCourseIdAndDeletedAtIsNull(Long courseId);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update LectureJpaEntity l
+            set l.lectureOrder = null
+            where l.courseId = :courseId
+              and l.deletedAt is not null
+              and l.lectureOrder in :lectureOrders
+            """)
+    int clearDeletedLectureOrders(
+            @Param("courseId") Long courseId,
+            @Param("lectureOrders") java.util.Collection<Integer> lectureOrders
+    );
+
     @Query("""
             select l.courseId as courseId, count(l) as lectureCount
             from LectureJpaEntity l

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureController.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.lecture.presentation.api;
 
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
+import com.wanted.codebombalms.lecture.application.command.UpdateLectureOrdersCommand;
 import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
 import com.wanted.codebombalms.lecture.application.usecase.FinalProblemSetRecommendationUseCase;
 import com.wanted.codebombalms.lecture.application.usecase.LectureCommandUseCase;
@@ -9,6 +10,7 @@ import com.wanted.codebombalms.lecture.application.usecase.LectureMaterialUseCas
 import com.wanted.codebombalms.lecture.application.usecase.LectureQueryUseCase;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureCreateRequest;
+import com.wanted.codebombalms.lecture.presentation.api.request.LectureOrderUpdateRequest;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureUpdateRequest;
 import com.wanted.codebombalms.lecture.presentation.api.response.FinalProblemSetCandidateResponse;
 import com.wanted.codebombalms.lecture.presentation.api.response.LectureDetailResponse;
@@ -134,6 +136,33 @@ public class LectureController {
                                 request.status()
                         )))
                 ));
+    }
+
+    @PutMapping("/courses/{courseId}/lectures/order")
+    @Operation(summary = "강의 순서 일괄 변경")
+    @PreAuthorize("hasRole('OPERATOR')")
+    public ResponseEntity<ApiResponse<?>> updateLectureOrders(
+            @PathVariable Long courseId,
+            @Valid @RequestBody LectureOrderUpdateRequest request
+    ) {
+        log.info("[LectureController] update lecture orders - courseId: {}, lectureCount: {}",
+                courseId, request.lectures().size());
+
+        lectureCommandUseCase.updateLectureOrders(new UpdateLectureOrdersCommand(
+                courseId,
+                request.lectures().stream()
+                        .map(item -> new UpdateLectureOrdersCommand.LectureOrderItem(
+                                item.lectureId(),
+                                item.lectureOrder()
+                        ))
+                        .toList()
+        ));
+
+        return ResponseEntity.ok(ApiResponse.success(
+                LectureResponseCode.UPDATED,
+                LectureResponseMessage.UPDATED,
+                null
+        ));
     }
 
     @PutMapping("/lectures/{lectureId}")

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/request/LectureOrderUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/request/LectureOrderUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.lecture.presentation.api.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.List;
+
+public record LectureOrderUpdateRequest(
+        @NotEmpty(message = "Lecture order list must not be empty.")
+        List<@Valid LectureOrderItem> lectures
+) {
+
+    public record LectureOrderItem(
+            @NotNull(message = "Lecture ID is required.")
+            @Positive(message = "Lecture ID must be positive.")
+            Long lectureId,
+
+            @NotNull(message = "Lecture order is required.")
+            @Positive(message = "Lecture order must be positive.")
+            Integer lectureOrder
+    ) {
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
@@ -38,7 +38,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -451,11 +450,10 @@ class LectureServiceTest {
                 )
         ));
 
-        assertEquals(2, first.getLectureOrder());
-        assertEquals(1, second.getLectureOrder());
-        verify(lectureRepository, times(2)).save(first);
-        verify(lectureRepository, times(2)).save(second);
-        verify(lectureRepository).flush();
+        verify(lectureRepository).updateLectureOrders(
+                List.of(first, second),
+                java.util.Map.of(1L, 2, 2L, 1)
+        );
         verify(lectureRepository).clearDeletedLectureOrders(courseId, List.of(2, 1));
     }
 
@@ -502,6 +500,30 @@ class LectureServiceTest {
 
         assertEquals(LectureErrorCode.INVALID_LECTURE_ORDER_REQUEST, exception.getErrorCode());
         verify(lectureRepository, never()).save(any(Lecture.class));
+    }
+
+    @Test
+    void updateLectureOrders_throwsValidation_whenLectureIdIsDuplicated() {
+        Long courseId = 1L;
+        Course course = createCourse(courseId, 10L, "Java");
+        Lecture first = createLecture(1L, course, "Java 1", LectureStatus.ACTIVE, 1);
+        Lecture second = createLecture(2L, course, "Java 2", LectureStatus.ACTIVE, 2);
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(first, second));
+
+        ValidationException exception = assertThrows(
+                ValidationException.class,
+                () -> lectureCommandService.updateLectureOrders(new UpdateLectureOrdersCommand(
+                        courseId,
+                        List.of(
+                                new UpdateLectureOrdersCommand.LectureOrderItem(1L, 1),
+                                new UpdateLectureOrdersCommand.LectureOrderItem(1L, 2)
+                        )
+                ))
+        );
+
+        assertEquals(LectureErrorCode.INVALID_LECTURE_ORDER_REQUEST, exception.getErrorCode());
+        verify(lectureRepository, never()).updateLectureOrders(any(), any());
     }
 
     @Test
@@ -668,7 +690,7 @@ class LectureServiceTest {
         lecture.setVideoUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
         lecture.setThumbnailUrl("lecture.png");
         lecture.setStatus(status);
-        lecture.setLectureOrder(lectureOrder);
+        lecture.updateOrder(lectureOrder);
         lecture.setCreatedAt(LocalDateTime.now());
         lecture.setUpdatedAt(LocalDateTime.now());
         return lecture;

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/LectureServiceTest.java
@@ -5,6 +5,7 @@ import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
+import com.wanted.codebombalms.lecture.application.command.UpdateLectureOrdersCommand;
 import com.wanted.codebombalms.lecture.application.policy.LectureCreationPolicy;
 import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
 import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
@@ -18,6 +19,7 @@ import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import com.wanted.codebombalms.lecture.domain.repository.LectureMaterialRepository;
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ConflictException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +38,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -83,6 +86,7 @@ class LectureServiceTest {
         assertEquals(courseId, result.getCourse().getCourseId());
         assertEquals("Java 1", result.getTitle());
         verify(lectureCreationPolicy).validate(course);
+        verify(lectureRepository).clearDeletedLectureOrders(courseId, List.of(1));
     }
 
     @Test
@@ -431,6 +435,76 @@ class LectureServiceTest {
     }
 
     @Test
+    void updateLectureOrders_updatesEveryLecture() {
+        Long courseId = 1L;
+        Course course = createCourse(courseId, 10L, "Java");
+        Lecture first = createLecture(1L, course, "Java 1", LectureStatus.ACTIVE, 1);
+        Lecture second = createLecture(2L, course, "Java 2", LectureStatus.ACTIVE, 2);
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(first, second));
+
+        lectureCommandService.updateLectureOrders(new UpdateLectureOrdersCommand(
+                courseId,
+                List.of(
+                        new UpdateLectureOrdersCommand.LectureOrderItem(1L, 2),
+                        new UpdateLectureOrdersCommand.LectureOrderItem(2L, 1)
+                )
+        ));
+
+        assertEquals(2, first.getLectureOrder());
+        assertEquals(1, second.getLectureOrder());
+        verify(lectureRepository, times(2)).save(first);
+        verify(lectureRepository, times(2)).save(second);
+        verify(lectureRepository).flush();
+        verify(lectureRepository).clearDeletedLectureOrders(courseId, List.of(2, 1));
+    }
+
+    @Test
+    void updateLectureOrders_throwsConflict_whenOrderIsDuplicated() {
+        Long courseId = 1L;
+        Course course = createCourse(courseId, 10L, "Java");
+        Lecture first = createLecture(1L, course, "Java 1", LectureStatus.ACTIVE, 1);
+        Lecture second = createLecture(2L, course, "Java 2", LectureStatus.ACTIVE, 2);
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(first, second));
+
+        ConflictException exception = assertThrows(
+                ConflictException.class,
+                () -> lectureCommandService.updateLectureOrders(new UpdateLectureOrdersCommand(
+                        courseId,
+                        List.of(
+                                new UpdateLectureOrdersCommand.LectureOrderItem(1L, 1),
+                                new UpdateLectureOrdersCommand.LectureOrderItem(2L, 1)
+                        )
+                ))
+        );
+
+        assertEquals(LectureErrorCode.LECTURE_ORDER_DUPLICATED, exception.getErrorCode());
+        verify(lectureRepository, never()).save(any(Lecture.class));
+    }
+
+    @Test
+    void updateLectureOrders_throwsValidation_whenLectureSetIsIncomplete() {
+        Long courseId = 1L;
+        Course course = createCourse(courseId, 10L, "Java");
+        Lecture first = createLecture(1L, course, "Java 1", LectureStatus.ACTIVE, 1);
+        Lecture second = createLecture(2L, course, "Java 2", LectureStatus.ACTIVE, 2);
+        given(lectureRepository.findByCourseIdAndDeletedAtIsNullOrderByLectureOrderAsc(courseId))
+                .willReturn(List.of(first, second));
+
+        ValidationException exception = assertThrows(
+                ValidationException.class,
+                () -> lectureCommandService.updateLectureOrders(new UpdateLectureOrdersCommand(
+                        courseId,
+                        List.of(new UpdateLectureOrdersCommand.LectureOrderItem(1L, 1))
+                ))
+        );
+
+        assertEquals(LectureErrorCode.INVALID_LECTURE_ORDER_REQUEST, exception.getErrorCode());
+        verify(lectureRepository, never()).save(any(Lecture.class));
+    }
+
+    @Test
     void deleteLecture_softDeletesMaterialsAndDeletesFiles() {
         Long lectureId = 1L;
         Lecture lecture = createLecture(lectureId, createCourse(1L, 10L, "Java"), "Java 1", LectureStatus.ACTIVE, 1);
@@ -485,6 +559,7 @@ class LectureServiceTest {
 
         assertEquals(LectureStatus.DELETED, lecture.getStatus());
         assertNotNull(lecture.getDeletedAt());
+        assertNull(lecture.getLectureOrder());
         assertNotNull(material.getDeletedAt());
         verify(lectureMaterialRepository).save(material);
         verify(lectureRepository).save(lecture);
@@ -569,6 +644,7 @@ class LectureServiceTest {
 
         assertEquals(LectureStatus.DELETED, lecture.getStatus());
         assertNotNull(lecture.getDeletedAt());
+        assertNull(lecture.getLectureOrder());
         verify(lectureRepository).save(lecture);
     }
 

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerSecurityTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerSecurityTest.java
@@ -1,0 +1,99 @@
+package com.wanted.codebombalms.lecture.controller;
+
+import com.wanted.codebombalms.admin.permission.application.service.AdminPermissionCheckService;
+import com.wanted.codebombalms.global.presentation.api.common.GlobalExceptionHandler;
+import com.wanted.codebombalms.lecture.application.command.UpdateLectureOrdersCommand;
+import com.wanted.codebombalms.lecture.application.usecase.FinalProblemSetRecommendationUseCase;
+import com.wanted.codebombalms.lecture.application.usecase.LectureCommandUseCase;
+import com.wanted.codebombalms.lecture.application.usecase.LectureMaterialUseCase;
+import com.wanted.codebombalms.lecture.application.usecase.LectureQueryUseCase;
+import com.wanted.codebombalms.lecture.presentation.api.LectureController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LectureController.class)
+@AutoConfigureMockMvc
+@ContextConfiguration(classes = {
+        LectureController.class,
+        GlobalExceptionHandler.class,
+        LectureControllerSecurityTest.TestSecurityConfig.class
+})
+class LectureControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LectureCommandUseCase lectureCommandUseCase;
+
+    @MockitoBean
+    private LectureQueryUseCase lectureQueryUseCase;
+
+    @MockitoBean
+    private FinalProblemSetRecommendationUseCase finalProblemSetRecommendationUseCase;
+
+    @MockitoBean
+    private LectureMaterialUseCase lectureMaterialUseCase;
+
+    @MockitoBean
+    private AdminPermissionCheckService adminPermissionCheckService;
+
+    @TestConfiguration
+    @EnableMethodSecurity
+    static class TestSecurityConfig {
+
+        @Bean
+        SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+    }
+
+    @Test
+    void updateLectureOrders_rejectsStudent() throws Exception {
+        String request = """
+                {
+                  "lectures": [
+                    { "lectureId": 1, "lectureOrder": 1 }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/courses/{courseId}/lectures/order", 1L)
+                        .with(authentication(studentUser(10L)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isForbidden());
+
+        verify(lectureCommandUseCase, never()).updateLectureOrders(any(UpdateLectureOrdersCommand.class));
+    }
+
+    private Authentication studentUser(Long userId) {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(userId, null, "ROLE_STUDENT");
+        authentication.setAuthenticated(true);
+        return authentication;
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
@@ -381,7 +381,7 @@ class LectureControllerTest {
         lecture.setVideoUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
         lecture.setThumbnailUrl("java-1.png");
         lecture.setStatus(LectureStatus.ACTIVE);
-        lecture.setLectureOrder(1);
+        lecture.updateOrder(1);
         lecture.setCreatedAt(LocalDateTime.now());
         lecture.setUpdatedAt(LocalDateTime.now());
         return lecture;

--- a/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/controller/LectureControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wanted.codebombalms.admin.permission.application.service.AdminPermissionCheckService;
 import com.wanted.codebombalms.lecture.application.command.CreateLectureCommand;
 import com.wanted.codebombalms.lecture.application.command.UpdateLectureCommand;
+import com.wanted.codebombalms.lecture.application.command.UpdateLectureOrdersCommand;
 import com.wanted.codebombalms.lecture.application.command.UploadLectureMaterialCommand;
 import com.wanted.codebombalms.lecture.application.usecase.FinalProblemSetRecommendationUseCase;
 import com.wanted.codebombalms.lecture.application.usecase.LectureCommandUseCase;
@@ -17,6 +18,7 @@ import com.wanted.codebombalms.lecture.domain.model.Lecture;
 import com.wanted.codebombalms.lecture.domain.model.LectureMaterial;
 import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureCreateRequest;
+import com.wanted.codebombalms.lecture.presentation.api.request.LectureOrderUpdateRequest;
 import com.wanted.codebombalms.lecture.presentation.api.request.LectureUpdateRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.junit.jupiter.api.DisplayName;
@@ -152,6 +154,40 @@ class LectureControllerTest {
                 .andExpect(jsonPath("$.code").value(LectureResponseCode.UPDATED))
                 .andExpect(jsonPath("$.message").value(LectureResponseMessage.UPDATED))
                 .andExpect(jsonPath("$.data.title").value("Updated Java"));
+    }
+
+    @Test
+    void updateLectureOrders_returnsApiResponse() throws Exception {
+        Long courseId = 1L;
+        LectureOrderUpdateRequest request = new LectureOrderUpdateRequest(List.of(
+                new LectureOrderUpdateRequest.LectureOrderItem(1L, 2),
+                new LectureOrderUpdateRequest.LectureOrderItem(2L, 1)
+        ));
+
+        mockMvc.perform(put("/api/v1/courses/{courseId}/lectures/order", courseId)
+                        .with(authentication(operatorUser(10L)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.code").value(LectureResponseCode.UPDATED))
+                .andExpect(jsonPath("$.message").value(LectureResponseMessage.UPDATED));
+
+        verify(lectureCommandUseCase).updateLectureOrders(any(UpdateLectureOrdersCommand.class));
+    }
+
+    @Test
+    void updateLectureOrders_returnsBadRequest_whenLecturesAreEmpty() throws Exception {
+        Long courseId = 1L;
+        LectureOrderUpdateRequest request = new LectureOrderUpdateRequest(List.of());
+
+        mockMvc.perform(put("/api/v1/courses/{courseId}/lectures/order", courseId)
+                        .with(authentication(operatorUser(10L)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(lectureCommandUseCase, never()).updateLectureOrders(any(UpdateLectureOrdersCommand.class));
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/infrastructure/persistence/LectureRepositoryAdapterTest.java
@@ -1,0 +1,94 @@
+package com.wanted.codebombalms.lecture.infrastructure.persistence;
+
+import com.wanted.codebombalms.course.domain.model.Course;
+import com.wanted.codebombalms.lecture.application.port.CourseCatalogPort;
+import com.wanted.codebombalms.lecture.domain.model.Lecture;
+import com.wanted.codebombalms.lecture.domain.model.LectureStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+class LectureRepositoryAdapterTest {
+
+    @Mock
+    private SpringDataLectureRepository springDataLectureRepository;
+
+    @Mock
+    private CourseCatalogPort courseCatalogPort;
+
+    @InjectMocks
+    private LectureRepositoryAdapter lectureRepositoryAdapter;
+
+    @Test
+    void updateLectureOrders_savesTemporaryOrdersBeforeFinalOrders() {
+        Course course = createCourse(1L);
+        Lecture first = createLecture(1L, course, 1);
+        Lecture second = createLecture(2L, course, 2);
+        LectureJpaEntity firstEntity = LectureJpaEntity.from(first);
+        LectureJpaEntity secondEntity = LectureJpaEntity.from(second);
+
+        given(springDataLectureRepository.findById(1L)).willReturn(Optional.of(firstEntity));
+        given(springDataLectureRepository.findById(2L)).willReturn(Optional.of(secondEntity));
+        given(springDataLectureRepository.save(any(LectureJpaEntity.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        lectureRepositoryAdapter.updateLectureOrders(
+                List.of(first, second),
+                Map.of(1L, 2, 2L, 1)
+        );
+
+        InOrder order = inOrder(springDataLectureRepository);
+        order.verify(springDataLectureRepository).findById(1L);
+        order.verify(springDataLectureRepository).save(firstEntity);
+        order.verify(springDataLectureRepository).findById(2L);
+        order.verify(springDataLectureRepository).save(secondEntity);
+        order.verify(springDataLectureRepository).flush();
+        order.verify(springDataLectureRepository).findById(1L);
+        order.verify(springDataLectureRepository).save(firstEntity);
+        order.verify(springDataLectureRepository).findById(2L);
+        order.verify(springDataLectureRepository).save(secondEntity);
+
+        assertEquals(2, firstEntity.getLectureOrder());
+        assertEquals(1, secondEntity.getLectureOrder());
+    }
+
+    private Course createCourse(Long courseId) {
+        Course course = new Course();
+        course.setCourseId(courseId);
+        course.setInstructorId(10L);
+        course.setTitle("Java");
+        course.setCreatedAt(LocalDateTime.now());
+        return course;
+    }
+
+    private Lecture createLecture(Long lectureId, Course course, Integer lectureOrder) {
+        return Lecture.restore(
+                lectureId,
+                course,
+                "Java " + lectureId,
+                "description",
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                "thumbnail.png",
+                3001L,
+                LectureStatus.ACTIVE,
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                null,
+                lectureOrder
+        );
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #619

---

## 🛠️ 기능 관련 작업 내용

- 강좌의 전체 강의 순서를 한 트랜잭션에서 반영하는 일괄 변경 API를 추가했습니다.
- 임시 음수 순서와 DB flush를 사용해 UNIQUE 제약이 있는 환경에서도 순서 교환이 가능하도록 수정했습니다.
- soft delete 시 강의 순서를 해제하고, 기존 삭제 데이터가 목표 순서를 보유한 경우 요청 시 자동 정리하도록 구현했습니다.
- 강의 ID·순서 중복, 강의 누락, 빈 요청 및 삭제 시 순서 해제 테스트를 추가했습니다.

---

## ♻️ 패키지 변경 사항

- `project/lecture/presentation`: 강의 순서 일괄 변경 엔드포인트 및 요청 DTO 추가
- `project/lecture/application`: 일괄 순서 검증, 삭제 데이터 자동 정리 및 2단계 순서 저장 로직 추가
- `project/lecture/domain`: 순서 변경 메서드, 삭제 시 순서 해제 정책 및 에러 코드 추가
- `project/lecture/infrastructure`: 삭제 강의 순서 자동 정리 쿼리와 DB flush 기능 추가
- `project/lecture/test`: Service·Controller 순서 변경 및 soft delete 검증 테스트 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 강의 순서를 한 번에 변경할 수 있는 API가 추가되었습니다.
  * 강의 목록 전체를 검증하여 중복되거나 누락된 순서 요청을 안내합니다.
  * 삭제된 강의의 순서 정보가 자동으로 정리됩니다.

* **버그 수정**
  * 강의 삭제 시 기존 순서 정보가 함께 초기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->