### PR TITLE
[Update] 추천 생성 배치 실행 시간 변경

### DIFF
--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
@@ -7,7 +7,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/** 매일 새벽 Python 추천 서버를 호출해 문제 세트 추천 결과를 갱신합니다. */
+/** 매일 오전/오후 Python 추천 서버를 호출해 문제 세트 추천 결과를 갱신합니다. */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -18,9 +18,9 @@ public class ProblemRecommendationScheduler {
     private final GenerateProblemSetRecommendationsUseCase generateUseCase;
     private final RecommendationBatchLockExecutor lockExecutor;
 
-    /** 매일 새벽 5시(Asia/Seoul)에 비동기로 추천 생성 배치를 실행합니다. */
+    /** 매일 오전 6시와 오후 6시(Asia/Seoul)에 비동기로 추천 생성 배치를 실행합니다. */
     @Async("recommendationTaskExecutor")
-    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 6,18 * * *", zone = "Asia/Seoul")
     public void generateDailyProblemSetRecommendations() {
         try {
             var generatedUserCount = lockExecutor.executeIfLockAcquired(LOCK_NAME, generateUseCase::generate);


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #확인필요

---

## 🛠️ 기능 관련 작업 내용
- 문제 추천 생성 배치 실행 시간을 매일 새벽 5시 1회에서 매일 오전 6시, 오후 6시 2회로 변경
- `Asia/Seoul` 기준 실행 정책 유지
- 스케줄러 주석을 실제 실행 시간과 일치하도록 수정

---

## ♻️ 패키지 변경 사항
- `project/recommendation/infrastructure/scheduler`: 문제 추천 생성 배치 cron 표현식 및 설명 주석 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 문제 추천 생성 일정이 매일 오전 5시에서 오전 6시와 오후 6시, 하루 2회로 변경되었습니다.
  * 추천 생성 배치가 한국 표준시(Asia/Seoul)를 기준으로 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->