### PR TITLE
[Feat] 강의문제풀이방 해설조회 연동 및 진입/접근 오류 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicy.java
@@ -1,6 +1,8 @@
 package com.wanted.codebombalms.learning.application.policy;
 
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.learning.application.port.LearningEnrollmentPort;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
 import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
@@ -14,7 +16,10 @@ public class LearningAccessPolicy {
     private final LearningEnrollmentPort learningEnrollmentPort;
 
     public void validateLectureProblemSetAccess(Long userId, LearningLectureProblemSet lectureProblemSet) {
-        if (userId == null || !learningEnrollmentPort.isActiveStudentOfCourse(
+        if (userId == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REQUIRED);
+        }
+        if (!learningEnrollmentPort.isActiveStudentOfCourse(
                 lectureProblemSet.courseId(),
                 userId
         )) {

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningProblemExplanationPort.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningProblemExplanationPort.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.learning.application.port;
+
+import java.util.List;
+import java.util.Set;
+
+public interface LearningProblemExplanationPort {
+
+    boolean existsViewed(Long userId, Long problemId);
+
+    Set<Long> findViewedProblemIds(Long userId, List<Long> problemIds);
+
+    void saveViewed(Long userId, Long problemId, Long problemSetId);
+}

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
@@ -7,6 +7,7 @@ import com.wanted.codebombalms.learning.application.command.RecordLectureProblem
 import com.wanted.codebombalms.learning.application.policy.LearningAccessPolicy;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemExplanationPort;
 import com.wanted.codebombalms.learning.application.port.LearningProblemGradingPort;
 import com.wanted.codebombalms.learning.application.port.LearningProblemPort;
 import com.wanted.codebombalms.learning.application.usecase.LectureProblemProgressCommandUseCase;
@@ -17,12 +18,15 @@ import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
 import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemProgressRepository;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
+import com.wanted.codebombalms.problems.explanation.application.usecase.ViewProblemExplanationUseCase.ExplanationView;
+import com.wanted.codebombalms.problems.progress.enums.ProblemProgressStatus;
 import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
 import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase.SubmissionView;
 import com.wanted.codebombalms.submission.exception.SubmissionErrorCode;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +42,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
     private final LearningLectureProblemSetPort learningLectureProblemSetPort;
     private final LearningProblemPort learningProblemPort;
     private final LearningProblemGradingPort learningProblemGradingPort;
+    private final LearningProblemExplanationPort learningProblemExplanationPort;
     private final LectureProblemProgressCommandUseCase lectureProblemProgressCommandUseCase;
     private final LectureProblemProgressRepository lectureProblemProgressRepository;
     private final LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
@@ -81,6 +86,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
         );
         Map<Long, LectureProblemSubmission> latestSubmissions =
                 findLatestSubmissions(userId, lectureProblemSet.lectureProblemSetId());
+        Set<Long> viewedProblemIds = findViewedProblemIds(userId, problemSet.problems());
         List<ProblemDetailView> problems = problemSet.problems()
                 .stream()
                 .map(problem -> new ProblemDetailView(
@@ -91,7 +97,13 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
                         problem.problemType(),
                         problem.point(),
                         problem.startCode(),
-                        statusOf(problem.problemNumber(), progress, latestSubmissions.get(problem.problemId())),
+                        statusOf(
+                                problem.problemId(),
+                                problem.problemNumber(),
+                                progress,
+                                latestSubmissions.get(problem.problemId()),
+                                viewedProblemIds
+                        ),
                         latestSubmissionId(latestSubmissions.get(problem.problemId()))
                 ))
                 .toList();
@@ -122,6 +134,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
                 .orElseGet(() -> LectureProblemProgress.create(userId, lectureProblemSetId));
         Map<Long, LectureProblemSubmission> latestSubmissions =
                 findLatestSubmissions(userId, lectureProblemSetId);
+        Set<Long> viewedProblemIds = findViewedProblemIds(userId, problemSet.problems());
 
         return new LectureProblemSetProgressView(
                 lectureProblemSet.lectureProblemSetId(),
@@ -137,9 +150,11 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
                                 problem.problemId(),
                                 problem.problemNumber(),
                                 statusOf(
+                                        problem.problemId(),
                                         problem.problemNumber(),
                                         progress,
-                                        latestSubmissions.get(problem.problemId())
+                                        latestSubmissions.get(problem.problemId()),
+                                        viewedProblemIds
                                 )
                         ))
                         .toList()
@@ -162,6 +177,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
         }
 
         var problem = learningProblemPort.loadProblem(problemId);
+
         LectureProblemProgress progress = lockProgress(command.userId(), lectureProblemSetId);
         validateSubmissionProgress(progress, problem.problemNumber());
 
@@ -240,6 +256,78 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
         );
     }
 
+    @Override
+    @Transactional
+    public ExplanationView viewExplanation(Long userId, Long lectureProblemSetId, Long problemId) {
+        LearningLectureProblemSet lectureProblemSet =
+                learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId);
+        learningAccessPolicy.validateLectureProblemSetAccess(userId, lectureProblemSet);
+
+        if (!learningProblemPort.existsProblem(problemId)) {
+            throw new NotFoundException(LearningErrorCode.PROBLEM_NOT_FOUND);
+        }
+        if (!learningProblemPort.existsProblemInSet(lectureProblemSet.problemSetId(), problemId)) {
+            throw new NotFoundException(LearningErrorCode.PROBLEM_NOT_IN_LECTURE_PROBLEM_SET);
+        }
+
+        var problem = learningProblemPort.loadProblem(problemId);
+
+        LectureProblemSubmission latestSubmission =
+                findLatestSubmissions(userId, lectureProblemSetId).get(problemId);
+        if (latestSubmission != null && latestSubmission.correct()) {
+            return readOnlyExplanation(problem, ProblemProgressStatus.CORRECT);
+        }
+
+        if (learningProblemExplanationPort.existsViewed(userId, problemId)) {
+            return readOnlyExplanation(problem, ProblemProgressStatus.EXPLANATION_VIEWED);
+        }
+
+        LectureProblemProgress progress = lockProgress(userId, lectureProblemSetId);
+        validateSubmissionProgress(progress, problem.problemNumber());
+
+        learningProblemExplanationPort.saveViewed(userId, problemId, lectureProblemSet.problemSetId());
+
+        var problemSet = learningProblemPort.loadProblemSet(lectureProblemSet.problemSetId());
+        Long nextProblemId = findNextProblemId(problemSet.problems(), problem.problemNumber());
+        boolean completed = nextProblemId == null;
+        int nextProblemNumber = completed ? problem.problemNumber() : problem.problemNumber() + 1;
+        recordLectureProblemProgress(userId, lectureProblemSet, nextProblemNumber, completed);
+
+        if (completed) {
+            serviceEventRecorder.record(ServiceEventEnvelope.business(
+                    ServiceEventType.PROBLEM_SET_COMPLETED, userId,
+                    lectureProblemSet.problemSetId(),
+                    "source=lecture lectureProblemSetId=" + lectureProblemSetId));
+        }
+
+        return new ExplanationView(
+                problemId,
+                ProblemProgressStatus.EXPLANATION_VIEWED,
+                ProblemProgressStatus.CORRECT,
+                problem.explanation(),
+                nextProblemId,
+                completed,
+                0,
+                false
+        );
+    }
+
+    private ExplanationView readOnlyExplanation(
+            LearningProblemPort.ProblemForLearning problem,
+            ProblemProgressStatus status
+    ) {
+        return new ExplanationView(
+                problem.problemId(),
+                status,
+                ProblemProgressStatus.CORRECT,
+                problem.explanation(),
+                null,
+                false,
+                0,
+                false
+        );
+    }
+
     private LectureProblemProgress findOrCreateProgress(Long userId, Long lectureProblemSetId) {
         return findProgress(userId, lectureProblemSetId, true);
     }
@@ -279,17 +367,35 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
     }
 
     private String statusOf(
+            Long problemId,
             Integer problemNumber,
             LectureProblemProgress progress,
-            LectureProblemSubmission submission
+            LectureProblemSubmission submission,
+            Set<Long> viewedProblemIds
     ) {
         if (!progress.isCompleted() && problemNumber > progress.getCurrentProblemNumber()) {
             return "LOCKED";
         }
+        if (submission != null && submission.correct()) {
+            return "CORRECT";
+        }
+        if (viewedProblemIds.contains(problemId)) {
+            return "EXPLANATION_VIEWED";
+        }
         if (submission == null) {
             return "UNSOLVED";
         }
-        return submission.correct() ? "CORRECT" : "WRONG";
+        return "WRONG";
+    }
+
+    private Set<Long> findViewedProblemIds(
+            Long userId,
+            List<LearningProblemPort.ProblemDetailForLearning> problems
+    ) {
+        return learningProblemExplanationPort.findViewedProblemIds(
+                userId,
+                problems.stream().map(LearningProblemPort.ProblemDetailForLearning::problemId).toList()
+        );
     }
 
     private Long latestSubmissionId(LectureProblemSubmission submission) {

--- a/src/main/java/com/wanted/codebombalms/learning/application/usecase/LectureProblemSubmissionUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/usecase/LectureProblemSubmissionUseCase.java
@@ -1,9 +1,12 @@
 package com.wanted.codebombalms.learning.application.usecase;
 
+import com.wanted.codebombalms.problems.explanation.application.usecase.ViewProblemExplanationUseCase.ExplanationView;
 import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
 import com.wanted.codebombalms.submission.application.usecase.SubmissionCommandUseCase.SubmissionView;
 
 public interface LectureProblemSubmissionUseCase {
 
     SubmissionView submit(Long lectureProblemSetId, Long problemId, SubmitCodeCommand command);
+
+    ExplanationView viewExplanation(Long userId, Long lectureProblemSetId, Long problemId);
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressConflictResolver.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressConflictResolver.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.learning.infrastructure.persistence;
+
+import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 최초 진입 INSERT가 유니크 제약 위반으로 실패한 직후에는 원래 트랜잭션의 영속성 컨텍스트를
+ * 그대로 재사용하면 안 되므로(플러시 예외 이후 동일 세션 재사용 위험), 별도 트랜잭션에서 재조회한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class LectureProblemProgressConflictResolver {
+
+    private final SpringDataLectureProblemProgressRepository springDataLectureProblemProgressRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+    public Optional<LectureProblemProgress> findAfterInsertConflict(Long userId, Long lectureProblemSetId) {
+        return springDataLectureProblemProgressRepository
+                .findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId)
+                .map(LectureProblemProgressJpaEntity::toDomain);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapter.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Repository;
 public class LectureProblemProgressRepositoryAdapter implements LectureProblemProgressRepository {
 
     private final SpringDataLectureProblemProgressRepository springDataLectureProblemProgressRepository;
+    private final LectureProblemProgressConflictResolver lectureProblemProgressConflictResolver;
 
     @Override
     public LectureProblemProgress save(LectureProblemProgress lectureProblemProgress) {
@@ -38,6 +39,7 @@ public class LectureProblemProgressRepositoryAdapter implements LectureProblemPr
     /**
      * 동일 사용자의 최초 진입 요청이 겹치면 두 요청 모두 기존 행이 없다고 판단해 동시에 INSERT를 시도할 수 있다.
      * 이 경우 나중 INSERT는 유니크 제약 위반으로 실패하므로, 먼저 성공한 행을 재조회해 그대로 반환한다.
+     * 재조회는 현재(오염됐을 수 있는) 트랜잭션이 아니라 별도 트랜잭션(REQUIRES_NEW)에서 수행한다.
      */
     private LectureProblemProgress insert(LectureProblemProgress lectureProblemProgress) {
         try {
@@ -45,12 +47,11 @@ public class LectureProblemProgressRepositoryAdapter implements LectureProblemPr
                     .save(LectureProblemProgressJpaEntity.from(lectureProblemProgress))
                     .toDomain();
         } catch (DataIntegrityViolationException e) {
-            return springDataLectureProblemProgressRepository
-                    .findByUserIdAndLectureProblemSetId(
+            return lectureProblemProgressConflictResolver
+                    .findAfterInsertConflict(
                             lectureProblemProgress.getUserId(),
                             lectureProblemProgress.getLectureProblemSetId()
                     )
-                    .map(LectureProblemProgressJpaEntity::toDomain)
                     .orElseThrow(() -> e);
         }
     }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapter.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,11 +20,12 @@ public class LectureProblemProgressRepositoryAdapter implements LectureProblemPr
 
     @Override
     public LectureProblemProgress save(LectureProblemProgress lectureProblemProgress) {
-        LectureProblemProgressJpaEntity entity = lectureProblemProgress.getLectureProblemProgressId() == null
-                ? LectureProblemProgressJpaEntity.from(lectureProblemProgress)
-                : springDataLectureProblemProgressRepository.findById(
-                        lectureProblemProgress.getLectureProblemProgressId()
-                )
+        if (lectureProblemProgress.getLectureProblemProgressId() == null) {
+            return insert(lectureProblemProgress);
+        }
+
+        LectureProblemProgressJpaEntity entity = springDataLectureProblemProgressRepository
+                .findById(lectureProblemProgress.getLectureProblemProgressId())
                 .map(found -> {
                     found.apply(lectureProblemProgress);
                     return found;
@@ -31,6 +33,26 @@ public class LectureProblemProgressRepositoryAdapter implements LectureProblemPr
                 .orElseGet(() -> LectureProblemProgressJpaEntity.from(lectureProblemProgress));
 
         return springDataLectureProblemProgressRepository.save(entity).toDomain();
+    }
+
+    /**
+     * 동일 사용자의 최초 진입 요청이 겹치면 두 요청 모두 기존 행이 없다고 판단해 동시에 INSERT를 시도할 수 있다.
+     * 이 경우 나중 INSERT는 유니크 제약 위반으로 실패하므로, 먼저 성공한 행을 재조회해 그대로 반환한다.
+     */
+    private LectureProblemProgress insert(LectureProblemProgress lectureProblemProgress) {
+        try {
+            return springDataLectureProblemProgressRepository
+                    .save(LectureProblemProgressJpaEntity.from(lectureProblemProgress))
+                    .toDomain();
+        } catch (DataIntegrityViolationException e) {
+            return springDataLectureProblemProgressRepository
+                    .findByUserIdAndLectureProblemSetId(
+                            lectureProblemProgress.getUserId(),
+                            lectureProblemProgress.getLectureProblemSetId()
+                    )
+                    .map(LectureProblemProgressJpaEntity::toDomain)
+                    .orElseThrow(() -> e);
+        }
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/problem/LearningProblemExplanationAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/problem/LearningProblemExplanationAdapter.java
@@ -1,0 +1,32 @@
+package com.wanted.codebombalms.learning.infrastructure.problem;
+
+import com.wanted.codebombalms.learning.application.port.LearningProblemExplanationPort;
+import com.wanted.codebombalms.problems.explanation.application.port.ProblemExplanationViewCommandPort;
+import com.wanted.codebombalms.problems.explanation.application.port.ProblemExplanationViewQueryPort;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LearningProblemExplanationAdapter implements LearningProblemExplanationPort {
+
+    private final ProblemExplanationViewQueryPort problemExplanationViewQueryPort;
+    private final ProblemExplanationViewCommandPort problemExplanationViewCommandPort;
+
+    @Override
+    public boolean existsViewed(Long userId, Long problemId) {
+        return problemExplanationViewQueryPort.existsViewed(userId, problemId);
+    }
+
+    @Override
+    public Set<Long> findViewedProblemIds(Long userId, List<Long> problemIds) {
+        return problemExplanationViewQueryPort.findViewedProblemIds(userId, problemIds);
+    }
+
+    @Override
+    public void saveViewed(Long userId, Long problemId, Long problemSetId) {
+        problemExplanationViewCommandPort.saveViewed(userId, problemId, problemSetId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningController.java
+++ b/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningController.java
@@ -21,6 +21,7 @@ import com.wanted.codebombalms.learning.presentation.api.response.LectureProblem
 import com.wanted.codebombalms.learning.presentation.api.response.LectureProgressResponse;
 import com.wanted.codebombalms.learning.presentation.api.response.StudentLearningProgressPageResponse;
 import com.wanted.codebombalms.learning.presentation.api.response.StudentLearningProgressResponse;
+import com.wanted.codebombalms.problems.explanation.presentation.api.response.ExplanationViewResponse;
 import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
 import com.wanted.codebombalms.submission.presentation.request.SubmissionRequest;
 import com.wanted.codebombalms.submission.presentation.response.SubmissionResponse;
@@ -116,7 +117,7 @@ public class LearningController {
     }
 
     @GetMapping("/admin/courses/{courseId}/students/{userId}/lecture-problem-sets/{lectureProblemSetId}")
-    @Operation(summary = "Admin student lecture problem set entry status")
+    @Operation(summary = "관리자 - 학생 강의 문제세트 진입 상태 조회")
     @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
     public ResponseEntity<ApiResponse<LectureProblemSetEntryResponse>> findStudentLectureProblemSet(
             @PathVariable Long courseId,
@@ -190,6 +191,23 @@ public class LearningController {
                         problemId,
                         new SubmitCodeCommand(userId, request.getCode())
                 ))
+        ));
+    }
+
+    @PostMapping("/lecture-problem-sets/{lectureProblemSetId}/problems/{problemId}/explanation-view")
+    @Operation(summary = "강의 문제 해설 조회")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<ExplanationViewResponse>> viewLectureProblemExplanation(
+            @PathVariable Long lectureProblemSetId,
+            @PathVariable Long problemId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(
+                LearningResponseCode.EXPLANATION_VIEWED,
+                LearningResponseMessage.EXPLANATION_VIEWED,
+                ExplanationViewResponse.from(
+                        lectureProblemSubmissionUseCase.viewExplanation(userId, lectureProblemSetId, problemId)
+                )
         ));
     }
 

--- a/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningResponseCode.java
@@ -8,4 +8,5 @@ public class LearningResponseCode {
     public static final String RETRIEVED = "LEARNING-RETRIEVED";
     public static final String UPDATED = "LEARNING-UPDATED";
     public static final String SUBMITTED = "LEARNING-SUBMITTED";
+    public static final String EXPLANATION_VIEWED = "LEARNING-EXPLANATION-VIEWED";
 }

--- a/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/learning/presentation/api/LearningResponseMessage.java
@@ -8,4 +8,5 @@ public class LearningResponseMessage {
     public static final String RETRIEVED = "학습 데이터를 조회했습니다.";
     public static final String UPDATED = "학습 진행 상태를 저장했습니다.";
     public static final String SUBMITTED = "강의 문제 답안을 제출했습니다.";
+    public static final String EXPLANATION_VIEWED = "문제 해설 조회에 성공했습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicy.java
@@ -1,10 +1,12 @@
 package com.wanted.codebombalms.lecture.application.policy;
 
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
@@ -25,7 +27,10 @@ public class LectureAccessPolicy {
         if (operator) {
             return;
         }
-        if (userId == null || !lectureEnrollmentPort.isActiveStudentOfCourse(
+        if (userId == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REQUIRED);
+        }
+        if (!lectureEnrollmentPort.isActiveStudentOfCourse(
                 lecture.getCourse().getCourseId(),
                 userId
         )) {
@@ -46,7 +51,10 @@ public class LectureAccessPolicy {
         if (course.getStatus() != CourseStatus.INACTIVE) {
             throw new ForbiddenException(LectureErrorCode.LECTURE_ACCESS_DENIED);
         }
-        if (userId == null || !lectureEnrollmentPort.isActiveStudentOfCourse(
+        if (userId == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REQUIRED);
+        }
+        if (!lectureEnrollmentPort.isActiveStudentOfCourse(
                 course.getCourseId(),
                 userId
         )) {

--- a/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/domain/exception/LectureErrorCode.java
@@ -8,20 +8,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum LectureErrorCode implements ErrorCode {
 
-    LECTURE_NOT_FOUND("LCT-001", "Lecture was not found."),
-    LECTURE_DELETE_STATUS_REQUIRES_DELETE("LCT-002", "Use the delete API to delete a lecture."),
-    LECTURE_ORDER_DUPLICATED("LCT-003", "A lecture with the same order already exists."),
-    INVALID_YOUTUBE_VIDEO_URL("LCT-004", "Lecture video URL must be a YouTube URL."),
-    LECTURE_MATERIAL_NOT_FOUND("LCT-005", "Lecture material was not found."),
-    LECTURE_MATERIAL_INVALID_FILE("LCT-006", "Lecture material file is invalid."),
-    LECTURE_MATERIAL_UPLOAD_FAILED("LCT-007", "Lecture material upload failed."),
-    LECTURE_MATERIAL_DOWNLOAD_URL_FAILED("LCT-008", "Lecture material download URL generation failed."),
-    LECTURE_MATERIAL_ACCESS_DENIED("LCT-009", "Lecture material access is denied."),
-    LECTURE_MATERIAL_DELETE_FAILED("LCT-010", "Lecture material delete failed."),
-    LECTURE_ACCESS_DENIED("LCT-011", "Only enrolled students can access lecture content."),
-    PREVIOUS_LECTURE_NOT_COMPLETED("LCT-012", "Previous lectures must be completed before accessing this lecture."),
-    FINAL_PROBLEM_SET_NOT_AVAILABLE("LCT-013", "Final problem set recommendations are available after completing the last lecture."),
-    INVALID_LECTURE_ORDER_REQUEST("LCT-014", "Lecture order request must include every active lecture exactly once.");
+    LECTURE_NOT_FOUND("LCT-001", "강의를 찾을 수 없습니다."),
+    LECTURE_DELETE_STATUS_REQUIRES_DELETE("LCT-002", "강의 삭제는 삭제 API를 이용해주세요."),
+    LECTURE_ORDER_DUPLICATED("LCT-003", "같은 순서의 강의가 이미 존재합니다."),
+    INVALID_YOUTUBE_VIDEO_URL("LCT-004", "강의 영상 URL은 올바른 YouTube URL이어야 합니다."),
+    LECTURE_MATERIAL_NOT_FOUND("LCT-005", "강의자료를 찾을 수 없습니다."),
+    LECTURE_MATERIAL_INVALID_FILE("LCT-006", "유효하지 않은 강의자료 파일입니다."),
+    LECTURE_MATERIAL_UPLOAD_FAILED("LCT-007", "강의자료 업로드에 실패했습니다."),
+    LECTURE_MATERIAL_DOWNLOAD_URL_FAILED("LCT-008", "강의자료 다운로드 URL 발급에 실패했습니다."),
+    LECTURE_MATERIAL_ACCESS_DENIED("LCT-009", "강의자료에 접근할 권한이 없습니다."),
+    LECTURE_MATERIAL_DELETE_FAILED("LCT-010", "강의자료 삭제에 실패했습니다."),
+    LECTURE_ACCESS_DENIED("LCT-011", "해당 강좌를 수강 중인 학생만 강의에 접근할 수 있습니다."),
+    PREVIOUS_LECTURE_NOT_COMPLETED("LCT-012", "이전 강의를 모두 완료해야 이 강의에 접근할 수 있습니다."),
+    FINAL_PROBLEM_SET_NOT_AVAILABLE("LCT-013", "마지막 강의를 완료한 후 FINAL 추천 문제세트를 조회할 수 있습니다."),
+    INVALID_LECTURE_ORDER_REQUEST("LCT-014", "삭제되지 않은 모든 강의를 중복 없이 한 번씩 포함해야 합니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureProblemSetController.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/LectureProblemSetController.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "Lecture Problem Set", description = "Lecture problem set connection APIs")
+@Tag(name = "강의 문제세트", description = "강의-문제세트 연결 관리 API")
 public class LectureProblemSetController {
 
     private static final Logger log = LoggerFactory.getLogger(LectureProblemSetController.class);
@@ -36,7 +36,7 @@ public class LectureProblemSetController {
     private final LectureProblemSetQueryUseCase lectureProblemSetQueryUseCase;
 
     @GetMapping("/courses/{courseId}/lecture-problem-sets")
-    @Operation(summary = "Find lecture problem sets by course")
+    @Operation(summary = "강좌별 강의 문제세트 목록 조회")
     public ResponseEntity<ApiResponse<?>> findProblemSetsByCourse(
             @PathVariable Long courseId,
             @AuthenticationPrincipal Long userId,
@@ -59,7 +59,7 @@ public class LectureProblemSetController {
     }
 
     @GetMapping("/lectures/{lectureId}/lecture-problem-sets")
-    @Operation(summary = "Find lecture problem sets by lecture")
+    @Operation(summary = "강의별 강의 문제세트 목록 조회")
     public ResponseEntity<ApiResponse<?>> findProblemSetsByLecture(
             @PathVariable Long lectureId,
             @AuthenticationPrincipal Long userId,
@@ -82,7 +82,7 @@ public class LectureProblemSetController {
     }
 
     @PutMapping("/courses/{courseId}/lecture-problem-sets")
-    @Operation(summary = "Configure course lecture problem sets")
+    @Operation(summary = "강좌 강의 문제세트 구성 설정")
     @PreAuthorize("hasRole('OPERATOR')")
     public ResponseEntity<ApiResponse<?>> configureProblemSets(
             @PathVariable Long courseId,

--- a/src/test/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/policy/LearningAccessPolicyTest.java
@@ -1,6 +1,8 @@
 package com.wanted.codebombalms.learning.application.policy;
 
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.learning.application.port.LearningEnrollmentPort;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
 import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
@@ -40,15 +42,15 @@ class LearningAccessPolicyTest {
     }
 
     @Test
-    void validateLectureProblemSetAccess_throwsForbidden_whenUserIdIsNull() {
+    void validateLectureProblemSetAccess_throwsUnauthorized_whenUserIdIsNull() {
         LearningLectureProblemSet lectureProblemSet = new LearningLectureProblemSet(6001L, 1L, 101L, 2001L);
 
-        ForbiddenException exception = assertThrows(
-                ForbiddenException.class,
+        UnauthorizedException exception = assertThrows(
+                UnauthorizedException.class,
                 () -> learningAccessPolicy.validateLectureProblemSetAccess(null, lectureProblemSet)
         );
 
-        assertEquals(LearningErrorCode.LECTURE_PROGRESS_ACCESS_DENIED, exception.getErrorCode());
+        assertEquals(AuthErrorCode.AUTH_REQUIRED, exception.getErrorCode());
         verify(learningEnrollmentPort, never()).isActiveStudentOfCourse(1L, null);
     }
 

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.learning.application.service;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
 import com.wanted.codebombalms.learning.application.policy.LearningAccessPolicy;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemExplanationPort;
 import com.wanted.codebombalms.learning.application.port.LearningProblemGradingPort;
 import com.wanted.codebombalms.learning.application.port.LearningProblemPort;
 import com.wanted.codebombalms.learning.application.usecase.LectureProblemProgressCommandUseCase;
@@ -10,10 +11,13 @@ import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
 import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemProgressRepository;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
+import com.wanted.codebombalms.problems.explanation.application.usecase.ViewProblemExplanationUseCase.ExplanationView;
+import com.wanted.codebombalms.problems.progress.enums.ProblemProgressStatus;
 import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -24,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -40,6 +45,9 @@ class LectureProblemSetServiceTest {
 
     @Mock
     private LearningProblemGradingPort learningProblemGradingPort;
+
+    @Mock
+    private LearningProblemExplanationPort learningProblemExplanationPort;
 
     @Mock
     private LectureProblemProgressCommandUseCase lectureProblemProgressCommandUseCase;
@@ -71,6 +79,8 @@ class LectureProblemSetServiceTest {
                 .willReturn(Optional.of(progress));
         given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
                 .willReturn(List.of(latestSubmission));
+        given(learningProblemExplanationPort.findViewedProblemIds(userId, List.of(3001L, 3002L)))
+                .willReturn(Set.of());
 
         var result = lectureProblemSetService.enterLectureProblemSet(userId, lectureProblemSetId);
 
@@ -289,6 +299,119 @@ class LectureProblemSetServiceTest {
                 userId,
                 new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
         );
+        verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
+    }
+
+    @Test
+    void viewExplanation_firstTime_recordsViewedAndAdvancesLectureProgress() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3001L;
+        var currentProgress = progress(userId, lectureProblemSetId, 1, false);
+
+        given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
+        given(learningProblemPort.existsProblem(problemId)).willReturn(true);
+        given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
+        given(learningProblemPort.loadProblem(problemId)).willReturn(
+                new LearningProblemPort.ProblemForLearning(
+                        problemId,
+                        problemSetId,
+                        1,
+                        "explanation text",
+                        10,
+                        3,
+                        true
+                )
+        );
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(List.of());
+        given(learningProblemExplanationPort.existsViewed(userId, problemId)).willReturn(false);
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(Optional.of(currentProgress));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetIdForUpdate(
+                userId,
+                lectureProblemSetId
+        )).willReturn(Optional.of(currentProgress));
+        given(learningProblemPort.loadProblemSet(problemSetId)).willReturn(problemSet(problemSetId));
+        given(lectureProblemProgressCommandUseCase.recordProgress(any()))
+                .willReturn(progress(userId, lectureProblemSetId, 2, false));
+
+        ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
+
+        assertEquals(ProblemProgressStatus.EXPLANATION_VIEWED, result.status());
+        assertEquals("explanation text", result.explanation());
+        assertEquals(3002L, result.nextProblemId());
+        assertFalse(result.problemSetCompleted());
+        verify(learningProblemExplanationPort).saveViewed(userId, problemId, problemSetId);
+        verify(lectureProblemProgressCommandUseCase).recordProgress(any());
+    }
+
+    @Test
+    void viewExplanation_alreadyCorrect_returnsReadOnlyWithoutSideEffects() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3001L;
+
+        given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
+        given(learningProblemPort.existsProblem(problemId)).willReturn(true);
+        given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
+        given(learningProblemPort.loadProblem(problemId)).willReturn(
+                new LearningProblemPort.ProblemForLearning(
+                        problemId,
+                        problemSetId,
+                        1,
+                        "explanation text",
+                        10,
+                        3,
+                        true
+                )
+        );
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(List.of(submission(9001L, userId, lectureProblemSetId, problemId, true, 1)));
+
+        ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
+
+        assertEquals(ProblemProgressStatus.CORRECT, result.status());
+        assertFalse(result.problemSetCompleted());
+        verify(learningProblemExplanationPort, never()).saveViewed(any(), any(), any());
+        verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
+    }
+
+    @Test
+    void viewExplanation_alreadyViewed_returnsReadOnlyWithoutSideEffects() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3001L;
+
+        given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
+        given(learningProblemPort.existsProblem(problemId)).willReturn(true);
+        given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
+        given(learningProblemPort.loadProblem(problemId)).willReturn(
+                new LearningProblemPort.ProblemForLearning(
+                        problemId,
+                        problemSetId,
+                        1,
+                        "explanation text",
+                        10,
+                        3,
+                        true
+                )
+        );
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(List.of());
+        given(learningProblemExplanationPort.existsViewed(userId, problemId)).willReturn(true);
+
+        ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
+
+        assertEquals(ProblemProgressStatus.EXPLANATION_VIEWED, result.status());
+        assertTrue(result.explanation() != null);
+        verify(learningProblemExplanationPort, never()).saveViewed(any(), any(), any());
         verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
     }
 

--- a/src/test/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapterTest.java
@@ -21,6 +21,9 @@ class LectureProblemProgressRepositoryAdapterTest {
     @Mock
     private SpringDataLectureProblemProgressRepository springDataLectureProblemProgressRepository;
 
+    @Mock
+    private LectureProblemProgressConflictResolver lectureProblemProgressConflictResolver;
+
     @InjectMocks
     private LectureProblemProgressRepositoryAdapter lectureProblemProgressRepositoryAdapter;
 
@@ -39,14 +42,13 @@ class LectureProblemProgressRepositoryAdapterTest {
                 LocalDateTime.now(),
                 LocalDateTime.now()
         );
-        LectureProblemProgressJpaEntity existingEntity = LectureProblemProgressJpaEntity.from(existingProgress);
 
         willThrow(new DataIntegrityViolationException("duplicate key"))
                 .given(springDataLectureProblemProgressRepository)
                 .save(any(LectureProblemProgressJpaEntity.class));
-        given(springDataLectureProblemProgressRepository
-                .findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
-                .willReturn(Optional.of(existingEntity));
+        given(lectureProblemProgressConflictResolver
+                .findAfterInsertConflict(userId, lectureProblemSetId))
+                .willReturn(Optional.of(existingProgress));
 
         LectureProblemProgress result = lectureProblemProgressRepositoryAdapter.save(newProgress);
 

--- a/src/test/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapterTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/infrastructure/persistence/LectureProblemProgressRepositoryAdapterTest.java
@@ -1,0 +1,57 @@
+package com.wanted.codebombalms.learning.infrastructure.persistence;
+
+import com.wanted.codebombalms.learning.domain.model.LectureProblemProgress;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+class LectureProblemProgressRepositoryAdapterTest {
+
+    @Mock
+    private SpringDataLectureProblemProgressRepository springDataLectureProblemProgressRepository;
+
+    @InjectMocks
+    private LectureProblemProgressRepositoryAdapter lectureProblemProgressRepositoryAdapter;
+
+    @Test
+    void save_returnsWinnerRow_whenConcurrentFirstEntryInsertConflicts() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        LectureProblemProgress newProgress = LectureProblemProgress.create(userId, lectureProblemSetId);
+        LectureProblemProgress existingProgress = LectureProblemProgress.restore(
+                999L,
+                userId,
+                lectureProblemSetId,
+                1,
+                false,
+                null,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+        LectureProblemProgressJpaEntity existingEntity = LectureProblemProgressJpaEntity.from(existingProgress);
+
+        willThrow(new DataIntegrityViolationException("duplicate key"))
+                .given(springDataLectureProblemProgressRepository)
+                .save(any(LectureProblemProgressJpaEntity.class));
+        given(springDataLectureProblemProgressRepository
+                .findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(Optional.of(existingEntity));
+
+        LectureProblemProgress result = lectureProblemProgressRepositoryAdapter.save(newProgress);
+
+        assertEquals(999L, result.getLectureProblemProgressId());
+        assertEquals(userId, result.getUserId());
+        assertEquals(lectureProblemSetId, result.getLectureProblemSetId());
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/policy/LectureAccessPolicyTest.java
@@ -1,10 +1,12 @@
 package com.wanted.codebombalms.lecture.application.policy;
 
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.course.domain.exception.CourseErrorCode;
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.course.domain.model.CourseStatus;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.lecture.application.port.LectureEnrollmentPort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.domain.exception.LectureErrorCode;
@@ -59,15 +61,15 @@ class LectureAccessPolicyTest {
     }
 
     @Test
-    void validateLearningContentAccess_throwsForbidden_whenUserIdIsNull() {
+    void validateLearningContentAccess_throwsUnauthorized_whenUserIdIsNull() {
         Lecture lecture = lecture(1L);
 
-        ForbiddenException exception = assertThrows(
-                ForbiddenException.class,
+        UnauthorizedException exception = assertThrows(
+                UnauthorizedException.class,
                 () -> lectureAccessPolicy.validateLearningContentAccess(lecture, null, false)
         );
 
-        assertEquals(LectureErrorCode.LECTURE_ACCESS_DENIED, exception.getErrorCode());
+        assertEquals(AuthErrorCode.AUTH_REQUIRED, exception.getErrorCode());
         verify(lectureEnrollmentPort, never()).isActiveStudentOfCourse(1L, null);
     }
 
@@ -119,6 +121,19 @@ class LectureAccessPolicyTest {
         assertDoesNotThrow(
                 () -> lectureAccessPolicy.validateCourseContentAccess(course, userId, false)
         );
+    }
+
+    @Test
+    void validateCourseContentAccess_throwsUnauthorizedForInactiveCourse_whenUserIdIsNull() {
+        Course course = course(1L, CourseStatus.INACTIVE);
+
+        UnauthorizedException exception = assertThrows(
+                UnauthorizedException.class,
+                () -> lectureAccessPolicy.validateCourseContentAccess(course, null, false)
+        );
+
+        assertEquals(AuthErrorCode.AUTH_REQUIRED, exception.getErrorCode());
+        verify(lectureEnrollmentPort, never()).isActiveStudentOfCourse(1L, null);
     }
 
     @Test


### PR DESCRIPTION
## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🪛 UPDATE
- [ ] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
<!-- 관련 이슈 번호를 연결해주세요 -->
- Closes #625 
- Closes #633 
- Closes #634

---

## 🛠️ 기능 관련 작업 내용

- 강의문제풀이방 최초 진입 시 동시 요청으로 인한 500 에러 수정 (레이스 컨디션 fallback 추가)
- 강의문제풀이방 해설조회(정답보기) API 신규 추가 및 진행상태/완료 처리 연동
- 비로그인 상태로 강의 콘텐츠 접근 시 403 대신 401 응답하도록 정책 수정 (#625)

---

## ♻️ 패키지 변경 사항

- `learning/infrastructure/persistence`: 강의문제풀이방 최초 진입 동시성 처리 (`LectureProblemProgressRepositoryAdapter`)
- `learning/application/port`, `learning/infrastructure/problem`: 해설조회 포트/어댑터 신규
- `learning/application/service`, `learning/application/usecase`: 강의문제풀이방 해설조회 로직 및 진행상태 전진/완료 처리 추가
- `learning/presentation/api`: 신규 엔드포인트, 응답 코드/메시지 추가
- `lecture/application/policy`, `learning/application/policy`: 비로그인/미수강 접근 예외 분리 (401/403 구분)

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 문제 해설을 조회하고 조회 상태를 저장할 수 있습니다.
  * 이미 해설을 본 문제는 진행 상태에 반영됩니다.
  * 해설 조회 결과와 다음 문제 및 문제 세트 완료 여부를 확인할 수 있습니다.

* **버그 수정**
  * 로그인하지 않은 상태에서는 권한 부족이 아닌 인증 필요 오류가 안내됩니다.
  * 동시 요청으로 인한 학습 진행 저장 충돌을 안정적으로 처리합니다.

* **개선**
  * 강의 및 문제 세트 관련 API 문서와 오류 메시지를 한국어로 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->