### PR TITLE
[Fix] 로그아웃·비밀번호 변경·재설정 시 세션(sid) 폐기 누락 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/service/LogoutService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/LogoutService.java
@@ -12,9 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class LogoutService implements LogoutUseCase {
 
     private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public void logout(Long userId) {
         refreshTokenRepository.deleteByUserId(userId);
+        authSessionManager.close(userId);
     }
 }

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/ResetPasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/ResetPasswordService.java
@@ -27,12 +27,14 @@ public class ResetPasswordService implements ResetPasswordUseCase {
     private final PasswordResetRepository passwordResetRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public void resetPassword(String email, String code, String newPassword) {
 
         // 0. 시도 횟수 제한 (email 단위) — 무차별 대입 차단 (429)
-        if (passwordResetRepository.getFailCount(email) >= PasswordResetPolicy.MAX_FAIL_ATTEMPTS) {            throw new TooManyRequestsException(AuthErrorCode.AUTH_PASSWORD_RESET_TOO_MANY);
+        if (passwordResetRepository.getFailCount(email) >= PasswordResetPolicy.MAX_FAIL_ATTEMPTS) {
+            throw new TooManyRequestsException(AuthErrorCode.AUTH_PASSWORD_RESET_TOO_MANY);
         }
 
         // 1. 코드 비파괴 조회 (짝 안 맞으면 코드 보존 → 타인 코드 무효화 DoS 방지)
@@ -57,8 +59,11 @@ public class ResetPasswordService implements ResetPasswordUseCase {
         user.changePassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);
 
-        // 6. Refresh Token 전체 삭제 (강제 재로그인)
+        // 6. Refresh Token 전체 삭제 (재발급 차단)
         refreshTokenRepository.deleteByUserId(user.getUserId());
+
+        // 6-1. 세션(sid) 폐기 → 발급된 AccessToken 즉시 무효 (계정 탈취 시 공격자 세션 차단)
+        authSessionManager.close(user.getUserId());
 
         // 7. 성공 — 실패 카운터 초기화
         passwordResetRepository.clearFailCount(email);

--- a/src/main/java/com/wanted/codebombalms/user/application/service/ChangePasswordService.java
+++ b/src/main/java/com/wanted/codebombalms/user/application/service/ChangePasswordService.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.user.application.service;
 
+import com.wanted.codebombalms.auth.application.service.AuthSessionManager;
 import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
@@ -25,6 +26,7 @@ public class ChangePasswordService implements ChangePasswordUseCase {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final ProfileEditVerificationRepository profileEditVerificationRepository;
+    private final AuthSessionManager authSessionManager;
 
     @Override
     public void changePassword(Long userId, String newPassword, String confirmPassword) {
@@ -46,10 +48,13 @@ public class ChangePasswordService implements ChangePasswordUseCase {
         user.changePassword(passwordEncoder.encode(newPassword));
         userRepository.save(user);
 
-        // 4. Refresh Token 전체 삭제 (강제 재로그인)
+        // 4. Refresh Token 전체 삭제 (재발급 차단)
         refreshTokenRepository.deleteByUserId(userId);
 
-        // 5. 재인증 도장 제거 (어차피 강제 재로그인 → 세션 종료)
+        // 4-1. 세션(sid) 폐기 → 발급된 AccessToken 즉시 무효 (진짜 강제 재로그인)
+        authSessionManager.close(userId);
+
+        // 5. 재인증 도장 제거
         profileEditVerificationRepository.clearVerified(userId);
 
         log.info("비밀번호 변경 완료 - userId={}", userId);

--- a/src/test/java/com/wanted/codebombalms/auth/application/service/LogoutServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/auth/application/service/LogoutServiceTest.java
@@ -17,11 +17,14 @@ class LogoutServiceTest {
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
 
+    @Mock
+    private AuthSessionManager authSessionManager;
+
     @InjectMocks
     private LogoutService logoutService;
 
     @Test
-    @DisplayName("로그아웃 시 해당 유저의 Refresh Token을 전부 삭제한다.")
+    @DisplayName("로그아웃 시 Refresh Token 삭제와 세션(sid) 폐기를 모두 수행한다.")
     void 로그아웃_성공() {
         // given
         Long userId = 1L;
@@ -31,5 +34,6 @@ class LogoutServiceTest {
 
         // then
         verify(refreshTokenRepository).deleteByUserId(userId);
+        verify(authSessionManager).close(userId);
     }
 }


### PR DESCRIPTION
- LogoutService/ChangePasswordService/ResetPasswordService에 authSessionManager.close() 추가
- RT만 삭제하고 sid를 남겨 기존 AccessToken이 만료까지 유효하던 문제 수정
- LogoutServiceTest에 세션 폐기 검증 보강

## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #637

---

## 🛠️ 기능 관련 작업 내용
- 로그아웃/비밀번호 변경/비밀번호 재설정 시 RefreshToken만 삭제하고 Redis 세션(sid)을 폐기하지 않아, 발급된 AccessToken이 만료(최대 1시간)까지 인증을 통과하던 문제 수정
- 3개 서비스에 `authSessionManager.close(userId)`를 추가해 sid를 즉시 폐기 (기존 WithdrawUserService·LockAccountService와 동일 패턴)
- LogoutServiceTest에 AuthSessionManager mock 및 세션 폐기 호출 검증 보강

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/application/service`: LogoutService, ResetPasswordService — 세션 폐기 호출 추가
- `codebombalms/user/application/service`: ChangePasswordService — 세션 폐기 호출 추가
- `codebombalms/auth/application/service`(test): LogoutServiceTest — mock/검증 보강

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로그아웃 시 관련 세션이 함께 종료되어 기존 인증 토큰이 즉시 무효화됩니다.
  * 비밀번호 변경 또는 재설정 후 기존 로그인 세션이 자동으로 종료됩니다.

* **버그 수정**
  * 비밀번호 변경·재설정 이후 이전 세션으로 계속 접근할 수 있는 문제를 개선했습니다.

* **테스트**
  * 로그아웃 시 세션 종료 동작에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->