### PR TITLE
[Feat] 관리자 운영 Q&A 챗봇 — Spring 릴레이 및 내부 조회 API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,7 @@ jobs:
           GCP_STORAGE_BUCKET: ${{ vars.GCP_STORAGE_BUCKET }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
           BRIEFING_API_KEY: ${{ secrets.BRIEFING_API_KEY }}
+          INTERNAL_API_TOKEN: ${{ secrets.INTERNAL_API_TOKEN }}
         run: |
           set -euo pipefail
           umask 077
@@ -110,7 +111,7 @@ jobs:
                    CORS_ALLOWED_ORIGINS FASTAPI_URL JWT_SECRET MAIL_USERNAME MAIL_PASSWORD \
                    GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_REDIRECT_URI \
                    OAUTH_ADDITIONAL_INFO_URI OAUTH_SUCCESS_URI OAUTH_ERROR_URI COOKIE_SECURE \
-                   GCP_PROJECT_ID GCP_STORAGE_BUCKET BRIEFING_API_KEY; do
+                   GCP_PROJECT_ID GCP_STORAGE_BUCKET BRIEFING_API_KEY INTERNAL_API_TOKEN; do
             v="${!k}"
             [ -n "$v" ] && printf '%s=%s\n' "$k" "$v" >> deploy.env
           done

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -62,6 +62,10 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // 모니터링 (Prometheus 스크레이핑)
                         .requestMatchers("/actuator/**").permitAll()
+                        // FastAPI opschat 도구 전용 내부 API — JWT 미사용.
+                        // 인증은 InternalOpsController 의 X-Internal-Token 검증(fail-closed)이 담당하고,
+                        // 배포에서는 SG 로 파이썬 박스만 접근 허용 (이중 방어)
+                        .requestMatchers("/internal/ops/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
                         // 인증 불필요
                         .requestMatchers("/api/v1/auth/**").permitAll()

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/OpsQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/OpsQueryPort.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.serviceevent.application.port;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 운영 Q&A 챗봇 도구용 읽기 전용 집계 포트.
+ *
+ * FastAPI opschat 의 function calling 도구가 내부 API(/internal/ops/*)를 통해 호출한다 —
+ * 쿼리·스키마 지식을 Spring 한 곳에 유지하기 위해 파이썬의 DB 직접 조회를 대체 (2026-07-20).
+ * category / eventType 필터는 null 허용(전체).
+ */
+public interface OpsQueryPort {
+
+    List<TypeCount> countEvents(LocalDateTime start, LocalDateTime end, String category, String eventType);
+
+    List<TimelineBucket> eventTimeline(LocalDateTime start, LocalDateTime end, String category, String eventType);
+
+    List<IpCount> topIps(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit);
+
+    List<EventDetail> recentEvents(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit);
+
+    record TypeCount(String eventType, long cnt) {
+    }
+
+    /** bucket = "yyyy-MM-dd HH:00" (KST 벽시계, 시간 단위) */
+    record TimelineBucket(String bucket, long cnt) {
+    }
+
+    record IpCount(String ipAddress, long cnt) {
+    }
+
+    /** detail 컬럼은 개인정보 여지가 있어 의도적으로 미포함 (opschat 방침과 동일) */
+    record EventDetail(
+            String category,
+            String eventType,
+            Long userId,
+            String ipAddress,
+            String uri,
+            Integer httpStatus,
+            Integer durationMs,
+            String traceId,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
@@ -1,0 +1,87 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.client;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wanted.codebombalms.serviceevent.presentation.api.request.OpsChatRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+/**
+ * FastAPI 운영 Q&A 챗봇(/ops-chat) 릴레이 클라이언트.
+ *
+ * 학생 챗봇(FastApiChatClient)과 달리 프레임을 도메인 모델로 파싱하지 않고
+ * SSE 를 그대로 재송출한다 — event 이름(status/done/error)과 토큰 프레임을
+ * FE 가 FastAPI 계약 그대로 받는다. (메시지 영속화·토큰 집계가 없어 파싱 불필요)
+ *
+ * WebClient 는 chatbot WebClientConfig 의 전역 빈(baseUrl=fastapi.url) 재사용 —
+ * 같은 FastAPI 서버의 다른 엔드포인트라 설정이 동일하다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OpsChatFastApiClient {
+
+    // FastAPI ops_gemini_client.py 의 OPS_RESPONSE_FAILED 와 공유하는 계약
+    private static final String OPS_RESPONSE_FAILED_CODE = "OPS-001";
+    private static final String CALL_FAILED_DATA =
+            "{\"code\": \"" + OPS_RESPONSE_FAILED_CODE + "\", \"message\": \"운영 챗봇 호출에 실패했습니다.\"}";
+
+    private final WebClient webClient;
+
+    public Flux<ServerSentEvent<String>> stream(OpsChatRequest request, String traceId) {
+        return webClient.post()
+                .uri("/ops-chat")
+                // BE↔FastAPI 로그를 같은 traceId 로 엮는다 (학생 챗봇과 동일 컨벤션)
+                .headers(h -> {
+                    if (traceId != null) {
+                        h.set("X-Trace-Id", traceId);
+                    }
+                })
+                .bodyValue(toFastApiRequest(request))
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
+                .map(this::passThrough)
+                .onErrorResume(e -> {
+                    log.warn("event=opschat_ai_call_failed traceId={} - FastAPI 운영 챗봇 호출 실패", traceId, e);
+                    return Flux.just(ServerSentEvent.<String>builder()
+                            .event("error")
+                            .data(CALL_FAILED_DATA)
+                            .build());
+                });
+    }
+
+    /** 수신 프레임을 event 이름 보존 채로 재조립 — 내용은 손대지 않는다. */
+    private ServerSentEvent<String> passThrough(ServerSentEvent<String> sse) {
+        ServerSentEvent.Builder<String> builder = ServerSentEvent.builder(sse.data() == null ? "" : sse.data());
+        if (sse.event() != null) {
+            builder.event(sse.event());
+        }
+        return builder.build();
+    }
+
+    private FastApiOpsChatRequest toFastApiRequest(OpsChatRequest request) {
+        List<FastApiOpsChatRequest.MessageDto> history = request.conversationHistory() == null
+                ? null
+                : request.conversationHistory().stream()
+                        .map(m -> new FastApiOpsChatRequest.MessageDto(m.role(), m.content()))
+                        .toList();
+        return new FastApiOpsChatRequest(request.userMessage(), history);
+    }
+
+    /** FastAPI OpsChatRequest(snake_case) 와의 전송 계약. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record FastApiOpsChatRequest(
+            @JsonProperty("user_message") String userMessage,
+            @JsonProperty("conversation_history") List<MessageDto> conversationHistory
+    ) {
+        record MessageDto(String role, String content) {
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -33,6 +34,11 @@ public class OpsChatFastApiClient {
     private static final String CALL_FAILED_DATA =
             "{\"code\": \"" + OPS_RESPONSE_FAILED_CODE + "\", \"message\": \"운영 챗봇 호출에 실패했습니다.\"}";
 
+    // 프레임 간(토큰 사이) 무응답 상한 — FastAPI 가 멈추거나 스트림을 닫지 않을 때
+    // 커넥션을 무한 점유하지 않도록 캡한다(정상 스트리밍은 프레임이 계속 흘러 안 걸림).
+    // 도구 라운드 사이 공백까지 감안한 여유값. 초과 시 아래 onErrorResume 으로 흡수.
+    private static final Duration STREAM_TIMEOUT = Duration.ofSeconds(150);
+
     private final WebClient webClient;
 
     public Flux<ServerSentEvent<String>> stream(OpsChatRequest request, String traceId) {
@@ -48,6 +54,7 @@ public class OpsChatFastApiClient {
                 .retrieve()
                 .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
                 .map(this::passThrough)
+                .timeout(STREAM_TIMEOUT)
                 .onErrorResume(e -> {
                     log.warn("event=opschat_ai_call_failed traceId={} - FastAPI 운영 챗봇 호출 실패", traceId, e);
                     return Flux.just(ServerSentEvent.<String>builder()

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/OpsQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/OpsQueryAdapter.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.persistence;
+
+import com.wanted.codebombalms.serviceevent.application.port.OpsQueryPort;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OpsQueryAdapter implements OpsQueryPort {
+
+    // 리포지토리 네이티브 쿼리의 고정 LIMIT 과 동기 유지
+    private static final int MAX_LIMIT = 20;
+
+    private final SpringDataServiceEventRepository repository;
+
+    @Override
+    public List<TypeCount> countEvents(LocalDateTime start, LocalDateTime end, String category, String eventType) {
+        return repository.countByTypeFiltered(start, end, category, eventType).stream()
+                .map(row -> new TypeCount(row.getEventType(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
+    public List<TimelineBucket> eventTimeline(LocalDateTime start, LocalDateTime end, String category, String eventType) {
+        return repository.eventTimeline(start, end, category, eventType).stream()
+                .map(row -> new TimelineBucket(row.getBucket(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
+    public List<IpCount> topIps(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit) {
+        return repository.topIpsFiltered(start, end, category, eventType).stream()
+                .limit(clamp(limit))
+                .map(row -> new IpCount(row.getIpAddress(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
+    public List<EventDetail> recentEvents(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit) {
+        return repository.recentEvents(start, end, category, eventType).stream()
+                .limit(clamp(limit))
+                .map(row -> new EventDetail(
+                        row.getCategory(), row.getEventType(), row.getUserId(), row.getIpAddress(),
+                        row.getUri(), row.getHttpStatus(), row.getDurationMs(), row.getTraceId(),
+                        row.getCreatedAt()))
+                .toList();
+    }
+
+    private long clamp(int limit) {
+        return Math.max(1, Math.min(limit, MAX_LIMIT));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -116,4 +116,73 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             LIMIT 1
             """, nativeQuery = true)
     ConcurrentPeakRow findConcurrentPeak(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // ===== 이하 운영 Q&A 챗봇(opschat) 도구용 — 전부 읽기 전용, 필터는 null=전체 =====
+    // LIMIT 고정 상수 규칙 유지: 동적 limit 은 OpsQueryAdapter 에서 subList 로 자른다.
+
+    interface TimelineBucketRow { String getBucket(); long getCnt(); }
+    interface RecentEventRow {
+        String getCategory(); String getEventType(); Long getUserId(); String getIpAddress();
+        String getUri(); Integer getHttpStatus(); Integer getDurationMs(); String getTraceId();
+        LocalDateTime getCreatedAt();
+    }
+
+    @Query(value = """
+            SELECT event_type AS eventType, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            GROUP BY event_type
+            ORDER BY cnt DESC
+            """, nativeQuery = true)
+    List<TypeCountRow> countByTypeFiltered(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
+
+    /** 시간(hour) 버킷 추이 — 최대 7일치(168버킷) */
+    @Query(value = """
+            SELECT DATE_FORMAT(created_at, '%Y-%m-%d %H:00') AS bucket, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            GROUP BY bucket
+            ORDER BY bucket
+            LIMIT 168
+            """, nativeQuery = true)
+    List<TimelineBucketRow> eventTimeline(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
+
+    @Query(value = """
+            SELECT ip_address AS ipAddress, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND ip_address IS NOT NULL
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            GROUP BY ip_address
+            ORDER BY cnt DESC
+            LIMIT 20
+            """, nativeQuery = true)
+    List<IpCountRow> topIpsFiltered(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
+
+    /** detail 컬럼 미포함(개인정보 방침) — opschat recent_events 도구 전용 */
+    @Query(value = """
+            SELECT category AS category, event_type AS eventType, user_id AS userId,
+                   ip_address AS ipAddress, uri AS uri, http_status AS httpStatus,
+                   duration_ms AS durationMs, trace_id AS traceId, created_at AS createdAt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            ORDER BY created_at DESC
+            LIMIT 20
+            """, nativeQuery = true)
+    List<RecentEventRow> recentEvents(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
@@ -17,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -33,6 +34,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class InternalOpsController {
 
+    // 조회 기간 상한 — GROUP BY 집계가 넓은 기간에 풀스캔되는 것을 막는다 (LLM 오요청 방어)
+    private static final Duration MAX_RANGE = Duration.ofDays(31);
+
     private final OpsQueryPort opsQueryPort;
     private final BriefingService briefingService;
 
@@ -48,6 +52,7 @@ public class InternalOpsController {
             @RequestParam(required = false) String eventType
     ) {
         verify(token);
+        guardRange(start, end);
         List<OpsQueryPort.TypeCount> rows = opsQueryPort.countEvents(start, end, category, eventType);
         long total = rows.stream().mapToLong(OpsQueryPort.TypeCount::cnt).sum();
         return new CountResponse(start, end, total, rows);
@@ -62,6 +67,7 @@ public class InternalOpsController {
             @RequestParam(required = false) String eventType
     ) {
         verify(token);
+        guardRange(start, end);
         return new TimelineResponse(start, end, "hour", opsQueryPort.eventTimeline(start, end, category, eventType));
     }
 
@@ -75,6 +81,7 @@ public class InternalOpsController {
             @RequestParam(defaultValue = "10") int limit
     ) {
         verify(token);
+        guardRange(start, end);
         return new TopIpsResponse(start, end, opsQueryPort.topIps(start, end, category, eventType, limit));
     }
 
@@ -88,6 +95,7 @@ public class InternalOpsController {
             @RequestParam(defaultValue = "10") int limit
     ) {
         verify(token);
+        guardRange(start, end);
         return new RecentEventsResponse(start, end, opsQueryPort.recentEvents(start, end, category, eventType, limit));
     }
 
@@ -107,6 +115,16 @@ public class InternalOpsController {
                 token.getBytes(StandardCharsets.UTF_8));
         if (!matches) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 내부 토큰");
+        }
+    }
+
+    /** 조회 기간 검증 — 역순/과대 범위를 400 으로 거절 (넓은 GROUP BY 풀스캔 방어) */
+    private void guardRange(LocalDateTime start, LocalDateTime end) {
+        if (!start.isBefore(end)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "start 는 end 보다 앞이어야 합니다.");
+        }
+        if (Duration.between(start, end).compareTo(MAX_RANGE) > 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "조회 기간은 최대 31일까지입니다.");
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
@@ -1,0 +1,131 @@
+package com.wanted.codebombalms.serviceevent.presentation.api;
+
+import com.wanted.codebombalms.serviceevent.application.port.OpsQueryPort;
+import com.wanted.codebombalms.serviceevent.application.query.BriefingResult;
+import com.wanted.codebombalms.serviceevent.application.service.BriefingService;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * FastAPI opschat 도구 전용 내부 조회 API — 외부 공개 아님.
+ *
+ * 인증: X-Internal-Token 헤더 = ${internal.api-token} (fail-closed — 설정이 비어 있으면 전부 401).
+ * 파이썬의 DB 직접 조회를 대체해 쿼리·스키마 지식을 Spring 한 곳에 유지한다 (2026-07-20).
+ * 응답은 opschat tools.py 가 LLM 도구 결과로 그대로 전달하는 계약 — ApiResponse 봉투 미사용.
+ */
+@Hidden
+@RestController
+@RequestMapping("/internal/ops")
+@RequiredArgsConstructor
+public class InternalOpsController {
+
+    private final OpsQueryPort opsQueryPort;
+    private final BriefingService briefingService;
+
+    @Value("${internal.api-token:}")
+    private String internalApiToken;
+
+    @GetMapping("/events/count")
+    public CountResponse countEvents(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType
+    ) {
+        verify(token);
+        List<OpsQueryPort.TypeCount> rows = opsQueryPort.countEvents(start, end, category, eventType);
+        long total = rows.stream().mapToLong(OpsQueryPort.TypeCount::cnt).sum();
+        return new CountResponse(start, end, total, rows);
+    }
+
+    @GetMapping("/events/timeline")
+    public TimelineResponse eventTimeline(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType
+    ) {
+        verify(token);
+        return new TimelineResponse(start, end, "hour", opsQueryPort.eventTimeline(start, end, category, eventType));
+    }
+
+    @GetMapping("/events/top-ips")
+    public TopIpsResponse topIps(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        verify(token);
+        return new TopIpsResponse(start, end, opsQueryPort.topIps(start, end, category, eventType, limit));
+    }
+
+    @GetMapping("/events/recent")
+    public RecentEventsResponse recentEvents(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        verify(token);
+        return new RecentEventsResponse(start, end, opsQueryPort.recentEvents(start, end, category, eventType, limit));
+    }
+
+    @GetMapping("/briefing/latest")
+    public BriefingResponse latestBriefing(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token
+    ) {
+        verify(token);
+        return new BriefingResponse(briefingService.getLatest().orElse(null));
+    }
+
+    /** 상수시간 비교 + fail-closed. 실패 시 401 (내부 소비자 전용이라 봉투 없는 기본 에러로 충분) */
+    private void verify(String token) {
+        boolean configured = internalApiToken != null && !internalApiToken.isBlank();
+        boolean matches = configured && token != null && MessageDigest.isEqual(
+                internalApiToken.getBytes(StandardCharsets.UTF_8),
+                token.getBytes(StandardCharsets.UTF_8));
+        if (!matches) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 내부 토큰");
+        }
+    }
+
+    public record CountResponse(LocalDateTime start, LocalDateTime end, long total,
+                         List<OpsQueryPort.TypeCount> byEventType) {
+    }
+
+    public record TimelineResponse(LocalDateTime start, LocalDateTime end, String unit,
+                            List<OpsQueryPort.TimelineBucket> timeline) {
+    }
+
+    public record TopIpsResponse(LocalDateTime start, LocalDateTime end,
+                          List<OpsQueryPort.IpCount> topIps) {
+    }
+
+    public record RecentEventsResponse(LocalDateTime start, LocalDateTime end,
+                                List<OpsQueryPort.EventDetail> events) {
+    }
+
+    public record BriefingResponse(BriefingResult briefing) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/OpsChatController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/OpsChatController.java
@@ -1,0 +1,61 @@
+package com.wanted.codebombalms.serviceevent.presentation.api;
+
+import com.wanted.codebombalms.serviceevent.infrastructure.client.OpsChatFastApiClient;
+import com.wanted.codebombalms.serviceevent.presentation.api.request.OpsChatRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 관리자 운영 Q&A 챗봇 API — ADMIN·MASTER 전용. 권한 설계는 SecuritySummaryController 와 동일.
+ *
+ * FastAPI(/ops-chat)로 릴레이하고 SSE 를 그대로 흘린다. 관리자 인증이 여기서 끝나므로
+ * FastAPI 쪽은 내부망 전용 무인증 (SG 로 Spring 박스만 허용 전제).
+ */
+@RestController
+@RequestMapping("/api/v1/admin/security/ops-chat")
+@PreAuthorize("hasAnyRole('ADMIN','MASTER')")
+@RequiredArgsConstructor
+public class OpsChatController {
+
+    private final OpsChatFastApiClient opsChatFastApiClient;
+
+    @Operation(
+            summary = "운영 Q&A 챗봇",
+            description = """
+                    관리자 질문을 FastAPI 운영 챗봇으로 릴레이하고 SSE 로 스트리밍합니다.
+                    LLM 이 function calling 으로 service_event/ops_briefing 을 읽기 전용 조회합니다.
+                    - data(이벤트명 없음): {"t": "토큰"}
+                    - event: status → {"tool", "message"} (도구 실행 안내)
+                    - event: done → 토큰 사용량 (누적)
+                    - event: error → {"code": "OPS-001", "message"}
+                    진입부 검증 에러(권한 등)는 스트림 시작 전이므로 기존 JSON 에러 응답을 따릅니다.""")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 스트림 시작"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "AUT-015: 권한 없음")
+    })
+    @PostMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<Flux<ServerSentEvent<String>>> chat(@Valid @RequestBody OpsChatRequest request) {
+        // SSE 스트림 콜백은 별도 reactor 스레드라 MDC(traceId)가 전파되지 않는다.
+        // 호출 스레드인 여기서 캡처해 넘긴다 (학생 챗봇 컨트롤러와 동일 컨벤션).
+        String traceId = MDC.get("traceId");
+
+        return ResponseEntity.ok()
+                .contentType(new MediaType(MediaType.TEXT_EVENT_STREAM, StandardCharsets.UTF_8))
+                .header("X-Accel-Buffering", "no")
+                .body(opsChatFastApiClient.stream(request, traceId));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.serviceevent.presentation.api.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+/**
+ * 관리자 운영 Q&A 챗봇 요청 (FE → Spring).
+ * 대화 이력은 FE 가 세션 내에서 들고 있다가 매 요청에 실어 보낸다 (서버 무상태).
+ */
+public record OpsChatRequest(
+        @NotBlank(message = "질문을 입력해주세요.")
+        String userMessage,
+
+        @Valid
+        List<Message> conversationHistory
+) {
+    public record Message(
+            @NotBlank String role,      // "user" or "ai"
+            @NotBlank String content
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
@@ -2,23 +2,34 @@ package com.wanted.codebombalms.serviceevent.presentation.api.request;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 /**
  * 관리자 운영 Q&A 챗봇 요청 (FE → Spring).
  * 대화 이력은 FE 가 세션 내에서 들고 있다가 매 요청에 실어 보낸다 (서버 무상태).
+ *
+ * 길이 제한은 과도한 페이로드가 FastAPI/LLM 으로 흘러가 토큰 비용·지연이 폭증하는 것을 막는다.
  */
 public record OpsChatRequest(
         @NotBlank(message = "질문을 입력해주세요.")
+        @Size(max = 2000, message = "질문은 2000자 이내여야 합니다.")
         String userMessage,
 
         @Valid
+        @Size(max = 40, message = "대화 이력은 최대 40개까지 전달할 수 있습니다.")
         List<Message> conversationHistory
 ) {
     public record Message(
-            @NotBlank String role,      // "user" or "ai"
-            @NotBlank String content
+            @NotBlank
+            @Pattern(regexp = "user|ai", message = "role 은 user 또는 ai 여야 합니다.")
+            String role,
+
+            @NotBlank
+            @Size(max = 4000, message = "메시지는 4000자 이내여야 합니다.")
+            String content
     ) {
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,6 +95,10 @@ cors:
 fastapi:
   url: ${FASTAPI_URL:http://localhost:8000}
 
+# FastAPI opschat 도구 → /internal/ops/* 호출용 공유 시크릿 (비어 있으면 fail-closed 전부 401)
+internal:
+  api-token: ${INTERNAL_API_TOKEN:}
+
 chat:
   max-history-messages: 20
 


### PR DESCRIPTION
- /api/v1/admin/security/ops-chat SSE 릴레이 (ADMIN·MASTER, FastAPI 패스스루)
- /internal/ops/* 읽기 전용 조회 5종 (X-Internal-Token fail-closed, 챗봇 도구 전용)
- OpsQueryPort/Adapter + service_event 네이티브 쿼리 4종
- deploy.yml에 INTERNAL_API_TOKEN 주입 추가

## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #645

---

## 🛠️ 기능 관련 작업 내용
- 관리자 운영 Q&A 챗봇 SSE 릴레이 추가 (`POST /api/v1/admin/security/ops-chat`, ADMIN·MASTER 전용) — FastAPI 챗봇으로 질문 전달 후 응답을 파싱 없이 스트리밍 패스스루
- FastAPI function calling 도구 전용 내부 조회 API 5종 추가 (`GET /internal/ops/*`) — service_event 집계·상세·브리핑 읽기 전용, `X-Internal-Token` 공유 시크릿으로 fail-closed 인증
- 파이썬의 DB 직접 조회를 Spring 경유로 전환 — 쿼리·스키마·권한 지식을 Spring 한 곳에 유지
- 배포 파이프라인에 `INTERNAL_API_TOKEN` 주입 추가

---

## ♻️ 패키지 변경 사항
- `codebombalms/serviceevent/presentation`: OpsChatController(관리자 SSE 릴레이)·InternalOpsController(내부 조회 5종, 토큰 검증)·OpsChatRequest 추가
- `codebombalms/serviceevent/infrastructure`: OpsChatFastApiClient(SSE 패스스루)·OpsQueryAdapter·SpringDataServiceEventRepository 집계 네이티브 쿼리 4종 추가
- `codebombalms/serviceevent/application`: OpsQueryPort(읽기 전용 집계 포트) 추가
- `codebombalms/global`: SecurityConfig에 `/internal/ops/**` permitAll 추가 (인증은 컨트롤러 토큰 검증이 담당)

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 운영 Q&A 챗봇을 추가했습니다. 대화 이력과 함께 질문하고 실시간 답변을 받을 수 있습니다.
  * 이벤트 유형별 집계, 시간대별 추이, 상위 IP, 최근 이벤트 및 최신 브리핑을 조회할 수 있습니다.
  * 기간과 이벤트 조건을 지정해 운영 데이터를 필터링할 수 있습니다.

* **보안**
  * 운영 데이터 조회 기능에 내부 인증 토큰 검증을 적용했습니다.
  * 배포에 필요한 내부 토큰이 누락되면 배포가 중단됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->