### PR TITLE
[Feat] 관리자 문의(Inquiry) API 구현

### DIFF
--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/ReplyInquiryCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/ReplyInquiryCommand.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+// 관리자 답변 등록 요청 값을 담는다.
+public record ReplyInquiryCommand(
+        Long inquiryId,
+        Long adminId,
+        String content
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryClassificationCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryClassificationCommand.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+
+// 관리자 분류(도메인/심각도) 수정 요청 값을 담는다.
+public record UpdateInquiryClassificationCommand(
+        Long inquiryId,
+        Long adminId,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        String reason
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryFilterCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryFilterCommand.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+// 관리자 필터링 처리/복구 요청 값을 담는다.
+public record UpdateInquiryFilterCommand(
+        Long inquiryId,
+        Long adminId,
+        Boolean filtered,
+        String reason
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryDetail.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryDetail.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+import java.time.LocalDateTime;
+
+// 관리자 문의 상세 화면에 필요한 원문/AI 분석/처리 결과 전체를 담는다.
+public record AdminInquiryDetail(
+        Long inquiryId,
+        Long userId,
+        String title,
+        String content,
+        String sourceUrl,
+        String estimatedUrl,
+        String summary,
+        String recommendedAction,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        String adminReply,
+        Long repliedBy,
+        LocalDateTime repliedAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryListItem.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryListItem.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+import java.time.LocalDateTime;
+
+// 관리자 문의 목록 한 행에 필요한 AI 요약 기준 정보만 담는다.
+public record AdminInquiryListItem(
+        Long inquiryId,
+        String title,
+        String summary,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/GetAdminInquiriesQuery.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/GetAdminInquiriesQuery.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+// 관리자 문의 목록 조회 조건을 담는다.
+public record GetAdminInquiriesQuery(
+        boolean isFiltered,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+
+import java.util.Optional;
+
+public interface InquiryQueryRepository {
+
+    PageResult<AdminInquiryListItem> findAdminInquiries(GetAdminInquiriesQuery query);
+
+    Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -89,16 +90,17 @@ public class AdminInquiryCommandService implements
                 .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
     }
 
-    // AI 값과 관리자 값이 다를 때만 inquiry_id + field_name 기준으로 마지막 보정값을 upsert한다.
+    // 수정 전 값과 관리자 값이 다를 때만 inquiry_id + field_name 기준으로 마지막 보정값을 upsert한다.
+    // previousValue는 비교 기준이면서, 보정 row가 처음 생성될 때는 그대로 ai_value로 저장된다.
     private void upsertCorrectionIfChanged(
             Long inquiryId,
             Long adminId,
             InquiryCorrectionField fieldName,
-            String aiValue,
+            String previousValue,
             String correctedValue,
             String reason
     ) {
-        if (aiValue.equals(correctedValue)) {
+        if (Objects.equals(previousValue, correctedValue)) {
             return;
         }
 
@@ -109,7 +111,7 @@ public class AdminInquiryCommandService implements
                     return existing;
                 })
                 .orElseGet(() -> InquiryAiCorrection.create(
-                        inquiryId, adminId, fieldName, aiValue, correctedValue, reason, now
+                        inquiryId, adminId, fieldName, previousValue, correctedValue, reason, now
                 ));
 
         inquiryAiCorrectionRepository.save(correction);

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
@@ -1,0 +1,133 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassificationCommand;
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
+import com.wanted.codebombalms.inquiry.application.usecase.ReplyInquiryUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryClassificationUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryFilterUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminInquiryCommandService implements
+        UpdateInquiryClassificationUseCase,
+        UpdateInquiryFilterUseCase,
+        ReplyInquiryUseCase {
+
+    private final InquiryRepository inquiryRepository;
+    private final InquiryAiCorrectionRepository inquiryAiCorrectionRepository;
+
+    @Override
+    // 문의를 조회해 도메인/심각도를 수정하고, 값이 바뀐 필드만 보정 이력에 upsert한다.
+    public Inquiry updateClassification(UpdateInquiryClassificationCommand command) {
+        validateClassificationCommand(command);
+
+        Inquiry inquiry = findInquiry(command.inquiryId());
+        String previousDomain = inquiry.getDomain().name();
+        String previousSeverity = inquiry.getSeverity().name();
+
+        inquiry.updateClassification(command.domain(), command.severity(), LocalDateTime.now());
+        Inquiry saved = inquiryRepository.save(inquiry);
+
+        upsertCorrectionIfChanged(
+                saved.getInquiryId(), command.adminId(), InquiryCorrectionField.DOMAIN,
+                previousDomain, command.domain().name(), command.reason()
+        );
+        upsertCorrectionIfChanged(
+                saved.getInquiryId(), command.adminId(), InquiryCorrectionField.SEVERITY,
+                previousSeverity, command.severity().name(), command.reason()
+        );
+
+        return saved;
+    }
+
+    @Override
+    // 문의를 조회해 필터링 상태를 바꾸고, 값이 바뀌었으면 보정 이력에 upsert한다.
+    public Inquiry updateFilter(UpdateInquiryFilterCommand command) {
+        validateFilterCommand(command);
+
+        Inquiry inquiry = findInquiry(command.inquiryId());
+        String previousFiltered = String.valueOf(inquiry.isFiltered());
+
+        inquiry.updateFilter(command.filtered(), LocalDateTime.now());
+        Inquiry saved = inquiryRepository.save(inquiry);
+
+        upsertCorrectionIfChanged(
+                saved.getInquiryId(), command.adminId(), InquiryCorrectionField.IS_FILTERED,
+                previousFiltered, String.valueOf(command.filtered()), command.reason()
+        );
+
+        return saved;
+    }
+
+    @Override
+    // 문의를 조회해 관리자 답변을 등록한다. 상태/노출 여부 변경은 도메인 모델이 함께 처리한다.
+    public Inquiry reply(ReplyInquiryCommand command) {
+        Inquiry inquiry = findInquiry(command.inquiryId());
+
+        inquiry.reply(command.content(), command.adminId(), LocalDateTime.now());
+
+        return inquiryRepository.save(inquiry);
+    }
+
+    private Inquiry findInquiry(Long inquiryId) {
+        return inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+    }
+
+    // AI 값과 관리자 값이 다를 때만 inquiry_id + field_name 기준으로 마지막 보정값을 upsert한다.
+    private void upsertCorrectionIfChanged(
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason
+    ) {
+        if (aiValue.equals(correctedValue)) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        InquiryAiCorrection correction = inquiryAiCorrectionRepository.findByInquiryIdAndFieldName(inquiryId, fieldName)
+                .map(existing -> {
+                    existing.updateCorrection(correctedValue, reason, adminId, now);
+                    return existing;
+                })
+                .orElseGet(() -> InquiryAiCorrection.create(
+                        inquiryId, adminId, fieldName, aiValue, correctedValue, reason, now
+                ));
+
+        inquiryAiCorrectionRepository.save(correction);
+    }
+
+    private void validateClassificationCommand(UpdateInquiryClassificationCommand command) {
+        if (command.domain() == null || command.severity() == null || isBlank(command.reason())) {
+            throw new ValidationException(InquiryErrorCode.INVALID_CLASSIFICATION_REQUEST);
+        }
+    }
+
+    private void validateFilterCommand(UpdateInquiryFilterCommand command) {
+        if (command.filtered() == null || isBlank(command.reason())) {
+            throw new ValidationException(InquiryErrorCode.INVALID_FILTER_REQUEST);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryQueryService.java
@@ -1,0 +1,44 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+import com.wanted.codebombalms.inquiry.application.query.InquiryQueryRepository;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiriesUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiryDetailUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminInquiryQueryService implements GetAdminInquiriesUseCase, GetAdminInquiryDetailUseCase {
+
+    private final InquiryQueryRepository inquiryQueryRepository;
+
+    @Override
+    // isFiltered/domain/severity/status 조건으로 관리자 문의 목록을 페이지 조회한다.
+    public PageResult<AdminInquiryListItem> getInquiries(GetAdminInquiriesQuery query) {
+        validatePage(query.page(), query.size());
+
+        return inquiryQueryRepository.findAdminInquiries(query);
+    }
+
+    @Override
+    // 문의 ID로 상세 정보를 조회하고 없으면 예외를 던진다.
+    public AdminInquiryDetail getInquiryDetail(Long inquiryId) {
+        return inquiryQueryRepository.findAdminInquiryDetail(inquiryId)
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+    }
+
+    private void validatePage(int page, int size) {
+        if (page < 0 || size <= 0 || size > 100) {
+            throw new ValidationException(InquiryErrorCode.INVALID_PAGE_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiriesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiriesUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+
+public interface GetAdminInquiriesUseCase {
+
+    PageResult<AdminInquiryListItem> getInquiries(GetAdminInquiriesQuery query);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiryDetailUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiryDetailUseCase.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+
+public interface GetAdminInquiryDetailUseCase {
+
+    // 문의 ID로 상세 정보를 조회한다.
+    AdminInquiryDetail getInquiryDetail(Long inquiryId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ReplyInquiryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ReplyInquiryUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 관리자가 문의에 답변을 등록하는 유스케이스 진입점이다.
+public interface ReplyInquiryUseCase {
+
+    Inquiry reply(ReplyInquiryCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryClassificationUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryClassificationUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassificationCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 관리자가 문의의 도메인/심각도 분류를 보정하는 유스케이스 진입점이다.
+public interface UpdateInquiryClassificationUseCase {
+
+    Inquiry updateClassification(UpdateInquiryClassificationCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryFilterUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryFilterUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 관리자가 문의 필터링 처리 또는 복구를 수행하는 유스케이스 진입점이다.
+public interface UpdateInquiryFilterUseCase {
+
+    Inquiry updateFilter(UpdateInquiryFilterCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/exception/InquiryErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/exception/InquiryErrorCode.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.inquiry.domain.exception;
+
+import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InquiryErrorCode implements ErrorCode {
+
+    // 조회
+    INVALID_PAGE_REQUEST("INQ-001", "페이지 요청 값이 올바르지 않습니다."),
+    INQUIRY_NOT_FOUND("INQ-002", "문의를 찾을 수 없습니다."),
+
+    // 분류 수정
+    INVALID_CLASSIFICATION_REQUEST("INQ-003", "문의 분류 수정 요청이 올바르지 않습니다."),
+
+    // 필터링 처리/복구
+    INVALID_FILTER_REQUEST("INQ-004", "문의 필터링 처리 요청이 올바르지 않습니다."),
+
+    // 답변 등록
+    INVALID_REPLY_REQUEST("INQ-005", "문의 답변 등록 요청이 올바르지 않습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
@@ -1,0 +1,211 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+
+import java.time.LocalDateTime;
+
+// 사용자 문의와 AI 분석/관리자 처리 결과를 함께 갖는 도메인 모델
+public class Inquiry {
+
+    private final Long inquiryId;
+    private final Long userId;
+    private String title;
+    private final String content;
+    private InquiryStatus status;
+    private InquirySeverity severity;
+    private InquiryDomain domain;
+    private final String sourceUrl;
+    private String estimatedUrl;
+    private String adminReply;
+    private Long repliedBy;
+    private LocalDateTime repliedAt;
+    private String aiSummary;
+    private String aiRecommendedAction;
+    private boolean filtered;
+    private boolean replyVisible;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private Inquiry(
+            Long inquiryId,
+            Long userId,
+            String title,
+            String content,
+            InquiryStatus status,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String sourceUrl,
+            String estimatedUrl,
+            String adminReply,
+            Long repliedBy,
+            LocalDateTime repliedAt,
+            String aiSummary,
+            String aiRecommendedAction,
+            boolean filtered,
+            boolean replyVisible,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.inquiryId = inquiryId;
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.severity = severity;
+        this.domain = domain;
+        this.sourceUrl = sourceUrl;
+        this.estimatedUrl = estimatedUrl;
+        this.adminReply = adminReply;
+        this.repliedBy = repliedBy;
+        this.repliedAt = repliedAt;
+        this.aiSummary = aiSummary;
+        this.aiRecommendedAction = aiRecommendedAction;
+        this.filtered = filtered;
+        this.replyVisible = replyVisible;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // DB에서 조회한 값으로 도메인 모델을 복원한다.
+    public static Inquiry restore(
+            Long inquiryId,
+            Long userId,
+            String title,
+            String content,
+            InquiryStatus status,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String sourceUrl,
+            String estimatedUrl,
+            String adminReply,
+            Long repliedBy,
+            LocalDateTime repliedAt,
+            String aiSummary,
+            String aiRecommendedAction,
+            boolean filtered,
+            boolean replyVisible,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new Inquiry(
+                inquiryId,
+                userId,
+                title,
+                content,
+                status,
+                severity,
+                domain,
+                sourceUrl,
+                estimatedUrl,
+                adminReply,
+                repliedBy,
+                repliedAt,
+                aiSummary,
+                aiRecommendedAction,
+                filtered,
+                replyVisible,
+                createdAt,
+                updatedAt
+        );
+    }
+
+    // 관리자가 AI 분류(도메인/심각도)를 보정한다.
+    public void updateClassification(InquiryDomain domain, InquirySeverity severity, LocalDateTime updatedAt) {
+        this.domain = domain;
+        this.severity = severity;
+        this.updatedAt = updatedAt;
+    }
+
+    // 관리자가 필터링 처리 또는 복구를 수행한다.
+    public void updateFilter(boolean filtered, LocalDateTime updatedAt) {
+        this.filtered = filtered;
+        this.updatedAt = updatedAt;
+    }
+
+    // 관리자 답변을 등록하고 상태를 답변 완료로 변경한다.
+    public void reply(String content, Long adminId, LocalDateTime repliedAt) {
+        if (content == null || content.isBlank()) {
+            throw new ValidationException(InquiryErrorCode.INVALID_REPLY_REQUEST);
+        }
+
+        this.adminReply = content;
+        this.repliedBy = adminId;
+        this.repliedAt = repliedAt;
+        this.status = InquiryStatus.ANSWERED;
+        this.replyVisible = true;
+        this.updatedAt = repliedAt;
+    }
+
+    public Long getInquiryId() {
+        return inquiryId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public InquiryStatus getStatus() {
+        return status;
+    }
+
+    public InquirySeverity getSeverity() {
+        return severity;
+    }
+
+    public InquiryDomain getDomain() {
+        return domain;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+
+    public String getEstimatedUrl() {
+        return estimatedUrl;
+    }
+
+    public String getAdminReply() {
+        return adminReply;
+    }
+
+    public Long getRepliedBy() {
+        return repliedBy;
+    }
+
+    public LocalDateTime getRepliedAt() {
+        return repliedAt;
+    }
+
+    public String getAiSummary() {
+        return aiSummary;
+    }
+
+    public String getAiRecommendedAction() {
+        return aiRecommendedAction;
+    }
+
+    public boolean isFiltered() {
+        return filtered;
+    }
+
+    public boolean isReplyVisible() {
+        return replyVisible;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryAiCorrection.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryAiCorrection.java
@@ -1,0 +1,131 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+import java.time.LocalDateTime;
+
+// AI 최초 분석값과 관리자 최종 보정값을 inquiry_id + field_name 기준으로 하나만 유지하는 도메인 모델
+public class InquiryAiCorrection {
+
+    private final Long correctionId;
+    private final Long inquiryId;
+    private Long adminId;
+    private final InquiryCorrectionField fieldName;
+    private final String aiValue;
+    private String correctedValue;
+    private String reason;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private InquiryAiCorrection(
+            Long correctionId,
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.correctionId = correctionId;
+        this.inquiryId = inquiryId;
+        this.adminId = adminId;
+        this.fieldName = fieldName;
+        this.aiValue = aiValue;
+        this.correctedValue = correctedValue;
+        this.reason = reason;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // 해당 필드의 첫 보정을 생성한다.
+    public static InquiryAiCorrection create(
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime now
+    ) {
+        return new InquiryAiCorrection(
+                null,
+                inquiryId,
+                adminId,
+                fieldName,
+                aiValue,
+                correctedValue,
+                reason,
+                now,
+                now
+        );
+    }
+
+    // DB에서 조회한 값으로 도메인 모델을 복원한다.
+    public static InquiryAiCorrection restore(
+            Long correctionId,
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new InquiryAiCorrection(
+                correctionId,
+                inquiryId,
+                adminId,
+                fieldName,
+                aiValue,
+                correctedValue,
+                reason,
+                createdAt,
+                updatedAt
+        );
+    }
+
+    // 같은 필드의 재보정. ai_value는 최초값을 유지하고 최종 보정값만 갱신한다.
+    public void updateCorrection(String correctedValue, String reason, Long adminId, LocalDateTime updatedAt) {
+        this.correctedValue = correctedValue;
+        this.reason = reason;
+        this.adminId = adminId;
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getCorrectionId() {
+        return correctionId;
+    }
+
+    public Long getInquiryId() {
+        return inquiryId;
+    }
+
+    public Long getAdminId() {
+        return adminId;
+    }
+
+    public InquiryCorrectionField getFieldName() {
+        return fieldName;
+    }
+
+    public String getAiValue() {
+        return aiValue;
+    }
+
+    public String getCorrectedValue() {
+        return correctedValue;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryCorrectionField.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryCorrectionField.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+// 관리자가 AI 분석 결과를 보정할 수 있는 inquiry 컬럼
+@Getter
+@RequiredArgsConstructor
+public enum InquiryCorrectionField {
+
+    DOMAIN("domain"),
+    SEVERITY("severity"),
+    IS_FILTERED("is_filtered");
+
+    private final String fieldName;
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryDomain.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryDomain.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+// 문의가 속한 서비스 도메인
+public enum InquiryDomain {
+    ADMIN,
+    AUTH,
+    BADGE,
+    CHATBOT,
+    COURSE,
+    ENROLLMENT,
+    PROBLEMS,
+    RANKING,
+    RECOMMENDATION,
+    USER,
+    LECTURE,
+    LEARNING,
+    ETC;
+
+    // Swagger 문서용 값별 의미 설명. @Schema/@Parameter description에서 재사용한다.
+    public static final String SCHEMA_DESCRIPTION =
+            "문의 도메인 (ADMIN: 관리자/운영, AUTH: 로그인/인증, BADGE: 뱃지, CHATBOT: 챗봇, "
+                    + "COURSE: 강의, ENROLLMENT: 수강신청/수강관리, PROBLEMS: 문제/채점/제출, RANKING: 랭킹, "
+                    + "RECOMMENDATION: 추천, USER: 회원/프로필, LECTURE: 강의 영상/자료, LEARNING: 학습 진행, ETC: 기타)";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquirySeverity.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquirySeverity.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+// 문의 심각도
+public enum InquirySeverity {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL;
+
+    // Swagger 문서용 값별 의미 설명. @Schema/@Parameter description에서 재사용한다.
+    public static final String SCHEMA_DESCRIPTION =
+            "문의 심각도 (LOW: 단순 문의/제안, MEDIUM: 일반 오류/불편, "
+                    + "HIGH: 기능 사용에 큰 지장, CRITICAL: 로그인/결제/학습 진행 불가급)";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryStatus.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryStatus.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+// 문의 처리 상태
+public enum InquiryStatus {
+    OPEN,
+    ANSWERED;
+
+    // Swagger 문서용 값별 의미 설명. @Schema/@Parameter description에서 재사용한다.
+    public static final String SCHEMA_DESCRIPTION = "문의 처리 상태 (OPEN: 새 문의, ANSWERED: 답변 완료)";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.inquiry.domain.repository;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+
+import java.util.Optional;
+
+public interface InquiryAiCorrectionRepository {
+
+    // inquiry_id + field_name 기준으로 마지막 보정 row를 조회한다.
+    Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+
+    InquiryAiCorrection save(InquiryAiCorrection correction);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.inquiry.domain.repository;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+import java.util.Optional;
+
+public interface InquiryRepository {
+
+    Optional<Inquiry> findById(Long inquiryId);
+
+    Inquiry save(Inquiry inquiry);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionJpaEntity.java
@@ -1,0 +1,95 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "inquiry_ai_correction",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_inquiry_ai_correction_field",
+                columnNames = {"inquiry_id", "field_name"}
+        )
+)
+@Getter
+@NoArgsConstructor
+public class InquiryAiCorrectionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "correction_id")
+    private Long correctionId;
+
+    @Column(name = "inquiry_id", nullable = false)
+    private Long inquiryId;
+
+    @Column(name = "admin_id", nullable = false)
+    private Long adminId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "field_name", nullable = false, length = 50)
+    private InquiryCorrectionField fieldName;
+
+    @Column(name = "ai_value", length = 500)
+    private String aiValue;
+
+    @Column(name = "corrected_value", nullable = false, length = 500)
+    private String correctedValue;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public InquiryAiCorrectionJpaEntity(
+            Long correctionId,
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.correctionId = correctionId;
+        this.inquiryId = inquiryId;
+        this.adminId = adminId;
+        this.fieldName = fieldName;
+        this.aiValue = aiValue;
+        this.correctedValue = correctedValue;
+        this.reason = reason;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionMapper.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionMapper.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+
+public class InquiryAiCorrectionMapper {
+
+    private InquiryAiCorrectionMapper() {
+    }
+
+    public static InquiryAiCorrection toDomain(InquiryAiCorrectionJpaEntity entity) {
+        return InquiryAiCorrection.restore(
+                entity.getCorrectionId(),
+                entity.getInquiryId(),
+                entity.getAdminId(),
+                entity.getFieldName(),
+                entity.getAiValue(),
+                entity.getCorrectedValue(),
+                entity.getReason(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+    public static InquiryAiCorrectionJpaEntity toEntity(InquiryAiCorrection domain) {
+        return new InquiryAiCorrectionJpaEntity(
+                domain.getCorrectionId(),
+                domain.getInquiryId(),
+                domain.getAdminId(),
+                domain.getFieldName(),
+                domain.getAiValue(),
+                domain.getCorrectedValue(),
+                domain.getReason(),
+                domain.getCreatedAt(),
+                domain.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InquiryAiCorrectionRepositoryAdapter implements InquiryAiCorrectionRepository {
+
+    private final SpringDataInquiryAiCorrectionRepository springDataRepository;
+
+    @Override
+    public Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName) {
+        return springDataRepository.findByInquiryIdAndFieldName(inquiryId, fieldName)
+                .map(InquiryAiCorrectionMapper::toDomain);
+    }
+
+    @Override
+    public InquiryAiCorrection save(InquiryAiCorrection correction) {
+        InquiryAiCorrectionJpaEntity saved = springDataRepository.save(InquiryAiCorrectionMapper.toEntity(correction));
+
+        return InquiryAiCorrectionMapper.toDomain(saved);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryJpaEntity.java
@@ -1,0 +1,137 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "inquiry")
+@Getter
+@NoArgsConstructor
+public class InquiryJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id")
+    private Long inquiryId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private InquiryStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", nullable = false, length = 30)
+    private InquirySeverity severity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "domain", nullable = false, length = 50)
+    private InquiryDomain domain;
+
+    @Column(name = "source_url", length = 500)
+    private String sourceUrl;
+
+    @Column(name = "estimated_url", length = 500)
+    private String estimatedUrl;
+
+    @Column(name = "admin_reply", columnDefinition = "TEXT")
+    private String adminReply;
+
+    @Column(name = "replied_by")
+    private Long repliedBy;
+
+    @Column(name = "replied_at")
+    private LocalDateTime repliedAt;
+
+    @Column(name = "ai_summary", length = 500)
+    private String aiSummary;
+
+    @Column(name = "ai_recommended_action", columnDefinition = "TEXT")
+    private String aiRecommendedAction;
+
+    @Column(name = "is_filtered", nullable = false)
+    private boolean filtered;
+
+    @Column(name = "reply_visible", nullable = false)
+    private boolean replyVisible;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public InquiryJpaEntity(
+            Long inquiryId,
+            Long userId,
+            String title,
+            String content,
+            InquiryStatus status,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String sourceUrl,
+            String estimatedUrl,
+            String adminReply,
+            Long repliedBy,
+            LocalDateTime repliedAt,
+            String aiSummary,
+            String aiRecommendedAction,
+            boolean filtered,
+            boolean replyVisible,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.inquiryId = inquiryId;
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.severity = severity;
+        this.domain = domain;
+        this.sourceUrl = sourceUrl;
+        this.estimatedUrl = estimatedUrl;
+        this.adminReply = adminReply;
+        this.repliedBy = repliedBy;
+        this.repliedAt = repliedAt;
+        this.aiSummary = aiSummary;
+        this.aiRecommendedAction = aiRecommendedAction;
+        this.filtered = filtered;
+        this.replyVisible = replyVisible;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryListProjection.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryListProjection.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+import java.time.LocalDateTime;
+
+// 목록 조회에서 원문 없이 AI 요약 기준 컬럼만 뽑아오는 JPQL constructor projection
+public record InquiryListProjection(
+        Long inquiryId,
+        String title,
+        String aiSummary,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryMapper.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryMapper.java
@@ -1,0 +1,55 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+public class InquiryMapper {
+
+    private InquiryMapper() {
+    }
+
+    public static Inquiry toDomain(InquiryJpaEntity entity) {
+        return Inquiry.restore(
+                entity.getInquiryId(),
+                entity.getUserId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getStatus(),
+                entity.getSeverity(),
+                entity.getDomain(),
+                entity.getSourceUrl(),
+                entity.getEstimatedUrl(),
+                entity.getAdminReply(),
+                entity.getRepliedBy(),
+                entity.getRepliedAt(),
+                entity.getAiSummary(),
+                entity.getAiRecommendedAction(),
+                entity.isFiltered(),
+                entity.isReplyVisible(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+    public static InquiryJpaEntity toEntity(Inquiry domain) {
+        return new InquiryJpaEntity(
+                domain.getInquiryId(),
+                domain.getUserId(),
+                domain.getTitle(),
+                domain.getContent(),
+                domain.getStatus(),
+                domain.getSeverity(),
+                domain.getDomain(),
+                domain.getSourceUrl(),
+                domain.getEstimatedUrl(),
+                domain.getAdminReply(),
+                domain.getRepliedBy(),
+                domain.getRepliedAt(),
+                domain.getAiSummary(),
+                domain.getAiRecommendedAction(),
+                domain.isFiltered(),
+                domain.isReplyVisible(),
+                domain.getCreatedAt(),
+                domain.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
@@ -1,0 +1,98 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+import com.wanted.codebombalms.inquiry.application.query.InquiryQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InquiryQueryAdapter implements InquiryQueryRepository {
+
+    private final SpringDataInquiryRepository springDataRepository;
+
+    @Override
+    // 최신 문의가 먼저 오도록 정렬해 관리자 목록을 페이지 조회한다.
+    public PageResult<AdminInquiryListItem> findAdminInquiries(GetAdminInquiriesQuery query) {
+        PageRequest pageRequest = PageRequest.of(
+                query.page(),
+                query.size(),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "inquiryId"))
+        );
+
+        Page<InquiryListProjection> result = springDataRepository.findAdminInquiries(
+                query.isFiltered(),
+                query.domain(),
+                query.severity(),
+                query.status(),
+                pageRequest
+        );
+
+        List<AdminInquiryListItem> content = result.getContent().stream()
+                .map(this::toListItem)
+                .toList();
+
+        return new PageResult<>(
+                content,
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.isFirst(),
+                result.isLast(),
+                result.hasNext(),
+                result.hasPrevious()
+        );
+    }
+
+    @Override
+    // 조인이 필요 없는 단일 테이블 조회라 JPA 기본 findById 결과를 그대로 상세 응답으로 변환한다.
+    public Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId) {
+        return springDataRepository.findById(inquiryId)
+                .map(this::toDetail);
+    }
+
+    private AdminInquiryListItem toListItem(InquiryListProjection projection) {
+        return new AdminInquiryListItem(
+                projection.inquiryId(),
+                projection.title(),
+                projection.aiSummary(),
+                projection.domain(),
+                projection.severity(),
+                projection.status(),
+                projection.filtered(),
+                projection.createdAt()
+        );
+    }
+
+    private AdminInquiryDetail toDetail(InquiryJpaEntity entity) {
+        return new AdminInquiryDetail(
+                entity.getInquiryId(),
+                entity.getUserId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getSourceUrl(),
+                entity.getEstimatedUrl(),
+                entity.getAiSummary(),
+                entity.getAiRecommendedAction(),
+                entity.getDomain(),
+                entity.getSeverity(),
+                entity.getStatus(),
+                entity.isFiltered(),
+                entity.getAdminReply(),
+                entity.getRepliedBy(),
+                entity.getRepliedAt(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InquiryRepositoryAdapter implements InquiryRepository {
+
+    private final SpringDataInquiryRepository springDataRepository;
+
+    @Override
+    public Optional<Inquiry> findById(Long inquiryId) {
+        return springDataRepository.findById(inquiryId)
+                .map(InquiryMapper::toDomain);
+    }
+
+    @Override
+    public Inquiry save(Inquiry inquiry) {
+        InquiryJpaEntity saved = springDataRepository.save(InquiryMapper.toEntity(inquiry));
+
+        return InquiryMapper.toDomain(saved);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataInquiryAiCorrectionRepository extends JpaRepository<InquiryAiCorrectionJpaEntity, Long> {
+
+    Optional<InquiryAiCorrectionJpaEntity> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
@@ -1,0 +1,42 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SpringDataInquiryRepository extends JpaRepository<InquiryJpaEntity, Long> {
+
+    // isFiltered는 항상 조건으로 걸고, domain/severity/status는 값이 있을 때만 조건에 추가한다.
+    @Query(
+            value = """
+                    select new com.wanted.codebombalms.inquiry.infrastructure.persistence.InquiryListProjection(
+                        i.inquiryId, i.title, i.aiSummary, i.domain, i.severity, i.status, i.filtered, i.createdAt
+                    )
+                    from InquiryJpaEntity i
+                    where i.filtered = :isFiltered
+                      and (:domain is null or i.domain = :domain)
+                      and (:severity is null or i.severity = :severity)
+                      and (:status is null or i.status = :status)
+                    """,
+            countQuery = """
+                    select count(i)
+                    from InquiryJpaEntity i
+                    where i.filtered = :isFiltered
+                      and (:domain is null or i.domain = :domain)
+                      and (:severity is null or i.severity = :severity)
+                      and (:status is null or i.status = :status)
+                    """
+    )
+    Page<InquiryListProjection> findAdminInquiries(
+            @Param("isFiltered") boolean isFiltered,
+            @Param("domain") InquiryDomain domain,
+            @Param("severity") InquirySeverity severity,
+            @Param("status") InquiryStatus status,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
@@ -1,0 +1,162 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiriesUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiryDetailUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.ReplyInquiryUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryClassificationUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryFilterUseCase;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryClassificationUpdateRequest;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryFilterUpdateRequest;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryReplyRequest;
+import com.wanted.codebombalms.inquiry.presentation.api.response.AdminInquiryDetailResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.AdminInquiryListResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryClassificationUpdateResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryFilterUpdateResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryReplyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin - 문의", description = "관리자 문의 목록/상세 조회, 분류 수정, 필터링 처리, 답변 등록 API")
+@RestController
+@RequestMapping("/api/v1/admin/inquiries")
+@RequiredArgsConstructor
+public class AdminInquiryController {
+
+    private final GetAdminInquiriesUseCase getAdminInquiriesUseCase;
+    private final GetAdminInquiryDetailUseCase getAdminInquiryDetailUseCase;
+    private final UpdateInquiryClassificationUseCase updateInquiryClassificationUseCase;
+    private final UpdateInquiryFilterUseCase updateInquiryFilterUseCase;
+    private final ReplyInquiryUseCase replyInquiryUseCase;
+
+    // 문의 목록 조회 (isFiltered로 정상/필터링 목록 구분, domain/severity/status 칼럼 필터)
+    @Operation(summary = "관리자 문의 목록 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-001: 페이지 요청 값이 올바르지 않습니다.")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<AdminInquiryListResponse>> findInquiries(
+            @Parameter(description = "true면 AI가 필터링(스팸/무의미)한 목록, false면 정상 목록", example = "false")
+            @RequestParam(defaultValue = "false") boolean isFiltered,
+            @Parameter(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS")
+            @RequestParam(required = false) InquiryDomain domain,
+            @Parameter(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH")
+            @RequestParam(required = false) InquirySeverity severity,
+            @Parameter(description = InquiryStatus.SCHEMA_DESCRIPTION, example = "OPEN")
+            @RequestParam(required = false) InquiryStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        var result = getAdminInquiriesUseCase.getInquiries(
+                new GetAdminInquiriesQuery(isFiltered, domain, severity, status, page, size)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.RETRIEVED,
+                InquiryResponseMessage.RETRIEVED,
+                AdminInquiryListResponse.from(result)
+        ));
+    }
+
+    // 문의 상세 조회 (원문, AI 분석, 관리자 처리 결과 전체)
+    @Operation(summary = "관리자 문의 상세 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<ApiResponse<AdminInquiryDetailResponse>> findInquiryDetail(
+            @PathVariable Long inquiryId
+    ) {
+        var result = getAdminInquiryDetailUseCase.getInquiryDetail(inquiryId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.RETRIEVED,
+                InquiryResponseMessage.RETRIEVED,
+                AdminInquiryDetailResponse.from(result)
+        ));
+    }
+
+    // 문의 분류(도메인/심각도) 수정, reason 필수
+    @Operation(summary = "관리자 문의 분류 수정")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-003: 문의 분류 수정 요청이 올바르지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PatchMapping("/{inquiryId}/classification")
+    public ResponseEntity<ApiResponse<InquiryClassificationUpdateResponse>> updateInquiryClassification(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long adminId,
+            @RequestBody InquiryClassificationUpdateRequest request
+    ) {
+        var result = updateInquiryClassificationUseCase.updateClassification(
+                request.toCommand(inquiryId, adminId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.CLASSIFICATION_UPDATED,
+                InquiryResponseMessage.CLASSIFICATION_UPDATED,
+                InquiryClassificationUpdateResponse.from(result)
+        ));
+    }
+
+    // 문의 필터링 처리 또는 복구, reason 필수
+    @Operation(summary = "관리자 문의 필터링 처리/복구")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-004: 문의 필터링 처리 요청이 올바르지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PatchMapping("/{inquiryId}/filter")
+    public ResponseEntity<ApiResponse<InquiryFilterUpdateResponse>> updateInquiryFilter(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long adminId,
+            @RequestBody InquiryFilterUpdateRequest request
+    ) {
+        var result = updateInquiryFilterUseCase.updateFilter(
+                request.toCommand(inquiryId, adminId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.FILTER_UPDATED,
+                InquiryResponseMessage.FILTER_UPDATED,
+                InquiryFilterUpdateResponse.from(result)
+        ));
+    }
+
+    // 답변 등록, 상태(ANSWERED)/노출 여부/답변자/답변시각까지 한 트랜잭션에서 갱신
+    @Operation(summary = "관리자 문의 답변 등록")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-005: 문의 답변 등록 요청이 올바르지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PostMapping("/{inquiryId}/reply")
+    public ResponseEntity<ApiResponse<InquiryReplyResponse>> replyInquiry(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long adminId,
+            @RequestBody InquiryReplyRequest request
+    ) {
+        var result = replyInquiryUseCase.reply(
+                request.toCommand(inquiryId, adminId)
+        );
+
+        return ResponseEntity.status(201).body(ApiResponse.created(
+                InquiryResponseCode.REPLIED,
+                InquiryResponseMessage.REPLIED,
+                InquiryReplyResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -99,7 +100,7 @@ public class AdminInquiryController {
     public ResponseEntity<ApiResponse<InquiryClassificationUpdateResponse>> updateInquiryClassification(
             @PathVariable Long inquiryId,
             @AuthenticationPrincipal Long adminId,
-            @RequestBody InquiryClassificationUpdateRequest request
+            @Valid @RequestBody InquiryClassificationUpdateRequest request
     ) {
         var result = updateInquiryClassificationUseCase.updateClassification(
                 request.toCommand(inquiryId, adminId)
@@ -123,7 +124,7 @@ public class AdminInquiryController {
     public ResponseEntity<ApiResponse<InquiryFilterUpdateResponse>> updateInquiryFilter(
             @PathVariable Long inquiryId,
             @AuthenticationPrincipal Long adminId,
-            @RequestBody InquiryFilterUpdateRequest request
+            @Valid @RequestBody InquiryFilterUpdateRequest request
     ) {
         var result = updateInquiryFilterUseCase.updateFilter(
                 request.toCommand(inquiryId, adminId)
@@ -147,7 +148,7 @@ public class AdminInquiryController {
     public ResponseEntity<ApiResponse<InquiryReplyResponse>> replyInquiry(
             @PathVariable Long inquiryId,
             @AuthenticationPrincipal Long adminId,
-            @RequestBody InquiryReplyRequest request
+            @Valid @RequestBody InquiryReplyRequest request
     ) {
         var result = replyInquiryUseCase.reply(
                 request.toCommand(inquiryId, adminId)

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+public class InquiryResponseCode {
+
+    private InquiryResponseCode() {}
+
+    public static final String RETRIEVED               = "ADMIN_INQUIRY-RETRIEVED";
+    public static final String CLASSIFICATION_UPDATED   = "ADMIN_INQUIRY-CLASSIFICATION_UPDATED";
+    public static final String FILTER_UPDATED           = "ADMIN_INQUIRY-FILTER_UPDATED";
+    public static final String REPLIED                  = "ADMIN_INQUIRY-REPLIED";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+public class InquiryResponseMessage {
+
+    private InquiryResponseMessage() {}
+
+    public static final String RETRIEVED               = "문의 조회에 성공했습니다.";
+    public static final String CLASSIFICATION_UPDATED   = "문의 분류가 수정되었습니다.";
+    public static final String FILTER_UPDATED           = "문의 필터링 상태가 변경되었습니다.";
+    public static final String REPLIED                  = "문의 답변이 등록되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
@@ -4,22 +4,24 @@ import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassifi
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
-@Getter
-@NoArgsConstructor
 // 관리자 문의 분류(도메인/심각도) 수정 요청을 받는다.
-public class InquiryClassificationUpdateRequest {
+public record InquiryClassificationUpdateRequest(
 
-    @Schema(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS")
-    private InquiryDomain domain;
+        @Schema(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "도메인은 필수입니다.")
+        InquiryDomain domain,
 
-    @Schema(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH")
-    private InquirySeverity severity;
+        @Schema(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "심각도는 필수입니다.")
+        InquirySeverity severity,
 
-    @Schema(description = "분류 수정 사유 (필수)", example = "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함")
-    private String reason;
+        @Schema(description = "분류 수정 사유 (필수)", example = "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "수정 사유는 필수입니다.")
+        String reason
+) {
 
     // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
     public UpdateInquiryClassificationCommand toCommand(Long inquiryId, Long adminId) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassificationCommand;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 관리자 문의 분류(도메인/심각도) 수정 요청을 받는다.
+public class InquiryClassificationUpdateRequest {
+
+    @Schema(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS")
+    private InquiryDomain domain;
+
+    @Schema(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH")
+    private InquirySeverity severity;
+
+    @Schema(description = "분류 수정 사유 (필수)", example = "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함")
+    private String reason;
+
+    // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
+    public UpdateInquiryClassificationCommand toCommand(Long inquiryId, Long adminId) {
+        return new UpdateInquiryClassificationCommand(inquiryId, adminId, domain, severity, reason);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
@@ -2,19 +2,20 @@ package com.wanted.codebombalms.inquiry.presentation.api.request;
 
 import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
-@Getter
-@NoArgsConstructor
 // 관리자 문의 필터링 처리/복구 요청을 받는다.
-public class InquiryFilterUpdateRequest {
+public record InquiryFilterUpdateRequest(
 
-    @Schema(description = "true면 필터링(스팸/무의미) 처리, false면 정상 목록으로 복구", example = "false")
-    private Boolean filtered;
+        @Schema(description = "true면 필터링(스팸/무의미) 처리, false면 정상 목록으로 복구", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "필터링 여부는 필수입니다.")
+        Boolean filtered,
 
-    @Schema(description = "필터링 처리/복구 사유 (필수)", example = "AI는 무의미 문의로 판단했지만 실제 문제 제출 오류 문의로 확인됨")
-    private String reason;
+        @Schema(description = "필터링 처리/복구 사유 (필수)", example = "AI는 무의미 문의로 판단했지만 실제 문제 제출 오류 문의로 확인됨", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "처리 사유는 필수입니다.")
+        String reason
+) {
 
     // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
     public UpdateInquiryFilterCommand toCommand(Long inquiryId, Long adminId) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 관리자 문의 필터링 처리/복구 요청을 받는다.
+public class InquiryFilterUpdateRequest {
+
+    @Schema(description = "true면 필터링(스팸/무의미) 처리, false면 정상 목록으로 복구", example = "false")
+    private Boolean filtered;
+
+    @Schema(description = "필터링 처리/복구 사유 (필수)", example = "AI는 무의미 문의로 판단했지만 실제 문제 제출 오류 문의로 확인됨")
+    private String reason;
+
+    // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
+    public UpdateInquiryFilterCommand toCommand(Long inquiryId, Long adminId) {
+        return new UpdateInquiryFilterCommand(inquiryId, adminId, filtered, reason);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 관리자 문의 답변 등록 요청을 받는다.
+public class InquiryReplyRequest {
+
+    private String content;
+
+    // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
+    public ReplyInquiryCommand toCommand(Long inquiryId, Long adminId) {
+        return new ReplyInquiryCommand(inquiryId, adminId, content);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
@@ -1,15 +1,16 @@
 package com.wanted.codebombalms.inquiry.presentation.api.request;
 
 import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
-@Getter
-@NoArgsConstructor
 // 관리자 문의 답변 등록 요청을 받는다.
-public class InquiryReplyRequest {
+public record InquiryReplyRequest(
 
-    private String content;
+        @Schema(description = "답변 내용", example = "문의 주신 문제 제출 오류를 확인했고 수정 반영했습니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "답변 내용은 필수입니다.")
+        String content
+) {
 
     // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
     public ReplyInquiryCommand toCommand(Long inquiryId, Long adminId) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
@@ -4,34 +4,28 @@ import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 문의 원문과 AI 분석, 관리자 처리 결과 전체를 응답에 담는다.
-public class AdminInquiryDetailResponse {
-
-    private Long inquiryId;
-    private Long userId;
-    private String title;
-    private String content;
-    private String sourceUrl;
-    private String estimatedUrl;
-    private String summary;
-    private String recommendedAction;
-    private InquiryDomain domain;
-    private InquirySeverity severity;
-    private InquiryStatus status;
-    private boolean filtered;
-    private String adminReply;
-    private Long repliedBy;
-    private LocalDateTime repliedAt;
-    private LocalDateTime createdAt;
+public record AdminInquiryDetailResponse(
+        Long inquiryId,
+        Long userId,
+        String title,
+        String content,
+        String sourceUrl,
+        String estimatedUrl,
+        String summary,
+        String recommendedAction,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        String adminReply,
+        Long repliedBy,
+        LocalDateTime repliedAt,
+        LocalDateTime createdAt
+) {
 
     public static AdminInquiryDetailResponse from(AdminInquiryDetail detail) {
         return new AdminInquiryDetailResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 문의 원문과 AI 분석, 관리자 처리 결과 전체를 응답에 담는다.
+public class AdminInquiryDetailResponse {
+
+    private Long inquiryId;
+    private Long userId;
+    private String title;
+    private String content;
+    private String sourceUrl;
+    private String estimatedUrl;
+    private String summary;
+    private String recommendedAction;
+    private InquiryDomain domain;
+    private InquirySeverity severity;
+    private InquiryStatus status;
+    private boolean filtered;
+    private String adminReply;
+    private Long repliedBy;
+    private LocalDateTime repliedAt;
+    private LocalDateTime createdAt;
+
+    public static AdminInquiryDetailResponse from(AdminInquiryDetail detail) {
+        return new AdminInquiryDetailResponse(
+                detail.inquiryId(),
+                detail.userId(),
+                detail.title(),
+                detail.content(),
+                detail.sourceUrl(),
+                detail.estimatedUrl(),
+                detail.summary(),
+                detail.recommendedAction(),
+                detail.domain(),
+                detail.severity(),
+                detail.status(),
+                detail.filtered(),
+                detail.adminReply(),
+                detail.repliedBy(),
+                detail.repliedAt(),
+                detail.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
@@ -2,26 +2,20 @@ package com.wanted.codebombalms.inquiry.presentation.api.response;
 
 import com.wanted.codebombalms.admin.operation.common.application.PageResult;
 import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class AdminInquiryListResponse {
-
-    private List<AdminInquiryResponse> content;
-    private int page;
-    private int size;
-    private long totalElements;
-    private int totalPages;
-    private boolean first;
-    private boolean last;
-    private boolean hasNext;
-    private boolean hasPrevious;
+public record AdminInquiryListResponse(
+        List<AdminInquiryResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last,
+        boolean hasNext,
+        boolean hasPrevious
+) {
 
     public static AdminInquiryListResponse from(PageResult<AdminInquiryListItem> pageResult) {
         return new AdminInquiryListResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
@@ -1,0 +1,41 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminInquiryListResponse {
+
+    private List<AdminInquiryResponse> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean first;
+    private boolean last;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    public static AdminInquiryListResponse from(PageResult<AdminInquiryListItem> pageResult) {
+        return new AdminInquiryListResponse(
+                pageResult.getContent().stream()
+                        .map(AdminInquiryResponse::from)
+                        .toList(),
+                pageResult.getPage(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                pageResult.isFirst(),
+                pageResult.isLast(),
+                pageResult.hasNext(),
+                pageResult.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 목록 한 행을 AI 요약 기준으로만 응답에 담는다.
+public class AdminInquiryResponse {
+
+    private Long inquiryId;
+    private String title;
+    private String summary;
+    private InquiryDomain domain;
+    private InquirySeverity severity;
+    private InquiryStatus status;
+    private boolean filtered;
+    private LocalDateTime createdAt;
+
+    public static AdminInquiryResponse from(AdminInquiryListItem item) {
+        return new AdminInquiryResponse(
+                item.inquiryId(),
+                item.title(),
+                item.summary(),
+                item.domain(),
+                item.severity(),
+                item.status(),
+                item.filtered(),
+                item.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
@@ -4,26 +4,20 @@ import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 목록 한 행을 AI 요약 기준으로만 응답에 담는다.
-public class AdminInquiryResponse {
-
-    private Long inquiryId;
-    private String title;
-    private String summary;
-    private InquiryDomain domain;
-    private InquirySeverity severity;
-    private InquiryStatus status;
-    private boolean filtered;
-    private LocalDateTime createdAt;
+public record AdminInquiryResponse(
+        Long inquiryId,
+        String title,
+        String summary,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        LocalDateTime createdAt
+) {
 
     public static AdminInquiryResponse from(AdminInquiryListItem item) {
         return new AdminInquiryResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
@@ -3,19 +3,13 @@ package com.wanted.codebombalms.inquiry.presentation.api.response;
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 분류 수정 결과로 바뀐 도메인/심각도만 응답에 담는다.
-public class InquiryClassificationUpdateResponse {
-
-    private Long inquiryId;
-    private InquiryDomain domain;
-    private InquirySeverity severity;
+public record InquiryClassificationUpdateResponse(
+        Long inquiryId,
+        InquiryDomain domain,
+        InquirySeverity severity
+) {
 
     public static InquiryClassificationUpdateResponse from(Inquiry inquiry) {
         return new InquiryClassificationUpdateResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 분류 수정 결과로 바뀐 도메인/심각도만 응답에 담는다.
+public class InquiryClassificationUpdateResponse {
+
+    private Long inquiryId;
+    private InquiryDomain domain;
+    private InquirySeverity severity;
+
+    public static InquiryClassificationUpdateResponse from(Inquiry inquiry) {
+        return new InquiryClassificationUpdateResponse(
+                inquiry.getInquiryId(),
+                inquiry.getDomain(),
+                inquiry.getSeverity()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
@@ -1,18 +1,12 @@
 package com.wanted.codebombalms.inquiry.presentation.api.response;
 
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 필터링 처리/복구 결과로 바뀐 상태만 응답에 담는다.
-public class InquiryFilterUpdateResponse {
-
-    private Long inquiryId;
-    private boolean filtered;
+public record InquiryFilterUpdateResponse(
+        Long inquiryId,
+        boolean filtered
+) {
 
     public static InquiryFilterUpdateResponse from(Inquiry inquiry) {
         return new InquiryFilterUpdateResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 필터링 처리/복구 결과로 바뀐 상태만 응답에 담는다.
+public class InquiryFilterUpdateResponse {
+
+    private Long inquiryId;
+    private boolean filtered;
+
+    public static InquiryFilterUpdateResponse from(Inquiry inquiry) {
+        return new InquiryFilterUpdateResponse(
+                inquiry.getInquiryId(),
+                inquiry.isFiltered()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
@@ -2,23 +2,17 @@ package com.wanted.codebombalms.inquiry.presentation.api.response;
 
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 답변 등록 결과로 바뀐 상태와 답변 내용을 응답에 담는다.
-public class InquiryReplyResponse {
-
-    private Long inquiryId;
-    private InquiryStatus status;
-    private String adminReply;
-    private Long repliedBy;
-    private LocalDateTime repliedAt;
+public record InquiryReplyResponse(
+        Long inquiryId,
+        InquiryStatus status,
+        String adminReply,
+        Long repliedBy,
+        LocalDateTime repliedAt
+) {
 
     public static InquiryReplyResponse from(Inquiry inquiry) {
         return new InquiryReplyResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
@@ -1,0 +1,32 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 답변 등록 결과로 바뀐 상태와 답변 내용을 응답에 담는다.
+public class InquiryReplyResponse {
+
+    private Long inquiryId;
+    private InquiryStatus status;
+    private String adminReply;
+    private Long repliedBy;
+    private LocalDateTime repliedAt;
+
+    public static InquiryReplyResponse from(Inquiry inquiry) {
+        return new InquiryReplyResponse(
+                inquiry.getInquiryId(),
+                inquiry.getStatus(),
+                inquiry.getAdminReply(),
+                inquiry.getRepliedBy(),
+                inquiry.getRepliedAt()
+        );
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #641 

---

## 🛠️ 기능 관련 작업 내용
- 관리자 문의 목록/상세 조회, 분류(도메인/심각도) 수정, 필터링 처리/복구, 답변 등록 API 5종 구현
- AI 초기값과 관리자 최종 보정값이 다를 때만 inquiry_ai_correction에 upsert하는 로직 구현
- Swagger 문서화(@Tag/@Schema/@Parameter)로 enum 값별 의미까지 노출

---

## ♻️ 패키지 변경 사항
- `inquiry/domain`: Inquiry, InquiryAiCorrection 도메인 모델, enum, 에러코드 신규
- `inquiry/application`: query/command/usecase/service 신규
- `inquiry/infrastructure/persistence`: JPA 엔티티/매퍼/어댑터 신규
- `inquiry/presentation/api`: AdminInquiryController 및 request/response DTO 신규
- `db/schema/inquiry.sql`: 테이블 DDL 신규

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 문의 목록을 조회하고 도메인, 심각도, 상태, 필터 여부로 검색할 수 있습니다.
  * 문의 상세 정보와 AI 분석 결과를 확인할 수 있습니다.
  * 문의 분류 및 필터 상태를 수정하고, 수정 사유를 기록할 수 있습니다.
  * 관리자가 문의에 답변을 등록할 수 있으며 답변 완료 상태로 변경됩니다.
  * 페이지네이션과 명확한 오류 응답을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->