### PR TITLE
[Feat] 관리자 학생 목록 이름 검색 기능 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/GetStudentsService.java
@@ -3,8 +3,8 @@ package com.wanted.codebombalms.user.application.service;
 import com.wanted.codebombalms.user.application.query.StudentPageResult;
 import com.wanted.codebombalms.user.application.query.StudentSummary;
 import com.wanted.codebombalms.user.application.usecase.GetStudentsUseCase;
-import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserPage;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import com.wanted.codebombalms.user.infrastructure.metrics.UserMetrics;
 import lombok.RequiredArgsConstructor;
@@ -24,28 +24,25 @@ public class GetStudentsService implements GetStudentsUseCase {
     private final UserMetrics userMetrics;
 
     @Override
-    public StudentPageResult getStudents(int page, int size) {
+    public StudentPageResult getStudents(int page, int size, String keyword) {
         long startedAt = System.nanoTime();
 
-        // 1. 학생 목록 조회 (가입 최신순) — 인덱스 부재 시 풀스캔 + filesort 발생 구간
-        List<User> users = userRepository.findAllByRole(UserRole.STUDENT, page, size);
-
-        // 2. 전체 학생 수
-        long totalElements = userRepository.countByRole(UserRole.STUDENT);
+        // 1. 학생 목록 + 전체 건수 조회 (가입 최신순, keyword 있으면 이름 중간 매칭)
+        UserPage userPage = userRepository.findAllByRoleAndKeyword(UserRole.STUDENT, keyword, page, size);
 
         long elapsedNanos = System.nanoTime() - startedAt;
         userMetrics.recordStudentListQuery(elapsedNanos);
-        log.info("event=user_student_list_queried page={} size={} resultCount={} durationMs={}",
-                page, size, users.size(), elapsedNanos / 1_000_000);
+        log.info("event=user_student_list_queried page={} size={} hasKeyword={} resultCount={} durationMs={}",
+                page, size, keyword != null && !keyword.isBlank(), userPage.content().size(), elapsedNanos / 1_000_000);
 
-        // 3. 전체 페이지 수 (size = 0 방어)
-        int totalPages = size <= 0 ? 0 : (int) Math.ceil((double) totalElements / size);
+        // 2. 전체 페이지 수 (size = 0 방어)
+        int totalPages = size <= 0 ? 0 : (int) Math.ceil((double) userPage.totalElements() / size);
 
-        // 4. 변환
-        List<StudentSummary> content = users.stream()
+        // 3. 변환
+        List<StudentSummary> content = userPage.content().stream()
                 .map(StudentSummary::from)
                 .toList();
 
-        return new StudentPageResult(content, totalElements, totalPages);
+        return new StudentPageResult(content, userPage.totalElements(), totalPages);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/application/usecase/GetStudentsUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/usecase/GetStudentsUseCase.java
@@ -4,5 +4,5 @@ import com.wanted.codebombalms.user.application.query.StudentPageResult;
 
 public interface GetStudentsUseCase {
 
-    StudentPageResult getStudents(int page, int size);
+    StudentPageResult getStudents(int page, int size, String keyword);
 }

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/UserPage.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/UserPage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.user.domain.repository;
+
+import com.wanted.codebombalms.user.domain.model.User;
+
+import java.util.List;
+
+public record UserPage(
+        List<User> content,
+        long totalElements
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/domain/repository/UserRepository.java
@@ -25,5 +25,5 @@ public interface UserRepository {
 
     List<User> findAllByRole(UserRole role, int page, int size);
 
-    long countByRole(UserRole role);
+    UserPage findAllByRoleAndKeyword(UserRole role, String keyword, int page, int size);
 }

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/SpringDataUserRepository.java
@@ -26,8 +26,6 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
 
     List<UserJpaEntity> findAllByRoleOrderByCreatedAtDesc(UserRole role, Pageable pageable);
 
-    long countByRole(UserRole role);
-
     @Query("""
             SELECT u
             FROM UserJpaEntity u
@@ -42,6 +40,22 @@ public interface SpringDataUserRepository extends JpaRepository<UserJpaEntity, L
             ORDER BY u.createdAt DESC, u.userId DESC
             """)
     Page<UserJpaEntity> findActiveByRoleAndKeyword(
+            @Param("role") UserRole role,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT u
+            FROM UserJpaEntity u
+            WHERE u.role = :role
+              AND (
+                    :keyword IS NULL
+                    OR LOWER(u.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+              )
+            ORDER BY u.createdAt DESC, u.userId DESC
+            """)
+    Page<UserJpaEntity> findActiveByRoleAndNameKeyword(
             @Param("role") UserRole role,
             @Param("keyword") String keyword,
             Pageable pageable

--- a/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/user/infrastructure/persistence/UserRepositoryAdapter.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import com.wanted.codebombalms.user.domain.repository.UserPage;
+import org.springframework.data.domain.Page;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -86,7 +89,25 @@ public class UserRepositoryAdapter implements UserRepository {
     }
 
     @Override
-    public long countByRole(UserRole role) {
-        return springDataUserRepository.countByRole(role);
+    public UserPage findAllByRoleAndKeyword(UserRole role, String keyword, int page, int size) {
+        Page<UserJpaEntity> result = springDataUserRepository.findActiveByRoleAndNameKeyword(
+                role,
+                normalizeKeyword(keyword),
+                PageRequest.of(page, size)
+        );
+
+        List<User> content = result.getContent().stream()
+                .map(UserJpaEntity::toDomain)
+                .toList();
+
+        return new UserPage(content, result.getTotalElements());
+    }
+
+    // 빈 검색어는 null로 바꿔 JPQL 조건에서 전체 조회로 처리되게 한다.
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return keyword.trim();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentsController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentsController.java
@@ -6,9 +6,12 @@ import com.wanted.codebombalms.user.application.usecase.GetStudentsUseCase;
 import com.wanted.codebombalms.user.presentation.api.response.StudentPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,24 +21,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
+@Validated
 public class GetStudentsController {
 
     private final GetStudentsUseCase getStudentsUseCase;
 
     @Operation(
             summary = "학생 전체 조회 (Admin)",
-            description = "역할 STUDENT 인 회원 목록 페이지 조회 (가입 최신순). 관리자 권한 필요."
+            description = "역할 STUDENT 인 회원 목록 페이지 조회 (가입 최신순). "
+                    + "keyword 전달 시 이름 기준 중간 매칭 검색 (대소문자 무시). 관리자 권한 필요."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "페이지 파라미터 범위 오류")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "AUT-015 권한 없음")
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<StudentPageResponse>> getStudents(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+            @RequestParam(required = false) String keyword
     ) {
-        StudentPageResult result = getStudentsUseCase.getStudents(page, size);
+        StudentPageResult result = getStudentsUseCase.getStudents(page, size, keyword);
 
         return ResponseEntity.ok(ApiResponse.success(
                 UserResponseCode.STUDENTS_RETRIEVED,

--- a/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentsController.java
+++ b/src/main/java/com/wanted/codebombalms/user/presentation/api/GetStudentsController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -29,7 +30,7 @@ public class GetStudentsController {
     @Operation(
             summary = "학생 전체 조회 (Admin)",
             description = "역할 STUDENT 인 회원 목록 페이지 조회 (가입 최신순). "
-                    + "keyword 전달 시 이름 기준 중간 매칭 검색 (대소문자 무시). 관리자 권한 필요."
+                    + "keyword 전달 시 이름 기준 중간 매칭 검색 (대소문자 무시, 최대 20자). 관리자 권한 필요."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "페이지 파라미터 범위 오류")
@@ -40,7 +41,7 @@ public class GetStudentsController {
     public ResponseEntity<ApiResponse<StudentPageResponse>> getStudents(
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) @Size(max = 20) String keyword
     ) {
         StudentPageResult result = getStudentsUseCase.getStudents(page, size, keyword);
 

--- a/src/test/java/com/wanted/codebombalms/user/application/service/GetStudentsServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/user/application/service/GetStudentsServiceTest.java
@@ -4,6 +4,7 @@ import com.wanted.codebombalms.user.application.query.StudentPageResult;
 import com.wanted.codebombalms.user.domain.model.AuthProvider;
 import com.wanted.codebombalms.user.domain.model.User;
 import com.wanted.codebombalms.user.domain.model.UserRole;
+import com.wanted.codebombalms.user.domain.repository.UserPage;
 import com.wanted.codebombalms.user.domain.repository.UserRepository;
 import com.wanted.codebombalms.user.infrastructure.metrics.UserMetrics;
 import org.junit.jupiter.api.DisplayName;
@@ -33,34 +34,49 @@ class GetStudentsServiceTest {
     private GetStudentsService getStudentsService;
 
     @Test
-    @DisplayName("학생 목록을 조회하고 전체 페이지 수를 올림 계산한다. (총 25명, size 10 → 3페이지)")
+    @DisplayName("keyword 없이 학생 목록을 조회하고 전체 페이지 수를 올림 계산한다. (총 25명, size 10 → 3페이지)")
     void 목록_조회_및_페이지_계산() {
         // given
-        given(userRepository.findAllByRole(UserRole.STUDENT, 0, 10))
-                .willReturn(List.of(createUser(1L), createUser(2L)));
-        given(userRepository.countByRole(UserRole.STUDENT)).willReturn(25L);
+        given(userRepository.findAllByRoleAndKeyword(UserRole.STUDENT, null, 0, 10))
+                .willReturn(new UserPage(List.of(createUser(1L), createUser(2L)), 25L));
 
         // when
-        StudentPageResult result = getStudentsService.getStudents(0, 10);
+        StudentPageResult result = getStudentsService.getStudents(0, 10, null);
 
         // then
         assertEquals(2, result.content().size());
         assertEquals(25L, result.totalElements());
         assertEquals(3, result.totalPages()); // ceil(25/10)
-        verify(userRepository).findAllByRole(UserRole.STUDENT, 0, 10);
+        verify(userRepository).findAllByRoleAndKeyword(UserRole.STUDENT, null, 0, 10);
         verify(userMetrics).recordStudentListQuery(anyLong()); // 쿼리 구간 계측이 실제로 호출되는지 고정
     }
 
     @Test
-    @DisplayName("size가 0이면 totalPages를 0으로 방어한다. (나눗셈 예외 방지)")
-    void size_0_방어() {
+    @DisplayName("keyword를 가공 없이 리포지토리로 전달한다. (공백 정규화는 어댑터 책임)")
+    void 키워드_리포지토리_위임() {
         // given
-        given(userRepository.findAllByRole(UserRole.STUDENT, 0, 0))
-                .willReturn(List.of());
-        given(userRepository.countByRole(UserRole.STUDENT)).willReturn(10L);
+        given(userRepository.findAllByRoleAndKeyword(UserRole.STUDENT, "  김학생 ", 0, 10))
+                .willReturn(new UserPage(List.of(createUser(1L)), 1L));
 
         // when
-        StudentPageResult result = getStudentsService.getStudents(0, 0);
+        StudentPageResult result = getStudentsService.getStudents(0, 10, "  김학생 ");
+
+        // then
+        assertEquals(1, result.content().size());
+        assertEquals(1L, result.totalElements());
+        assertEquals(1, result.totalPages());
+        verify(userRepository).findAllByRoleAndKeyword(UserRole.STUDENT, "  김학생 ", 0, 10);
+    }
+
+    @Test
+    @DisplayName("size가 0이면 totalPages를 0으로 방어한다. (컨트롤러 @Min(1) 뒤의 2차 방어선)")
+    void size_0_방어() {
+        // given
+        given(userRepository.findAllByRoleAndKeyword(UserRole.STUDENT, null, 0, 0))
+                .willReturn(new UserPage(List.of(), 10L));
+
+        // when
+        StudentPageResult result = getStudentsService.getStudents(0, 0, null);
 
         // then
         assertEquals(0, result.totalPages());
@@ -71,11 +87,11 @@ class GetStudentsServiceTest {
     @DisplayName("조회 중 예외가 발생하면 그대로 전파하고, 메트릭은 기록하지 않는다.")
     void 조회_예외_전파() {
         // given
-        given(userRepository.findAllByRole(UserRole.STUDENT, 0, 10))
+        given(userRepository.findAllByRoleAndKeyword(UserRole.STUDENT, null, 0, 10))
                 .willThrow(new RuntimeException("DB unavailable"));
 
         // when & then
-        assertThrows(RuntimeException.class, () -> getStudentsService.getStudents(0, 10));
+        assertThrows(RuntimeException.class, () -> getStudentsService.getStudents(0, 10, null));
         // 실패 시엔 쿼리 구간 계측을 남기지 않는다(성공 케이스만 집계 — finally 미사용 동작 고정)
         verify(userMetrics, never()).recordStudentListQuery(anyLong());
     }


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #628 

---

## 🛠️ 기능 관련 작업 내용
- `GET /api/v1/users` 에 `keyword` 쿼리 파라미터 추가 — 이름 기준 중간 매칭(`LIKE '%keyword%'`, 대소문자 무시). 미전달·공백이면 기존 전체 조회 동작 그대로 유지
- 이름 전용 검색 쿼리 `findActiveByRoleAndNameKeyword` 를 신규 추가. 이슈에 적힌 기존 `findActiveByRoleAndKeyword` 재사용은 하지 않음 — 그 쿼리는 email·name·nickname 3필드를 검색해 이슈 요구("이름 기준")와 범위가 다르고, 관리자 계정 검색(`AdminAccountQueryAdapter`)이 같은 쿼리를 쓰고 있어 이름만으로 좁히면 그쪽 기능이 깨짐
- 목록 조회 + 전체 건수를 `UserPage` 로 묶어 리포지토리 호출 2회를 1회로 통합 (실행되는 SQL 은 목록+count 2회로 기존과 동일). 호출부가 사라진 `countByRole` 은 제거
- `?size=0` 요청 시 `PageRequest.of` 에서 500 나던 것을 `@Min(1) @Max(100)` 검증으로 400 처리

---

## ♻️ 패키지 변경 사항
- `codebombalms/user/domain/repository`: `UserPage` record 신규 + `UserRepository#findAllByRoleAndKeyword` 추가. `countByRole` 은 호출부 0이 되어 제거, `findAllByRole` 은 `UserOperationQueryService` 가 사용 중이라 유지
- `codebombalms/user/infrastructure/persistence`: `SpringDataUserRepository` 에 이름 전용 JPQL 추가, `UserRepositoryAdapter` 에서 검색어 공백→null 정규화 후 연결
- `codebombalms/user/application`: `GetStudentsUseCase`/`GetStudentsService` 에 keyword 추가. 검색어는 학생 실명(PII)이라 로그엔 원문 대신 `hasKeyword` 만 기록. 2-arg 오버로드는 두지 않음(호출부가 컨트롤러 1곳뿐이라 즉시 죽은 코드가 됨) — 이슈의 "호환 유지" 항목 관련해 공유 필요
- `codebombalms/user/presentation/api`: `GetStudentsController` 에 `keyword` 파라미터 + `@Validated` 기반 page/size 범위 검증 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 관리자 학생 목록에서 이름으로 검색할 수 있습니다.
  - 검색어는 이름 일부만 입력해도 조회되며, 대소문자를 구분하지 않습니다.
  - 검색 결과에 전체 학생 수와 페이지 정보가 함께 제공됩니다.

- **버그 수정**
  - 페이지 번호와 페이지 크기에 대한 입력 검증을 강화했습니다.
  - 페이지는 0 이상, 페이지 크기는 1~100 범위로 제한됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## 📐 API 명세 변경 (`GET /api/v1/users`)

**Query Parameter — `keyword` 추가**

| 파라미터명 | 타입 | 필수 | 설명 |
|-----------|------|------|------|
| page | int | N | 페이지 번호 (기본값 0, 0 이상) |
| size | int | N | 페이지 크기 (기본값 20, 1~100) |
| keyword | String | N | 이름 검색어 (최대 20자 = `name` 컬럼 길이). 이름 기준 중간 매칭(`LIKE '%keyword%'`, 대소문자 무시). 미전달·공백이면 전체 조회 |

**Status Code — 400 추가**

| 코드 | 상태 | 설명 |
|------|------|------|
| 200 | OK | 조회 성공 |
| 400 | Bad Request | 파라미터 범위 오류 (`page < 0`, `size < 1`, `size > 100`, `keyword` 20자 초과) |
| 401 | Unauthorized | AUT-016 인증이 필요합니다 |
| 403 | Forbidden | AUT-015 권한 없음 |

**Request 예시**

```
GET /api/v1/users?page=0&size=20&keyword=김
```

> Response 구조는 변경 없음. 검색은 **이름(`name`)만** 매칭하며, 이메일·닉네임은 대상이 아닙니다 (관리자 계정 검색의 3필드 검색과 다름).