### PR TITLE
[Ref] 5XX 세분화

### DIFF
--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
@@ -24,8 +24,8 @@ public interface SecuritySummaryQueryPort {
 
     List<RouteAnomaly> findHttpAnomalies(LocalDateTime start, LocalDateTime end);
 
-    /** (route, type) 별 http_status 세부 분포 — statusBreakdown 맵 조립용 */
-    List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end);
+    /** 지정 라우트 집합의 http_status 세부 분포 — statusBreakdown 맵 조립용 (top-N 라우트로 스코핑) */
+    List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end, List<String> routes);
 
     List<HourlyCount> hourlyDistribution(LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
@@ -99,13 +99,19 @@ public class SecuritySummaryService {
                 enrollmentsDelta
         );
 
+        List<SecuritySummaryQueryPort.RouteAnomaly> anomalies = summaryQuery.findHttpAnomalies(start, end);
+        List<String> anomalyRoutes = anomalies.stream()
+                .map(SecuritySummaryQueryPort.RouteAnomaly::route)
+                .distinct()
+                .toList();
+        List<SecuritySummaryQueryPort.StatusBreakdown> breakdowns =
+                summaryQuery.findHttpStatusBreakdown(start, end, anomalyRoutes);
+
         return new SecuritySummaryResult(
                 period.code,
                 kpi,
                 toDomainCounts(categoryCounts),
-                toHttpAnomalies(
-                        summaryQuery.findHttpAnomalies(start, end),
-                        summaryQuery.findHttpStatusBreakdown(start, end)),
+                toHttpAnomalies(anomalies, breakdowns),
                 toRiskIps(summaryQuery.findTopRiskIps(start, end)),
                 toHourly(summaryQuery.hourlyDistribution(start, end))
         );

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
@@ -50,8 +50,11 @@ public class SecuritySummaryQueryAdapter implements SecuritySummaryQueryPort {
     }
 
     @Override
-    public List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end) {
-        return repository.findHttpStatusBreakdown(start, end).stream()
+    public List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end, List<String> routes) {
+        if (routes.isEmpty()) {
+            return List.of(); // 빈 목록이면 native IN () 문법 오류 방지 — 조회 생략
+        }
+        return repository.findHttpStatusBreakdown(start, end, routes).stream()
                 .map(row -> new StatusBreakdown(
                         row.getUri(), row.getEventType(), row.getStatus(), row.getCnt()))
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -104,10 +104,12 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             WHERE created_at >= :start AND created_at < :end
               AND category = 'http_anomaly'
               AND http_status IS NOT NULL
+              AND uri IN (:uris)
             GROUP BY uri, event_type, http_status
             """, nativeQuery = true)
     List<HttpStatusBreakdownRow> findHttpStatusBreakdown(
-            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("uris") List<String> uris);
 
     @Query(value = """
             SELECT HOUR(created_at) AS hr, COUNT(*) AS cnt


### PR DESCRIPTION


findHttpAnomalies의 top-10 라우트를 distinct 추출해
IN (:uris)로 스코핑하고, 빈 목록일 때는 adapter에서 조회를 생략해
IN () 문법 오류를 방지했습니다.
(참고: uri는 raw URL이 아니라 핸들러 패턴으로 정규화되고 unmatched는
단일 토큰으로 접혀서 실제 카디널리티 폭발 위험은 제한적이지만,
불필요한 전체 집계를 없애는 개선으로 반영했습니다.)

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.
