### PR TITLE
[Release] v2.3.0

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/application/command/SaveFeedbackCommand.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/command/SaveFeedbackCommand.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.chatbot.application.command;
+
+import com.wanted.codebombalms.chatbot.domain.model.FeedbackRating;
+
+public record SaveFeedbackCommand(
+        Long userId,
+        Long messageId,
+        FeedbackRating rating
+) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/result/ChatMessageResult.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/result/ChatMessageResult.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.chatbot.application.result;
 
+import com.wanted.codebombalms.chatbot.domain.model.FeedbackRating;
 import com.wanted.codebombalms.chatbot.domain.model.MessageRole;
 
 import java.time.Instant;
@@ -8,5 +9,7 @@ public record ChatMessageResult(
         Long messageId,
         MessageRole role,
         String content,
-        Instant createdAt
+        Instant createdAt,
+        // AI 메시지에 남긴 내 평가(UP/DOWN). 평가 없거나 USER 메시지면 null.
+        FeedbackRating feedback
 ) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/ChatMessageQueryService.java
@@ -3,13 +3,17 @@ package com.wanted.codebombalms.chatbot.application.service;
 import com.wanted.codebombalms.chatbot.application.result.ChatMessageResult;
 import com.wanted.codebombalms.chatbot.application.usecase.ChatMessageQueryUseCase;
 import com.wanted.codebombalms.chatbot.domain.model.ChatMessage;
+import com.wanted.codebombalms.chatbot.domain.model.FeedbackRating;
+import com.wanted.codebombalms.chatbot.domain.model.MessageFeedback;
 import com.wanted.codebombalms.chatbot.domain.repository.ChatMessageRepository;
 import com.wanted.codebombalms.chatbot.domain.repository.ChatRoomRepository;
+import com.wanted.codebombalms.chatbot.domain.repository.MessageFeedbackRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,23 +23,33 @@ public class ChatMessageQueryService implements ChatMessageQueryUseCase {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final MessageFeedbackRepository messageFeedbackRepository;
 
     @Override
     public List<ChatMessageResult> listMessages(Long roomId, Long userId) {
         chatRoomRepository.getById(roomId).verifyOwner(userId);
 
-        return chatMessageRepository.findByRoomId(roomId)
+        List<ChatMessage> messages = chatMessageRepository.findByRoomId(roomId);
+
+        List<Long> messageIds = messages.stream()
+                .map(ChatMessage::getId)
+                .collect(Collectors.toList());
+        Map<Long, FeedbackRating> feedbackByMessageId = messageFeedbackRepository.findByMessageIdIn(messageIds)
                 .stream()
-                .map(this::toResult)
+                .collect(Collectors.toMap(MessageFeedback::getMessageId, MessageFeedback::getRating));
+
+        return messages.stream()
+                .map(message -> toResult(message, feedbackByMessageId.get(message.getId())))
                 .collect(Collectors.toList());
     }
 
-    private ChatMessageResult toResult(ChatMessage message) {
+    private ChatMessageResult toResult(ChatMessage message, FeedbackRating feedback) {
         return new ChatMessageResult(
                 message.getId(),
                 message.getRole(),
                 message.getContent(),
-                message.getCreatedAt()
+                message.getCreatedAt(),
+                feedback
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/service/MessageFeedbackCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/service/MessageFeedbackCommandService.java
@@ -1,0 +1,52 @@
+package com.wanted.codebombalms.chatbot.application.service;
+
+import com.wanted.codebombalms.chatbot.application.command.SaveFeedbackCommand;
+import com.wanted.codebombalms.chatbot.application.usecase.MessageFeedbackCommandUseCase;
+import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
+import com.wanted.codebombalms.chatbot.domain.model.ChatMessage;
+import com.wanted.codebombalms.chatbot.domain.model.MessageFeedback;
+import com.wanted.codebombalms.chatbot.domain.model.MessageRole;
+import com.wanted.codebombalms.chatbot.domain.repository.ChatMessageRepository;
+import com.wanted.codebombalms.chatbot.domain.repository.ChatRoomRepository;
+import com.wanted.codebombalms.chatbot.domain.repository.MessageFeedbackRepository;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MessageFeedbackCommandService implements MessageFeedbackCommandUseCase {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final MessageFeedbackRepository messageFeedbackRepository;
+
+    @Override
+    public MessageFeedback save(SaveFeedbackCommand command) {
+        ChatMessage message = chatMessageRepository.getById(command.messageId());
+        if (message.getRole() != MessageRole.AI) {
+            throw new ValidationException(ChatErrorCode.FEEDBACK_TARGET_NOT_AI);
+        }
+        chatRoomRepository.getById(message.getRoomId()).verifyOwner(command.userId());
+
+        MessageFeedback feedback = messageFeedbackRepository.findByMessageId(command.messageId())
+                .map(existing -> {
+                    existing.changeRating(command.rating());
+                    return existing;
+                })
+                .orElseGet(() -> MessageFeedback.create(
+                        command.messageId(), command.userId(), command.rating()));
+
+        return messageFeedbackRepository.save(feedback);
+    }
+
+    @Override
+    public void delete(Long messageId, Long userId) {
+        ChatMessage message = chatMessageRepository.getById(messageId);
+        chatRoomRepository.getById(message.getRoomId()).verifyOwner(userId);
+
+        messageFeedbackRepository.deleteByMessageId(messageId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/application/usecase/MessageFeedbackCommandUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/usecase/MessageFeedbackCommandUseCase.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.chatbot.application.usecase;
+
+import com.wanted.codebombalms.chatbot.application.command.SaveFeedbackCommand;
+import com.wanted.codebombalms.chatbot.domain.model.MessageFeedback;
+
+public interface MessageFeedbackCommandUseCase {
+
+    // AI 메시지 평가 설정/전환 (upsert, 멱등)
+    MessageFeedback save(SaveFeedbackCommand command);
+
+    // 평가 취소 (없으면 no-op)
+    void delete(Long messageId, Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/exception/ChatErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/exception/ChatErrorCode.java
@@ -12,7 +12,9 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_FORBIDDEN("CHT-002", "채팅방에 접근 권한이 없습니다."),
     AI_RESPONSE_FAILED("CHT-003", "AI 응답 생성에 실패했습니다."),
     CHAT_ROOM_TITLE_INVALID("CHT-004", "채팅방 제목이 올바르지 않습니다."),
-    INVALID_TOKEN_USAGE("CHT-005", "토큰 사용량 값이 올바르지 않습니다.");
+    INVALID_TOKEN_USAGE("CHT-005", "토큰 사용량 값이 올바르지 않습니다."),
+    MESSAGE_NOT_FOUND("CHT-006", "메시지를 찾을 수 없습니다."),
+    FEEDBACK_TARGET_NOT_AI("CHT-007", "AI 응답 메시지에만 평가할 수 있습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/model/FeedbackRating.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/model/FeedbackRating.java
@@ -1,0 +1,7 @@
+package com.wanted.codebombalms.chatbot.domain.model;
+
+public enum FeedbackRating {
+
+    UP,
+    DOWN
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/model/MessageFeedback.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/model/MessageFeedback.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.chatbot.domain.model;
+
+import java.time.Instant;
+
+public class MessageFeedback {
+
+    private final Long id;
+    private final Long messageId;
+    private final Long userId;
+    private FeedbackRating rating;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    private MessageFeedback(
+            Long id,
+            Long messageId,
+            Long userId,
+            FeedbackRating rating,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        this.id = id;
+        this.messageId = messageId;
+        this.userId = userId;
+        this.rating = rating;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static MessageFeedback create(Long messageId, Long userId, FeedbackRating rating) {
+        return new MessageFeedback(null, messageId, userId, rating, null, null);
+    }
+
+    public static MessageFeedback restore(
+            Long id,
+            Long messageId,
+            Long userId,
+            FeedbackRating rating,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        return new MessageFeedback(id, messageId, userId, rating, createdAt, updatedAt);
+    }
+
+    // 이미 존재하는 평가의 값을 전환한다(UP↔DOWN). updatedAt 은 영속 계층(@PreUpdate)에서 갱신.
+    public void changeRating(FeedbackRating newRating) {
+        this.rating = newRating;
+    }
+
+    public Long getId() { return id; }
+    public Long getMessageId() { return messageId; }
+    public Long getUserId() { return userId; }
+    public FeedbackRating getRating() { return rating; }
+    public Instant getCreatedAt() { return createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/repository/ChatMessageRepository.java
@@ -1,13 +1,25 @@
 package com.wanted.codebombalms.chatbot.domain.repository;
 
+import com.wanted.codebombalms.chatbot.domain.exception.ChatErrorCode;
 import com.wanted.codebombalms.chatbot.domain.model.ChatMessage;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatMessageRepository {
 
     // 메시지 저장
     ChatMessage save(ChatMessage chatMessage);
+
+    // messageId 로 메시지 단건 조회
+    Optional<ChatMessage> findById(Long messageId);
+
+    // messageId 로 메시지 조회, 없으면 NotFoundException
+    default ChatMessage getById(Long messageId) {
+        return findById(messageId)
+                .orElseThrow(() -> new NotFoundException(ChatErrorCode.MESSAGE_NOT_FOUND));
+    }
 
     // roomId로 전체 메시지 조회
     List<ChatMessage> findByRoomId(Long roomId);

--- a/src/main/java/com/wanted/codebombalms/chatbot/domain/repository/MessageFeedbackRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/domain/repository/MessageFeedbackRepository.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.chatbot.domain.repository;
+
+import com.wanted.codebombalms.chatbot.domain.model.MessageFeedback;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MessageFeedbackRepository {
+
+    // 평가 저장 (생성/수정)
+    MessageFeedback save(MessageFeedback feedback);
+
+    // messageId 로 평가 단건 조회
+    Optional<MessageFeedback> findByMessageId(Long messageId);
+
+    // messageId 묶음으로 평가 일괄 조회 (내역조회 N+1 방지)
+    List<MessageFeedback> findByMessageIdIn(List<Long> messageIds);
+
+    // messageId 로 평가 삭제 (없으면 no-op)
+    void deleteByMessageId(Long messageId);
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatMessageRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/ChatMessageRepositoryAdapter.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Repository
@@ -18,6 +19,12 @@ public class ChatMessageRepositoryAdapter implements ChatMessageRepository {
     public ChatMessage save(ChatMessage chatMessage) {
         ChatMessageJpaEntity saved = springDataRepository.save(ChatMessageMapper.toEntity(chatMessage));
         return ChatMessageMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<ChatMessage> findById(Long messageId) {
+        return springDataRepository.findById(messageId)
+                .map(ChatMessageMapper::toDomain);
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/MessageFeedbackJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/MessageFeedbackJpaEntity.java
@@ -1,0 +1,67 @@
+package com.wanted.codebombalms.chatbot.infrastructure.persistence;
+
+import com.wanted.codebombalms.chatbot.domain.model.FeedbackRating;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "chat_message_feedback",
+        uniqueConstraints = @UniqueConstraint(name = "uq_feedback_message", columnNames = "message_id")
+)
+@Getter
+@NoArgsConstructor
+public class MessageFeedbackJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "message_id", nullable = false)
+    private Long messageId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "rating", nullable = false, length = 4)
+    private FeedbackRating rating;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public MessageFeedbackJpaEntity(
+            Long id,
+            Long messageId,
+            Long userId,
+            FeedbackRating rating,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+        this.id = id;
+        this.messageId = messageId;
+        this.userId = userId;
+        this.rating = rating;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/MessageFeedbackMapper.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/MessageFeedbackMapper.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.chatbot.infrastructure.persistence;
+
+import com.wanted.codebombalms.chatbot.domain.model.MessageFeedback;
+
+public class MessageFeedbackMapper {
+
+    private MessageFeedbackMapper() {}
+
+    public static MessageFeedback toDomain(MessageFeedbackJpaEntity entity) {
+        return MessageFeedback.restore(
+                entity.getId(),
+                entity.getMessageId(),
+                entity.getUserId(),
+                entity.getRating(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+    public static MessageFeedbackJpaEntity toEntity(MessageFeedback domain) {
+        return new MessageFeedbackJpaEntity(
+                domain.getId(),
+                domain.getMessageId(),
+                domain.getUserId(),
+                domain.getRating(),
+                domain.getCreatedAt(),
+                domain.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/MessageFeedbackRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/MessageFeedbackRepositoryAdapter.java
@@ -1,0 +1,45 @@
+package com.wanted.codebombalms.chatbot.infrastructure.persistence;
+
+import com.wanted.codebombalms.chatbot.domain.model.MessageFeedback;
+import com.wanted.codebombalms.chatbot.domain.repository.MessageFeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class MessageFeedbackRepositoryAdapter implements MessageFeedbackRepository {
+
+    private final SpringDataMessageFeedbackRepository springDataRepository;
+
+    @Override
+    public MessageFeedback save(MessageFeedback feedback) {
+        MessageFeedbackJpaEntity saved = springDataRepository.save(MessageFeedbackMapper.toEntity(feedback));
+        return MessageFeedbackMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<MessageFeedback> findByMessageId(Long messageId) {
+        return springDataRepository.findByMessageId(messageId)
+                .map(MessageFeedbackMapper::toDomain);
+    }
+
+    @Override
+    public List<MessageFeedback> findByMessageIdIn(List<Long> messageIds) {
+        if (messageIds.isEmpty()) {
+            return List.of();
+        }
+        return springDataRepository.findByMessageIdIn(messageIds)
+                .stream()
+                .map(MessageFeedbackMapper::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteByMessageId(Long messageId) {
+        springDataRepository.deleteByMessageId(messageId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SpringDataMessageFeedbackRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SpringDataMessageFeedbackRepository.java
@@ -1,0 +1,15 @@
+package com.wanted.codebombalms.chatbot.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SpringDataMessageFeedbackRepository extends JpaRepository<MessageFeedbackJpaEntity, Long> {
+
+    Optional<MessageFeedbackJpaEntity> findByMessageId(Long messageId);
+
+    List<MessageFeedbackJpaEntity> findByMessageIdIn(List<Long> messageIds);
+
+    void deleteByMessageId(Long messageId);
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatFeedbackController.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatFeedbackController.java
@@ -1,0 +1,85 @@
+package com.wanted.codebombalms.chatbot.presentation.api;
+
+import com.wanted.codebombalms.chatbot.application.command.SaveFeedbackCommand;
+import com.wanted.codebombalms.chatbot.application.usecase.MessageFeedbackCommandUseCase;
+import com.wanted.codebombalms.chatbot.presentation.api.request.MessageFeedbackRequest;
+import com.wanted.codebombalms.chatbot.presentation.api.response.MessageFeedbackResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Chatbot - 메시지 피드백", description = "AI 응답 품질 피드백(👍/👎) API")
+@RestController
+@RequestMapping("/api/v1/chat")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+public class ChatFeedbackController {
+
+    private final MessageFeedbackCommandUseCase messageFeedbackCommandUseCase;
+
+    @Operation(
+            summary = "메시지 평가 설정/전환 (👍/👎)",
+            description = "AI 응답 메시지에 UP/DOWN 평가를 남깁니다. 이미 있으면 값을 전환합니다(멱등)."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200", description = "평가 저장 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400", description = "CHT-007 - AI 응답 메시지가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403", description = "CHT-002 - 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404", description = "CHT-006 - 메시지 없음")
+    })
+    @PutMapping("/messages/{messageId}/feedback")
+    public ResponseEntity<ApiResponse<MessageFeedbackResponse>> saveFeedback(
+            @Parameter(description = "평가할 AI 메시지 ID", example = "2")
+            @PathVariable Long messageId,
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody MessageFeedbackRequest request
+    ) {
+        MessageFeedbackResponse response = MessageFeedbackResponse.from(
+                messageFeedbackCommandUseCase.save(
+                        new SaveFeedbackCommand(userId, messageId, request.rating())
+                )
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        ChatResponseCode.FEEDBACK_SAVED,
+                        ChatResponseMessage.FEEDBACK_SAVED,
+                        response
+                )
+        );
+    }
+
+    @Operation(
+            summary = "메시지 평가 취소",
+            description = "메시지에 남긴 평가를 삭제합니다. 평가가 없어도 204로 응답합니다(멱등)."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "204", description = "평가 취소 성공 (없어도 no-op)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403", description = "CHT-002 - 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404", description = "CHT-006 - 메시지 없음")
+    })
+    @DeleteMapping("/messages/{messageId}/feedback")
+    public ResponseEntity<Void> deleteFeedback(
+            @Parameter(description = "평가를 취소할 메시지 ID", example = "2")
+            @PathVariable Long messageId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        messageFeedbackCommandUseCase.delete(messageId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseCode.java
@@ -7,4 +7,5 @@ public class ChatResponseCode {
     public static final String ROOM_RETRIEVED = "CHAT-ROOM-RETRIEVED";
     public static final String MESSAGES_RETRIEVED = "CHAT-MESSAGES-RETRIEVED";
     public static final String ROOM_RENAMED = "CHAT-ROOM-RENAMED";
+    public static final String FEEDBACK_SAVED = "CHAT-FEEDBACK-SAVED";
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/ChatResponseMessage.java
@@ -8,5 +8,6 @@ public class ChatResponseMessage {
     public static final String MESSAGES_RETRIEVED = "채팅 내역 조회에 성공했습니다.";
     public static final String ROOM_RENAMED = "채팅방 제목이 변경되었습니다.";
     public static final String ROOM_FOUND = "채팅방 조회에 성공했습니다.";
+    public static final String FEEDBACK_SAVED = "메시지 평가가 저장되었습니다.";
 
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/MessageFeedbackRequest.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/request/MessageFeedbackRequest.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.chatbot.presentation.api.request;
+
+import com.wanted.codebombalms.chatbot.domain.model.FeedbackRating;
+import jakarta.validation.constraints.NotNull;
+
+public record MessageFeedbackRequest(
+        @NotNull(message = "평가 값(UP/DOWN)을 입력해주세요.")
+        FeedbackRating rating
+) {}

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/ChatMessageResponse.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/ChatMessageResponse.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.chatbot.presentation.api.response;
 
 import com.wanted.codebombalms.chatbot.application.result.ChatMessageResult;
+import com.wanted.codebombalms.chatbot.domain.model.FeedbackRating;
 import com.wanted.codebombalms.chatbot.domain.model.MessageRole;
 
 import java.time.Instant;
@@ -9,14 +10,17 @@ public record ChatMessageResponse(
         Long messageId,
         MessageRole role,
         String content,
-        Instant createdAt
+        Instant createdAt,
+        // AI 메시지에 남긴 내 평가(UP/DOWN). 평가 없거나 USER 메시지면 null.
+        FeedbackRating feedback
 ) {
     public static ChatMessageResponse from(ChatMessageResult result) {
         return new ChatMessageResponse(
                 result.messageId(),
                 result.role(),
                 result.content(),
-                result.createdAt()
+                result.createdAt(),
+                result.feedback()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/MessageFeedbackResponse.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/presentation/api/response/MessageFeedbackResponse.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.chatbot.presentation.api.response;
+
+import com.wanted.codebombalms.chatbot.domain.model.FeedbackRating;
+import com.wanted.codebombalms.chatbot.domain.model.MessageFeedback;
+
+public record MessageFeedbackResponse(
+        Long messageId,
+        FeedbackRating rating
+) {
+    public static MessageFeedbackResponse from(MessageFeedback feedback) {
+        return new MessageFeedbackResponse(
+                feedback.getMessageId(),
+                feedback.getRating()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
+++ b/src/main/java/com/wanted/codebombalms/recommendation/infrastructure/scheduler/ProblemRecommendationScheduler.java
@@ -7,7 +7,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/** 매일 새벽 Python 추천 서버를 호출해 문제 세트 추천 결과를 갱신합니다. */
+/** 매일 오전/오후 Python 추천 서버를 호출해 문제 세트 추천 결과를 갱신합니다. */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -18,9 +18,9 @@ public class ProblemRecommendationScheduler {
     private final GenerateProblemSetRecommendationsUseCase generateUseCase;
     private final RecommendationBatchLockExecutor lockExecutor;
 
-    /** 매일 새벽 5시(Asia/Seoul)에 비동기로 추천 생성 배치를 실행합니다. */
+    /** 매일 오전 6시와 오후 6시(Asia/Seoul)에 비동기로 추천 생성 배치를 실행합니다. */
     @Async("recommendationTaskExecutor")
-    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 6,18 * * *", zone = "Asia/Seoul")
     public void generateDailyProblemSetRecommendations() {
         try {
             var generatedUserCount = lockExecutor.executeIfLockAcquired(LOCK_NAME, generateUseCase::generate);

--- a/src/main/resources/db/schema/chat_message_feedback.sql
+++ b/src/main/resources/db/schema/chat_message_feedback.sql
@@ -1,0 +1,24 @@
+-- ==============================================
+-- chat_message_feedback : AI 응답 품질 피드백(👍/👎)
+-- 적용 순서: 이 CREATE 를 각 환경 DB 에 먼저 적용한 뒤 새 코드를 배포한다.
+--           (ddl-auto: validate 이므로 테이블/컬럼이 없으면 부팅 실패)
+-- 규칙:
+--  - 채팅방은 1인 소유 → 메시지당 평가 1행 (uq_feedback_message).
+--  - rating = 'UP' | 'DOWN' (FeedbackRating enum, STRING 매핑).
+--  - user_id = 평가자(방 주인). message_id→room→user 로 유도 가능하나
+--    소유검증·per-user 분석 편의를 위해 비정규화 저장한다.
+--  - 취소는 행 삭제(hard delete).
+-- ==============================================
+
+CREATE TABLE chat_message_feedback (
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    message_id  BIGINT       NOT NULL,
+    user_id     BIGINT       NOT NULL,
+    rating      VARCHAR(4)   NOT NULL,
+    created_at  DATETIME(6)  NOT NULL,
+    updated_at  DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_feedback_message UNIQUE (message_id),
+    CONSTRAINT fk_feedback_message FOREIGN KEY (message_id)
+        REFERENCES chat_message (message_id)
+);


### PR DESCRIPTION
# 🚀 Backend Release Pull Request

> PR 제목은 반드시 `[Release] vX.Y.Z` 형식으로 작성해주세요.
>
> 예시: `[Release] v1.2.0`
>
> Release PR이 `main`에 머지되면 GitHub Actions가 PR 제목의 버전을 기준으로 태그와 GitHub Release를 생성합니다.

## 📌 릴리즈 정보

| 항목 | 내용 |
|------|------|
| **버전** | `v2.2.0 → v2.3.0` |
| **릴리즈 날짜** | 2026-07-14 |
| **기준 브랜치** | `develop` |
| **병합 브랜치** | `main` |
| **배포 환경** | `EC2 / Docker Compose / ECR / SSM / RDS / Redis / GCP Storage` |

---

# 📖 릴리즈 요약

> 이번 릴리즈에서 추가되거나 변경된 주요 백엔드 내용을 간략하게 작성해주세요.

- AI 채팅 응답에 `UP/DOWN` 피드백을 등록·변경·취소하는 기능을 추가했습니다.
- 채팅 메시지 조회 응답에 현재 사용자의 피드백 정보를 추가했습니다.
- 문제 추천 생성 배치 실행 시간을 매일 오전 6시와 오후 6시로 변경했습니다.
- 채팅 메시지 피드백 저장을 위한 DB 스키마를 추가했습니다.

---

# 📋 릴리즈 노트

## Auth / User

### Added

- AI 채팅 메시지 피드백 등록·전환 API 추가
- AI 채팅 메시지 피드백 취소 API 추가
- 메시지별 `UP/DOWN` 피드백 도메인 및 영속성 구조 추가

### Changed

- 채팅 메시지 조회 응답에 사용자의 `feedback` 필드 추가

### Fixed

- 없음

---

## Course / Lecture / Enrollment / Learning

### Added

- 없음

### Changed

- 강의 도메인 오류 메시지 정리

### Fixed

- 없음

---

## Problem / Submission / Ranking / Badge / Recommendation

### Added

- 없음

### Changed

- 문제 추천 생성 배치 실행 시간을 매일 오전 6시 1회에서 오전 6시·오후 6시 2회로 변경

### Fixed

- 없음

---

## Admin / Monitoring / Deploy

### Added

- 채팅 메시지 피드백 테이블 생성 SQL 추가

### Changed

- 없음

### Fixed

- 없음

---

# 🔌 API / DB / 환경변수 변경 사항

## API 변경

- [ ] 없음
- [x] 있음

| 구분 | Method | URL | 변경 내용 | 프론트 영향 |
|------|--------|-----|----------|------------|
| 추가 | `PUT` | `/api/v1/chat/messages/{messageId}/feedback` | AI 응답 평가 등록 또는 `UP/DOWN` 전환 | 있음 |
| 추가 | `DELETE` | `/api/v1/chat/messages/{messageId}/feedback` | AI 응답 평가 취소 | 있음 |
| 변경 | `GET` | 기존 채팅 메시지 조회 API | 메시지 응답에 `feedback` 필드 추가 | 있음 |

## DB 변경

- [ ] 없음
- [x] 있음

변경 내용:

- `chat_message_feedback` 테이블 신규 생성
- `message_id` 단일 평가 보장을 위한 UNIQUE 제약조건 추가
- `chat_message.message_id`를 참조하는 외래키 추가
- `ddl-auto: validate` 환경이므로 새 코드 배포 전에 `src/main/resources/db/schema/chat_message_feedback.sql`을 각 환경 DB에 먼저 적용해야 함

## 환경변수 / Secrets 변경

- [x] 없음
- [ ] 있음

변경 내용:

- 없음

운영 반영 필요 여부:

- [x] 없음
- [ ] GitHub Secrets 변경 필요
- [ ] EC2 `.env` 변경 필요
- [ ] SSM Parameter Store 변경 필요

> Secret 값은 PR에 작성하지 않고, 키 이름과 반영 위치만 작성합니다.

---

# 🧪 릴리즈 체크리스트

- [x] `develop` 브랜치의 최신 코드가 반영되었습니다.
- [x] `develop → main` 방향의 Release PR입니다.
- [ ] GitHub Actions CI build가 통과했습니다.
- [ ] 로컬 또는 테스트 환경에서 `./gradlew build`를 확인했습니다.
- [ ] 주요 API 및 도메인 기능 테스트를 완료했습니다.
- [ ] 인증/인가가 필요한 API의 권한 검증을 확인했습니다.
- [x] API 변경사항이 Swagger 또는 `.ai/API.md`에 반영되었습니다.
- [x] DB 스키마 / 시드 데이터 변경사항을 확인했습니다.
- [x] 운영 환경변수 또는 Secrets 변경사항을 확인했습니다.
- [x] 환경변수 / Secrets 키 추가·변경·삭제 여부를 확인했습니다.
- [x] Secret 값은 PR 본문에 노출하지 않았습니다.
- [x] Docker / EC2 배포 설정 변경사항을 확인했습니다.
- [ ] Merge Conflict가 없습니다.
- [x] 릴리즈 노트를 작성했습니다.
- [x] main 머지 후 생성할 Git Tag 버전을 확인했습니다.

---

# 🏷 버전 정보

| 이전 버전 | 변경 버전 | 버전 변경 유형 |
|----------|----------|----------------|
| `v2.2.0` | `v2.3.0` | `MINOR` |

### 버전 변경 사유

- AI 채팅 응답 피드백이라는 새로운 사용자 기능과 신규 API가 추가되어 `MINOR` 버전으로 제안합니다.
- 기존 채팅 메시지 응답에 nullable `feedback` 필드가 추가되지만, 기존 필드를 제거하거나 인증 방식을 변경하는 하위 호환 중단은 확인되지 않았습니다.

---

# 📦 Git Tag

> 태그는 Release PR이 `main`에 머지된 후, `main` 브랜치 기준으로만 생성합니다.

```bash
git checkout main
git pull origin main

git tag v2.3.0
git push origin v2.3.0
```

---

# ✅ 배포 후 검증

```bash
curl http://<BACKEND_HOST>:8080/actuator/health
```

- [ ] `/actuator/health` 상태가 정상입니다.
- [ ] 로그인 / 회원가입이 정상 동작합니다.
- [ ] 채팅 메시지 피드백 등록·전환·취소가 정상 동작합니다.
- [ ] 채팅 메시지 조회 응답에 `feedback` 값이 정상 표시됩니다.
- [ ] 문제 추천 배치 스케줄이 오전 6시·오후 6시로 적용되었습니다.
- [ ] DB / Redis / GCP Storage 연결이 정상입니다.
- [ ] EC2 Docker 컨테이너 로그를 확인했습니다.

---

# 💬 기타 사항

> 리뷰어가 확인해야 할 사항이나 배포 시 주의사항을 작성해주세요.

- `ddl-auto: validate` 설정으로 인해 배포 전 `chat_message_feedback` 테이블 생성 SQL을 운영 DB에 먼저 적용해야 합니다.
- 현재 로컬 `refactor/lecture` 브랜치의 미커밋 변경은 이번 `origin/develop → origin/main` 릴리즈 범위에서 제외했습니다.
- GitHub Actions CI 통과 여부와 Merge Conflict 여부는 PR 생성 화면에서 최종 확인해주세요.