### PR TITLE
[Fix] 강의문제 제출 시 시도 횟수 제한으로 막히는 오류 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
@@ -186,7 +186,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
                 lectureProblemSetId,
                 problemId
         );
-        validateAttempt(problem.attemptLimit(), problem.retriable(), previousAttemptCount);
+        validateAttempt(problem.retriable(), previousAttemptCount);
 
         var gradingResult = learningProblemGradingPort.grade(
                 lectureProblemSet.problemSetId(),
@@ -232,10 +232,8 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
             }
         }
 
-        Integer remainingAttemptCount = calculateRemainingAttempts(problem.attemptLimit(), attemptNo);
-        boolean canRetry = !gradingResult.correct()
-                && Boolean.TRUE.equals(problem.retriable())
-                && (remainingAttemptCount == null || remainingAttemptCount > 0);
+        Integer remainingAttemptCount = null;
+        boolean canRetry = !gradingResult.correct() && Boolean.TRUE.equals(problem.retriable());
 
         return new SubmissionView(
                 savedSubmission.lectureProblemSubmissionId(),
@@ -433,17 +431,10 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
         return progress.getCurrentProblemNumber().equals(problemNumber);
     }
 
-    private void validateAttempt(Integer attemptLimit, Boolean retriable, int previousAttemptCount) {
+    private void validateAttempt(Boolean retriable, int previousAttemptCount) {
         if (!Boolean.TRUE.equals(retriable) && previousAttemptCount > 0) {
             throw new ValidationException(SubmissionErrorCode.PROBLEM_NOT_RETRIABLE);
         }
-        if (attemptLimit != null && previousAttemptCount >= attemptLimit) {
-            throw new ValidationException(SubmissionErrorCode.ATTEMPT_LIMIT_EXCEEDED);
-        }
-    }
-
-    private Integer calculateRemainingAttempts(Integer attemptLimit, int attemptNo) {
-        return attemptLimit == null ? null : Math.max(attemptLimit - attemptNo, 0);
     }
 
     private Long findNextProblemId(

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -207,7 +207,7 @@ class LectureProblemSetServiceTest {
         );
 
         assertFalse(result.correct());
-        assertEquals(2, result.remainingAttemptCount());
+        assertEquals(null, result.remainingAttemptCount());
         assertEquals(null, result.nextProblemId());
         verify(learningAccessPolicy).validateLectureProblemSetAccess(
                 userId,
@@ -248,30 +248,34 @@ class LectureProblemSetServiceTest {
     }
 
     @Test
-    void submit_attemptLimitExceeded_doesNotGradeOrSave() {
+    void submit_pastAttemptLimit_stillGradesAndSaves() {
         Long userId = 10L;
         Long lectureProblemSetId = 6001L;
         Long problemSetId = 2001L;
         Long problemId = 3001L;
         var currentProgress = progress(userId, lectureProblemSetId, 1, false);
         givenSubmitContext(userId, lectureProblemSetId, problemSetId, problemId, currentProgress, 3, 3);
+        given(learningProblemGradingPort.grade(problemSetId, problemId, "answer"))
+                .willReturn(new LearningProblemGradingPort.GradingResult(
+                        false,
+                        1,
+                        2,
+                        "WRONG_ANSWER",
+                        "failed"
+                ));
+        given(lectureProblemSubmissionRepository.save(any(LectureProblemSubmission.class)))
+                .willReturn(submission(9003L, userId, lectureProblemSetId, problemId, false, 4));
 
-        assertThrows(
-                com.wanted.codebombalms.global.domain.common.error.exception.ValidationException.class,
-                () -> lectureProblemSetService.submit(
-                        lectureProblemSetId,
-                        problemId,
-                        new SubmitCodeCommand(userId, "answer")
-                )
+        var result = lectureProblemSetService.submit(
+                lectureProblemSetId,
+                problemId,
+                new SubmitCodeCommand(userId, "answer")
         );
 
-        verify(learningProblemGradingPort, never()).grade(any(), any(), any());
-        verify(lectureProblemSubmissionRepository, never()).save(any());
-        verify(learningAccessPolicy).validateLectureProblemSetAccess(
-                userId,
-                new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
-        );
-        verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
+        assertFalse(result.correct());
+        assertEquals(null, result.remainingAttemptCount());
+        verify(learningProblemGradingPort).grade(problemSetId, problemId, "answer");
+        verify(lectureProblemSubmissionRepository).save(any(LectureProblemSubmission.class));
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -279,6 +279,29 @@ class LectureProblemSetServiceTest {
     }
 
     @Test
+    void submit_notRetriableWithPriorAttempt_throwsException() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3001L;
+        var currentProgress = progress(userId, lectureProblemSetId, 1, false);
+        givenSubmitContext(userId, lectureProblemSetId, problemSetId, problemId, currentProgress, 1, 3, false);
+
+        assertThrows(
+                com.wanted.codebombalms.global.domain.common.error.exception.ValidationException.class,
+                () -> lectureProblemSetService.submit(
+                        lectureProblemSetId,
+                        problemId,
+                        new SubmitCodeCommand(userId, "answer")
+                )
+        );
+
+        verify(learningProblemGradingPort, never()).grade(any(), any(), any());
+        verify(lectureProblemSubmissionRepository, never()).save(any());
+        verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
+    }
+
+    @Test
     void submit_gradingFailure_doesNotSaveSubmissionOrProgress() {
         Long userId = 10L;
         Long lectureProblemSetId = 6001L;
@@ -428,6 +451,28 @@ class LectureProblemSetServiceTest {
             int previousAttemptCount,
             int attemptLimit
     ) {
+        givenSubmitContext(
+                userId,
+                lectureProblemSetId,
+                problemSetId,
+                problemId,
+                progress,
+                previousAttemptCount,
+                attemptLimit,
+                true
+        );
+    }
+
+    private void givenSubmitContext(
+            Long userId,
+            Long lectureProblemSetId,
+            Long problemSetId,
+            Long problemId,
+            LectureProblemProgress progress,
+            int previousAttemptCount,
+            int attemptLimit,
+            boolean retriable
+    ) {
         given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
                 .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
         given(learningProblemPort.existsProblem(problemId)).willReturn(true);
@@ -440,7 +485,7 @@ class LectureProblemSetServiceTest {
                         "explanation",
                         10,
                         attemptLimit,
-                        true
+                        retriable
                 )
         );
         given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #확인 필요

---

## 🛠️ 기능 관련 작업 내용
- 강의문제 제출 시 `attemptLimit` 값에 따라 제출 횟수가 막히던 로직 제거 (제출 무제한 허용)
- `retriable = false`인 문제는 기존대로 1회 제출 제한 유지
- 응답의 `remainingAttemptCount`, `canRetry`도 횟수 제한 없이 동작하도록 수정

---

## ♻️ 패키지 변경 사항
- `learning/application/service`: `LectureProblemSetService`에서 시도 횟수(`attemptLimit`) 검증 로직 제거, `calculateRemainingAttempts` 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 문제 제출 시 시도 횟수 제한이 적용되지 않도록 변경되었습니다.
  * 시도 제한에 도달한 이후에도 제출물이 채점되고 저장됩니다.
  * 오답 제출 결과에서 남은 시도 횟수 정보가 제공되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->