### PR TITLE
[Feat] 제출 실행결과를 ChatContext 통해 FastAPI로 전달

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatContextPort.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/application/port/ChatContextPort.java
@@ -30,7 +30,11 @@ public interface ChatContextPort {
             String content,
             String problemType,
             String explanation,
-            String submittedCode
+            String submittedCode,
+            String executionStatus,
+            Integer passedTestCount,
+            Integer totalTestCount,
+            String errorMessage
     ) {}
 
     record SessionProgressInfo(

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/adapter/ChatContextAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/adapter/ChatContextAdapter.java
@@ -32,16 +32,17 @@ public class ChatContextAdapter implements ChatContextPort {
     public List<ProblemInfo> findProblems(Long problemSetId, Long userId) {
         return problemQueryService.findProblemsForChat(problemSetId).stream()
                 .map(p -> {
-                    String submittedCode = submissionQueryService
-                            .findLatestResult(userId, p.problemId())
-                            .map(LatestSubmission::submittedCode)
-                            .orElse(null);
+                    var latest = submissionQueryService.findLatestResult(userId, p.problemId());
                     return new ProblemInfo(
                             p.title(),
                             p.content(),
                             p.problemType(),
                             p.explanation(),
-                            submittedCode
+                            latest.map(LatestSubmission::submittedCode).orElse(null),
+                            latest.map(LatestSubmission::executionStatus).orElse(null),
+                            latest.map(LatestSubmission::passedTestCount).orElse(null),
+                            latest.map(LatestSubmission::totalTestCount).orElse(null),
+                            latest.map(LatestSubmission::errorMessage).orElse(null)
                     );
                 })
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatClient.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatClient.java
@@ -103,6 +103,10 @@ public class FastApiChatClient implements AiChatClient {
                         .problemType(p.problemType())
                         .explanation(p.explanation())
                         .submittedCode(p.submittedCode())
+                        .executionStatus(p.executionStatus())
+                        .passedTestCount(p.passedTestCount())
+                        .totalTestCount(p.totalTestCount())
+                        .errorMessage(p.errorMessage())
                         .build())
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatRequest.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/client/FastApiChatRequest.java
@@ -62,6 +62,18 @@ public class FastApiChatRequest {
 
         @JsonProperty("submitted_answer")
         private String submittedCode;
+
+        @JsonProperty("execution_status")
+        private String executionStatus;
+
+        @JsonProperty("passed_test_count")
+        private Integer passedTestCount;
+
+        @JsonProperty("total_test_count")
+        private Integer totalTestCount;
+
+        @JsonProperty("error_message")
+        private String errorMessage;
     }
 
     @Getter

--- a/src/main/java/com/wanted/codebombalms/submission/domain/model/LatestSubmission.java
+++ b/src/main/java/com/wanted/codebombalms/submission/domain/model/LatestSubmission.java
@@ -8,6 +8,10 @@ public record LatestSubmission(
         Integer problemOrder,
         String submittedCode,
         Boolean correct,
-        LocalDateTime submittedAt
+        LocalDateTime submittedAt,
+        String executionStatus,
+        Integer passedTestCount,
+        Integer totalTestCount,
+        String errorMessage
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionQueryPersistenceAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/submission/infrastructure/persistence/SubmissionQueryPersistenceAdapter.java
@@ -30,7 +30,11 @@ public class SubmissionQueryPersistenceAdapter implements SubmissionQueryPort {
                 submission.getProblem().getProblemOrder(),
                 submission.getSubmittedCode(),
                 submission.getCorrect(),
-                submission.getSubmittedAt()
+                submission.getSubmittedAt(),
+                submission.getExecutionStatus(),
+                submission.getPassedTestCount(),
+                submission.getTotalTestCount(),
+                submission.getErrorMessage()
         );
     }
 


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

- Closes #

---

## 🛠️ 기능 관련 작업 내용

- 제출(Submission) 실행결과 필드 4개(executionStatus, passedTestCount, totalTestCount, errorMessage)를 LatestSubmission 레코드에 추가
- ChatContextPort/Adapter를 통해 제출 실행결과를 ChatContext 데이터로 노출
- FastApiChatRequest/Client에서 제출 실행결과를 FastAPI 챗봇 요청에 포함하여 전달

---

## ♻️ 패키지 변경 사항

- `submission/domain/model/LatestSubmission` : 제출 실행결과 필드 4개 추가
- `submission/infrastructure/persistence/SubmissionQueryPersistenceAdapter` : 쿼리 결과 매핑 수정
- `chatbot/application/port/ChatContextPort` : 제출 실행결과 필드 노출
- `chatbot/infrastructure/adapter/ChatContextAdapter` : ChatContext 구성 로직 수정
- `chatbot/infrastructure/client/FastApiChatRequest` : 제출 실행결과 필드 추가
- `chatbot/infrastructure/client/FastApiChatClient` : FastAPI 요청 시 실행결과 전달

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 챗봇이 문제별 최신 제출 결과를 더 상세히 활용합니다.
  * 실행 상태, 통과한 테스트 수, 전체 테스트 수, 오류 메시지가 문제 정보에 포함됩니다.

* **개선 사항**
  * 제출 결과 정보가 챗봇 요청에 전달되어 코드 실행 결과를 반영한 응답을 제공할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->