### PR TITLE
[Feat] 보안 요약 콘솔 P5 — AI 브리핑 생성·조회·재생성 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,6 +84,7 @@ jobs:
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_STORAGE_BUCKET: ${{ vars.GCP_STORAGE_BUCKET }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+          BRIEFING_API_KEY: ${{ secrets.BRIEFING_API_KEY }}
         run: |
           set -euo pipefail
           umask 077
@@ -109,7 +110,7 @@ jobs:
                    CORS_ALLOWED_ORIGINS FASTAPI_URL JWT_SECRET MAIL_USERNAME MAIL_PASSWORD \
                    GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_REDIRECT_URI \
                    OAUTH_ADDITIONAL_INFO_URI OAUTH_SUCCESS_URI OAUTH_ERROR_URI COOKIE_SECURE \
-                   GCP_PROJECT_ID GCP_STORAGE_BUCKET; do
+                   GCP_PROJECT_ID GCP_STORAGE_BUCKET BRIEFING_API_KEY; do
             v="${!k}"
             [ -n "$v" ] && printf '%s=%s\n' "$k" "$v" >> deploy.env
           done

--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ architecture-user-auth.html
 /monitoring-deploy/k6/results/
 /src/main/resources/db/seed/03_trusted_device_loadtest.sql
 /rds-tunnel.sh
+/src/main/resources/db/schema/ops_briefing.sql

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    // 관리자 AI 브리핑 — Claude API (#609)
+    implementation 'com.anthropic:anthropic-java:2.34.0'
+    implementation 'com.google.genai:google-genai:1.57.0'
+
 
     // 적응형 인증 - GeoIP (MaxMind GeoLite2 로컬 DB)
     implementation 'com.maxmind.geoip2:geoip2:4.2.0'

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/metrics/AuthSecurityEventRecorder.java
@@ -15,20 +15,17 @@ import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 /**
- * 비정상 행위를 Prometheus(집계) + Loki(상세) + DB(service_event, 조회·액션) 삼중 기록한다.
- *
- * <p>메트릭은 저카디널리티 집계용 {@code auth_security_event_total{category,type}} 하나로 통일.
- * ip/userId 같은 고카디널리티 정보는 메트릭 라벨이 아니라 로그 본문(logfmt)과 DB 행에만 담는다.
- * DB 적재는 best-effort — 실패해도 본 흐름에 영향 없다 (#606).
+ * 비정상 행위를 Prometheus(집계) + Loki(상세) + DB(service_event) 삼중 기록.
+ * 고카디널리티 값(ip·userId)은 메트릭 라벨 금지 — 로그 본문·DB 행에만 기록 (DB 는 best-effort).
  */
 @Slf4j
 @Component
 public class AuthSecurityEventRecorder implements SecurityEventReporter {
 
-    // 등록명엔 _total 을 붙이지 않는다. Counter 라서 Prometheus 가 auth_security_event_total 로 변환한다.
+    // 등록명에 _total 미부여 — Counter 는 Prometheus 가 auth_security_event_total 로 자동 변환
     private static final String METRIC = "auth_security_event";
 
-    // ErrorCode(AUT-*) → 이벤트. 흐름성/모호 코드(AUT-009 등)는 서비스에서 직접 기록한다.
+    // ErrorCode(AUT-*) → 이벤트 매핑. 흐름성·모호 코드(AUT-009 등)는 서비스에서 직접 기록
     private static final Map<String, AuthSecurityEvent> BY_CODE = Map.ofEntries(
             Map.entry("AUT-001", LOGIN_FAIL),
             Map.entry("AUT-014", EMAIL_SEND_BLOCKED),
@@ -58,7 +55,7 @@ public class AuthSecurityEventRecorder implements SecurityEventReporter {
         this.serviceEventWriter = serviceEventWriter;
     }
 
-    /** 흐름 기반 이벤트(의심 로그인 등) 직접 기록. ip/uri 는 MDC(MdcLoggingFilter)에서 가져온다. */
+    /** 흐름 기반 이벤트(의심 로그인 등) 직접 기록. ip/uri 는 MDC(MdcLoggingFilter) 값 사용. */
     public void record(AuthSecurityEvent event, Long userId) {
         registry.counter(METRIC, "category", event.getCategory(), "type", event.getType()).increment();
         log.warn("event=security_event traceId={} category={} type={} userId={} clientIp={} uri={}",
@@ -78,9 +75,8 @@ public class AuthSecurityEventRecorder implements SecurityEventReporter {
     }
 
     /**
-     * DB 세 번째 줄기 (#606). 반드시 요청 스레드에서 MDC 값을 캡처해 봉투에 고정한다
-     * — writer 의 @Async 스레드에는 MDC 가 전파되지 않는다.
-     * publishEvent(AFTER_COMMIT) 금지: 로그인 실패 흐름은 트랜잭션 롤백 중이라 유실된다.
+     * DB(service_event) 적재. 요청 스레드에서 MDC 값 캡처 필수 — @Async 스레드 미전파.
+     * publishEvent(AFTER_COMMIT) 금지 — 로그인 실패(롤백) 흐름에서 유실.
      */
     private void recordToServiceEvent(AuthSecurityEvent event, Long userId) {
         try {

--- a/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/auth/infrastructure/persistence/SpringDataLoginHistoryRepository.java
@@ -26,7 +26,7 @@ public interface SpringDataLoginHistoryRepository extends JpaRepository<LoginHis
         LocalDateTime getLatestLoginAt();
     }
 
-    /** 기간 내 로그인 고유 회원 수 — 보안 요약 KPI 용 읽기 전용 (#608) */
+    /** 기간 내 로그인 고유 회원 수 조회 — 보안 요약 KPI 용 읽기 전용 */
     @Query("""
             select count(distinct lh.userId)
             from LoginHistoryJpaEntity lh

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -47,10 +47,8 @@ public class SchedulingConfig {
 
 
     /**
-     * 서비스 이벤트 적재 전용 풀 (#605).
-     * 기존 풀 재사용 금지 — 추천풀(core=max=1, Abort)은 즉시 거절되고,
-     * 메일풀(CallerRuns)은 포화 시 요청 스레드로 역류해 응답 지연을 전파한다.
-     * 이벤트는 best-effort: 포화 시 드랍하고 카운터만 올린다 (응답 보호 최우선).
+     * 서비스 이벤트 적재 전용 풀 — 포화 시 드랍 + 카운터 기록 (best-effort, 응답 보호).
+     * 기존 풀(추천·메일) 재사용 금지 — 즉시 거절 또는 요청 스레드 역류로 응답 지연 전파.
      */
     @Bean
     public ThreadPoolTaskExecutor serviceEventTaskExecutor(MeterRegistry meterRegistry) {

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/LoggingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/LoggingConfig.java
@@ -16,7 +16,7 @@ public class LoggingConfig {
             ServiceEventWriter serviceEventWriter,
             HttpAnomalyGuard httpAnomalyGuard,
             @Value("${service-event.anomaly.slow-threshold-ms:3000}") long slowThresholdMs) {
-        if (slowThresholdMs <= 0) { // 0 이하면 모든 요청이 slow_request 로 분류돼 지표가 왜곡된다 — 기동 시 차단
+        if (slowThresholdMs <= 0) { // 0 이하 설정 — 전 요청 slow 분류로 지표 왜곡, 기동 차단
             throw new IllegalStateException(
                     "service-event.anomaly.slow-threshold-ms 는 양수여야 합니다: " + slowThresholdMs);
         }

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -88,11 +88,11 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     /** 예외 신호만 조건부 적재 — 정상 요청(2xx·3xx·일반 4xx) 제외, 예외는 응답에 미전파 (best-effort) */
     private void recordAnomalyIfNeeded(
             HttpServletRequest request, HttpServletResponse response,
-            long durationMs, String userIdAttribute, String traceId) {
+            long durationMs, String resolvedUserId, String traceId) {
         try {
             int status = response.getStatus();
             String route = HttpRequestAnomalySupport.normalizedRoute(request);
-            Long userId = HttpRequestAnomalySupport.parseUserId(userIdAttribute);
+            Long userId = HttpRequestAnomalySupport.parseUserId(resolvedUserId);
             String clientIp = ClientIpResolver.resolve(request);
 
             if (durationMs >= slowThresholdMs && anomalyGuard.tryAcquire("slow:" + route)) {

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/logging/MdcLoggingFilter.java
@@ -25,10 +25,7 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     private static final Logger log = LoggerFactory.getLogger(MdcLoggingFilter.class);
     private static final String ANONYMOUS = "anonymous";
 
-    /**
-     * GlobalExceptionHandler 가 이미 상세(예외 클래스명 포함)를 기록한 요청에 세팅하는 마커.
-     * 필터의 상태코드 기반 기록과 중복 적재를 막는다 (#606).
-     */
+    /** GlobalExceptionHandler 상세 기록 완료 마커 — 필터의 상태코드 기반 기록과 중복 방지 */
     public static final String ANOMALY_RECORDED_ATTRIBUTE = "serviceEvent.anomalyRecorded";
 
     private final ServiceEventWriter serviceEventWriter;
@@ -52,7 +49,7 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         long startAt = System.nanoTime();
-        // traceId 는 로컬 변수로 잡아둔다 — doFilter 내부 필터가 MDC.clear() 해도 완료 로그에 안전.
+        // traceId 로컬 변수 캡처 — 내부 필터의 MDC.clear() 에도 완료 로그 안전
         String traceId = UUID.randomUUID().toString().substring(0, 8);
 
         try {
@@ -88,10 +85,7 @@ public class MdcLoggingFilter extends OncePerRequestFilter {
         }
     }
 
-    /**
-     * 예외 신호만 조건부 적재 (#606). 정상 요청(2xx·3xx·일반 4xx)은 절대 적재하지 않는다.
-     * 어떤 예외도 응답에 영향을 주지 않는다 (best-effort).
-     */
+    /** 예외 신호만 조건부 적재 — 정상 요청(2xx·3xx·일반 4xx) 제외, 예외는 응답에 미전파 (best-effort) */
     private void recordAnomalyIfNeeded(
             HttpServletRequest request, HttpServletResponse response,
             long durationMs, String userIdAttribute, String traceId) {

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/HttpAnomalyReporter.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/metrics/HttpAnomalyReporter.java
@@ -3,15 +3,14 @@ package com.wanted.codebombalms.global.infrastructure.metrics;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
- * 5xx 상세 기록 포트 (#607 리뷰 반영).
- * SecurityEventReporter 와 동일한 패턴 — presentation(GlobalExceptionHandler)은
- * 이 인터페이스만 알고, 구현(service_event 적재)은 serviceevent infra 에 둔다.
+ * 5xx 상세 기록 포트 (구현은 serviceevent infra).
+ * 사용처: GlobalExceptionHandler
  */
 public interface HttpAnomalyReporter {
 
     /**
-     * 서버 오류(500·502)를 원인 예외와 함께 기록한다.
-     * 구현은 절대 예외를 던지지 않아야 한다 (에러 응답 보호).
+     * 서버 오류(500·502)를 원인 예외와 함께 기록.
+     * 구현은 예외 미전파 필수 (에러 응답 보호).
      */
     void reportServerError(HttpServletRequest request, int httpStatus, Exception cause);
 }

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -41,13 +41,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleDomainException(
             DomainException e, HttpServletRequest request) {
         log.warn("[{}] {} - path: {}", e.getHttpStatus(), e.getMessage(), request.getRequestURI());
-        // 보안 이벤트 기록 실패가 원래 에러 응답을 깨지 않도록 삼킨다.
+        // 보안 이벤트 기록 실패는 삼킴 — 원래 에러 응답 보호
         try {
             securityEventReporter.ifAvailable(r -> r.reportByErrorCode(e.getErrorCode().getCode()));
         } catch (Exception ignored) {
             log.warn("보안 이벤트 기록 실패 (무시): {}", ignored.getMessage());
         }
-        // 외부 서비스 예외(502)는 원인 클래스명까지 상세 기록 — 필터의 상태코드 기록보다 정보가 많다 (#606)
+        // 외부 서비스 예외(502)는 원인 클래스명 포함 상세 기록
         if (e instanceof ExternalServiceException) {
             reportServerErrorQuietly(request, e.getHttpStatus(), e);
         }
@@ -91,7 +91,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleException(
             Exception e, HttpServletRequest request) {
         log.error("[500] 예상치 못한 예외 - path: {}", request.getRequestURI(), e);
-        // unhandled 500 — 예외 클래스명 상세는 HttpAnomalyReporter 구현이 기록한다 (#606)
+        // unhandled 500 — 예외 클래스명 상세 기록은 HttpAnomalyReporter 구현 담당
         reportServerErrorQuietly(request, 500, e);
         String message = isDev() ? e.getMessage() : "서버 오류가 발생했습니다.";
         return ResponseEntity.status(500)
@@ -122,7 +122,7 @@ public class GlobalExceptionHandler {
         }
     }
 
-    /** 5xx 상세 기록 위임 — SecurityEventReporter 와 동일한 ifAvailable+삼킴 패턴 (#607 리뷰 반영) */
+    /** 5xx 상세 기록 위임 — ifAvailable(빈 부재 시 무시) + 예외 삼킴 */
     private void reportServerErrorQuietly(HttpServletRequest request, int httpStatus, Exception cause) {
         try {
             httpAnomalyReporter.ifAvailable(r -> r.reportServerError(request, httpStatus, cause));

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProgressService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProgressService.java
@@ -57,7 +57,7 @@ public class LectureProgressService implements LectureProgressCommandUseCase, Le
         boolean firstCompletion = !progress.isCompleted();
         progress.complete();
         LectureProgress saved = lectureProgressRepository.save(progress);
-        if (firstCompletion) { // 이미 완료된 강의 재호출 시 중복 적재 방지 (KPI 왜곡 방지)
+        if (firstCompletion) { // 재완료 시 이벤트 중복 적재 방지
             serviceEventRecorder.record(ServiceEventEnvelope.business(
                     ServiceEventType.LESSON_COMPLETED, userId, lectureId));
         }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ActiveLoginUserCountPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ActiveLoginUserCountPort.java
@@ -3,8 +3,8 @@ package com.wanted.codebombalms.serviceevent.application.port;
 import java.time.LocalDateTime;
 
 /**
- * 기간 내 로그인한 고유 회원 수 조회 포트 (#608).
- * 소스는 auth 의 login_history — 읽기 전용(테이블·기존 로직 무변경 원칙).
+ * 기간 내 로그인 고유 회원 수 조회 포트.
+ * 소스는 auth 의 login_history — 읽기 전용.
  */
 public interface ActiveLoginUserCountPort {
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/BriefingLlmPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/BriefingLlmPort.java
@@ -4,18 +4,12 @@ import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
 import java.time.LocalDateTime;
 
 /**
- * AI 브리핑 생성 포트 (#609). 구현은 infrastructure(Claude SDK)에 두고,
- * 모델 교체는 설정(${BRIEFING_MODEL})만 바꾸면 된다.
- *
- * <p>PII 정책: input 에는 집계 수치·마스킹된 IP 라벨만 담는다.
- * user_id·이메일·원본 IP 는 절대 포함하지 않는다 (설계서 §8-2).
+ * AI 브리핑 생성 포트.
+ * PII 미반출 — input 은 집계 수치·마스킹 IP 라벨만 (user_id·이메일·원본 IP 금지).
  */
 public interface BriefingLlmPort {
 
-    /**
-     * 집계 스냅샷으로 브리핑을 생성한다.
-     * 실패(네트워크·refusal 포함)는 예외로 던진다 — 호출측이 FAILED 기록을 담당.
-     */
+    /** 집계 스냅샷으로 브리핑 생성 — 실패는 예외 전파, FAILED 기록은 호출측 담당 */
     BriefingContent generate(BriefingSource source);
 
     /** 사용 중인 모델명 (ops_briefing.model 기록용) */

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/BriefingLlmPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/BriefingLlmPort.java
@@ -1,0 +1,33 @@
+package com.wanted.codebombalms.serviceevent.application.port;
+
+import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
+import java.time.LocalDateTime;
+
+/**
+ * AI 브리핑 생성 포트 (#609). 구현은 infrastructure(Claude SDK)에 두고,
+ * 모델 교체는 설정(${BRIEFING_MODEL})만 바꾸면 된다.
+ *
+ * <p>PII 정책: input 에는 집계 수치·마스킹된 IP 라벨만 담는다.
+ * user_id·이메일·원본 IP 는 절대 포함하지 않는다 (설계서 §8-2).
+ */
+public interface BriefingLlmPort {
+
+    /**
+     * 집계 스냅샷으로 브리핑을 생성한다.
+     * 실패(네트워크·refusal 포함)는 예외로 던진다 — 호출측이 FAILED 기록을 담당.
+     */
+    BriefingContent generate(BriefingSource source);
+
+    /** 사용 중인 모델명 (ops_briefing.model 기록용) */
+    String modelName();
+
+    /**
+     * 프롬프트 재료 — 이미 집계·마스킹이 끝난 문자열/숫자만 담는 봉투.
+     * @param aggregatesText 사람이 읽을 수 있는 집계 요약 텍스트 (마스킹 완료본)
+     */
+    record BriefingSource(
+            LocalDateTime periodStart,
+            LocalDateTime periodEnd,
+            String aggregatesText
+    ) {}
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
@@ -26,6 +26,4 @@ public interface SecuritySummaryQueryPort {
     List<HourlyCount> hourlyDistribution(LocalDateTime start, LocalDateTime end);
 
     Optional<ConcurrentPeak> findConcurrentPeak(LocalDateTime start, LocalDateTime end);
-
-    long countDistinctActiveUsers(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
@@ -4,10 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * summary 집계 조회 포트 (#608). 서비스는 이 포트만 알고, 구현(native 쿼리)은 infra 에 둔다.
- * QueryDSL 도입(D트랙) 시 어댑터만 교체하면 된다.
- */
+/** 보안 요약(summary) 집계 조회 포트. */
 public interface SecuritySummaryQueryPort {
 
     record CategoryCount(String category, long count) {}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventRecorder.java
@@ -3,10 +3,8 @@ package com.wanted.codebombalms.serviceevent.application.port;
 import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
 
 /**
- * 도메인 서비스가 비즈니스 이벤트를 기록할 때 쓰는 발행 포트
- * 사용법 (도메인 코드에 1줄):
- *   serviceEventRecorder.record(ServiceEventEnvelope.business(ENROLL_CREATED, userId, courseId));
- * 트랜잭션 커밋 후(AFTER_COMMIT)에만 기록되므로 롤백된 행위는 남지 않는다.
+ * 비즈니스 이벤트 발행 포트.
+ * AFTER_COMMIT 기록 — 롤백된 행위는 미기록.
  */
 public interface ServiceEventRecorder {
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventStore.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventStore.java
@@ -3,17 +3,11 @@ package com.wanted.codebombalms.serviceevent.application.port;
 import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
 import java.time.LocalDateTime;
 
-/**
- * service_event 영속화 포트.
- * 구현은 infrastructure(JPA)에 두고, 적재기/파기 로직은 이 포트에만 의존한다.
- */
+/** service_event 영속화 포트. */
 public interface ServiceEventStore {
 
     void save(ServiceEventEnvelope envelope);
 
-    /**
-     * threshold 이전 이벤트를 청크 단위로 삭제하고 삭제 건수를 반환한다.
-     * 호출측(파기 배치)이 0이 나올 때까지 반복 호출한다.
-     */
+    /** threshold 이전 이벤트를 청크 단위로 삭제 후 건수 반환 — 호출측이 0이 될 때까지 반복 호출 */
     int deleteChunkCreatedBefore(LocalDateTime threshold);
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventStore.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/ServiceEventStore.java
@@ -8,6 +8,6 @@ public interface ServiceEventStore {
 
     void save(ServiceEventEnvelope envelope);
 
-    /** threshold 이전 이벤트를 청크 단위로 삭제 후 건수 반환 — 호출측이 0이 될 때까지 반복 호출 */
+    /** threshold 이전 이벤트를 청크 단위로 삭제 후 건수 반환 — 호출측은 청크 크기 미만 반환 또는 실행 상한까지 반복 */
     int deleteChunkCreatedBefore(LocalDateTime threshold);
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/query/BriefingResult.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/query/BriefingResult.java
@@ -4,8 +4,8 @@ import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
 import java.time.LocalDateTime;
 
 /**
- * GET /api/v1/admin/security/briefing 응답 data 형태 (#609).
- * stale=true 는 최신 생성이 실패해 직전 성공본을 보여주는 중이라는 뜻 (FE: 실패 뱃지).
+ * GET /api/v1/admin/security/briefing 응답 data 형태.
+ * stale=true — 최신 생성 실패로 직전 성공본 서비스 중.
  */
 public record BriefingResult(
         Long briefingId,

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/query/BriefingResult.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/query/BriefingResult.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.serviceevent.application.query;
+
+import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
+import java.time.LocalDateTime;
+
+/**
+ * GET /api/v1/admin/security/briefing 응답 data 형태 (#609).
+ * stale=true 는 최신 생성이 실패해 직전 성공본을 보여주는 중이라는 뜻 (FE: 실패 뱃지).
+ */
+public record BriefingResult(
+        Long briefingId,
+        LocalDateTime periodStart,
+        LocalDateTime periodEnd,
+        LocalDateTime generatedAt,
+        LocalDateTime nextScheduledAt,
+        boolean stale,
+        BriefingContent content
+) {}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/query/SecuritySummaryResult.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/query/SecuritySummaryResult.java
@@ -4,8 +4,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * GET /api/v1/admin/security/summary 응답 data 형태 (#608).
- * 필드 구조는 API.md M3 섹션·FE 전달 문서와 1:1 — 변경 시 두 문서 동시 갱신.
+ * GET /api/v1/admin/security/summary 응답 data 형태.
+ * 필드 구조는 API.md·FE 전달 문서와 1:1 — 변경 시 문서 동시 갱신.
  */
 public record SecuritySummaryResult(
         String period,

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/service/BriefingService.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/service/BriefingService.java
@@ -1,0 +1,223 @@
+package com.wanted.codebombalms.serviceevent.application.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.global.domain.common.error.exception.TooManyRequestsException;
+import com.wanted.codebombalms.serviceevent.application.port.ActiveLoginUserCountPort;
+import com.wanted.codebombalms.serviceevent.application.port.BriefingLlmPort;
+import com.wanted.codebombalms.serviceevent.application.port.SecuritySummaryQueryPort;
+import com.wanted.codebombalms.serviceevent.application.query.BriefingResult;
+import com.wanted.codebombalms.serviceevent.domain.exception.ServiceEventErrorCode;
+import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
+import com.wanted.codebombalms.serviceevent.infrastructure.persistence.OpsBriefingJpaEntity;
+import com.wanted.codebombalms.serviceevent.infrastructure.persistence.SpringDataOpsBriefingRepository;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * AI 브리핑 생성·조회 (#609).
+ *
+ * <p>생성 = 최근 24시간 집계 → 마스킹 → LLM → ops_briefing 저장.
+ * 실패 시 FAILED 행을 남기고 직전 SUCCESS 본이 계속 서비스된다 (stale=true).
+ * 조회 = 저장본만 반환, LLM 호출 없음 (즉시 응답).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BriefingService {
+
+    private static final Duration BRIEFING_WINDOW = Duration.ofHours(24);
+    private static final Duration REGENERATE_COOLDOWN = Duration.ofMinutes(1);
+    private static final List<LocalTime> SCHEDULE_TIMES =
+            List.of(LocalTime.of(9, 5), LocalTime.of(15, 0), LocalTime.of(21, 0));
+    private static final DateTimeFormatter HOUR_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final SecuritySummaryQueryPort summaryQuery;
+    private final ActiveLoginUserCountPort loginUserCountPort;
+    private final BriefingLlmPort briefingLlm;
+    private final SpringDataOpsBriefingRepository briefingRepository;
+    private final ObjectMapper objectMapper;
+
+    private final AtomicReference<LocalDateTime> lastManualGeneration = new AtomicReference<>();
+
+    /** 스케줄러 진입점 — 실패해도 예외를 밖으로 던지지 않는다 (FAILED 기록으로 충분) */
+    public void generateScheduled() {
+        try {
+            generateAndStore();
+        } catch (Exception e) {
+            log.warn("event=briefing_scheduled_generation_failed", e);
+        }
+    }
+
+    /** 수동 재생성 — 쿨다운(분당 1회) 통과 시 동기 생성 후 새 브리핑 반환 (실패는 502 전파) */
+    public BriefingResult regenerate() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime last = lastManualGeneration.get();
+        if (last != null && Duration.between(last, now).compareTo(REGENERATE_COOLDOWN) < 0) {
+            throw new TooManyRequestsException(ServiceEventErrorCode.BRIEFING_REGENERATE_COOLDOWN);
+        }
+        lastManualGeneration.set(now);
+
+        generateAndStore();
+        return getLatest().orElseThrow(
+                () -> new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED));
+    }
+
+    /** 최신 저장본 조회 — 생성 이력이 전혀 없으면 empty (FE: "브리핑 준비 중") */
+    public Optional<BriefingResult> getLatest() {
+        Optional<OpsBriefingJpaEntity> latestSuccess =
+                briefingRepository.findTopByStatusOrderByGeneratedAtDesc(OpsBriefingJpaEntity.STATUS_SUCCESS);
+        if (latestSuccess.isEmpty()) {
+            return Optional.empty();
+        }
+
+        OpsBriefingJpaEntity entity = latestSuccess.get();
+        boolean stale = briefingRepository.findTopByOrderByGeneratedAtDesc()
+                .map(latest -> !latest.isSuccess())
+                .orElse(false);
+
+        return Optional.of(new BriefingResult(
+                entity.getId(),
+                entity.getPeriodStart(),
+                entity.getPeriodEnd(),
+                entity.getGeneratedAt(),
+                nextScheduledAt(LocalDateTime.now()),
+                stale,
+                deserializeContent(entity.getContentJson())
+        ));
+    }
+
+    private void generateAndStore() {
+        LocalDateTime end = LocalDateTime.now();
+        LocalDateTime start = end.minus(BRIEFING_WINDOW);
+        try {
+            String aggregatesText = buildAggregatesText(start, end);
+            BriefingContent content = briefingLlm.generate(
+                    new BriefingLlmPort.BriefingSource(start, end, aggregatesText));
+            briefingRepository.save(OpsBriefingJpaEntity.success(
+                    start, end, briefingLlm.modelName(), serializeContent(content)));
+            log.info("event=briefing_generated periodStart={} periodEnd={}", start, end);
+        } catch (Exception e) {
+            briefingRepository.save(OpsBriefingJpaEntity.failed(start, end, briefingLlm.modelName()));
+            throw e;
+        }
+    }
+
+    /**
+     * LLM 입력용 집계 텍스트 (설계서 §8-2 PII 정책).
+     * 집계 수치·마스킹 IP 라벨만 포함 — user_id 는 "표적 계정 N개"로 개수만.
+     */
+    private String buildAggregatesText(LocalDateTime start, LocalDateTime end) {
+        LocalDateTime prevStart = start.minus(BRIEFING_WINDOW);
+
+        var categories = summaryQuery.countByCategory(start, end);
+        var prevCategories = summaryQuery.countByCategory(prevStart, start);
+        var types = summaryQuery.countByType(start, end);
+        var riskIps = summaryQuery.findTopRiskIps(start, end);
+        var anomalies = summaryQuery.findHttpAnomalies(start, end);
+        var hourly = summaryQuery.hourlyDistribution(start, end);
+        var peak = summaryQuery.findConcurrentPeak(start, end);
+        long loginUsers = loginUserCountPort.countDistinctLoginUsers(start, end);
+
+        StringBuilder text = new StringBuilder();
+
+        text.append("[카테고리별 이벤트 수 (직전 24시간 대비)]\n");
+        for (var c : categories) {
+            long prev = prevCategories.stream()
+                    .filter(p -> p.category().equals(c.category()))
+                    .mapToLong(SecuritySummaryQueryPort.CategoryCount::count)
+                    .findFirst().orElse(0L);
+            text.append("- %s: %d건 (직전 %d건)%n".formatted(c.category(), c.count(), prev));
+        }
+
+        text.append("\n[세부 타입 상위]\n");
+        types.stream()
+                .sorted(Comparator.comparingLong(SecuritySummaryQueryPort.TypeCount::count).reversed())
+                .limit(8)
+                .forEach(t -> text.append("- %s: %d건%n".formatted(t.type(), t.count())));
+
+        text.append("\n[보안 이벤트 다발 IP (마스킹)]\n");
+        if (riskIps.isEmpty()) {
+            text.append("- 없음\n");
+        }
+        for (var ip : riskIps) {
+            text.append("- %s: %d건, 주요타입 %s, 표적 계정 %d개%n".formatted(
+                    maskIp(ip.ip()), ip.count(), ip.mainType(), ip.targetUserIds().size()));
+        }
+
+        text.append("\n[HTTP 예외 신호]\n");
+        if (anomalies.isEmpty()) {
+            text.append("- 없음\n");
+        }
+        for (var a : anomalies) {
+            text.append("- %s %s: %d건%s%n".formatted(
+                    a.route(), a.type(), a.count(),
+                    a.maxDurationMs() == null ? "" : " (최대 %dms)".formatted(a.maxDurationMs())));
+        }
+
+        text.append("\n[시간대별 이벤트 집중 상위]\n");
+        hourly.stream()
+                .sorted(Comparator.comparingLong(SecuritySummaryQueryPort.HourlyCount::count).reversed())
+                .limit(3)
+                .forEach(h -> text.append("- %02d시: %d건%n".formatted(h.hour(), h.count())));
+
+        text.append("\n[운영 지표]\n");
+        text.append("- 로그인 고유 회원: %d명%n".formatted(loginUsers));
+        peak.ifPresentOrElse(
+                p -> text.append("- 최대 동시접속: %d명 (%s)%n".formatted(
+                        p.peak(), p.occurredAt().format(HOUR_FORMAT))),
+                () -> text.append("- 최대 동시접속: 집계 없음\n"));
+
+        return text.toString();
+    }
+
+    /** IPv4 는 마지막 옥텟, IPv6 는 두 번째 그룹 이후를 마스킹 — 원본 IP 미반출 (설계서 §8-2) */
+    static String maskIp(String ip) {
+        if (ip == null || ip.isBlank()) {
+            return "unknown";
+        }
+        if (ip.contains(".")) {
+            int lastDot = ip.lastIndexOf('.');
+            return ip.substring(0, lastDot) + ".xx";
+        }
+        String[] groups = ip.split(":");
+        String prefix = groups.length >= 2 ? groups[0] + ":" + groups[1] : ip;
+        return prefix + ":xx";
+    }
+
+    private LocalDateTime nextScheduledAt(LocalDateTime now) {
+        LocalDate today = now.toLocalDate();
+        return SCHEDULE_TIMES.stream()
+                .map(today::atTime)
+                .filter(t -> t.isAfter(now))
+                .findFirst()
+                .orElseGet(() -> today.plusDays(1).atTime(SCHEDULE_TIMES.get(0)));
+    }
+
+    private String serializeContent(BriefingContent content) {
+        try {
+            return objectMapper.writeValueAsString(content);
+        } catch (Exception e) {
+            throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED, e);
+        }
+    }
+
+    private BriefingContent deserializeContent(String json) {
+        try {
+            return objectMapper.readValue(json, BriefingContent.class);
+        } catch (Exception e) {
+            log.warn("event=briefing_content_deserialize_failed", e);
+            return null; // 조회는 죽이지 않는다 — FE 는 content null 이면 재생성 유도
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/service/BriefingService.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/service/BriefingService.java
@@ -23,13 +23,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
- * AI 브리핑 생성·조회 (#609).
- *
- * <p>생성 = 최근 24시간 집계 → 마스킹 → LLM → ops_briefing 저장.
- * 실패 시 FAILED 행을 남기고 직전 SUCCESS 본이 계속 서비스된다 (stale=true).
- * 조회 = 저장본만 반환, LLM 호출 없음 (즉시 응답).
+ * AI 브리핑 생성·조회 서비스.
+ * 생성 = 최근 24시간 집계 → 마스킹 → LLM → ops_briefing 저장, 실패 시 FAILED 행 기록 후 직전 SUCCESS 본 유지(stale).
+ * 조회 = 저장본만 반환 (LLM 호출 없음).
  */
 @Slf4j
 @Service
@@ -50,7 +49,7 @@ public class BriefingService {
 
     private final AtomicReference<LocalDateTime> lastManualGeneration = new AtomicReference<>();
 
-    /** 스케줄러 진입점 — 실패해도 예외를 밖으로 던지지 않는다 (FAILED 기록으로 충분) */
+    /** 스케줄러 진입점 — 실패 시 예외 미전파 (FAILED 기록으로 충분) */
     public void generateScheduled() {
         try {
             generateAndStore();
@@ -66,15 +65,25 @@ public class BriefingService {
         if (last != null && Duration.between(last, now).compareTo(REGENERATE_COOLDOWN) < 0) {
             throw new TooManyRequestsException(ServiceEventErrorCode.BRIEFING_REGENERATE_COOLDOWN);
         }
-        lastManualGeneration.set(now);
+        // CAS 로 슬롯 선점 — 동시 요청은 한 건만 통과 (쿨다운 인메모리 — 단일 인스턴스 전제)
+        if (!lastManualGeneration.compareAndSet(last, now)) {
+            throw new TooManyRequestsException(ServiceEventErrorCode.BRIEFING_REGENERATE_COOLDOWN);
+        }
 
         generateAndStore();
-        return getLatest().orElseThrow(
+        // 내부 호출은 프록시 미경유(self-invocation) — 비어노테이션 메서드 직접 사용
+        return readLatest().orElseThrow(
                 () -> new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED));
     }
 
     /** 최신 저장본 조회 — 생성 이력이 전혀 없으면 empty (FE: "브리핑 준비 중") */
+    @Transactional(readOnly = true)
     public Optional<BriefingResult> getLatest() {
+        return readLatest();
+    }
+
+    /** 최신 저장본 조회 본문 — getLatest 의 트랜잭션 안에서 실행 */
+    private Optional<BriefingResult> readLatest() {
         Optional<OpsBriefingJpaEntity> latestSuccess =
                 briefingRepository.findTopByStatusOrderByGeneratedAtDesc(OpsBriefingJpaEntity.STATUS_SUCCESS);
         if (latestSuccess.isEmpty()) {
@@ -113,10 +122,7 @@ public class BriefingService {
         }
     }
 
-    /**
-     * LLM 입력용 집계 텍스트 (설계서 §8-2 PII 정책).
-     * 집계 수치·마스킹 IP 라벨만 포함 — user_id 는 "표적 계정 N개"로 개수만.
-     */
+    /** LLM 입력용 집계 텍스트 — PII 미반출 (집계 수치·마스킹 IP 라벨만, user_id 는 개수만) */
     private String buildAggregatesText(LocalDateTime start, LocalDateTime end) {
         LocalDateTime prevStart = start.minus(BRIEFING_WINDOW);
 
@@ -151,8 +157,11 @@ public class BriefingService {
             text.append("- 없음\n");
         }
         for (var ip : riskIps) {
-            text.append("- %s: %d건, 주요타입 %s, 표적 계정 %d개%n".formatted(
-                    maskIp(ip.ip()), ip.count(), ip.mainType(), ip.targetUserIds().size()));
+            // 표적 계정 목록은 LIMIT 5 샘플 — 5개면 실제로는 그 이상 가능
+            int targetCount = ip.targetUserIds().size();
+            String targetLabel = targetCount >= 5 ? "5개 이상" : targetCount + "개";
+            text.append("- %s: %d건, 주요타입 %s, 표적 계정 %s%n".formatted(
+                    maskIp(ip.ip()), ip.count(), ip.mainType(), targetLabel));
         }
 
         text.append("\n[HTTP 예외 신호]\n");
@@ -181,7 +190,7 @@ public class BriefingService {
         return text.toString();
     }
 
-    /** IPv4 는 마지막 옥텟, IPv6 는 두 번째 그룹 이후를 마스킹 — 원본 IP 미반출 (설계서 §8-2) */
+    /** IPv4 는 마지막 옥텟, IPv6 는 두 번째 그룹 이후를 마스킹 — 원본 IP 미반출 */
     static String maskIp(String ip) {
         if (ip == null || ip.isBlank()) {
             return "unknown";
@@ -217,7 +226,7 @@ public class BriefingService {
             return objectMapper.readValue(json, BriefingContent.class);
         } catch (Exception e) {
             log.warn("event=briefing_content_deserialize_failed", e);
-            return null; // 조회는 죽이지 않는다 — FE 는 content null 이면 재생성 유도
+            return null; // 역직렬화 실패에도 조회 유지 — content null 이면 FE 가 재생성 유도
         }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
@@ -20,9 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 보안 요약 집계 조립 (#608).
- * 증감률(deltaPct)은 직전 동일 길이 구간과 비교한다 — today 는 "어제 같은 시각까지"와 비교(공정 비교).
- * 2m 은 비교 구간이 보존기간(2개월) 밖이라 delta 를 제공하지 않는다(null).
+ * 보안 요약 집계 조립 서비스.
+ * 증감률(deltaPct)은 직전 동일 길이 구간과 비교 — today 는 어제 같은 시각까지, 2m 은 보존기간 밖이라 null.
  */
 @Slf4j
 @Service
@@ -95,7 +94,7 @@ public class SecuritySummaryService {
                 securityEvents,
                 securityDelta,
                 http5xxCount,
-                null, // 오류율 분모(전체 요청 수)는 미수집 원칙상 없음 — 그라파나 영역, v1 은 null
+                null, // 오류율 분모(전체 요청 수) 미수집 — v1 은 null
                 enrollments,
                 enrollmentsDelta
         );
@@ -116,7 +115,7 @@ public class SecuritySummaryService {
                 SecuritySummaryQueryPort.TypeCount::count));
     }
 
-    /** ops_metric(동시접속 샘플)은 관측용 행이라 "이벤트 수"에서 제외한다 */
+    /** ops_metric(동시접속 샘플)은 관측용 행 — 이벤트 수에서 제외 */
     private long sumTotal(List<SecuritySummaryQueryPort.CategoryCount> counts) {
         return counts.stream()
                 .filter(c -> !OPS_METRIC_CODE.equals(c.category()))
@@ -163,7 +162,7 @@ public class SecuritySummaryService {
                 .toList();
     }
 
-    /** GeoIP 해상 실패(null/예외)가 요약 전체를 죽이지 않도록 IP 단위로 격리한다 */
+    /** GeoIP 조회 실패(null/예외)를 IP 단위로 격리 — 요약 전체 실패 방지 */
     private String resolveCountrySafely(String ip) {
         try {
             return geoIpResolver.resolve(ip).country();
@@ -179,7 +178,7 @@ public class SecuritySummaryService {
                 .toList();
     }
 
-    /** 증감률(%). 비교값이 0이면 null (무한대 방지 — FE 는 "—" 표기) */
+    /** 증감률(%) — 비교값 0이면 null (무한대 방지) */
     private Double deltaPct(long current, long previous) {
         if (previous == 0) {
             return null;

--- a/src/main/java/com/wanted/codebombalms/serviceevent/domain/exception/ServiceEventErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/domain/exception/ServiceEventErrorCode.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ServiceEventErrorCode implements ErrorCode {
 
-    // 브리핑 (P5 예약: SEC-001 쿨다운, SEC-002 생성 실패)
+    // 브리핑
     BRIEFING_REGENERATE_COOLDOWN("SEC-001", "브리핑 재생성은 분당 1회만 가능합니다."),
     BRIEFING_GENERATION_FAILED("SEC-002", "AI 브리핑 생성에 실패했습니다."),
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/BriefingContent.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/BriefingContent.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
 
 /**
- * AI 브리핑 본문 (#609).
- * Claude 구조화 출력(outputConfig) 스키마이자 ops_briefing.content_json 직렬화 형태,
- * 그리고 GET /admin/security/briefing 응답의 content 필드다 — 세 곳이 이 record 하나로 정합.
+ * AI 브리핑 본문.
+ * LLM 구조화 출력 스키마·ops_briefing.content_json·브리핑 응답 content 필드가 이 record 하나로 정합.
  */
 public record BriefingContent(
         @JsonPropertyDescription("전체 상황을 한 문장으로 요약한 헤드라인 (가장 중요한 변화 중심)")

--- a/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/BriefingContent.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/BriefingContent.java
@@ -1,0 +1,32 @@
+package com.wanted.codebombalms.serviceevent.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import java.util.List;
+
+/**
+ * AI 브리핑 본문 (#609).
+ * Claude 구조화 출력(outputConfig) 스키마이자 ops_briefing.content_json 직렬화 형태,
+ * 그리고 GET /admin/security/briefing 응답의 content 필드다 — 세 곳이 이 record 하나로 정합.
+ */
+public record BriefingContent(
+        @JsonPropertyDescription("전체 상황을 한 문장으로 요약한 헤드라인 (가장 중요한 변화 중심)")
+        String headline,
+        @JsonPropertyDescription("운영 상황 서술 3~5문장 — 제공된 집계 숫자만 인용, 추측 금지")
+        String narrative,
+        @JsonPropertyDescription("관리자가 즉시 조치해야 할 항목 (없으면 빈 배열)")
+        List<BriefingItem> actionRequired,
+        @JsonPropertyDescription("당장 조치는 불필요하나 관찰이 필요한 항목")
+        List<BriefingItem> watching,
+        @JsonPropertyDescription("정상 동작 중임을 확인해주는 항목")
+        List<BriefingItem> healthy
+) {
+
+    public record BriefingItem(
+            @JsonPropertyDescription("항목 제목 (10자 내외)")
+            String title,
+            @JsonPropertyDescription("한 줄 상세 설명")
+            String detail,
+            @JsonPropertyDescription("관련 카테고리 코드 (authn_attack, http_anomaly, enrollment 등)")
+            String relatedCategory
+    ) {}
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/ServiceEventCategory.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/ServiceEventCategory.java
@@ -2,11 +2,11 @@ package com.wanted.codebombalms.serviceevent.domain.model;
 
 /**
  * 서비스 이벤트 대분류.
- * DB(service_event.category)에는 code(소문자)로 저장된다.
+ * DB(service_event.category)에는 code(소문자)로 저장.
  */
 public enum ServiceEventCategory {
 
-    // 보안 (기존 AuthSecurityEvent 카테고리 승계)
+    // 보안
     AUTHN_ATTACK("authn_attack"),
     TAKEOVER("takeover"),
     OAUTH("oauth"),

--- a/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/ServiceEventEnvelope.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/ServiceEventEnvelope.java
@@ -3,9 +3,8 @@ package com.wanted.codebombalms.serviceevent.domain.model;
 import java.time.LocalDateTime;
 
 /**
- * 이벤트 발생 시점의 컨텍스트를 값으로 캡처하는 봉투.
- * 비동기 적재 경계(@Async)를 넘어가므로 MDC 등 스레드 로컬에 의존하지 않고
- * 생성 시점에 모든 값을 고정한다. 불변(record).
+ * 이벤트 발생 시점의 컨텍스트를 값으로 캡처하는 불변 봉투.
+ * 비동기(@Async) 경계를 넘으므로 스레드 로컬 미의존 — 생성 시점에 모든 값 고정.
  */
 public record ServiceEventEnvelope(
         ServiceEventType type,
@@ -29,14 +28,14 @@ public record ServiceEventEnvelope(
             throw new IllegalArgumentException("ServiceEventType must not be null");
         }
         if (occurredAt == null) {
-            occurredAt = LocalDateTime.now(); // 직접 생성 시 누락 보정 — created_at NOT NULL 제약 보호
+            occurredAt = LocalDateTime.now(); // occurredAt null → now() 보정
         }
         uri = truncate(uri, MAX_URI);
         detail = truncate(detail, MAX_DETAIL);
         traceId = truncate(traceId, MAX_TRACE_ID);
     }
 
-    /** 갈래 A — 비즈니스 이벤트 (도메인 서비스 1줄 발행용) */
+    /** 비즈니스 이벤트용 */
     public static ServiceEventEnvelope business(ServiceEventType type, Long userId, Long targetId) {
         return business(type, userId, targetId, null);
     }
@@ -47,14 +46,14 @@ public record ServiceEventEnvelope(
                 type, userId, targetId, null, null, null, null, null, detail, LocalDateTime.now());
     }
 
-    /** 갈래 B — 보안 이벤트 (AuthSecurityEventRecorder가 MDC 값을 캡처해 전달) */
+    /** 보안 이벤트용 — 호출측이 MDC 값을 캡처해 전달 */
     public static ServiceEventEnvelope security(
             ServiceEventType type, Long userId, String ipAddress, String uri, String traceId) {
         return new ServiceEventEnvelope(
                 type, userId, null, ipAddress, uri, null, null, traceId, null, LocalDateTime.now());
     }
 
-    /** 갈래 C — HTTP 예외 신호 (필터/예외 핸들러용) */
+    /** HTTP 예외 신호용 (필터/예외 핸들러) */
     public static ServiceEventEnvelope httpAnomaly(
             ServiceEventType type, String uri, Integer httpStatus, Integer durationMs,
             String ipAddress, Long userId, String traceId, String detail) {
@@ -63,7 +62,7 @@ public record ServiceEventEnvelope(
                 LocalDateTime.now());
     }
 
-    /** 운영 지표 스냅샷 — 카운트를 targetId에 저장 (동시접속 샘플러용) */
+    /** 운영 지표 스냅샷 — 카운트를 targetId에 저장 */
     public static ServiceEventEnvelope opsMetric(ServiceEventType type, long count) {
         return new ServiceEventEnvelope(
                 type, null, count, null, null, null, null, null, null, LocalDateTime.now());

--- a/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/ServiceEventType.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/domain/model/ServiceEventType.java
@@ -3,8 +3,8 @@ package com.wanted.codebombalms.serviceevent.domain.model;
 import static com.wanted.codebombalms.serviceevent.domain.model.ServiceEventCategory.*;
 
 /**
- * 서비스 이벤트 세부 타입. 각 타입은 카테고리에 소속된다.
- * DB(service_event.event_type)에는 code(소문자)로 저장된다.
+ * 서비스 이벤트 세부 타입 — 각 타입은 카테고리에 소속.
+ * DB(service_event.event_type)에는 code(소문자)로 저장.
  */
 public enum ServiceEventType {
 
@@ -62,6 +62,7 @@ public enum ServiceEventType {
     // admin_audit
     PERMISSION_TOGGLED(ADMIN_AUDIT, "permission_toggled"),
     ACCOUNT_LOCKED(ADMIN_AUDIT, "account_locked"),
+    ACCOUNT_UNLOCKED(ADMIN_AUDIT, "account_unlocked"),
     ALERT_RESOLVED(ADMIN_AUDIT, "alert_resolved"),
 
     // http_anomaly

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/cleanup/ServiceEventCleanupConfig.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/cleanup/ServiceEventCleanupConfig.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.serviceevent.infrastructure.cleanup;
 import com.wanted.codebombalms.global.application.cleanup.DefaultHardDeleteTarget;
 import com.wanted.codebombalms.global.application.cleanup.port.HardDeleteTarget;
 import com.wanted.codebombalms.serviceevent.application.port.ServiceEventStore;
+import com.wanted.codebombalms.serviceevent.infrastructure.persistence.SpringDataOpsBriefingRepository;
 import java.time.LocalDateTime;
 import java.time.Period;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,16 @@ public class ServiceEventCleanupConfig {
 
     private static final int CHUNK_SIZE = 1000;
     private static final int MAX_CHUNKS_PER_RUN = 200; // 1회 실행 상한 20만 행 — 03시 잡 폭주 방지
+
+    /** ops_briefing 도 이벤트 파생물 — 2개월 동반 파기 (#609). 하루 3행 수준이라 단발 DELETE 로 충분 */
+    @Bean
+    public HardDeleteTarget opsBriefingHardDeleteTarget(SpringDataOpsBriefingRepository repository) {
+        return new DefaultHardDeleteTarget(
+                "ops-briefing",
+                Period.ofMonths(2),
+                repository::deleteByGeneratedAtBefore
+        );
+    }
 
     @Bean
     public HardDeleteTarget serviceEventHardDeleteTarget(ServiceEventStore store) {

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/cleanup/ServiceEventCleanupConfig.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/cleanup/ServiceEventCleanupConfig.java
@@ -11,9 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * service_event 2개월 보존 파기 (#605).
- * 빈만 등록하면 기존 HardDeleteScheduler(매일 03시)가 자동 실행한다 — 신규 스케줄러 불필요.
- * HardDeleteExecutor는 하루 1회만 호출하므로, 여기서 청크(1000행)를 소진될 때까지 반복한다.
+ * service_event 2개월 보존 파기 설정 — 기존 HardDeleteScheduler(매일 03시)가 실행.
+ * 하루 1회 호출 — 청크(1000행) 소진까지 반복 삭제.
  */
 @Slf4j
 @Configuration
@@ -22,7 +21,7 @@ public class ServiceEventCleanupConfig {
     private static final int CHUNK_SIZE = 1000;
     private static final int MAX_CHUNKS_PER_RUN = 200; // 1회 실행 상한 20만 행 — 03시 잡 폭주 방지
 
-    /** ops_briefing 도 이벤트 파생물 — 2개월 동반 파기 (#609). 하루 3행 수준이라 단발 DELETE 로 충분 */
+    /** ops_briefing 2개월 동반 파기 */
     @Bean
     public HardDeleteTarget opsBriefingHardDeleteTarget(SpringDataOpsBriefingRepository repository) {
         return new DefaultHardDeleteTarget(
@@ -50,7 +49,7 @@ public class ServiceEventCleanupConfig {
             } catch (Exception e) {
                 log.error("event=service_event_cleanup_failed totalDeleted={} — 남은 청크는 다음 실행(03시)에서 재시도",
                         total, e);
-                return total; // 부분 성과는 보존, 예외는 전파하지 않음 — 다른 HardDeleteTarget 파기 보호
+                return total; // 부분 성과 보존·예외 비전파 — 다른 HardDeleteTarget 파기 보호
             }
             total += deleted;
             if (deleted < CHUNK_SIZE) {

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/ServiceEventListener.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/ServiceEventListener.java
@@ -13,15 +13,8 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
- * 갈래 A 수집 리스너
- *
- * ① 신규 발행 경로: 도메인이 ServiceEventRecorder 로 발행한 envelope 을 커밋 후 적재.
- * ② 기존 이벤트 경로: submission·reward 가 이미 발행 중인 이벤트 3종을 구독만 한다
- *    — 발행측 코드 0줄, 기존 리스너(포인트 지급·뱃지 동기화)와 완전 독립.
- *
- * 모든 예외는 여기서 삼킨다 — 같은 이벤트를 구독하는 다른 리스너에 절대 전파하지 않는다.
- * 무거운 작업(INSERT)은 writer 의 @Async 풀에서 실행되므로 이 리스너 자체는
- * 큐 등록만 하고 즉시 반환한다 (발행 스레드 부담 = 마이크로초 단위).
+ * 서비스 이벤트 수집 리스너 — 신규 발행 envelope 과 기존 도메인 이벤트 3종을 적재.
+ * AFTER_COMMIT — 성공 커밋만 기록. 예외는 모두 흡수 — 같은 이벤트의 다른 리스너에 비전파.
  */
 @Slf4j
 @Component
@@ -30,13 +23,13 @@ public class ServiceEventListener {
 
     private final ServiceEventWriter serviceEventWriter;
 
-    /** 신규 발행 경로 — fallbackExecution: 트랜잭션 밖 발행(리액티브 흐름 등)도 수집 */
+    /** 신규 발행 경로 — fallbackExecution=true: 트랜잭션 밖 발행도 수신 */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void onServiceEvent(ServiceEventEnvelope envelope) {
         forward(envelope);
     }
 
-    /** 기존 이벤트 구독 — 문제 정답 (submission 발행, 코드 무변경) */
+    /** 기존 이벤트 구독 — 문제 정답 (submission 발행) */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onProblemSolved(ProblemSolvedEvent event) {
         forward(ServiceEventEnvelope.business(
@@ -44,14 +37,14 @@ public class ServiceEventListener {
                 "submissionId=" + event.submissionId() + " point=" + event.point()));
     }
 
-    /** 기존 이벤트 구독 — 문제집 완료 (submission 발행, 코드 무변경) */
+    /** 기존 이벤트 구독 — 문제집 완료 (submission 발행) */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onProblemSetCompleted(ProblemSetCompletedEvent event) {
         forward(ServiceEventEnvelope.business(
                 ServiceEventType.PROBLEM_SET_COMPLETED, event.userId(), event.problemSetId(), null));
     }
 
-    /** 기존 이벤트 구독 — 포인트 지급 (reward.point 발행, 코드 무변경) */
+    /** 기존 이벤트 구독 — 포인트 지급 (reward.point 발행) */
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onPointGranted(PointGrantedEvent event) {
         forward(ServiceEventEnvelope.business(

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/SpringServiceEventAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/event/SpringServiceEventAdapter.java
@@ -7,8 +7,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 /**
- * 발행 어댑터 — envelope 를 Spring ApplicationEvent 로 발행
- * 기존 SpringProblemSolvedEventAdapter 등과 동일한 패턴.
+ * 발행 어댑터 — envelope 를 Spring ApplicationEvent 로 발행.
  */
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/AnthropicBriefingAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/AnthropicBriefingAdapter.java
@@ -1,0 +1,122 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.llm;
+
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
+import com.anthropic.models.messages.MessageCreateParams;
+import com.anthropic.models.messages.StopReason;
+import com.anthropic.models.messages.ThinkingConfigAdaptive;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.serviceevent.application.port.BriefingLlmPort;
+import com.wanted.codebombalms.serviceevent.domain.exception.ServiceEventErrorCode;
+import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Claude API 브리핑 어댑터 (#609).
+ *
+ * <p>구조화 출력(outputConfig)으로 응답이 BriefingContent 스키마를 강제받는다 — 파싱 실패 원천 차단.
+ * 모델은 ${BRIEFING_MODEL}(기본 claude-opus-4-8), 키는 ${ANTHROPIC_API_KEY} — 키 미설정 시
+ * 부팅은 정상, 생성 요청만 실패(FAILED 기록)한다.
+ * 보안 이벤트 요약은 안전 분류기가 드물게 거절(stop_reason=refusal)할 수 있어
+ * 프롬프트를 "방어 관점 운영 보고서"로 프레이밍하고 refusal 은 생성 실패로 처리한다.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "briefing.provider", havingValue = "anthropic")
+public class AnthropicBriefingAdapter implements BriefingLlmPort {
+
+    private static final DateTimeFormatter PERIOD_FORMAT = DateTimeFormatter.ofPattern("MM-dd HH:mm");
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 온라인 코딩 교육 플랫폼 '코드봄바'의 보안·운영 브리핑 작성자다.
+            관리자(방어자)가 서비스 상태를 빠르게 파악하고 계정 보호 조치를 하도록 돕는 것이 목적이다.
+            규칙:
+            - 제공된 집계 수치만 인용한다. 제공되지 않은 사실·수치를 만들어내지 않는다.
+            - 공격 기법의 실행 방법은 절대 서술하지 않는다. 방어와 조치 관점으로만 쓴다.
+            - 서로 다른 신호가 같은 시간대·같은 맥락으로 겹치면 연결해서 진단한다.
+            - 이상 신호가 없으면 없다고 명확히 쓰고 healthy 를 채운다. 과장 금지.
+            - 한국어 경어체(~습니다)로 작성한다.
+            """;
+
+    private final AnthropicClient client;
+    private final String model;
+
+    public AnthropicBriefingAdapter(
+            @Value("${briefing.api-key:}") String apiKey,
+            @Value("${briefing.model:claude-opus-4-8}") String model) {
+        this.model = model;
+        this.client = (apiKey == null || apiKey.isBlank())
+                ? null
+                : AnthropicOkHttpClient.builder().apiKey(apiKey).build();
+        if (this.client == null) {
+            log.warn("event=briefing_llm_disabled reason=api_key_not_set — 브리핑 생성 요청은 실패 처리됩니다");
+        }
+    }
+
+    @Override
+    public BriefingContent generate(BriefingSource source) {
+        if (client == null) {
+            throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED);
+        }
+        try {
+            var params = MessageCreateParams.builder()
+                    .model(model)
+                    .maxTokens(8000L)
+                    .thinking(ThinkingConfigAdaptive.builder().build())
+                    .system(SYSTEM_PROMPT)
+                    .outputConfig(BriefingContent.class)
+                    .addUserMessage(buildUserPrompt(source))
+                    .build();
+
+            var message = client.messages().create(params);
+
+            boolean refused = message.stopReason()
+                    .map(StopReason.REFUSAL::equals)
+                    .orElse(false);
+            if (refused) {
+                log.warn("event=briefing_generation_refused model={}", model);
+                throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED);
+            }
+
+            return message.content().stream()
+                    .flatMap(block -> block.text().stream())
+                    .findFirst()
+                    .orElseThrow(() -> new ExternalServiceException(
+                            ServiceEventErrorCode.BRIEFING_GENERATION_FAILED))
+                    .text();
+        } catch (ExternalServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("event=briefing_generation_failed model={}", model, e);
+            throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED, e);
+        }
+    }
+
+    @Override
+    public String modelName() {
+        return model;
+    }
+
+    private String buildUserPrompt(BriefingSource source) {
+        return """
+                다음은 %s ~ %s 구간의 서비스 이벤트 집계입니다.
+                이 데이터만 근거로 운영 브리핑을 작성하세요.
+
+                %s
+
+                작성 지침:
+                - headline: 이 구간에서 가장 중요한 변화 한 문장
+                - narrative: 3~5문장. 증감·시간대·신호 간 연관을 서술
+                - actionRequired: 즉시 조치가 필요한 항목만 (없으면 빈 배열)
+                - watching: 관찰 필요 항목
+                - healthy: 정상 확인 항목 (비즈니스 지표 포함)
+                """.formatted(
+                source.periodStart().format(PERIOD_FORMAT),
+                source.periodEnd().format(PERIOD_FORMAT),
+                source.aggregatesText());
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/AnthropicBriefingAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/AnthropicBriefingAdapter.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServ
 import com.wanted.codebombalms.serviceevent.application.port.BriefingLlmPort;
 import com.wanted.codebombalms.serviceevent.domain.exception.ServiceEventErrorCode;
 import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
+import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,13 +17,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 /**
- * Claude API 브리핑 어댑터 (#609).
- *
- * <p>구조화 출력(outputConfig)으로 응답이 BriefingContent 스키마를 강제받는다 — 파싱 실패 원천 차단.
- * 모델은 ${BRIEFING_MODEL}(기본 claude-opus-4-8), 키는 ${ANTHROPIC_API_KEY} — 키 미설정 시
- * 부팅은 정상, 생성 요청만 실패(FAILED 기록)한다.
- * 보안 이벤트 요약은 안전 분류기가 드물게 거절(stop_reason=refusal)할 수 있어
- * 프롬프트를 "방어 관점 운영 보고서"로 프레이밍하고 refusal 은 생성 실패로 처리한다.
+ * Claude API 브리핑 어댑터.
+ * 구조화 출력(outputConfig)으로 BriefingContent 스키마 강제, refusal 응답은 생성 실패 처리.
+ * 키 미설정 시 부팅 정상·생성만 실패.
  */
 @Slf4j
 @Component
@@ -51,7 +48,10 @@ public class AnthropicBriefingAdapter implements BriefingLlmPort {
         this.model = model;
         this.client = (apiKey == null || apiKey.isBlank())
                 ? null
-                : AnthropicOkHttpClient.builder().apiKey(apiKey).build();
+                : AnthropicOkHttpClient.builder()
+                        .apiKey(apiKey)
+                        .timeout(Duration.ofMillis(120_000)) // timeout — 공급자 지연 시 스레드 점유 방지
+                        .build();
         if (this.client == null) {
             log.warn("event=briefing_llm_disabled reason=api_key_not_set — 브리핑 생성 요청은 실패 처리됩니다");
         }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/GeminiBriefingAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/GeminiBriefingAdapter.java
@@ -58,7 +58,7 @@ public class GeminiBriefingAdapter implements BriefingLlmPort {
 
     public GeminiBriefingAdapter(
             @Value("${briefing.api-key:}") String apiKey,
-            @Value("${briefing.model:gemini-2.5-flash}") String model,
+            @Value("${briefing.model:gemini-3.5-flash}") String model,
             ObjectMapper objectMapper) {
         this.model = model;
         this.objectMapper = objectMapper;

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/GeminiBriefingAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/GeminiBriefingAdapter.java
@@ -1,0 +1,132 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.llm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.genai.Client;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.serviceevent.application.port.BriefingLlmPort;
+import com.wanted.codebombalms.serviceevent.domain.exception.ServiceEventErrorCode;
+import com.wanted.codebombalms.serviceevent.domain.model.BriefingContent;
+import java.time.format.DateTimeFormatter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Gemini API 브리핑 어댑터 (#609) — 기본 프로바이더 (학교 지원 API 키).
+ *
+ * <p>Gemini JSON 모드(responseMimeType=application/json) + 프롬프트 내 스키마 명세로
+ * BriefingContent 형태를 유도하고, Jackson 파싱 + 필수 필드 검증으로 확정한다.
+ * 파싱·검증 실패는 생성 실패(FAILED 기록)로 처리 — 조회 경로는 절대 오염되지 않는다.
+ * 키 미설정 시 부팅은 정상, 생성 요청만 실패한다.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(name = "briefing.provider", havingValue = "gemini", matchIfMissing = true)
+public class GeminiBriefingAdapter implements BriefingLlmPort {
+
+    private static final DateTimeFormatter PERIOD_FORMAT = DateTimeFormatter.ofPattern("MM-dd HH:mm");
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 온라인 코딩 교육 플랫폼 '코드봄바'의 보안·운영 브리핑 작성자다.
+            관리자(방어자)가 서비스 상태를 빠르게 파악하고 계정 보호 조치를 하도록 돕는 것이 목적이다.
+            규칙:
+            - 제공된 집계 수치만 인용한다. 제공되지 않은 사실·수치를 만들어내지 않는다.
+            - 공격 기법의 실행 방법은 절대 서술하지 않는다. 방어와 조치 관점으로만 쓴다.
+            - 서로 다른 신호가 같은 시간대·같은 맥락으로 겹치면 연결해서 진단한다.
+            - 이상 신호가 없으면 없다고 명확히 쓰고 healthy 를 채운다. 과장 금지.
+            - 한국어 경어체(~습니다)로 작성한다.
+            """;
+
+    private static final String SCHEMA_GUIDE = """
+            반드시 아래 JSON 스키마 형태로만 응답하세요 (마크다운·설명 없이 JSON 객체 하나만):
+            {
+              "headline": "가장 중요한 변화 한 문장",
+              "narrative": "운영 상황 서술 3~5문장",
+              "actionRequired": [ { "title": "항목 제목", "detail": "한 줄 상세", "relatedCategory": "카테고리 코드" } ],
+              "watching": [ { "title": "...", "detail": "...", "relatedCategory": "..." } ],
+              "healthy": [ { "title": "...", "detail": "...", "relatedCategory": "..." } ]
+            }
+            조치할 것이 없으면 actionRequired 는 빈 배열 [] 로 둡니다.
+            """;
+
+    private final Client client;
+    private final String model;
+    private final ObjectMapper objectMapper;
+
+    public GeminiBriefingAdapter(
+            @Value("${briefing.api-key:}") String apiKey,
+            @Value("${briefing.model:gemini-2.5-flash}") String model,
+            ObjectMapper objectMapper) {
+        this.model = model;
+        this.objectMapper = objectMapper;
+        this.client = (apiKey == null || apiKey.isBlank())
+                ? null
+                : Client.builder().apiKey(apiKey).build();
+        if (this.client == null) {
+            log.warn("event=briefing_llm_disabled provider=gemini reason=api_key_not_set — 브리핑 생성 요청은 실패 처리됩니다");
+        }
+    }
+
+    @Override
+    public BriefingContent generate(BriefingSource source) {
+        if (client == null) {
+            throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED);
+        }
+        try {
+            GenerateContentConfig config = GenerateContentConfig.builder()
+                    .responseMimeType("application/json")
+                    .build();
+
+            GenerateContentResponse response =
+                    client.models.generateContent(model, buildPrompt(source), config);
+
+            String json = response.text();
+            if (json == null || json.isBlank()) {
+                throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED);
+            }
+
+            BriefingContent content = objectMapper.readValue(json, BriefingContent.class);
+            validate(content);
+            return content;
+        } catch (ExternalServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("event=briefing_generation_failed provider=gemini model={}", model, e);
+            throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED, e);
+        }
+    }
+
+    @Override
+    public String modelName() {
+        return model;
+    }
+
+    private String buildPrompt(BriefingSource source) {
+        return SYSTEM_PROMPT + "\n"
+                + SCHEMA_GUIDE + "\n"
+                + """
+                다음은 %s ~ %s 구간의 서비스 이벤트 집계입니다.
+                이 데이터만 근거로 운영 브리핑을 작성하세요.
+
+                %s
+                """.formatted(
+                source.periodStart().format(PERIOD_FORMAT),
+                source.periodEnd().format(PERIOD_FORMAT),
+                source.aggregatesText());
+    }
+
+    /** JSON 모드는 스키마를 100% 강제하지 않으므로 필수 필드를 여기서 확정한다 */
+    private void validate(BriefingContent content) {
+        if (content == null
+                || content.headline() == null || content.headline().isBlank()
+                || content.narrative() == null || content.narrative().isBlank()
+                || content.actionRequired() == null
+                || content.watching() == null
+                || content.healthy() == null) {
+            throw new ExternalServiceException(ServiceEventErrorCode.BRIEFING_GENERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/GeminiBriefingAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/llm/GeminiBriefingAdapter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.genai.Client;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.HttpOptions;
 import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.serviceevent.application.port.BriefingLlmPort;
 import com.wanted.codebombalms.serviceevent.domain.exception.ServiceEventErrorCode;
@@ -15,12 +16,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 /**
- * Gemini API 브리핑 어댑터 (#609) — 기본 프로바이더 (학교 지원 API 키).
- *
- * <p>Gemini JSON 모드(responseMimeType=application/json) + 프롬프트 내 스키마 명세로
- * BriefingContent 형태를 유도하고, Jackson 파싱 + 필수 필드 검증으로 확정한다.
- * 파싱·검증 실패는 생성 실패(FAILED 기록)로 처리 — 조회 경로는 절대 오염되지 않는다.
- * 키 미설정 시 부팅은 정상, 생성 요청만 실패한다.
+ * Gemini API 브리핑 어댑터 — 기본 프로바이더.
+ * JSON 모드 + 프롬프트 스키마로 BriefingContent 유도, 파싱·검증 실패는 생성 실패(FAILED) 처리.
+ * 키 미설정 시 부팅 정상·생성만 실패.
  */
 @Slf4j
 @Component
@@ -28,6 +26,9 @@ import org.springframework.stereotype.Component;
 public class GeminiBriefingAdapter implements BriefingLlmPort {
 
     private static final DateTimeFormatter PERIOD_FORMAT = DateTimeFormatter.ofPattern("MM-dd HH:mm");
+
+    /** timeout — 공급자 지연 시 스레드 점유 방지 */
+    private static final int TIMEOUT_MS = 120_000;
 
     private static final String SYSTEM_PROMPT = """
             당신은 온라인 코딩 교육 플랫폼 '코드봄바'의 보안·운영 브리핑 작성자다.
@@ -64,7 +65,10 @@ public class GeminiBriefingAdapter implements BriefingLlmPort {
         this.objectMapper = objectMapper;
         this.client = (apiKey == null || apiKey.isBlank())
                 ? null
-                : Client.builder().apiKey(apiKey).build();
+                : Client.builder()
+                        .apiKey(apiKey)
+                        .httpOptions(HttpOptions.builder().timeout(TIMEOUT_MS).build())
+                        .build();
         if (this.client == null) {
             log.warn("event=briefing_llm_disabled provider=gemini reason=api_key_not_set — 브리핑 생성 요청은 실패 처리됩니다");
         }
@@ -118,7 +122,7 @@ public class GeminiBriefingAdapter implements BriefingLlmPort {
                 source.aggregatesText());
     }
 
-    /** JSON 모드는 스키마를 100% 강제하지 않으므로 필수 필드를 여기서 확정한다 */
+    /** JSON 모드는 스키마 비강제 — 필수 필드 수동 검증 */
     private void validate(BriefingContent content) {
         if (content == null
                 || content.headline() == null || content.headline().isBlank()

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/OpsBriefingJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/OpsBriefingJpaEntity.java
@@ -1,0 +1,71 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ops_briefing")
+public class OpsBriefingJpaEntity {
+
+    public static final String STATUS_SUCCESS = "SUCCESS";
+    public static final String STATUS_FAILED = "FAILED";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ops_briefing_id")
+    private Long id;
+
+    @Column(name = "period_start", nullable = false)
+    private LocalDateTime periodStart;
+
+    @Column(name = "period_end", nullable = false)
+    private LocalDateTime periodEnd;
+
+    @Column(name = "model", nullable = false, length = 40)
+    private String model;
+
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "content_json", columnDefinition = "TEXT")
+    private String contentJson;
+
+    @Column(name = "generated_at", nullable = false, updatable = false)
+    private LocalDateTime generatedAt;
+
+    public static OpsBriefingJpaEntity success(
+            LocalDateTime periodStart, LocalDateTime periodEnd, String model, String contentJson) {
+        return of(periodStart, periodEnd, model, STATUS_SUCCESS, contentJson);
+    }
+
+    public static OpsBriefingJpaEntity failed(
+            LocalDateTime periodStart, LocalDateTime periodEnd, String model) {
+        return of(periodStart, periodEnd, model, STATUS_FAILED, null);
+    }
+
+    private static OpsBriefingJpaEntity of(
+            LocalDateTime periodStart, LocalDateTime periodEnd, String model, String status, String contentJson) {
+        OpsBriefingJpaEntity entity = new OpsBriefingJpaEntity();
+        entity.periodStart = periodStart;
+        entity.periodEnd = periodEnd;
+        entity.model = model;
+        entity.status = status;
+        entity.contentJson = contentJson;
+        entity.generatedAt = LocalDateTime.now();
+        return entity;
+    }
+
+    public boolean isSuccess() {
+        return STATUS_SUCCESS.equals(status);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
@@ -63,9 +63,4 @@ public class SecuritySummaryQueryAdapter implements SecuritySummaryQueryPort {
                 ? Optional.empty()
                 : Optional.of(new ConcurrentPeak(row.getPeak(), row.getOccurredAt()));
     }
-
-    @Override
-    public long countDistinctActiveUsers(LocalDateTime start, LocalDateTime end) {
-        return repository.countDistinctActiveUsers(start, end);
-    }
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/ServiceEventWriter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/ServiceEventWriter.java
@@ -8,8 +8,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 /**
- * service_event 비동기 적재기 — 갈래 B/C의 직호출 대상이자 갈래 A 리스너의 최종 목적지.
- * 원칙: 적재 실패가 호출측 응답/트랜잭션에 절대 영향을 주지 않는다 (best-effort).
+ * service_event 비동기 적재기 — 적재 실패가 호출측 응답/트랜잭션에 영향 없음(best-effort).
+ * 별도 스레드(@Async) 실행 — 예외 삼킴, 호출부 전파 없음.
  */
 @Slf4j
 @Component

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataOpsBriefingRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataOpsBriefingRepository.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.persistence;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SpringDataOpsBriefingRepository extends JpaRepository<OpsBriefingJpaEntity, Long> {
+
+    Optional<OpsBriefingJpaEntity> findTopByStatusOrderByGeneratedAtDesc(String status);
+
+    Optional<OpsBriefingJpaEntity> findTopByOrderByGeneratedAtDesc();
+
+    /** 보존 2개월 파기 — 하루 3행(스케줄) + 수동 소량이라 청크 루프 불필요 */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+            DELETE FROM ops_briefing
+            WHERE generated_at < :threshold
+            """, nativeQuery = true)
+    int deleteByGeneratedAtBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataOpsBriefingRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataOpsBriefingRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SpringDataOpsBriefingRepository extends JpaRepository<OpsBriefingJpaEntity, Long> {
 
@@ -13,7 +14,8 @@ public interface SpringDataOpsBriefingRepository extends JpaRepository<OpsBriefi
 
     Optional<OpsBriefingJpaEntity> findTopByOrderByGeneratedAtDesc();
 
-    /** 보존 2개월 파기 — 하루 3행(스케줄) + 수동 소량이라 청크 루프 불필요 */
+    /** 보존 2개월 초과분 삭제 — HardDelete 실행 경로 트랜잭션 부재, 여기서 @Transactional 필수 */
+    @Transactional
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
             DELETE FROM ops_briefing

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -12,10 +12,7 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
     /** 보안 카테고리 목록 — ServiceEventCategory.isSecurity() 와 동기 유지 (native @Query 는 컴파일타임 상수만 허용) */
     String SECURITY_CATEGORIES = "'authn_attack','takeover','oauth','token','signup'";
 
-    /**
-     * 보존기간 초과분 청크 삭제. 단발 대량 DELETE 금지(롱 락·undo 폭증)락
-     * LIMIT 1000 고정 청크로 지운다 — 기존 UserHardDeleteAdapter의 MAX_BATCH 관례.
-     */
+    /** 보존기간 초과분 1000행 단위 삭제 — 사용처: ServiceEventCleanupConfig(03시 잡) */
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """
             DELETE FROM service_event
@@ -24,7 +21,7 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             """, nativeQuery = true)
     int deleteChunkByCreatedAtBefore(@Param("threshold") LocalDateTime threshold);
 
-    // ===== 이하 summary 집계 (#608) — 전부 읽기 전용, LIMIT 은 고정 상수(드라이버 호환 관례) =====
+    // ===== 이하 summary 집계 — 전부 읽기 전용, LIMIT 은 고정 상수(드라이버 호환) =====
 
     interface CategoryCountRow { String getCategory(); long getCnt(); }
     interface TypeCountRow { String getEventType(); long getCnt(); }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -116,12 +116,4 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             LIMIT 1
             """, nativeQuery = true)
     ConcurrentPeakRow findConcurrentPeak(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
-
-    @Query(value = """
-            SELECT COUNT(DISTINCT user_id)
-            FROM service_event
-            WHERE created_at >= :start AND created_at < :end
-              AND user_id IS NOT NULL
-            """, nativeQuery = true)
-    long countDistinctActiveUsers(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/sampler/ConcurrentUserSampler.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/sampler/ConcurrentUserSampler.java
@@ -12,14 +12,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 최대 동시접속자 샘플러
- *
- * <p>P0 단일세션 Redis 키(auth:session:{userId})는 로그인 시 생기고
- * 로그아웃·잠금·만료 시 사라진다 — 즉 키 개수 = 현재 접속 중인 회원 수.
- * 5분마다 개수를 스냅샷해 ops_metric/concurrent_sample 로 적재하면
- * 기간 내 MAX(target_id) 가 최대 동시접속자가 된다 (±5분 오차).
- *
- * <p>반드시 SCAN 사용 — KEYS 는 운영 Redis 를 블로킹한다.
+ * 최대 동시접속자 샘플러 — 세션 키(auth:session:*) 개수를 주기 스냅샷해 ops_metric 으로 적재.
+ * SCAN 사용 — KEYS 금지(운영 Redis 블로킹).
  */
 @Slf4j
 @Component

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/scheduler/BriefingScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/scheduler/BriefingScheduler.java
@@ -6,9 +6,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * AI 브리핑 스케줄 생성 (#609) — 하루 3회.
- * 09:05 는 기존 09:00 잡(OperationRuleScheduler)과 5분 비껴 건다.
- * 실패는 BriefingService 가 FAILED 행으로 기록하므로 여기선 트리거만 담당.
+ * AI 브리핑 정기 생성 트리거 — 하루 3회. 실패는 BriefingService 가 FAILED 행으로 기록.
  */
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/scheduler/BriefingScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/scheduler/BriefingScheduler.java
@@ -1,0 +1,33 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.scheduler;
+
+import com.wanted.codebombalms.serviceevent.application.service.BriefingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * AI 브리핑 스케줄 생성 (#609) — 하루 3회.
+ * 09:05 는 기존 09:00 잡(OperationRuleScheduler)과 5분 비껴 건다.
+ * 실패는 BriefingService 가 FAILED 행으로 기록하므로 여기선 트리거만 담당.
+ */
+@Component
+@RequiredArgsConstructor
+public class BriefingScheduler {
+
+    private final BriefingService briefingService;
+
+    @Scheduled(cron = "0 5 9 * * *")
+    public void generateMorning() {
+        briefingService.generateScheduled();
+    }
+
+    @Scheduled(cron = "0 0 15 * * *")
+    public void generateAfternoon() {
+        briefingService.generateScheduled();
+    }
+
+    @Scheduled(cron = "0 0 21 * * *")
+    public void generateEvening() {
+        briefingService.generateScheduled();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/HttpAnomalyGuard.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/HttpAnomalyGuard.java
@@ -10,11 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
- * HTTP 예외 신호(갈래 C)의 분당 적재 상한 가드 (#606).
- *
- * <p>목적: 봇 스캔·장애 폭주 시 service_event INSERT 폭발 방지.
- * 키는 반드시 정규화된 라우트 템플릿 기반이어야 한다(raw URI 금지 — 스캐너가
- * 무한 경로를 만들면 키 카디널리티가 폭발한다). 캐시 자체도 maximumSize 로 바운드.
+ * HTTP 예외 신호의 분당 적재 상한 가드 — 키는 정규화 라우트 필수(카디널리티 폭발 방지).
  */
 @Component
 public class HttpAnomalyGuard {
@@ -31,7 +27,7 @@ public class HttpAnomalyGuard {
             MeterRegistry meterRegistry,
             @Value("${service-event.anomaly.route-limit-per-minute:10}") int routeLimitPerMinute,
             @Value("${service-event.anomaly.anon-401-limit-per-minute:60}") int anonymous401LimitPerMinute) {
-        if (routeLimitPerMinute <= 0 || anonymous401LimitPerMinute <= 0) { // 0 이하면 모든 신호가 억제된다 — 기동 시 차단
+        if (routeLimitPerMinute <= 0 || anonymous401LimitPerMinute <= 0) { // 0 이하면 모든 신호 억제 — 기동 시 차단
             throw new IllegalStateException(
                     "service-event.anomaly 분당 상한은 양수여야 합니다: route=%d, anon401=%d"
                             .formatted(routeLimitPerMinute, anonymous401LimitPerMinute));
@@ -52,7 +48,7 @@ public class HttpAnomalyGuard {
         return tryAcquire(key, routeLimitPerMinute);
     }
 
-    /** 미인증 401 은 라우트 무관 전역 하드 캡 — 스캔 트래픽은 경로가 산탄이라 라우트 키가 무의미 */
+    /** 미인증 401 — 라우트 무관 전역 하드 캡 */
     public boolean tryAcquireAnonymous401() {
         return tryAcquire(ANONYMOUS_401_KEY, anonymous401LimitPerMinute);
     }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/HttpRequestAnomalySupport.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/HttpRequestAnomalySupport.java
@@ -4,18 +4,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.servlet.HandlerMapping;
 
 /**
- * HTTP 예외 신호 수집 공용 유틸 (#607 리뷰 반영).
- * MdcLoggingFilter 와 ServerErrorEventRecorder 가 같은 정규화 규칙을 쓰도록 단일화한다.
+ * HTTP 예외 신호 수집 공용 유틸.
+ * 사용처: MdcLoggingFilter·ServerErrorEventRecorder — 동일 정규화 규칙 공유.
  */
 public final class HttpRequestAnomalySupport {
 
     private HttpRequestAnomalySupport() {
     }
 
-    /**
-     * 정규화된 라우트 키 — raw URI 금지(경로변수·스캔 경로로 카디널리티 폭발).
-     * DispatcherServlet 도달 전 차단된 요청(401 등)은 패턴이 없어 "unmatched".
-     */
+    /** 정규화 라우트 키 — raw URI 금지(카디널리티 폭발 방지). 매칭 패턴 없으면 "unmatched" */
     public static String normalizedRoute(HttpServletRequest request) {
         Object pattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
         return request.getMethod() + " " + (pattern == null ? "unmatched" : pattern.toString());

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/ServerErrorEventRecorder.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/web/ServerErrorEventRecorder.java
@@ -14,10 +14,8 @@ import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
 /**
- * 5xx 상세 기록 구현 (#606, #607 리뷰로 GlobalExceptionHandler 에서 이관).
- * 예외 클래스명을 detail 로 남기고, 중복 방지 마커를 세워 MdcLoggingFilter 의
- * 상태코드 기반 기록이 같은 요청을 다시 적재하지 않게 한다.
- * 기록 실패는 전부 삼킨다 — 에러 응답을 절대 깨지 않는다 (best-effort).
+ * 5xx 상세 기록 구현 — 예외 클래스명을 detail 로 적재, 중복 방지 마커로 MdcLoggingFilter 재적재 차단.
+ * 기록 실패는 전부 흡수 — 에러 응답 비파괴 (best-effort).
  */
 @Slf4j
 @Component

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/BriefingController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/BriefingController.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.serviceevent.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.serviceevent.application.query.BriefingResult;
+import com.wanted.codebombalms.serviceevent.application.service.BriefingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 AI 브리핑 API (#609). 권한 설계는 SecuritySummaryController 와 동일 —
+ * ADMIN·MASTER 전용(@PreAuthorize), 인터셉터 세밀권한 미적용(관리자 공통 랜딩).
+ */
+@RestController
+@RequestMapping("/api/v1/admin/security/briefing")
+@PreAuthorize("hasAnyRole('ADMIN','MASTER')")
+@RequiredArgsConstructor
+public class BriefingController {
+
+    private final BriefingService briefingService;
+
+    @Operation(summary = "AI 브리핑 조회", description = "최신 저장본 즉시 반환 (LLM 호출 없음). 생성 이력 없으면 data=null")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "AUT-015: 권한 없음")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<BriefingResult>> getBriefing() {
+        return ResponseEntity.ok(ApiResponse.success(
+                "SECURITY-BRIEFING-RETRIEVED",
+                "브리핑 조회 성공",
+                briefingService.getLatest().orElse(null)
+        ));
+    }
+
+    @Operation(summary = "AI 브리핑 재생성", description = "즉시 재생성 (동기 5~30초, 쿨다운 분당 1회)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재생성 성공 (새 브리핑 반환)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "SEC-001: 재생성 쿨다운"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "502", description = "SEC-002: AI 생성 실패")
+    })
+    @PostMapping("/regenerate")
+    public ResponseEntity<ApiResponse<BriefingResult>> regenerate() {
+        return ResponseEntity.ok(ApiResponse.success(
+                "SECURITY-BRIEFING-REGENERATED",
+                "브리핑 재생성 성공",
+                briefingService.regenerate()
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/BriefingController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/BriefingController.java
@@ -14,8 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 관리자 AI 브리핑 API (#609). 권한 설계는 SecuritySummaryController 와 동일 —
- * ADMIN·MASTER 전용(@PreAuthorize), 인터셉터 세밀권한 미적용(관리자 공통 랜딩).
+ * 관리자 AI 브리핑 API — ADMIN·MASTER 전용. 권한 설계는 SecuritySummaryController 와 동일.
  */
 @RestController
 @RequestMapping("/api/v1/admin/security/briefing")

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/SecuritySummaryController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/SecuritySummaryController.java
@@ -14,13 +14,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 관리자 보안 요약 콘솔 API (#608).
- *
- * <p>권한 설계: SecurityConfig 의 /api/v1/admin/** 는 OPERATOR 도 통과시키지만
- * 보안 데이터(IP·표적 계정)는 ADMIN·MASTER 전용 → @PreAuthorize 로 좁힌다.
- * AdminPermissionInterceptor 세밀권한(USER_MANAGEMENT 등)은 걸지 않는다 — 관리자
- * 공통 랜딩 화면이라 무권한 admin 도 조회는 가능해야 하고, 액션(계정 잠금)은
- * 기존 lock API 의 USER_MANAGEMENT 룰이 그대로 지킨다 (의도된 결정, #608).
+ * 관리자 보안 요약 콘솔 API — ADMIN·MASTER 전용.
+ * 메서드 권한 필수 — SecurityConfig 는 /api/v1/admin/** 에 OPERATOR 도 통과.
+ * 인터셉터 세밀권한 미적용 — 관리자 공통 랜딩, 액션 권한은 기존 lock API 담당.
  */
 @RestController
 @RequestMapping("/api/v1/admin/security")

--- a/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/ChangeStudentLockService.java
@@ -42,7 +42,8 @@ public class ChangeStudentLockService implements ChangeStudentLockUseCase {
         userRepository.save(user);
 
         serviceEventRecorder.record(ServiceEventEnvelope.business(
-                ServiceEventType.ACCOUNT_LOCKED, userId, null,
+                locked ? ServiceEventType.ACCOUNT_LOCKED : ServiceEventType.ACCOUNT_UNLOCKED,
+                userId, null,
                 "locked=" + locked));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,6 +82,13 @@ app:
     secure: ${COOKIE_SECURE:false}
 
 # CORS 허용 오리진(콤마 구분). 기본 로컬 FE, 배포는 .env override
+# 관리자 AI 브리핑 (#609) — provider 교체 시 model 도 함께 변경, 키는 절대 커밋 금지
+# provider: gemini(기본, 학교 지원 키) | anthropic
+briefing:
+  provider: ${BRIEFING_PROVIDER:gemini}
+  model: ${BRIEFING_MODEL:gemini-2.5-flash}
+  api-key: ${BRIEFING_API_KEY:}
+
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3001}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,7 +86,7 @@ app:
 # provider: gemini(기본) | anthropic
 briefing:
   provider: ${BRIEFING_PROVIDER:gemini}
-  model: ${BRIEFING_MODEL:gemini-2.5-flash}
+  model: ${BRIEFING_MODEL:gemini-3.5-flash}
   api-key: ${BRIEFING_API_KEY:}
 
 cors:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,8 +82,7 @@ app:
     secure: ${COOKIE_SECURE:false}
 
 # CORS 허용 오리진(콤마 구분). 기본 로컬 FE, 배포는 .env override
-# 관리자 AI 브리핑 — provider 교체 시 model 도 함께 변경
-# provider: gemini(기본) | anthropic
+# 관리자 AI 브리핑 — provider 교체 시 model 동시 변경 (gemini 기본 | anthropic)
 briefing:
   provider: ${BRIEFING_PROVIDER:gemini}
   model: ${BRIEFING_MODEL:gemini-3.5-flash}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,8 +82,8 @@ app:
     secure: ${COOKIE_SECURE:false}
 
 # CORS 허용 오리진(콤마 구분). 기본 로컬 FE, 배포는 .env override
-# 관리자 AI 브리핑 (#609) — provider 교체 시 model 도 함께 변경, 키는 절대 커밋 금지
-# provider: gemini(기본, 학교 지원 키) | anthropic
+# 관리자 AI 브리핑 — provider 교체 시 model 도 함께 변경
+# provider: gemini(기본) | anthropic
 briefing:
   provider: ${BRIEFING_PROVIDER:gemini}
   model: ${BRIEFING_MODEL:gemini-2.5-flash}

--- a/src/test/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecurityCategoriesSyncTest.java
+++ b/src/test/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecurityCategoriesSyncTest.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventCategory;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** SECURITY_CATEGORIES 상수(native query용) ↔ ServiceEventCategory.isSecurity() 동기화 검증 */
+@DisplayName("보안 카테고리 상수 동기화 검증")
+class SecurityCategoriesSyncTest {
+
+    @Test
+    void securityCategoriesConstant_matchesEnumDefinition() {
+        Set<String> fromConstant = Arrays.stream(
+                        SpringDataServiceEventRepository.SECURITY_CATEGORIES.split(","))
+                .map(s -> s.trim().replace("'", ""))
+                .collect(Collectors.toSet());
+
+        Set<String> fromEnum = Arrays.stream(ServiceEventCategory.values())
+                .filter(ServiceEventCategory::isSecurity)
+                .map(ServiceEventCategory::code)
+                .collect(Collectors.toSet());
+
+        assertEquals(fromEnum, fromConstant,
+                "SECURITY_CATEGORIES 상수가 ServiceEventCategory.isSecurity() 와 불일치 — 두 곳을 함께 갱신할 것");
+    }
+}


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #609 

---

## 🛠️ 기능 관련 작업 내용
- AI 브리핑 생성 파이프라인 — 24시간 집계를 마스킹 후 Claude API(구조화 출력)로 생성, ops_briefing 저장
- GET /admin/security/briefing(저장본 즉시 반환, LLM 호출 없음) + POST regenerate(동기, 쿨다운 분당 1회)
- 하루 3회 스케줄(09:05/15:00/21:00) + 실패 시 FAILED 기록·직전 성공본 유지(stale 플래그)
- PII 정책: user_id·이메일·원본 IP 외부 미반출 (집계 수치 + 마스킹 IP만)

---

## ♻️ 패키지 변경 사항
- `codebombalms/serviceevent`: 브리핑 스키마·포트·Claude 어댑터·서비스·스케줄러·컨트롤러·영속화 신규 (9파일)
- 루트: `build.gradle`(anthropic-java) / `application.yml`(briefing env 설정)
- `resources/db/schema`: `ops_briefing.sql` (DDL 적용 필요 — 로컬은 권한 계정, 배포 RDS는 머지 후 공지)
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관리자용 보안 요약 및 AI 브리핑 대시보드 API를 추가했습니다(보안 요약: 기간별 조회, 브리핑: 최신 조회 및 재생성).
  * AI 브리핑을 매일 3회 자동 생성하며, Gemini 및 Claude 기반 생성을 지원합니다.
  * 최신 브리핑 생성 실패 시 직전 성공 결과를 “stale”로 표시합니다.
  * 계정 잠금/해제 이벤트를 구분해 기록합니다.
* **개선**
  * 보안 요약에 KPI·도메인 분포·HTTP 이상·위험 IP·시간대별 통계를 포함했습니다.
  * 오래된 브리핑 데이터 정리 정책을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->