### PR TITLE
[Update] 보안 요약 HTTP 예외 신호에 status별 세분화(statusBreakdown) 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
@@ -11,6 +11,7 @@ public interface SecuritySummaryQueryPort {
     record TypeCount(String type, long count) {}
     record RiskIp(String ip, long count, String mainType, List<Long> targetUserIds) {}
     record RouteAnomaly(String route, String type, long count, Integer maxDurationMs) {}
+    record StatusBreakdown(String route, String type, int status, long count) {}
     record HourlyCount(int hour, long count) {}
     record ConcurrentPeak(long peak, LocalDateTime occurredAt) {}
 
@@ -22,6 +23,9 @@ public interface SecuritySummaryQueryPort {
     List<RiskIp> findTopRiskIps(LocalDateTime start, LocalDateTime end);
 
     List<RouteAnomaly> findHttpAnomalies(LocalDateTime start, LocalDateTime end);
+
+    /** (route, type) 별 http_status 세부 분포 — statusBreakdown 맵 조립용 */
+    List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end);
 
     List<HourlyCount> hourlyDistribution(LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/query/SecuritySummaryResult.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/query/SecuritySummaryResult.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.serviceevent.application.query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * GET /api/v1/admin/security/summary 응답 data 형태.
@@ -32,7 +33,9 @@ public record SecuritySummaryResult(
 
     public record DomainCount(String group, String label, long count) {}
 
-    public record HttpAnomaly(String route, String type, long count, Integer maxDurationMs) {}
+    public record HttpAnomaly(
+            String route, String type, long count, Integer maxDurationMs,
+            Map<Integer, Long> statusBreakdown) {}
 
     public record RiskIp(String ip, String country, long eventCount, String mainType, List<Long> targetUserIds) {}
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
@@ -103,7 +103,9 @@ public class SecuritySummaryService {
                 period.code,
                 kpi,
                 toDomainCounts(categoryCounts),
-                toHttpAnomalies(summaryQuery.findHttpAnomalies(start, end)),
+                toHttpAnomalies(
+                        summaryQuery.findHttpAnomalies(start, end),
+                        summaryQuery.findHttpStatusBreakdown(start, end)),
                 toRiskIps(summaryQuery.findTopRiskIps(start, end)),
                 toHourly(summaryQuery.hourlyDistribution(start, end))
         );
@@ -145,10 +147,24 @@ public class SecuritySummaryService {
     }
 
     private List<SecuritySummaryResult.HttpAnomaly> toHttpAnomalies(
-            List<SecuritySummaryQueryPort.RouteAnomaly> anomalies) {
+            List<SecuritySummaryQueryPort.RouteAnomaly> anomalies,
+            List<SecuritySummaryQueryPort.StatusBreakdown> breakdowns) {
+        Map<String, Map<Integer, Long>> byRouteType = breakdowns.stream()
+                .collect(Collectors.groupingBy(
+                        b -> routeTypeKey(b.route(), b.type()),
+                        Collectors.toMap(
+                                SecuritySummaryQueryPort.StatusBreakdown::status,
+                                SecuritySummaryQueryPort.StatusBreakdown::count)));
         return anomalies.stream()
-                .map(a -> new SecuritySummaryResult.HttpAnomaly(a.route(), a.type(), a.count(), a.maxDurationMs()))
+                .map(a -> new SecuritySummaryResult.HttpAnomaly(
+                        a.route(), a.type(), a.count(), a.maxDurationMs(),
+                        byRouteType.getOrDefault(routeTypeKey(a.route(), a.type()), Map.of())))
                 .toList();
+    }
+
+    /** (route, type) 복합 키 — 널 안전, 구분자로 route 값 충돌 방지 */
+    private String routeTypeKey(String route, String type) {
+        return route + ' ' + type;
     }
 
     private List<SecuritySummaryResult.RiskIp> toRiskIps(List<SecuritySummaryQueryPort.RiskIp> riskIps) {

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
@@ -50,6 +50,14 @@ public class SecuritySummaryQueryAdapter implements SecuritySummaryQueryPort {
     }
 
     @Override
+    public List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end) {
+        return repository.findHttpStatusBreakdown(start, end).stream()
+                .map(row -> new StatusBreakdown(
+                        row.getUri(), row.getEventType(), row.getStatus(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
     public List<HourlyCount> hourlyDistribution(LocalDateTime start, LocalDateTime end) {
         return repository.hourlyDistribution(start, end).stream()
                 .map(row -> new HourlyCount(row.getHr(), row.getCnt()))

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -27,6 +27,7 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
     interface TypeCountRow { String getEventType(); long getCnt(); }
     interface IpCountRow { String getIpAddress(); long getCnt(); }
     interface RouteAnomalyRow { String getUri(); String getEventType(); long getCnt(); Integer getMaxDuration(); }
+    interface HttpStatusBreakdownRow { String getUri(); String getEventType(); Integer getStatus(); long getCnt(); }
     interface HourlyRow { int getHr(); long getCnt(); }
     interface ConcurrentPeakRow { long getPeak(); LocalDateTime getOccurredAt(); }
 
@@ -96,6 +97,17 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             LIMIT 10
             """, nativeQuery = true)
     List<RouteAnomalyRow> findHttpAnomalies(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    @Query(value = """
+            SELECT uri AS uri, event_type AS eventType, http_status AS status, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND category = 'http_anomaly'
+              AND http_status IS NOT NULL
+            GROUP BY uri, event_type, http_status
+            """, nativeQuery = true)
+    List<HttpStatusBreakdownRow> findHttpStatusBreakdown(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     @Query(value = """
             SELECT HOUR(created_at) AS hr, COUNT(*) AS cnt


### PR DESCRIPTION
## 🚨 Pull Request 유형


해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [x] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #확인 필요

---

## 🛠️ 기능 관련 작업 내용
- HTTP 예외 신호가 `http_5xx` 한 타입으로 뭉쳐 500/502/503 구분이 안 되던 문제 해결
- `service_event.http_status` 컬럼(이미 적재 중)을 status별로 집계하는 조회 추가
- `httpAnomalies[]` 응답에 `statusBreakdown` 맵 필드 추가 (예: `{"500":3,"502":2}`)
- 기존 `type`·`count`·KPI(`http5xxCount`) 로직은 변경 없음 — 하위 호환 유지

---

## ♻️ 패키지 변경 사항
- `codebombalms/serviceevent/infrastructure/persistence`: `SpringDataServiceEventRepository`에 `findHttpStatusBreakdown` 네이티브 쿼리 + Row 인터페이스, `SecuritySummaryQueryAdapter`에 매핑 구현 추가
- `codebombalms/serviceevent/application/port`: `SecuritySummaryQueryPort`에 `StatusBreakdown` record + 조회 메서드 추가
- `codebombalms/serviceevent/application/query`: `SecuritySummaryResult.HttpAnomaly`에 `statusBreakdown` 필드 추가
- `codebombalms/serviceevent/application/service`: `SecuritySummaryService.toHttpAnomalies`에서 (route, type)별 브레이크다운 조립

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * HTTP 이상 현황에 상태 코드별 발생 건수 분포가 추가되었습니다.
  * 경로와 이벤트 유형별로 상태 코드 집계 정보를 확인할 수 있습니다.
  * 기존 HTTP 이상 요약에 상태 코드 분석 정보가 함께 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->