### PR TITLE
[Feat] 사용자 문의(Inquiry) 등록 + Python AI 분석 연동

### DIFF
--- a/http/inquiry.http
+++ b/http/inquiry.http
@@ -16,7 +16,7 @@ POST http://localhost:8080/api/v1/inquiries
 Content-Type: application/json
 
 {
-  "content": "병신 관리자",
+  "content": "시발 관리자",
   "sourceUrl": "/user/problems/123"
 }
 
@@ -50,7 +50,7 @@ Content-Type: application/json
 GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=false
 
 ### 8. 관리자 - 문의 상세 조회 (2번 응답의 inquiryId 확인 후 입력)
-GET http://localhost:8080/api/v1/admin/inquiries/1
+GET http://localhost:8080/api/v1/admin/inquiries/7
 
 ### 9. 관리자 - 존재하지 않는 문의 상세 조회 → 404 INQ-002
 GET http://localhost:8080/api/v1/admin/inquiries/999999
@@ -75,24 +75,24 @@ Content-Type: application/json
 }
 
 ### 12. 관리자 - 문의 필터링 처리 (스팸/무의미로 판단한 경우 시나리오, reason 필수)
-PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+PATCH http://localhost:8080/api/v1/admin/inquiries/10/filter
 Content-Type: application/json
 
 {
   "filtered": true,
-  "reason": "AI는 정상 문의로 판단했지만 실제로는 광고성 문의로 확인됨"
+  "reason": "욕설은 안보고 싶음"
 }
 
 ### 13. 관리자 - 필터링 목록 조회 (12번에서 필터링 처리한 문의가 보여야 정상)
 GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=true
 
 ### 14. 관리자 - 문의 필터링 복구 (다시 정상 문의로, reason 필수)
-PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+PATCH http://localhost:8080/api/v1/admin/inquiries/7/filter
 Content-Type: application/json
 
 {
   "filtered": false,
-  "reason": "재확인 결과 실제 문제 제출 오류 문의로 확인됨"
+  "reason": "욕설 또한 관리자가 볼 필요가 있을거같아요, 이후 신고 처리 가능"
 }
 
 ### 15. 관리자 - 답변 등록 (status=ANSWERED / reply_visible=true 로 함께 갱신됨)

--- a/http/inquiry.http
+++ b/http/inquiry.http
@@ -1,0 +1,149 @@
+### ===== Inquiry API 테스트 시나리오 =====
+### 사전 조건: 사용자 계정(u01@test.com), 관리자 계정(admin@test.com) 가입 완료 상태
+### 흐름: 사용자 문의 등록 → 관리자 목록/상세 확인 → 분류 수정/필터링 → 답변 등록 → 사용자 답변 확인/비노출
+
+### 1. 사용자 로그인 — 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "op@test.com",
+  "password": "Test1234!"
+}
+
+### 2. 사용자 - 문의 등록 (정상). 응답의 data.inquiryId를 이후 요청에 계속 사용한다
+POST http://localhost:8080/api/v1/inquiries
+Content-Type: application/json
+
+{
+  "content": "병신 관리자",
+  "sourceUrl": "/user/problems/123"
+}
+
+### 3. 사용자 - 문의 등록 시도, content 누락 → 400
+POST http://localhost:8080/api/v1/inquiries
+Content-Type: application/json
+
+{
+  "sourceUrl": "/user/problems/123"
+}
+
+### 4. 사용자 - 미확인 답변 조회 (아직 관리자 답변 전이라 data.replies는 빈 배열이어야 정상)
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 5. (사전) 로그아웃 → 관리자 로그인 준비
+POST http://localhost:8080/api/v1/auth/logout
+
+
+### ===== 관리자 처리 =====
+
+### 6. 관리자 로그인 — 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "admin@test.com",
+  "password": "Test1234!"
+}
+
+### 7. 관리자 - 문의 목록 조회 (정상 목록, isFiltered=false)
+GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=false
+
+### 8. 관리자 - 문의 상세 조회 (2번 응답의 inquiryId 확인 후 입력)
+GET http://localhost:8080/api/v1/admin/inquiries/1
+
+### 9. 관리자 - 존재하지 않는 문의 상세 조회 → 404 INQ-002
+GET http://localhost:8080/api/v1/admin/inquiries/999999
+
+### 10. 관리자 - 문의 분류 수정 (8번의 inquiryId 입력, reason 필수)
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/classification
+Content-Type: application/json
+
+{
+  "domain": "PROBLEMS",
+  "severity": "HIGH",
+  "reason": "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함"
+}
+
+### 11. 관리자 - 문의 분류 수정 시도, reason 누락 → 400
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/classification
+Content-Type: application/json
+
+{
+  "domain": "PROBLEMS",
+  "severity": "HIGH"
+}
+
+### 12. 관리자 - 문의 필터링 처리 (스팸/무의미로 판단한 경우 시나리오, reason 필수)
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+Content-Type: application/json
+
+{
+  "filtered": true,
+  "reason": "AI는 정상 문의로 판단했지만 실제로는 광고성 문의로 확인됨"
+}
+
+### 13. 관리자 - 필터링 목록 조회 (12번에서 필터링 처리한 문의가 보여야 정상)
+GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=true
+
+### 14. 관리자 - 문의 필터링 복구 (다시 정상 문의로, reason 필수)
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+Content-Type: application/json
+
+{
+  "filtered": false,
+  "reason": "재확인 결과 실제 문제 제출 오류 문의로 확인됨"
+}
+
+### 15. 관리자 - 답변 등록 (status=ANSWERED / reply_visible=true 로 함께 갱신됨)
+POST http://localhost:8080/api/v1/admin/inquiries/1/reply
+Content-Type: application/json
+
+{
+  "content": "문의 주신 문제 제출 오류를 확인했고 수정 반영했습니다."
+}
+
+### 16. (사전) 로그아웃 → 사용자 재로그인 준비
+POST http://localhost:8080/api/v1/auth/logout
+
+
+### ===== 사용자 답변 확인 =====
+
+### 17. 사용자 재로그인
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
+### 18. 사용자 - 미확인 답변 조회 (15번 답변이 data.replies에 노출돼야 정상)
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 19. 사용자 - 답변 비노출 처리 (모달 닫기(X) 액션, 18번 응답의 inquiryId 입력)
+PATCH http://localhost:8080/api/v1/inquiries/1/reply-visibility
+
+### 20. 사용자 - 미확인 답변 재조회 (19번 이후엔 다시 빈 배열이어야 정상)
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 21. (사전) 로그아웃 → 비로그인 상태 준비
+POST http://localhost:8080/api/v1/auth/logout
+
+
+### ===== 인증 실패 시나리오 (비로그인 상태) =====
+
+### 22. 비로그인 상태 - 문의 등록 시도 → 401 AUT-016
+POST http://localhost:8080/api/v1/inquiries
+Content-Type: application/json
+
+{
+  "content": "로그인 안 하고 문의 등록 시도",
+  "sourceUrl": "/user/problems/123"
+}
+
+### 23. 비로그인 상태 - 미확인 답변 조회 시도 → 401 AUT-016
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 24. 비로그인 상태 - 답변 비노출 처리 시도 → 401 AUT-016
+PATCH http://localhost:8080/api/v1/inquiries/1/reply-visibility

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -46,6 +46,20 @@ public class SchedulingConfig {
     }
 
 
+    /** 문의 등록 후 Python AI 분석 호출 전용 풀 — 포화 시 드랍 + 로그 기록 (best-effort, 사용자 응답에 영향 없음). */
+    @Bean(name = "inquiryTaskExecutor")
+    public Executor inquiryTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("inquiry-ai-");
+        executor.setRejectedExecutionHandler((runnable, pool) ->
+                log.warn("event=inquiry_ai_analysis_dropped reason=queue_full queueCapacity=100"));
+        executor.initialize();
+        return executor;
+    }
+
     /**
      * 서비스 이벤트 적재 전용 풀 — 포화 시 드랍 + 카운터 기록 (best-effort, 응답 보호).
      * 기존 풀(추천·메일) 재사용 금지 — 즉시 거절 또는 요청 스레드 역류로 응답 지연 전파.

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/ApplyInquiryAiAnalysisCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/ApplyInquiryAiAnalysisCommand.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+
+// Python AI 분석 결과를 문의에 반영할 때 사용하는 값을 담는다.
+public record ApplyInquiryAiAnalysisCommand(
+        Long inquiryId,
+        String title,
+        String aiSummary,
+        InquirySeverity severity,
+        InquiryDomain domain,
+        String estimatedUrl,
+        String aiRecommendedAction,
+        boolean filtered
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/CorrectionExample.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/CorrectionExample.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+
+// Python AI 분석 요청에 함께 실어보낼 관리자 보정 사례 한 건
+public record CorrectionExample(
+        InquiryCorrectionField fieldName,
+        String aiValue,
+        String correctedValue,
+        String reason
+) {
+
+    public static CorrectionExample from(InquiryAiCorrection correction) {
+        return new CorrectionExample(
+                correction.getFieldName(),
+                correction.getAiValue(),
+                correction.getCorrectedValue(),
+                correction.getReason()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/CreateInquiryCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/CreateInquiryCommand.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+// 사용자 문의 등록 요청 값을 담는다.
+public record CreateInquiryCommand(
+        Long userId,
+        String content,
+        String sourceUrl
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/RequestInquiryAnalysisCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/RequestInquiryAnalysisCommand.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import java.util.List;
+
+// Python AI 분석 서버에 전달할 문의 원문 정보와 관리자 보정 학습 컨텍스트를 담는다.
+public record RequestInquiryAnalysisCommand(
+        Long inquiryId,
+        Long userId,
+        String sourceUrl,
+        String content,
+        List<CorrectionExample> correctionExamples
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/port/InquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/port/InquiryAnalysisClient.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.port;
+
+import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
+
+// 문의 원문을 Python AI 분석 서버에 전달하는 외부 호출 포트다.
+public interface InquiryAnalysisClient {
+
+    void analyze(RequestInquiryAnalysisCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/ActiveInquiryReply.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/ActiveInquiryReply.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import java.time.LocalDateTime;
+
+// 로그인 첫 화면에 띄울 미확인 문의 답변 정보
+public record ActiveInquiryReply(
+        Long inquiryId,
+        String title,
+        String content,
+        String adminReply,
+        LocalDateTime repliedAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.inquiry.application.query;
 
 import com.wanted.codebombalms.admin.operation.common.application.PageResult;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InquiryQueryRepository {
@@ -9,4 +10,6 @@ public interface InquiryQueryRepository {
     PageResult<AdminInquiryListItem> findAdminInquiries(GetAdminInquiriesQuery query);
 
     Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId);
+
+    List<ActiveInquiryReply> findActiveRepliesByUserId(Long userId);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/InquiryAiAnalysisApplyService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/InquiryAiAnalysisApplyService.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+// UserInquiryCommandService와 별도 빈으로 분리했다.
+// FastApiInquiryAnalysisClient가 이 유스케이스를 호출하는데, UserInquiryCommandService가
+// FastApiInquiryAnalysisClient(InquiryAnalysisClient)를 의존하고 있어서 같은 클래스에 두면
+// UserInquiryCommandService -> FastApiInquiryAnalysisClient -> UserInquiryCommandService
+// 순환 참조가 생긴다.
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InquiryAiAnalysisApplyService implements ApplyInquiryAiAnalysisUseCase {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    // Python AI 분석 응답을 받아 문의의 분류/요약/추정 URL/필터링 여부를 반영한다.
+    public Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command) {
+        Inquiry inquiry = inquiryRepository.findById(command.inquiryId())
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+
+        inquiry.applyAiAnalysis(
+                command.title(),
+                command.aiSummary(),
+                command.severity(),
+                command.domain(),
+                command.estimatedUrl(),
+                command.aiRecommendedAction(),
+                command.filtered(),
+                LocalDateTime.now()
+        );
+
+        return inquiryRepository.save(inquiry);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -14,6 +14,8 @@ import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,12 +33,27 @@ public class UserInquiryCommandService implements CreateInquiryUseCase, HideInqu
     private final InquiryAnalysisClient inquiryAnalysisClient;
 
     @Override
-    // 문의를 등록하고 저장이 끝난 뒤 Python AI 분석을 비동기로 요청한다. 사용자 응답은 분석 결과를 기다리지 않는다.
+    // 문의를 등록하고, 트랜잭션이 실제로 커밋된 뒤에 Python AI 분석을 비동기로 요청한다.
+    // 사용자 응답은 분석 결과를 기다리지 않는다.
     public Inquiry create(CreateInquiryCommand command) {
         Inquiry inquiry = Inquiry.create(command.userId(), command.content(), command.sourceUrl(), LocalDateTime.now());
 
         Inquiry saved = inquiryRepository.save(inquiry);
 
+        // 커밋 전에 analyze()(@Async)를 호출하면, Python 응답이 아주 빠르거나 커밋이 지연될 때
+        // 분석 결과 반영(findById)이 아직 안 보이는 row를 조회해 NotFoundException이 날 수 있다.
+        // 커밋 완료 후로 미뤄서 이 레이스 컨디션을 없앤다.
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                requestAiAnalysis(saved);
+            }
+        });
+
+        return saved;
+    }
+
+    private void requestAiAnalysis(Inquiry saved) {
         List<CorrectionExample> correctionExamples = inquiryAiCorrectionRepository
                 .findRecentCorrections(MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT)
                 .stream()
@@ -50,8 +67,6 @@ public class UserInquiryCommandService implements CreateInquiryUseCase, HideInqu
                 saved.getContent(),
                 correctionExamples
         ));
-
-        return saved;
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -1,22 +1,81 @@
 package com.wanted.codebombalms.inquiry.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
+import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
+import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.port.InquiryAnalysisClient;
+import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.CreateInquiryUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
 import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
 import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserInquiryCommandService implements HideInquiryReplyUseCase {
+public class UserInquiryCommandService
+        implements CreateInquiryUseCase, HideInquiryReplyUseCase, ApplyInquiryAiAnalysisUseCase {
+
+    // 운영 데이터가 쌓일수록 AI 분석 컨텍스트가 좋아지도록, 지금 규모에서는 사실상 전체 보정 이력을 보낸다는 의미의 상한이다.
+    private static final int MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT = 1000;
 
     private final InquiryRepository inquiryRepository;
+    private final InquiryAiCorrectionRepository inquiryAiCorrectionRepository;
+    private final InquiryAnalysisClient inquiryAnalysisClient;
+
+    @Override
+    // 문의를 등록하고 저장이 끝난 뒤 Python AI 분석을 비동기로 요청한다. 사용자 응답은 분석 결과를 기다리지 않는다.
+    public Inquiry create(CreateInquiryCommand command) {
+        Inquiry inquiry = Inquiry.create(command.userId(), command.content(), command.sourceUrl(), LocalDateTime.now());
+
+        Inquiry saved = inquiryRepository.save(inquiry);
+
+        List<CorrectionExample> correctionExamples = inquiryAiCorrectionRepository
+                .findRecentCorrections(MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT)
+                .stream()
+                .map(CorrectionExample::from)
+                .toList();
+
+        inquiryAnalysisClient.analyze(new RequestInquiryAnalysisCommand(
+                saved.getInquiryId(),
+                saved.getUserId(),
+                saved.getSourceUrl(),
+                saved.getContent(),
+                correctionExamples
+        ));
+
+        return saved;
+    }
+
+    @Override
+    // Python AI 분석 응답을 받아 문의의 분류/요약/추정 URL/필터링 여부를 반영한다.
+    public Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command) {
+        Inquiry inquiry = inquiryRepository.findById(command.inquiryId())
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+
+        inquiry.applyAiAnalysis(
+                command.title(),
+                command.aiSummary(),
+                command.severity(),
+                command.domain(),
+                command.estimatedUrl(),
+                command.aiRecommendedAction(),
+                command.filtered(),
+                LocalDateTime.now()
+        );
+
+        return inquiryRepository.save(inquiry);
+    }
 
     @Override
     // 본인 문의 답변을 로그인 첫 화면에서 비노출 처리한다.

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -1,12 +1,10 @@
 package com.wanted.codebombalms.inquiry.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
-import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
 import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
 import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
 import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
 import com.wanted.codebombalms.inquiry.application.port.InquiryAnalysisClient;
-import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.CreateInquiryUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
 import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
@@ -23,8 +21,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserInquiryCommandService
-        implements CreateInquiryUseCase, HideInquiryReplyUseCase, ApplyInquiryAiAnalysisUseCase {
+public class UserInquiryCommandService implements CreateInquiryUseCase, HideInquiryReplyUseCase {
 
     // 운영 데이터가 쌓일수록 AI 분석 컨텍스트가 좋아지도록, 지금 규모에서는 사실상 전체 보정 이력을 보낸다는 의미의 상한이다.
     private static final int MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT = 1000;
@@ -55,26 +52,6 @@ public class UserInquiryCommandService
         ));
 
         return saved;
-    }
-
-    @Override
-    // Python AI 분석 응답을 받아 문의의 분류/요약/추정 URL/필터링 여부를 반영한다.
-    public Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command) {
-        Inquiry inquiry = inquiryRepository.findById(command.inquiryId())
-                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
-
-        inquiry.applyAiAnalysis(
-                command.title(),
-                command.aiSummary(),
-                command.severity(),
-                command.domain(),
-                command.estimatedUrl(),
-                command.aiRecommendedAction(),
-                command.filtered(),
-                LocalDateTime.now()
-        );
-
-        return inquiryRepository.save(inquiry);
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserInquiryCommandService implements HideInquiryReplyUseCase {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    // 본인 문의 답변을 로그인 첫 화면에서 비노출 처리한다.
+    public Inquiry hideReply(Long inquiryId, Long userId) {
+        Inquiry inquiry = inquiryRepository.findByIdAndUserId(inquiryId, userId)
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+
+        inquiry.hideReply(LocalDateTime.now());
+
+        return inquiryRepository.save(inquiry);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryQueryService.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+import com.wanted.codebombalms.inquiry.application.query.InquiryQueryRepository;
+import com.wanted.codebombalms.inquiry.application.usecase.GetActiveInquiryRepliesUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserInquiryQueryService implements GetActiveInquiryRepliesUseCase {
+
+    private final InquiryQueryRepository inquiryQueryRepository;
+
+    @Override
+    // 로그인 첫 화면에 노출할 답변 확인 전 문의 답변 목록을 조회한다.
+    public List<ActiveInquiryReply> getActiveReplies(Long userId) {
+        return inquiryQueryRepository.findActiveRepliesByUserId(userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ApplyInquiryAiAnalysisUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ApplyInquiryAiAnalysisUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// Python AI 분석 결과를 문의에 반영하는 유스케이스 진입점이다.
+public interface ApplyInquiryAiAnalysisUseCase {
+
+    Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/CreateInquiryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/CreateInquiryUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 사용자가 새 문의를 등록하는 유스케이스 진입점이다.
+public interface CreateInquiryUseCase {
+
+    Inquiry create(CreateInquiryCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetActiveInquiryRepliesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetActiveInquiryRepliesUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+
+import java.util.List;
+
+public interface GetActiveInquiryRepliesUseCase {
+
+    List<ActiveInquiryReply> getActiveReplies(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/HideInquiryReplyUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/HideInquiryReplyUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+public interface HideInquiryReplyUseCase {
+
+    Inquiry hideReply(Long inquiryId, Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
@@ -67,6 +67,30 @@ public class Inquiry {
         this.updatedAt = updatedAt;
     }
 
+    // 사용자가 새로 등록한 문의를 생성한다. AI 분석 전까지는 기본값(OPEN/LOW/ETC)을 갖는다.
+    public static Inquiry create(Long userId, String content, String sourceUrl, LocalDateTime createdAt) {
+        return new Inquiry(
+                null,
+                userId,
+                null,
+                content,
+                InquiryStatus.OPEN,
+                InquirySeverity.LOW,
+                InquiryDomain.ETC,
+                sourceUrl,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                createdAt,
+                createdAt
+        );
+    }
+
     // DB에서 조회한 값으로 도메인 모델을 복원한다.
     public static Inquiry restore(
             Long inquiryId,
@@ -108,6 +132,27 @@ public class Inquiry {
                 createdAt,
                 updatedAt
         );
+    }
+
+    // Python AI 분석 결과를 반영한다. 관리자가 아직 보정하지 않은 초기값이므로 전체 필드를 덮어쓴다.
+    public void applyAiAnalysis(
+            String title,
+            String aiSummary,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String estimatedUrl,
+            String aiRecommendedAction,
+            boolean filtered,
+            LocalDateTime updatedAt
+    ) {
+        this.title = title;
+        this.aiSummary = aiSummary;
+        this.severity = severity;
+        this.domain = domain;
+        this.estimatedUrl = estimatedUrl;
+        this.aiRecommendedAction = aiRecommendedAction;
+        this.filtered = filtered;
+        this.updatedAt = updatedAt;
     }
 
     // 관리자가 AI 분류(도메인/심각도)를 보정한다.

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
@@ -137,6 +137,12 @@ public class Inquiry {
         this.updatedAt = repliedAt;
     }
 
+    // 사용자가 답변을 확인하면 로그인 첫 화면에 다시 노출하지 않는다.
+    public void hideReply(LocalDateTime updatedAt) {
+        this.replyVisible = false;
+        this.updatedAt = updatedAt;
+    }
+
     public Long getInquiryId() {
         return inquiryId;
     }

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
@@ -3,12 +3,16 @@ package com.wanted.codebombalms.inquiry.domain.repository;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InquiryAiCorrectionRepository {
 
     // inquiry_id + field_name 기준으로 마지막 보정 row를 조회한다.
     Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+
+    // AI 분석 컨텍스트로 전달할 최근 보정 사례를 최신순으로 최대 limit건 조회한다.
+    List<InquiryAiCorrection> findRecentCorrections(int limit);
 
     InquiryAiCorrection save(InquiryAiCorrection correction);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
@@ -8,5 +8,7 @@ public interface InquiryRepository {
 
     Optional<Inquiry> findById(Long inquiryId);
 
+    Optional<Inquiry> findByIdAndUserId(Long inquiryId, Long userId);
+
     Inquiry save(Inquiry inquiry);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysi
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import io.netty.channel.ChannelOption;
+import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,22 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
     @Value("${fastapi.url}")
     private String fastApiBaseUrl;
 
+    private WebClient webClient;
+
+    // @Value 필드 주입이 끝난 뒤(생성자 호출 이후) 커넥션 풀을 가진 WebClient를 한 번만 만들어 재사용한다.
+    // 호출마다 새로 만들면 매번 새 커넥션 풀이 생겨 재사용이 안 되고 리소스가 낭비된다.
+    @PostConstruct
+    private void initWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
+
+        this.webClient = WebClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
     /** 문의 등록 요청 스레드를 막지 않도록 전용 executor에서 Python 분석 endpoint를 호출하고, 응답을 받으면 바로 문의에 반영합니다. */
     @Async("inquiryTaskExecutor")
     @Override
@@ -45,7 +62,7 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
         long startedAt = System.nanoTime();
 
         try {
-            PythonInquiryAnalysisResponse response = webClient().post()
+            PythonInquiryAnalysisResponse response = webClient.post()
                     .uri(properties.getAnalyzePath())
                     .bodyValue(toRequest(command))
                     .retrieve()
@@ -75,18 +92,6 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
                 command.content(),
                 command.correctionExamples().stream().map(PythonCorrectionExample::from).toList()
         );
-    }
-
-    /** 문의 기능이 다른 도메인의 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
-    private WebClient webClient() {
-        HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
-                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
-
-        return WebClient.builder()
-                .baseUrl(fastApiBaseUrl)
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .build();
     }
 
     /** Python 문의 분석 API에 전달하는 요청 본문. 단어 하나짜리 필드(content)는 어노테이션이 필요 없다. */

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.inquiry.infrastructure.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
 import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
 import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
@@ -19,7 +20,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
-/** 문의 원문을 Python AI 분석 endpoint로 비동기 전달하고, 응답을 받아 문의에 반영하는 client입니다. */
+/** 문의 원문을 Python AI 분석 endpoint로 비동기 전달하고, 응답을 받아 문의에 반영하는 client입니다.
+ *  chatbot(FastApiChatRequest)과 동일하게 필드별 {@code @JsonProperty}로 snake_case 계약을 맞춘다. */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -45,13 +47,7 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
         try {
             PythonInquiryAnalysisResponse response = webClient().post()
                     .uri(properties.getAnalyzePath())
-                    .bodyValue(new PythonInquiryAnalysisRequest(
-                            command.inquiryId(),
-                            command.userId(),
-                            command.sourceUrl(),
-                            command.content(),
-                            command.correctionExamples()
-                    ))
+                    .bodyValue(toRequest(command))
                     .retrieve()
                     .bodyToMono(PythonInquiryAnalysisResponse.class)
                     .block();
@@ -71,6 +67,16 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
         }
     }
 
+    private PythonInquiryAnalysisRequest toRequest(RequestInquiryAnalysisCommand command) {
+        return new PythonInquiryAnalysisRequest(
+                command.inquiryId(),
+                command.userId(),
+                command.sourceUrl(),
+                command.content(),
+                command.correctionExamples().stream().map(PythonCorrectionExample::from).toList()
+        );
+    }
+
     /** 문의 기능이 다른 도메인의 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
     private WebClient webClient() {
         HttpClient httpClient = HttpClient.create()
@@ -83,14 +89,31 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
                 .build();
     }
 
-    /** Python 문의 분석 API에 전달하는 요청 본문입니다. */
+    /** Python 문의 분석 API에 전달하는 요청 본문. 단어 하나짜리 필드(content)는 어노테이션이 필요 없다. */
     private record PythonInquiryAnalysisRequest(
-            Long inquiryId,
-            Long userId,
-            String sourceUrl,
+            @JsonProperty("inquiry_id") Long inquiryId,
+            @JsonProperty("user_id") Long userId,
+            @JsonProperty("source_url") String sourceUrl,
             String content,
-            List<CorrectionExample> correctionExamples
+            @JsonProperty("correction_examples") List<PythonCorrectionExample> correctionExamples
     ) {
+    }
+
+    /** 관리자 보정 사례 한 건. 애플리케이션 커맨드(CorrectionExample)가 JSON 표현을 몰라도 되도록 어댑터 전용 타입으로 매핑한다. */
+    private record PythonCorrectionExample(
+            @JsonProperty("field_name") String fieldName,
+            @JsonProperty("ai_value") String aiValue,
+            @JsonProperty("corrected_value") String correctedValue,
+            String reason
+    ) {
+        private static PythonCorrectionExample from(CorrectionExample example) {
+            return new PythonCorrectionExample(
+                    example.fieldName().name(),
+                    example.aiValue(),
+                    example.correctedValue(),
+                    example.reason()
+            );
+        }
     }
 
     /** Python 문의 분석 API의 응답 본문입니다. */
@@ -99,8 +122,8 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
             String summary,
             InquirySeverity severity,
             InquiryDomain domain,
-            String estimatedUrl,
-            String recommendedAction,
+            @JsonProperty("estimated_url") String estimatedUrl,
+            @JsonProperty("recommended_action") String recommendedAction,
             Boolean filtered
     ) {
 

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
@@ -1,0 +1,120 @@
+package com.wanted.codebombalms.inquiry.infrastructure.client;
+
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
+import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.port.InquiryAnalysisClient;
+import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+/** 문의 원문을 Python AI 분석 endpoint로 비동기 전달하고, 응답을 받아 문의에 반영하는 client입니다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
+
+    private final InquiryPythonProperties properties;
+    private final ApplyInquiryAiAnalysisUseCase applyInquiryAiAnalysisUseCase;
+
+    @Value("${fastapi.url}")
+    private String fastApiBaseUrl;
+
+    /** 문의 등록 요청 스레드를 막지 않도록 전용 executor에서 Python 분석 endpoint를 호출하고, 응답을 받으면 바로 문의에 반영합니다. */
+    @Async("inquiryTaskExecutor")
+    @Override
+    public void analyze(RequestInquiryAnalysisCommand command) {
+        if (!properties.isEnabled()) {
+            log.info("Python 문의 분석 호출이 비활성화되어 요청을 건너뜁니다. inquiryId={}", command.inquiryId());
+            return;
+        }
+
+        long startedAt = System.nanoTime();
+
+        try {
+            PythonInquiryAnalysisResponse response = webClient().post()
+                    .uri(properties.getAnalyzePath())
+                    .bodyValue(new PythonInquiryAnalysisRequest(
+                            command.inquiryId(),
+                            command.userId(),
+                            command.sourceUrl(),
+                            command.content(),
+                            command.correctionExamples()
+                    ))
+                    .retrieve()
+                    .bodyToMono(PythonInquiryAnalysisResponse.class)
+                    .block();
+
+            log.info("event=inquiry_ai_analysis_requested inquiryId={} correctionExampleCount={} durationMs={}",
+                    command.inquiryId(), command.correctionExamples().size(), (System.nanoTime() - startedAt) / 1_000_000);
+
+            if (response == null) {
+                log.warn("event=inquiry_ai_analysis_empty_response inquiryId={}", command.inquiryId());
+                return;
+            }
+
+            applyInquiryAiAnalysisUseCase.applyAiAnalysis(response.toCommand(command.inquiryId()));
+        } catch (RuntimeException exception) {
+            log.warn("event=inquiry_ai_analysis_failed inquiryId={} exceptionType={}",
+                    command.inquiryId(), exception.getClass().getSimpleName());
+        }
+    }
+
+    /** 문의 기능이 다른 도메인의 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
+    private WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
+
+        return WebClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    /** Python 문의 분석 API에 전달하는 요청 본문입니다. */
+    private record PythonInquiryAnalysisRequest(
+            Long inquiryId,
+            Long userId,
+            String sourceUrl,
+            String content,
+            List<CorrectionExample> correctionExamples
+    ) {
+    }
+
+    /** Python 문의 분석 API의 응답 본문입니다. */
+    private record PythonInquiryAnalysisResponse(
+            String title,
+            String summary,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String estimatedUrl,
+            String recommendedAction,
+            Boolean filtered
+    ) {
+
+        private ApplyInquiryAiAnalysisCommand toCommand(Long inquiryId) {
+            return new ApplyInquiryAiAnalysisCommand(
+                    inquiryId,
+                    title,
+                    summary,
+                    severity,
+                    domain,
+                    estimatedUrl,
+                    recommendedAction,
+                    Boolean.TRUE.equals(filtered)
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/InquiryPythonProperties.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/InquiryPythonProperties.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.inquiry.infrastructure.client;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/** 문의 AI 분석 전용 Python FastAPI 호출 설정입니다. */
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "inquiry.python")
+public class InquiryPythonProperties {
+
+    private boolean enabled = true;
+
+    @NotBlank
+    private String analyzePath = "/internal/inquiries/analyze";
+
+    @Positive
+    private int connectTimeoutMs = 3000;
+
+    @Positive
+    private int readTimeoutMs = 10000;
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
@@ -4,8 +4,10 @@ import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
 import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,6 +20,14 @@ public class InquiryAiCorrectionRepositoryAdapter implements InquiryAiCorrection
     public Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName) {
         return springDataRepository.findByInquiryIdAndFieldName(inquiryId, fieldName)
                 .map(InquiryAiCorrectionMapper::toDomain);
+    }
+
+    @Override
+    public List<InquiryAiCorrection> findRecentCorrections(int limit) {
+        return springDataRepository.findAllByOrderByUpdatedAtDesc(PageRequest.of(0, limit))
+                .stream()
+                .map(InquiryAiCorrectionMapper::toDomain)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
@@ -24,7 +24,7 @@ public class InquiryAiCorrectionRepositoryAdapter implements InquiryAiCorrection
 
     @Override
     public List<InquiryAiCorrection> findRecentCorrections(int limit) {
-        return springDataRepository.findAllByOrderByUpdatedAtDesc(PageRequest.of(0, limit))
+        return springDataRepository.findAllByOrderByUpdatedAtDescCorrectionIdDesc(PageRequest.of(0, limit))
                 .stream()
                 .map(InquiryAiCorrectionMapper::toDomain)
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.inquiry.infrastructure.persistence;
 
 import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
 import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
 import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
 import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
@@ -60,6 +61,12 @@ public class InquiryQueryAdapter implements InquiryQueryRepository {
     public Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId) {
         return springDataRepository.findById(inquiryId)
                 .map(this::toDetail);
+    }
+
+    @Override
+    // 로그인 첫 화면에 필요한 미확인 답변만 최신 답변순으로 조회한다.
+    public List<ActiveInquiryReply> findActiveRepliesByUserId(Long userId) {
+        return springDataRepository.findActiveRepliesByUserId(userId);
     }
 
     private AdminInquiryListItem toListItem(InquiryListProjection projection) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
@@ -20,6 +20,12 @@ public class InquiryRepositoryAdapter implements InquiryRepository {
     }
 
     @Override
+    public Optional<Inquiry> findByIdAndUserId(Long inquiryId, Long userId) {
+        return springDataRepository.findByInquiryIdAndUserId(inquiryId, userId)
+                .map(InquiryMapper::toDomain);
+    }
+
+    @Override
     public Inquiry save(Inquiry inquiry) {
         InquiryJpaEntity saved = springDataRepository.save(InquiryMapper.toEntity(inquiry));
 

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
@@ -11,5 +11,6 @@ public interface SpringDataInquiryAiCorrectionRepository extends JpaRepository<I
 
     Optional<InquiryAiCorrectionJpaEntity> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
 
-    List<InquiryAiCorrectionJpaEntity> findAllByOrderByUpdatedAtDesc(Pageable pageable);
+    // updatedAt만으로는 동시각 row 간 순서가 안정적이지 않아, 고유 식별자(correctionId)를 2차 정렬 기준으로 둔다.
+    List<InquiryAiCorrectionJpaEntity> findAllByOrderByUpdatedAtDescCorrectionIdDesc(Pageable pageable);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
@@ -1,11 +1,15 @@
 package com.wanted.codebombalms.inquiry.infrastructure.persistence;
 
 import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpringDataInquiryAiCorrectionRepository extends JpaRepository<InquiryAiCorrectionJpaEntity, Long> {
 
     Optional<InquiryAiCorrectionJpaEntity> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+
+    List<InquiryAiCorrectionJpaEntity> findAllByOrderByUpdatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.inquiry.infrastructure.persistence;
 
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
@@ -9,7 +10,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface SpringDataInquiryRepository extends JpaRepository<InquiryJpaEntity, Long> {
+
+    Optional<InquiryJpaEntity> findByInquiryIdAndUserId(Long inquiryId, Long userId);
 
     // isFiltered는 항상 조건으로 걸고, domain/severity/status는 값이 있을 때만 조건에 추가한다.
     @Query(
@@ -39,4 +45,16 @@ public interface SpringDataInquiryRepository extends JpaRepository<InquiryJpaEnt
             @Param("status") InquiryStatus status,
             Pageable pageable
     );
+
+    @Query("""
+            select new com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply(
+                i.inquiryId, i.title, i.content, i.adminReply, i.repliedAt
+            )
+            from InquiryJpaEntity i
+            where i.userId = :userId
+              and i.status = com.wanted.codebombalms.inquiry.domain.model.InquiryStatus.ANSWERED
+              and i.replyVisible = true
+            order by i.repliedAt desc, i.inquiryId desc
+            """)
+    List<ActiveInquiryReply> findActiveRepliesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
@@ -1,0 +1,78 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.inquiry.application.usecase.GetActiveInquiryRepliesUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
+import com.wanted.codebombalms.inquiry.presentation.api.response.ActiveInquiryReplyListResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryReplyVisibilityResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Inquiry - 사용자 문의", description = "로그인 사용자의 문의 답변 조회/노출 상태 변경 API")
+@RestController
+@RequestMapping("/api/v1/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final GetActiveInquiryRepliesUseCase getActiveInquiryRepliesUseCase;
+    private final HideInquiryReplyUseCase hideInquiryReplyUseCase;
+
+    @Operation(summary = "내 미확인 문의 답변 조회", description = "로그인 첫 화면에서 모달로 노출할 답변 확인 전 문의 답변 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016: 인증이 필요합니다.")
+    })
+    @GetMapping("/me/replies/active")
+    public ResponseEntity<ApiResponse<ActiveInquiryReplyListResponse>> findActiveReplies(
+            @AuthenticationPrincipal Long userId
+    ) {
+        validateAuthenticated(userId);
+
+        var result = getActiveInquiryRepliesUseCase.getActiveReplies(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.ACTIVE_REPLIES_RETRIEVED,
+                InquiryResponseMessage.ACTIVE_REPLIES_RETRIEVED,
+                ActiveInquiryReplyListResponse.from(result)
+        ));
+    }
+
+    @Operation(summary = "문의 답변 비노출 처리", description = "사용자가 답변 모달을 닫으면 해당 문의 답변을 로그인 첫 화면에서 다시 노출하지 않습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016: 인증이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PatchMapping("/{inquiryId}/reply-visibility")
+    public ResponseEntity<ApiResponse<InquiryReplyVisibilityResponse>> hideReply(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        validateAuthenticated(userId);
+
+        var result = hideInquiryReplyUseCase.hideReply(inquiryId, userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.REPLY_VISIBILITY_UPDATED,
+                InquiryResponseMessage.REPLY_VISIBILITY_UPDATED,
+                InquiryReplyVisibilityResponse.from(result)
+        ));
+    }
+
+    private void validateAuthenticated(Long userId) {
+        if (userId == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
@@ -3,30 +3,58 @@ package com.wanted.codebombalms.inquiry.presentation.api;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.inquiry.application.usecase.CreateInquiryUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.GetActiveInquiryRepliesUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryCreateRequest;
 import com.wanted.codebombalms.inquiry.presentation.api.response.ActiveInquiryReplyListResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryCreateResponse;
 import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryReplyVisibilityResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Inquiry - 사용자 문의", description = "로그인 사용자의 문의 답변 조회/노출 상태 변경 API")
+@Tag(name = "Inquiry - 사용자 문의", description = "로그인 사용자의 문의 등록/답변 조회/노출 상태 변경 API")
 @RestController
 @RequestMapping("/api/v1/inquiries")
 @RequiredArgsConstructor
 public class InquiryController {
 
+    private final CreateInquiryUseCase createInquiryUseCase;
     private final GetActiveInquiryRepliesUseCase getActiveInquiryRepliesUseCase;
     private final HideInquiryReplyUseCase hideInquiryReplyUseCase;
+
+    @Operation(summary = "문의 등록", description = "자연어 문의를 등록합니다. 등록 즉시 응답하며, AI 분석은 내부적으로 비동기 처리됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016: 인증이 필요합니다.")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<InquiryCreateResponse>> createInquiry(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody InquiryCreateRequest request
+    ) {
+        validateAuthenticated(userId);
+
+        var result = createInquiryUseCase.create(request.toCommand(userId));
+
+        return ResponseEntity.status(201).body(ApiResponse.created(
+                InquiryResponseCode.CREATED,
+                InquiryResponseMessage.CREATED,
+                InquiryCreateResponse.from(result)
+        ));
+    }
 
     @Operation(summary = "내 미확인 문의 답변 조회", description = "로그인 첫 화면에서 모달로 노출할 답변 확인 전 문의 답변 목록을 조회합니다.")
     @ApiResponses({

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
@@ -10,4 +10,5 @@ public class InquiryResponseCode {
     public static final String REPLIED                  = "ADMIN_INQUIRY-REPLIED";
     public static final String ACTIVE_REPLIES_RETRIEVED = "INQUIRY-ACTIVE_REPLIES_RETRIEVED";
     public static final String REPLY_VISIBILITY_UPDATED = "INQUIRY-REPLY_VISIBILITY_UPDATED";
+    public static final String CREATED                  = "INQUIRY-CREATED";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
@@ -8,4 +8,6 @@ public class InquiryResponseCode {
     public static final String CLASSIFICATION_UPDATED   = "ADMIN_INQUIRY-CLASSIFICATION_UPDATED";
     public static final String FILTER_UPDATED           = "ADMIN_INQUIRY-FILTER_UPDATED";
     public static final String REPLIED                  = "ADMIN_INQUIRY-REPLIED";
+    public static final String ACTIVE_REPLIES_RETRIEVED = "INQUIRY-ACTIVE_REPLIES_RETRIEVED";
+    public static final String REPLY_VISIBILITY_UPDATED = "INQUIRY-REPLY_VISIBILITY_UPDATED";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
@@ -10,4 +10,5 @@ public class InquiryResponseMessage {
     public static final String REPLIED                  = "문의 답변이 등록되었습니다.";
     public static final String ACTIVE_REPLIES_RETRIEVED = "미확인 문의 답변을 조회했습니다.";
     public static final String REPLY_VISIBILITY_UPDATED = "문의 답변 노출 상태가 변경되었습니다.";
+    public static final String CREATED                  = "문의가 접수되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
@@ -8,4 +8,6 @@ public class InquiryResponseMessage {
     public static final String CLASSIFICATION_UPDATED   = "문의 분류가 수정되었습니다.";
     public static final String FILTER_UPDATED           = "문의 필터링 상태가 변경되었습니다.";
     public static final String REPLIED                  = "문의 답변이 등록되었습니다.";
+    public static final String ACTIVE_REPLIES_RETRIEVED = "미확인 문의 답변을 조회했습니다.";
+    public static final String REPLY_VISIBILITY_UPDATED = "문의 답변 노출 상태가 변경되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryCreateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryCreateRequest.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// 사용자 문의 등록 요청을 받는다.
+public record InquiryCreateRequest(
+
+        @Schema(description = "문의 원문", example = "문제 제출했는데 계속 로딩만 되고 결과가 안 나와요.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "문의 내용은 필수입니다.")
+        String content,
+
+        @Schema(description = "문의를 작성한 프론트 페이지 경로", example = "/user/problems/123")
+        @Size(max = 500, message = "sourceUrl은 500자를 넘을 수 없습니다.")
+        String sourceUrl
+) {
+
+    // 인증된 사용자 ID를 더해 command로 변환한다.
+    public CreateInquiryCommand toCommand(Long userId) {
+        return new CreateInquiryCommand(userId, content, sourceUrl);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyListResponse.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+
+import java.util.List;
+
+// 미확인 답변이 없으면 replies는 빈 배열로 응답한다.
+public record ActiveInquiryReplyListResponse(
+        List<ActiveInquiryReplyResponse> replies
+) {
+
+    public static ActiveInquiryReplyListResponse from(List<ActiveInquiryReply> replies) {
+        return new ActiveInquiryReplyListResponse(
+                replies.stream()
+                        .map(ActiveInquiryReplyResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyResponse.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+
+import java.time.LocalDateTime;
+
+// 로그인 첫 화면에서 모달로 보여줄 문의 답변 한 건
+public record ActiveInquiryReplyResponse(
+        Long inquiryId,
+        String title,
+        String content,
+        String adminReply,
+        LocalDateTime repliedAt
+) {
+
+    public static ActiveInquiryReplyResponse from(ActiveInquiryReply reply) {
+        return new ActiveInquiryReplyResponse(
+                reply.inquiryId(),
+                reply.title(),
+                reply.content(),
+                reply.adminReply(),
+                reply.repliedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryCreateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryCreateResponse.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+// 문의 등록 결과. AI 분석은 비동기로 진행되므로 등록 시점 상태만 내려준다.
+public record InquiryCreateResponse(
+        Long inquiryId,
+        InquiryStatus status
+) {
+
+    public static InquiryCreateResponse from(Inquiry inquiry) {
+        return new InquiryCreateResponse(
+                inquiry.getInquiryId(),
+                inquiry.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyVisibilityResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyVisibilityResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 답변 확인 후 노출 상태 변경 결과
+public record InquiryReplyVisibilityResponse(
+        Long inquiryId,
+        boolean replyVisible
+) {
+
+    public static InquiryReplyVisibilityResponse from(Inquiry inquiry) {
+        return new InquiryReplyVisibilityResponse(
+                inquiry.getInquiryId(),
+                inquiry.isReplyVisible()
+        );
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #확인 필요

---

## 🛠️ 기능 관련 작업 내용
- `GET /api/v1/inquiries/me/replies/active`, `PATCH /api/v1/inquiries/{id}/reply-visibility` 구현 — 로그인 첫 화면 답변 확인/비노출
- `POST /api/v1/inquiries` 구현 — 등록 즉시 응답하고, Python AI 분석은 `inquiryTaskExecutor` 전용 스레드에서 비동기 호출
- 관리자 보정 이력(`inquiry_ai_correction`)을 최대 1000건 조회해 분석 요청에 함께 전달, Python 응답을 받아 `inquiry`에 반영하는 로직까지 완성
- Python과의 JSON 계약을 chatbot 컨벤션과 동일하게 snake_case로 통일, Gemini 응답 처리를 별도 빈(`InquiryAiAnalysisApplyService`)으로 분리해 순환 참조 제거

---

## ♻️ 패키지 변경 사항
- `inquiry/presentation/api/InquiryController.java`: `POST /api/v1/inquiries` 등 3종 endpoint
- `inquiry/application/service/UserInquiryCommandService.java`: 문의 등록 + 답변 비노출 처리
- `inquiry/application/service/InquiryAiAnalysisApplyService.java`: Python 분석 결과 반영 전담 (신규)
- `inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java`: Python 비동기 호출 client, snake_case 계약
- `inquiry/domain/model/Inquiry.java`: `create()`/`applyAiAnalysis()` 도메인 메서드 추가
- `global/infrastructure/config/SchedulingConfig.java`: `inquiryTaskExecutor` 빈 추가
- `http/inquiry.http`: 사용자/관리자 로그인 포함 전체 흐름 테스트 시나리오 (신규)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 문의를 등록하고, 답변이 도착한 문의 목록을 확인할 수 있습니다.
  * 사용자가 문의 답변의 노출 여부를 직접 변경할 수 있습니다.
  * 문의 등록 후 AI 분석이 비동기로 진행되며, 분석 결과가 문의 정보에 반영됩니다.
  * 관리자 보정 사례를 활용해 AI 분석 품질을 개선합니다.
  * AI 분석 서버 오류나 처리 지연이 발생해도 문의 등록 응답에는 영향을 주지 않습니다.
* **개선**
  * 인증된 사용자만 자신의 문의와 답변을 조회·관리할 수 있습니다.
  * 문의 등록 및 입력 URL에 대한 유효성 검사가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->