### PR TITLE
[Feat] 강좌 완료 AI 문제세트 추천 연동

### DIFF
--- a/src/main/java/com/wanted/codebombalms/learning/README.md
+++ b/src/main/java/com/wanted/codebombalms/learning/README.md
@@ -10,6 +10,7 @@
 - 문제 제출을 학습 흐름에서 처리한다.
 - 강좌별, 사용자별, 강의별 학습 진행률을 집계한다.
 - 학습 진행률 요약과 문제 통계를 제공한다.
+- 강좌 완료 시 MAIN 풀이·해설 기록을 조립해 Python AI 문제세트 추천을 요청한다.
 
 ## 패키지 구조
 
@@ -29,6 +30,7 @@ learning
 │   ├── lecture
 │   ├── persistence
 │   ├── problem
+│   ├── client
 │   └── user
 └── presentation
     └── api          # LearningController, request/response DTO
@@ -53,6 +55,7 @@ learning
 | `LectureProblemProgressService` | 강의 문제 진행률 기록/조회 |
 | `LectureProblemSetService` | 강의 문제 세트 상세 조회와 제출 흐름 |
 | `AdminLearningProgressQueryService` | 관리자용 학습 진행률 집계 조회 |
+| `FinalProblemSetRankingService` | MAIN 학습 지표·강좌 문맥 조립과 Python 추천 요청 |
 
 ## API 목록
 
@@ -82,4 +85,13 @@ learning
 | `submission` | 문제 제출 결과와 풀이 상태 반영 |
 | `enrollment` | 수강 중인 사용자/강좌 기준 검증 |
 | `user` | 사용자별 학습 진행률 집계 |
+
+## 강좌 완료 AI 문제세트 추천
+
+- 기존 `GET /api/v1/lectures/{lectureId}/final-problem-set-candidates`의 마지막 강의·완료 조건은 lecture 도메인이 유지한다.
+- learning 도메인은 MAIN 문제의 정답 제출, 해설 조회, 제출 횟수, 최신 테스트 통과율을 집계한다.
+- 직접 풀이는 정답 제출이 있고 해설 조회 이력이 없는 문제로 계산한다.
+- MAIN 문제가 없거나 운영자 미리보기이면 개인 학습 지표를 모두 0으로 전달한다.
+- Python은 같은 문제 카테고리에서 MAIN 문제세트를 제외하고 최대 2개를 점수순으로 반환한다.
+- Python 호출이 실패하거나 응답이 잘못되면 기존 ID순 후보 조회로 복구한다.
 

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningLecture.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningLecture.java
@@ -2,6 +2,11 @@ package com.wanted.codebombalms.learning.application.port;
 
 public record LearningLecture(
         Long lectureId,
-        String title
+        String title,
+        String description
 ) {
+
+    public LearningLecture(Long lectureId, String title) {
+        this(lectureId, title, null);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
@@ -1,0 +1,70 @@
+package com.wanted.codebombalms.learning.application.port;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/** Python FastAPI의 강좌 완료 문제세트 추천을 호출하는 출력 포트입니다. */
+public interface LearningRecommendationClient {
+
+    LearningRecommendationResult rankFinalProblemSets(LearningRecommendationRequest request);
+
+    record LearningRecommendationRequest(
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            List<Long> excludedProblemSetIds,
+            int recommendationCount,
+            LearningProfile learningProfile,
+            LearningContext learningContext
+    ) {
+    }
+
+    record LearningProfile(
+            int totalMainProblemCount,
+            int correctProblemCount,
+            double directSolveRate,
+            int explanationViewCount,
+            double explanationViewRate,
+            double averageAttemptCount,
+            double averageTestPassRate
+    ) {
+
+        public static LearningProfile empty() {
+            return new LearningProfile(0, 0, 0.0, 0, 0.0, 0.0, 0.0);
+        }
+    }
+
+    record LearningContext(
+            String courseTitle,
+            String courseDescription,
+            List<LectureContext> lectures
+    ) {
+    }
+
+    record LectureContext(
+            String title,
+            String description
+    ) {
+    }
+
+    record LearningRecommendationResult(
+            String algorithm,
+            List<RankedProblemSet> recommendations
+    ) {
+    }
+
+    record RankedProblemSet(
+            Long problemSetId,
+            BigDecimal score,
+            ReasonCode reasonCode,
+            String recommendationReason
+    ) {
+    }
+
+    enum ReasonCode {
+        COURSE_RELATED,
+        REVIEW_WEAK_AREA,
+        LEVEL_MATCHED,
+        NEXT_DIFFICULTY
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
@@ -6,6 +6,8 @@ import java.util.List;
 /** Python FastAPI의 강좌 완료 문제세트 추천을 호출하는 출력 포트입니다. */
 public interface LearningRecommendationClient {
 
+    int MAX_RECOMMENDATION_COUNT = 2;
+
     LearningRecommendationResult rankFinalProblemSets(LearningRecommendationRequest request);
 
     record LearningRecommendationRequest(

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
@@ -1,0 +1,238 @@
+package com.wanted.codebombalms.learning.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningCourseProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningCoursePort;
+import com.wanted.codebombalms.learning.application.port.LearningLecture;
+import com.wanted.codebombalms.learning.application.port.LearningLecturePort;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemExplanationPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningContext;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningProfile;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LectureContext;
+import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
+import com.wanted.codebombalms.learning.domain.model.LearningCourse;
+import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
+import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** MAIN 학습 기록과 강좌 문맥을 조립해 Python 추천 순위를 요청합니다. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FinalProblemSetRankingService implements FinalProblemSetRankingUseCase {
+
+    private static final int RECOMMENDATION_COUNT = 2;
+    private static final int MAX_EXCLUDED_PROBLEM_SET_COUNT = 100;
+    private static final int MAX_LECTURE_CONTEXT_COUNT = 100;
+    private static final int MAX_TITLE_LENGTH = 100;
+    private static final int MAX_DESCRIPTION_LENGTH = 2000;
+
+    private final LearningRecommendationClient learningRecommendationClient;
+    private final LearningCoursePort learningCoursePort;
+    private final LearningLecturePort learningLecturePort;
+    private final LearningCourseProblemPort learningCourseProblemPort;
+    private final LearningLectureProblemSetPort learningLectureProblemSetPort;
+    private final LearningProblemPort learningProblemPort;
+    private final LearningProblemExplanationPort learningProblemExplanationPort;
+    private final LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
+
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public LearningRecommendationResult rankFinalProblemSets(
+            Long userId,
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            Set<Long> excludedProblemSetIds,
+            boolean operator
+    ) {
+        if (excludedProblemSetIds.size() > MAX_EXCLUDED_PROBLEM_SET_COUNT) {
+            log.warn(
+                    "event=learning_recommendation_skipped reason=excluded_problem_set_limit count={}",
+                    excludedProblemSetIds.size()
+            );
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE);
+        }
+
+        LearningProfile profile = operator || userId == null
+                ? LearningProfile.empty()
+                : buildLearningProfile(userId, courseId);
+        LearningContext context = buildLearningContext(courseId);
+
+        LearningRecommendationRequest request = new LearningRecommendationRequest(
+                courseId,
+                lectureId,
+                problemCategoryId,
+                excludedProblemSetIds.stream().sorted().toList(),
+                RECOMMENDATION_COUNT,
+                profile,
+                context
+        );
+        return learningRecommendationClient.rankFinalProblemSets(request);
+    }
+
+    private LearningProfile buildLearningProfile(Long userId, Long courseId) {
+        List<Long> mainLectureProblemSetIds =
+                learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(courseId);
+        if (mainLectureProblemSetIds.isEmpty()) {
+            return LearningProfile.empty();
+        }
+
+        Map<Long, LearningProblemPort.ProblemDetailForLearning> problemsById = new LinkedHashMap<>();
+        Map<Long, List<LectureProblemSubmission>> submissionsByProblemId = new HashMap<>();
+
+        for (Long lectureProblemSetId : mainLectureProblemSetIds) {
+            Long problemSetId = learningLectureProblemSetPort
+                    .findLectureProblemSet(lectureProblemSetId)
+                    .problemSetId();
+            LearningProblemPort.ProblemSetForLearning problemSet =
+                    learningProblemPort.loadProblemSet(problemSetId);
+            for (LearningProblemPort.ProblemDetailForLearning problem : problemSet.problems()) {
+                problemsById.putIfAbsent(problem.problemId(), problem);
+            }
+
+            for (LectureProblemSubmission submission :
+                    lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(
+                            userId,
+                            lectureProblemSetId
+                    )) {
+                if (problemsById.containsKey(submission.problemId())) {
+                    submissionsByProblemId
+                            .computeIfAbsent(submission.problemId(), ignored -> new ArrayList<>())
+                            .add(submission);
+                }
+            }
+        }
+
+        int totalProblemCount = problemsById.size();
+        if (totalProblemCount == 0) {
+            return LearningProfile.empty();
+        }
+
+        Set<Long> viewedProblemIds = learningProblemExplanationPort.findViewedProblemIds(
+                userId,
+                List.copyOf(problemsById.keySet())
+        );
+
+        int correctProblemCount = 0;
+        int directSolveCount = 0;
+        int totalAttemptCount = 0;
+        double totalLatestTestPassRate = 0.0;
+
+        for (Long problemId : problemsById.keySet()) {
+            List<LectureProblemSubmission> submissions =
+                    submissionsByProblemId.getOrDefault(problemId, List.of());
+            totalAttemptCount += submissions.size();
+
+            boolean correct = submissions.stream().anyMatch(LectureProblemSubmission::correct);
+            if (correct) {
+                correctProblemCount++;
+                if (!viewedProblemIds.contains(problemId)) {
+                    directSolveCount++;
+                }
+            }
+
+            LectureProblemSubmission latest = submissions.stream()
+                    .max(this::compareSubmissionTime)
+                    .orElse(null);
+            totalLatestTestPassRate += calculateTestPassRate(latest);
+        }
+
+        return new LearningProfile(
+                totalProblemCount,
+                correctProblemCount,
+                percentage(directSolveCount, totalProblemCount),
+                viewedProblemIds.size(),
+                percentage(viewedProblemIds.size(), totalProblemCount),
+                roundFour(totalAttemptCount / (double) totalProblemCount),
+                roundFour(totalLatestTestPassRate / totalProblemCount)
+        );
+    }
+
+    private LearningContext buildLearningContext(Long courseId) {
+        LearningCourse course = learningCoursePort.findActiveCourse(courseId);
+        List<LectureContext> lectures = learningLecturePort.findLecturesByCourse(courseId)
+                .stream()
+                .limit(MAX_LECTURE_CONTEXT_COUNT)
+                .map(this::toLectureContext)
+                .toList();
+
+        return new LearningContext(
+                normalizeTitle(course.title(), "강좌 " + courseId),
+                normalizeDescription(course.description()),
+                lectures
+        );
+    }
+
+    private LectureContext toLectureContext(LearningLecture lecture) {
+        return new LectureContext(
+                normalizeTitle(lecture.title(), "강의 " + lecture.lectureId()),
+                normalizeDescription(lecture.description())
+        );
+    }
+
+    private int compareSubmissionTime(
+            LectureProblemSubmission left,
+            LectureProblemSubmission right
+    ) {
+        Comparator<LocalDateTime> timeComparator = Comparator.nullsFirst(Comparator.naturalOrder());
+        int timeCompared = timeComparator.compare(left.submittedAt(), right.submittedAt());
+        if (timeCompared != 0) {
+            return timeCompared;
+        }
+        return Comparator.nullsFirst(Long::compareTo).compare(
+                left.lectureProblemSubmissionId(),
+                right.lectureProblemSubmissionId()
+        );
+    }
+
+    private double calculateTestPassRate(LectureProblemSubmission submission) {
+        if (submission == null
+                || submission.totalTestCount() == null
+                || submission.totalTestCount() <= 0
+                || submission.passedTestCount() == null) {
+            return 0.0;
+        }
+        int passed = Math.max(0, Math.min(submission.passedTestCount(), submission.totalTestCount()));
+        return passed * 100.0 / submission.totalTestCount();
+    }
+
+    private double percentage(int numerator, int denominator) {
+        return roundFour(numerator * 100.0 / denominator);
+    }
+
+    private double roundFour(double value) {
+        return Math.round(value * 10_000.0) / 10_000.0;
+    }
+
+    private String normalizeTitle(String value, String fallback) {
+        String normalized = value == null || value.isBlank() ? fallback : value.strip();
+        return normalized.substring(0, Math.min(normalized.length(), MAX_TITLE_LENGTH));
+    }
+
+    private String normalizeDescription(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.strip();
+        return normalized.substring(0, Math.min(normalized.length(), MAX_DESCRIPTION_LENGTH));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
@@ -39,7 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FinalProblemSetRankingService implements FinalProblemSetRankingUseCase {
 
-    private static final int RECOMMENDATION_COUNT = 2;
     private static final int MAX_EXCLUDED_PROBLEM_SET_COUNT = 100;
     private static final int MAX_LECTURE_CONTEXT_COUNT = 100;
     private static final int MAX_TITLE_LENGTH = 100;
@@ -57,6 +56,39 @@ public class FinalProblemSetRankingService implements FinalProblemSetRankingUseC
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public LearningRecommendationResult rankFinalProblemSets(
+            Long userId,
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            Set<Long> excludedProblemSetIds,
+            boolean operator
+    ) {
+        try {
+            return requestRanking(
+                    userId,
+                    courseId,
+                    lectureId,
+                    problemCategoryId,
+                    excludedProblemSetIds,
+                    operator
+            );
+        } catch (ExternalServiceException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "event=learning_recommendation_preparation_failed courseId={} lectureId={} exceptionType={}",
+                    courseId,
+                    lectureId,
+                    exception.getClass().getSimpleName()
+            );
+            throw new ExternalServiceException(
+                    LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE,
+                    exception
+            );
+        }
+    }
+
+    private LearningRecommendationResult requestRanking(
             Long userId,
             Long courseId,
             Long lectureId,
@@ -82,7 +114,7 @@ public class FinalProblemSetRankingService implements FinalProblemSetRankingUseC
                 lectureId,
                 problemCategoryId,
                 excludedProblemSetIds.stream().sorted().toList(),
-                RECOMMENDATION_COUNT,
+                LearningRecommendationClient.MAX_RECOMMENDATION_COUNT,
                 profile,
                 context
         );

--- a/src/main/java/com/wanted/codebombalms/learning/application/usecase/FinalProblemSetRankingUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/usecase/FinalProblemSetRankingUseCase.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.learning.application.usecase;
+
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import java.util.Set;
+
+/** 사용자의 강좌 학습 기록을 기반으로 FINAL 문제세트 순위를 조회합니다. */
+public interface FinalProblemSetRankingUseCase {
+
+    LearningRecommendationResult rankFinalProblemSets(
+            Long userId,
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            Set<Long> excludedProblemSetIds,
+            boolean operator
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/learning/domain/exception/LearningErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/learning/domain/exception/LearningErrorCode.java
@@ -18,7 +18,9 @@ public enum LearningErrorCode implements ErrorCode {
     LECTURE_PROBLEM_NOT_UNLOCKED("LRN-008", "Lecture problem is not unlocked."),
     LECTURE_PROBLEM_SET_ALREADY_COMPLETED("LRN-009", "Lecture problem set is already completed."),
     INVALID_LECTURE_PROGRESS("LRN-010", "Lecture progress value is invalid."),
-    LECTURE_PROGRESS_ACCESS_DENIED("LRN-011", "Only enrolled students can access lecture learning content.");
+    LECTURE_PROGRESS_ACCESS_DENIED("LRN-011", "Only enrolled students can access lecture learning content."),
+    LEARNING_RECOMMENDATION_UNAVAILABLE("LRN-012", "AI learning recommendation service is unavailable."),
+    LEARNING_RECOMMENDATION_INVALID_RESPONSE("LRN-013", "AI learning recommendation response is invalid.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/learning/domain/model/LearningCourse.java
+++ b/src/main/java/com/wanted/codebombalms/learning/domain/model/LearningCourse.java
@@ -2,6 +2,11 @@ package com.wanted.codebombalms.learning.domain.model;
 
 public record LearningCourse(
         Long courseId,
-        String title
+        String title,
+        String description
 ) {
+
+    public LearningCourse(Long courseId, String title) {
+        this(courseId, title, null);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
@@ -1,0 +1,123 @@
+package com.wanted.codebombalms.learning.infrastructure.client;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
+import io.netty.channel.ChannelOption;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+/** 강좌 완료 추천 전용 FastAPI client입니다. */
+@Slf4j
+@Component
+public class FastApiLearningRecommendationClient implements LearningRecommendationClient {
+
+    private static final int MAX_RECOMMENDATION_COUNT = 2;
+    private static final int MAX_REASON_LENGTH = 300;
+    private static final int MAX_RESPONSE_IN_MEMORY_BYTES = 512 * 1024;
+
+    private final LearningRecommendationProperties properties;
+    private final WebClient webClient;
+
+    public FastApiLearningRecommendationClient(
+            LearningRecommendationProperties properties,
+            @Value("${fastapi.url}") String fastApiBaseUrl
+    ) {
+        this.properties = properties;
+        this.webClient = buildWebClient(fastApiBaseUrl, properties);
+    }
+
+    @Override
+    public LearningRecommendationResult rankFinalProblemSets(LearningRecommendationRequest request) {
+        if (!properties.isEnabled()) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE);
+        }
+
+        long startedAt = System.nanoTime();
+        try {
+            LearningRecommendationResult response = webClient.post()
+                    .uri(properties.getRankPath())
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(LearningRecommendationResult.class)
+                    .block();
+
+            validateResponse(response);
+            log.info(
+                    "event=learning_recommendation_called recommendationCount={} durationMs={}",
+                    response.recommendations().size(),
+                    (System.nanoTime() - startedAt) / 1_000_000
+            );
+            return response;
+        } catch (ExternalServiceException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "event=learning_recommendation_failed exceptionType={} durationMs={}",
+                    exception.getClass().getSimpleName(),
+                    (System.nanoTime() - startedAt) / 1_000_000
+            );
+            throw new ExternalServiceException(
+                    LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE,
+                    exception
+            );
+        }
+    }
+
+    private void validateResponse(LearningRecommendationResult response) {
+        if (response == null
+                || response.algorithm() == null
+                || response.algorithm().isBlank()
+                || response.recommendations() == null
+                || response.recommendations().size() > MAX_RECOMMENDATION_COUNT) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        Set<Long> ids = new HashSet<>();
+        for (RankedProblemSet item : response.recommendations()) {
+            if (!isValidItem(item) || !ids.add(item.problemSetId())) {
+                throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+            }
+        }
+    }
+
+    private boolean isValidItem(RankedProblemSet item) {
+        if (item == null
+                || item.problemSetId() == null
+                || item.problemSetId() <= 0
+                || item.score() == null
+                || item.reasonCode() == null
+                || item.recommendationReason() == null
+                || item.recommendationReason().isBlank()
+                || item.recommendationReason().length() > MAX_REASON_LENGTH) {
+            return false;
+        }
+        return item.score().compareTo(BigDecimal.ZERO) >= 0
+                && item.score().compareTo(BigDecimal.ONE) <= 0;
+    }
+
+    private WebClient buildWebClient(
+            String fastApiBaseUrl,
+            LearningRecommendationProperties properties
+    ) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
+
+        return WebClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(configurer -> configurer.defaultCodecs()
+                        .maxInMemorySize(MAX_RESPONSE_IN_MEMORY_BYTES))
+                .build();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
@@ -21,7 +21,6 @@ import reactor.netty.http.client.HttpClient;
 @Component
 public class FastApiLearningRecommendationClient implements LearningRecommendationClient {
 
-    private static final int MAX_RECOMMENDATION_COUNT = 2;
     private static final int MAX_REASON_LENGTH = 300;
     private static final int MAX_RESPONSE_IN_MEMORY_BYTES = 512 * 1024;
 
@@ -78,7 +77,8 @@ public class FastApiLearningRecommendationClient implements LearningRecommendati
                 || response.algorithm() == null
                 || response.algorithm().isBlank()
                 || response.recommendations() == null
-                || response.recommendations().size() > MAX_RECOMMENDATION_COUNT) {
+                || response.recommendations().size()
+                > LearningRecommendationClient.MAX_RECOMMENDATION_COUNT) {
             throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
         }
 

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.learning.infrastructure.client;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/** learning 도메인의 Python 추천 API 호출 설정입니다. */
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "learning.recommendation.python")
+public class LearningRecommendationProperties {
+
+    private boolean enabled = true;
+
+    @NotBlank
+    private String rankPath = "/internal/learning/final-problem-sets/rank";
+
+    @Positive
+    private int connectTimeoutMs = 3000;
+
+    @Positive
+    private int readTimeoutMs = 10000;
+}

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
@@ -25,5 +25,5 @@ public class LearningRecommendationProperties {
     private int connectTimeoutMs = 3000;
 
     @Positive
-    private int readTimeoutMs = 10000;
+    private int readTimeoutMs = 15000;
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseAdapter.java
@@ -36,6 +36,10 @@ public class LearningCourseAdapter implements LearningCoursePort {
     }
 
     private LearningCourse toLearningCourse(Course course) {
-        return new LearningCourse(course.getCourseId(), course.getTitle());
+        return new LearningCourse(
+                course.getCourseId(),
+                course.getTitle(),
+                course.getDescription()
+        );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/lecture/LearningLectureAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/lecture/LearningLectureAdapter.java
@@ -54,7 +54,11 @@ public class LearningLectureAdapter implements LearningLecturePort {
         try {
             return lectureQueryUseCase.findLecturesByCourseId(courseId)
                     .stream()
-                    .map(lecture -> new LearningLecture(lecture.getLectureId(), lecture.getTitle()))
+                    .map(lecture -> new LearningLecture(
+                            lecture.getLectureId(),
+                            lecture.getTitle(),
+                            lecture.getDescription()
+                    ))
                     .toList();
         } catch (NotFoundException e) {
             throw new NotFoundException(LearningErrorCode.COURSE_NOT_FOUND, e);

--- a/src/main/java/com/wanted/codebombalms/lecture/application/port/FinalProblemSetCandidatePort.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/port/FinalProblemSetCandidatePort.java
@@ -7,4 +7,6 @@ import java.util.Set;
 public interface FinalProblemSetCandidatePort {
 
     List<ProblemSetSummary> findCandidates(Long problemCategoryId, Set<Long> excludedProblemSetIds, int limit);
+
+    List<ProblemSetSummary> findByProblemSetIds(List<Long> problemSetIds);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
@@ -2,6 +2,11 @@ package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.RankedProblemSet;
+import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
 import com.wanted.codebombalms.lecture.application.port.FinalProblemSetCandidatePort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
@@ -13,14 +18,18 @@ import com.wanted.codebombalms.lecture.domain.repository.LectureProblemSetReposi
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FinalProblemSetRecommendationService implements FinalProblemSetRecommendationUseCase {
@@ -32,6 +41,7 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
     private final FinalProblemSetCandidatePort finalProblemSetCandidatePort;
     private final LectureAccessPolicy lectureAccessPolicy;
     private final LectureProgressPort lectureProgressPort;
+    private final FinalProblemSetRankingUseCase finalProblemSetRankingUseCase;
 
     @Override
     public List<FinalProblemSetCandidateView> findFinalProblemSetCandidates(Long lectureId, Long userId, boolean operator) {
@@ -50,14 +60,24 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
                 .map(problemSet -> problemSet.getProblemSetId())
                 .collect(Collectors.toSet());
 
-        return finalProblemSetCandidatePort.findCandidates(
-                        lecture.getProblemCategoryId(),
-                        mainProblemSetIds,
-                        MAX_RECOMMENDATION_COUNT
-                )
-                .stream()
-                .map(this::toView)
-                .toList();
+        try {
+            LearningRecommendationResult ranking = finalProblemSetRankingUseCase.rankFinalProblemSets(
+                    userId,
+                    lecture.getCourse().getCourseId(),
+                    lectureId,
+                    lecture.getProblemCategoryId(),
+                    mainProblemSetIds,
+                    operator
+            );
+            return toRankedViews(ranking, mainProblemSetIds);
+        } catch (ExternalServiceException exception) {
+            log.warn(
+                    "event=final_problem_set_ai_fallback lectureId={} exceptionType={}",
+                    lectureId,
+                    exception.getClass().getSimpleName()
+            );
+            return findLegacyCandidates(lecture, mainProblemSetIds);
+        }
     }
 
     private void validateFinalProblemSetAvailable(Lecture lecture, Long userId, boolean operator) {
@@ -84,7 +104,55 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
         }
     }
 
-    private FinalProblemSetCandidateView toView(ProblemSetSummary problemSet) {
+    private List<FinalProblemSetCandidateView> toRankedViews(
+            LearningRecommendationResult ranking,
+            Set<Long> excludedProblemSetIds
+    ) {
+        if (ranking == null || ranking.recommendations() == null) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        List<Long> rankedIds = ranking.recommendations()
+                .stream()
+                .map(RankedProblemSet::problemSetId)
+                .toList();
+        if (rankedIds.stream().anyMatch(excludedProblemSetIds::contains)) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        List<ProblemSetSummary> problemSets = finalProblemSetCandidatePort.findByProblemSetIds(rankedIds);
+        if (problemSets.size() != rankedIds.size()) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        Map<Long, ProblemSetSummary> problemSetById = new HashMap<>();
+        for (ProblemSetSummary problemSet : problemSets) {
+            problemSetById.put(problemSet.getProblemSetId(), problemSet);
+        }
+
+        return ranking.recommendations().stream()
+                .map(item -> toView(problemSetById.get(item.problemSetId()), item))
+                .toList();
+    }
+
+    private List<FinalProblemSetCandidateView> findLegacyCandidates(
+            Lecture lecture,
+            Set<Long> excludedProblemSetIds
+    ) {
+        return finalProblemSetCandidatePort.findCandidates(
+                        lecture.getProblemCategoryId(),
+                        excludedProblemSetIds,
+                        MAX_RECOMMENDATION_COUNT
+                )
+                .stream()
+                .map(this::toFallbackView)
+                .toList();
+    }
+
+    private FinalProblemSetCandidateView toView(
+            ProblemSetSummary problemSet,
+            RankedProblemSet ranked
+    ) {
         return new FinalProblemSetCandidateView(
                 problemSet.getProblemSetId(),
                 problemSet.getProblemNumber(),
@@ -92,7 +160,25 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
                 problemSet.getDescription(),
                 problemSet.getDifficulty(),
                 problemSet.getAccuracyRate(),
-                problemSet.getCreatedAt()
+                problemSet.getCreatedAt(),
+                ranked.score(),
+                ranked.reasonCode().name(),
+                ranked.recommendationReason()
+        );
+    }
+
+    private FinalProblemSetCandidateView toFallbackView(ProblemSetSummary problemSet) {
+        return new FinalProblemSetCandidateView(
+                problemSet.getProblemSetId(),
+                problemSet.getProblemNumber(),
+                problemSet.getTitle(),
+                problemSet.getDescription(),
+                problemSet.getDifficulty(),
+                problemSet.getAccuracyRate(),
+                problemSet.getCreatedAt(),
+                null,
+                "COURSE_RELATED",
+                "강좌에서 학습한 내용과 연관된 문제 세트예요."
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.lecture.application.service;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.RankedProblemSet;
 import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
@@ -33,8 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FinalProblemSetRecommendationService implements FinalProblemSetRecommendationUseCase {
-
-    private static final int MAX_RECOMMENDATION_COUNT = 2;
 
     private final LectureRepository lectureRepository;
     private final LectureProblemSetRepository lectureProblemSetRepository;
@@ -142,7 +141,7 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
         return finalProblemSetCandidatePort.findCandidates(
                         lecture.getProblemCategoryId(),
                         excludedProblemSetIds,
-                        MAX_RECOMMENDATION_COUNT
+                        LearningRecommendationClient.MAX_RECOMMENDATION_COUNT
                 )
                 .stream()
                 .map(this::toFallbackView)

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/FinalProblemSetRecommendationUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/FinalProblemSetRecommendationUseCase.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.lecture.application.usecase;
 
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface FinalProblemSetRecommendationUseCase {
@@ -14,7 +15,33 @@ public interface FinalProblemSetRecommendationUseCase {
             String description,
             String difficulty,
             Double accuracyRate,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            BigDecimal score,
+            String reasonCode,
+            String recommendationReason
     ) {
+
+        public FinalProblemSetCandidateView(
+                Long problemSetId,
+                Integer problemNumber,
+                String title,
+                String description,
+                String difficulty,
+                Double accuracyRate,
+                LocalDateTime createdAt
+        ) {
+            this(
+                    problemSetId,
+                    problemNumber,
+                    title,
+                    description,
+                    difficulty,
+                    accuracyRate,
+                    createdAt,
+                    null,
+                    null,
+                    null
+            );
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/problem/FinalProblemSetCandidateAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/problem/FinalProblemSetCandidateAdapter.java
@@ -4,10 +4,14 @@ import com.wanted.codebombalms.lecture.application.port.FinalProblemSetCandidate
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetStatus;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import com.wanted.codebombalms.problems.set.infrastructure.persistence.ProblemSetMapper;
+import com.wanted.codebombalms.problems.set.infrastructure.persistence.ProblemSetJpaEntity;
 import com.wanted.codebombalms.problems.set.infrastructure.persistence.SpringDataProblemSetRepository;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +35,30 @@ public class FinalProblemSetCandidateAdapter implements FinalProblemSetCandidate
                 .filter(problemSet -> !excludedProblemSetIds.contains(problemSet.getProblemSetId()))
                 .limit(limit)
                 .map(problemSet -> ProblemSetMapper.toSummary(problemSet, problemNumber.getAndIncrement()))
+                .toList();
+    }
+
+    @Override
+    public List<ProblemSetSummary> findByProblemSetIds(List<Long> problemSetIds) {
+        if (problemSetIds.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, ProblemSetJpaEntity> entitiesById = problemSetRepository.findByProblemSetIdInAndStatus(
+                        problemSetIds,
+                        ProblemSetStatus.ACTIVE
+                )
+                .stream()
+                .collect(Collectors.toMap(
+                        ProblemSetJpaEntity::getProblemSetId,
+                        Function.identity()
+                ));
+
+        AtomicInteger problemNumber = new AtomicInteger(1);
+        return problemSetIds.stream()
+                .map(entitiesById::get)
+                .filter(java.util.Objects::nonNull)
+                .map(entity -> ProblemSetMapper.toSummary(entity, problemNumber.getAndIncrement()))
                 .toList();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/FinalProblemSetCandidateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/FinalProblemSetCandidateResponse.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.lecture.presentation.api.response;
 
 import com.wanted.codebombalms.lecture.application.usecase.FinalProblemSetRecommendationUseCase.FinalProblemSetCandidateView;
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 public record FinalProblemSetCandidateResponse(
         Long problemSetId,
@@ -11,7 +12,10 @@ public record FinalProblemSetCandidateResponse(
         String difficulty,
         Double accuracyRate,
         LocalDateTime createdAt,
-        String entryPath
+        String entryPath,
+        BigDecimal score,
+        String reasonCode,
+        String recommendationReason
 ) {
 
     private static final String PROBLEM_SET_ENTRY_PATH_PREFIX = "/api/v1/problem-sets/";
@@ -25,7 +29,10 @@ public record FinalProblemSetCandidateResponse(
                 candidate.difficulty(),
                 candidate.accuracyRate(),
                 candidate.createdAt(),
-                PROBLEM_SET_ENTRY_PATH_PREFIX + candidate.problemSetId()
+                PROBLEM_SET_ENTRY_PATH_PREFIX + candidate.problemSetId(),
+                candidate.score(),
+                candidate.reasonCode(),
+                candidate.recommendationReason()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
@@ -35,6 +35,11 @@ public interface SpringDataProblemSetRepository extends JpaRepository<ProblemSet
             ProblemSetStatus status
     );
 
+    List<ProblemSetJpaEntity> findByProblemSetIdInAndStatus(
+            Collection<Long> problemSetIds,
+            ProblemSetStatus status
+    );
+
     Page<ProblemSetJpaEntity> findByStatusOrderByProblemSetIdAsc(
             ProblemSetStatus status,
             Pageable pageable

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,6 +95,14 @@ cors:
 fastapi:
   url: ${FASTAPI_URL:http://localhost:8000}
 
+learning:
+  recommendation:
+    python:
+      enabled: ${LEARNING_RECOMMENDATION_ENABLED:true}
+      rank-path: ${LEARNING_RECOMMENDATION_RANK_PATH:/internal/learning/final-problem-sets/rank}
+      connect-timeout-ms: ${LEARNING_RECOMMENDATION_CONNECT_TIMEOUT_MS:3000}
+      read-timeout-ms: ${LEARNING_RECOMMENDATION_READ_TIMEOUT_MS:10000}
+
 chat:
   max-history-messages: 20
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,7 +101,7 @@ learning:
       enabled: ${LEARNING_RECOMMENDATION_ENABLED:true}
       rank-path: ${LEARNING_RECOMMENDATION_RANK_PATH:/internal/learning/final-problem-sets/rank}
       connect-timeout-ms: ${LEARNING_RECOMMENDATION_CONNECT_TIMEOUT_MS:3000}
-      read-timeout-ms: ${LEARNING_RECOMMENDATION_READ_TIMEOUT_MS:10000}
+      read-timeout-ms: ${LEARNING_RECOMMENDATION_READ_TIMEOUT_MS:15000}
 
 chat:
   max-history-messages: 20

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
@@ -1,5 +1,7 @@
 package com.wanted.codebombalms.learning.application.service;
 
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.learning.application.port.LearningCourseProblemPort;
 import com.wanted.codebombalms.learning.application.port.LearningCoursePort;
 import com.wanted.codebombalms.learning.application.port.LearningLecture;
@@ -13,10 +15,13 @@ import com.wanted.codebombalms.learning.application.port.LearningRecommendationC
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
 import com.wanted.codebombalms.learning.domain.model.LearningCourse;
 import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -25,6 +30,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -138,6 +145,79 @@ class FinalProblemSetRankingServiceTest {
         assertEquals(LearningRecommendationClient.LearningProfile.empty(),
                 captor.getValue().learningProfile());
         verify(learningCourseProblemPort, never()).findMainLectureProblemSetIdsByCourse(1L);
+    }
+
+    @Test
+    void rankFinalProblemSets_rejectsMoreThanMaximumExcludedProblemSets() {
+        Set<Long> excludedProblemSetIds = LongStream.rangeClosed(1, 101)
+                .boxed()
+                .collect(Collectors.toSet());
+
+        assertThrows(ExternalServiceException.class, () ->
+                service.rankFinalProblemSets(
+                        20L,
+                        1L,
+                        10L,
+                        3001L,
+                        excludedProblemSetIds,
+                        false
+                )
+        );
+
+        verify(learningRecommendationClient, never())
+                .rankFinalProblemSets(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void rankFinalProblemSets_convertsProfileAssemblyFailureToFallbackSignal() {
+        NotFoundException cause = new NotFoundException(
+                LearningErrorCode.LECTURE_PROBLEM_SET_NOT_FOUND
+        );
+        given(learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(1L))
+                .willThrow(cause);
+
+        ExternalServiceException exception = assertThrows(
+                ExternalServiceException.class,
+                () -> service.rankFinalProblemSets(
+                        20L,
+                        1L,
+                        10L,
+                        3001L,
+                        Set.of(),
+                        false
+                )
+        );
+
+        assertSame(cause, exception.getCause());
+        verify(learningRecommendationClient, never())
+                .rankFinalProblemSets(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void rankFinalProblemSets_propagatesRecommendationClientFallbackSignal() {
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", null));
+        given(learningLecturePort.findLecturesByCourse(1L)).willReturn(List.of());
+        ExternalServiceException cause = new ExternalServiceException(
+                LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE
+        );
+        given(learningRecommendationClient.rankFinalProblemSets(
+                org.mockito.ArgumentMatchers.any()
+        )).willThrow(cause);
+
+        ExternalServiceException exception = assertThrows(
+                ExternalServiceException.class,
+                () -> service.rankFinalProblemSets(
+                        null,
+                        1L,
+                        10L,
+                        3001L,
+                        Set.of(),
+                        true
+                )
+        );
+
+        assertSame(cause, exception);
     }
 
     private LearningProblemPort.ProblemSetForLearning problemSet(

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
@@ -1,0 +1,192 @@
+package com.wanted.codebombalms.learning.application.service;
+
+import com.wanted.codebombalms.learning.application.port.LearningCourseProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningCoursePort;
+import com.wanted.codebombalms.learning.application.port.LearningLecture;
+import com.wanted.codebombalms.learning.application.port.LearningLecturePort;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemExplanationPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.domain.model.LearningCourse;
+import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
+import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class FinalProblemSetRankingServiceTest {
+
+    @Mock
+    private LearningRecommendationClient learningRecommendationClient;
+    @Mock
+    private LearningCoursePort learningCoursePort;
+    @Mock
+    private LearningLecturePort learningLecturePort;
+    @Mock
+    private LearningCourseProblemPort learningCourseProblemPort;
+    @Mock
+    private LearningLectureProblemSetPort learningLectureProblemSetPort;
+    @Mock
+    private LearningProblemPort learningProblemPort;
+    @Mock
+    private LearningProblemExplanationPort learningProblemExplanationPort;
+    @Mock
+    private LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
+
+    @InjectMocks
+    private FinalProblemSetRankingService service;
+
+    @Test
+    void rankFinalProblemSets_buildsAllMainLearningMetrics() {
+        given(learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(1L))
+                .willReturn(List.of(100L, 101L));
+        given(learningLectureProblemSetPort.findLectureProblemSet(100L))
+                .willReturn(new LearningLectureProblemSet(100L, 1L, 10L, 1000L));
+        given(learningLectureProblemSetPort.findLectureProblemSet(101L))
+                .willReturn(new LearningLectureProblemSet(101L, 1L, 11L, 1001L));
+        given(learningProblemPort.loadProblemSet(1000L))
+                .willReturn(problemSet(1000L, problem(1L, 1), problem(2L, 2)));
+        given(learningProblemPort.loadProblemSet(1001L))
+                .willReturn(problemSet(1001L, problem(3L, 1)));
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(20L, 100L))
+                .willReturn(List.of(
+                        submission(1L, 100L, 1L, true, 1, 2, 2, LocalDateTime.of(2026, 7, 20, 10, 0)),
+                        submission(2L, 100L, 2L, false, 1, 0, 2, LocalDateTime.of(2026, 7, 20, 10, 1)),
+                        submission(3L, 100L, 2L, true, 2, 1, 2, LocalDateTime.of(2026, 7, 20, 10, 2))
+                ));
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(20L, 101L))
+                .willReturn(List.of());
+        given(learningProblemExplanationPort.findViewedProblemIds(20L, List.of(1L, 2L, 3L)))
+                .willReturn(Set.of(2L, 3L));
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", "Python basics"));
+        given(learningLecturePort.findLecturesByCourse(1L))
+                .willReturn(List.of(new LearningLecture(10L, "Loop", "for and while")));
+        given(learningRecommendationClient.rankFinalProblemSets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(new LearningRecommendationResult("algorithm", List.of()));
+
+        service.rankFinalProblemSets(20L, 1L, 10L, 3001L, Set.of(1000L), false);
+
+        ArgumentCaptor<LearningRecommendationRequest> captor =
+                ArgumentCaptor.forClass(LearningRecommendationRequest.class);
+        verify(learningRecommendationClient).rankFinalProblemSets(captor.capture());
+        var request = captor.getValue();
+        var profile = request.learningProfile();
+
+        assertEquals(3, profile.totalMainProblemCount());
+        assertEquals(2, profile.correctProblemCount());
+        assertEquals(33.3333, profile.directSolveRate());
+        assertEquals(2, profile.explanationViewCount());
+        assertEquals(66.6667, profile.explanationViewRate());
+        assertEquals(1.0, profile.averageAttemptCount());
+        assertEquals(50.0, profile.averageTestPassRate());
+        assertEquals(List.of(1000L), request.excludedProblemSetIds());
+        assertEquals("Python basics", request.learningContext().courseDescription());
+        assertEquals("for and while", request.learningContext().lectures().get(0).description());
+    }
+
+    @Test
+    void rankFinalProblemSets_sendsZeroProfile_whenCourseHasNoMainProblems() {
+        given(learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(1L))
+                .willReturn(List.of());
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", null));
+        given(learningLecturePort.findLecturesByCourse(1L)).willReturn(List.of());
+        given(learningRecommendationClient.rankFinalProblemSets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(new LearningRecommendationResult("algorithm", List.of()));
+
+        service.rankFinalProblemSets(20L, 1L, 10L, 3001L, Set.of(), false);
+
+        ArgumentCaptor<LearningRecommendationRequest> captor =
+                ArgumentCaptor.forClass(LearningRecommendationRequest.class);
+        verify(learningRecommendationClient).rankFinalProblemSets(captor.capture());
+        assertEquals(LearningRecommendationClient.LearningProfile.empty(),
+                captor.getValue().learningProfile());
+        verify(learningProblemExplanationPort, never())
+                .findViewedProblemIds(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    void rankFinalProblemSets_sendsZeroProfile_forOperatorPreview() {
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", null));
+        given(learningLecturePort.findLecturesByCourse(1L)).willReturn(List.of());
+        given(learningRecommendationClient.rankFinalProblemSets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(new LearningRecommendationResult("algorithm", List.of()));
+
+        service.rankFinalProblemSets(null, 1L, 10L, 3001L, Set.of(), true);
+
+        ArgumentCaptor<LearningRecommendationRequest> captor =
+                ArgumentCaptor.forClass(LearningRecommendationRequest.class);
+        verify(learningRecommendationClient).rankFinalProblemSets(captor.capture());
+        assertEquals(LearningRecommendationClient.LearningProfile.empty(),
+                captor.getValue().learningProfile());
+        verify(learningCourseProblemPort, never()).findMainLectureProblemSetIdsByCourse(1L);
+    }
+
+    private LearningProblemPort.ProblemSetForLearning problemSet(
+            Long problemSetId,
+            LearningProblemPort.ProblemDetailForLearning... problems
+    ) {
+        return new LearningProblemPort.ProblemSetForLearning(
+                problemSetId,
+                "Problem Set",
+                "description",
+                List.of(problems)
+        );
+    }
+
+    private LearningProblemPort.ProblemDetailForLearning problem(Long problemId, int number) {
+        return new LearningProblemPort.ProblemDetailForLearning(
+                problemId,
+                number,
+                "Problem",
+                "content",
+                "SQL",
+                0,
+                ""
+        );
+    }
+
+    private LectureProblemSubmission submission(
+            Long submissionId,
+            Long lectureProblemSetId,
+            Long problemId,
+            boolean correct,
+            int attemptNo,
+            int passedTestCount,
+            int totalTestCount,
+            LocalDateTime submittedAt
+    ) {
+        return new LectureProblemSubmission(
+                submissionId,
+                20L,
+                lectureProblemSetId,
+                problemId,
+                "code",
+                correct,
+                attemptNo,
+                passedTestCount,
+                totalTestCount,
+                "SUCCESS",
+                null,
+                submittedAt
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
@@ -8,6 +8,7 @@ import com.wanted.codebombalms.learning.application.port.LearningRecommendationC
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LectureContext;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -97,6 +98,43 @@ class FastApiLearningRecommendationClientTest {
 
         assertThrows(ExternalServiceException.class, () ->
                 client.rankFinalProblemSets(request())
+        );
+    }
+
+    @Test
+    void rankFinalProblemSets_rejectsCall_whenRecommendationIsDisabled() {
+        LearningRecommendationProperties properties = new LearningRecommendationProperties();
+        properties.setEnabled(false);
+        FastApiLearningRecommendationClient disabledClient =
+                new FastApiLearningRecommendationClient(
+                        properties,
+                        server.url("/").toString()
+                );
+
+        assertThrows(ExternalServiceException.class, () ->
+                disabledClient.rankFinalProblemSets(request())
+        );
+
+        assertEquals(0, server.getRequestCount());
+    }
+
+    @Test
+    void rankFinalProblemSets_convertsReadTimeoutToFallbackSignal() {
+        LearningRecommendationProperties properties = new LearningRecommendationProperties();
+        properties.setReadTimeoutMs(50);
+        FastApiLearningRecommendationClient timeoutClient =
+                new FastApiLearningRecommendationClient(
+                        properties,
+                        server.url("/").toString()
+                );
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{}")
+                .setBodyDelay(500, TimeUnit.MILLISECONDS));
+
+        assertThrows(ExternalServiceException.class, () ->
+                timeoutClient.rankFinalProblemSets(request())
         );
     }
 

--- a/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
@@ -1,0 +1,118 @@
+package com.wanted.codebombalms.learning.infrastructure.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningContext;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningProfile;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LectureContext;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FastApiLearningRecommendationClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private MockWebServer server;
+    private FastApiLearningRecommendationClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        LearningRecommendationProperties properties = new LearningRecommendationProperties();
+        client = new FastApiLearningRecommendationClient(
+                properties,
+                server.url("/").toString()
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void rankFinalProblemSets_matchesPythonJsonContract() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "algorithm": "GEMINI_EMBEDDING_PERSONALIZED",
+                          "recommendations": [
+                            {
+                              "problemSetId": 53,
+                              "score": 0.8914,
+                              "reasonCode": "REVIEW_WEAK_AREA",
+                              "recommendationReason": "해설을 확인한 학습 기록을 바탕으로 복습용 문제를 추천해요."
+                            }
+                          ]
+                        }
+                        """));
+
+        var result = client.rankFinalProblemSets(request());
+
+        assertEquals(1, result.recommendations().size());
+        assertEquals(53L, result.recommendations().get(0).problemSetId());
+        assertEquals("REVIEW_WEAK_AREA", result.recommendations().get(0).reasonCode().name());
+
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals("/internal/learning/final-problem-sets/rank", recorded.getPath());
+        JsonNode body = objectMapper.readTree(recorded.getBody().readUtf8());
+        assertEquals(20L, body.get("courseId").asLong());
+        assertEquals(30L, body.get("lectureId").asLong());
+        assertEquals(3106L, body.get("problemCategoryId").asLong());
+        assertEquals(1001L, body.get("excludedProblemSetIds").get(0).asLong());
+        assertEquals(10, body.get("learningProfile").get("totalMainProblemCount").asInt());
+        assertEquals("Python", body.get("learningContext").get("courseTitle").asText());
+    }
+
+    @Test
+    void rankFinalProblemSets_rejectsInvalidPythonResponse() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "algorithm": "GEMINI_EMBEDDING_PERSONALIZED",
+                          "recommendations": [
+                            {
+                              "problemSetId": 53,
+                              "score": 1.5,
+                              "reasonCode": "COURSE_RELATED",
+                              "recommendationReason": "추천 문구예요."
+                            }
+                          ]
+                        }
+                        """));
+
+        assertThrows(ExternalServiceException.class, () ->
+                client.rankFinalProblemSets(request())
+        );
+    }
+
+    private LearningRecommendationRequest request() {
+        return new LearningRecommendationRequest(
+                20L,
+                30L,
+                3106L,
+                List.of(1001L),
+                2,
+                new LearningProfile(10, 6, 60.0, 3, 30.0, 2.4, 72.5),
+                new LearningContext(
+                        "Python",
+                        "Python basics",
+                        List.of(new LectureContext("Loop", "for and while"))
+                )
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationServiceTest.java
@@ -2,7 +2,13 @@ package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.RankedProblemSet;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.ReasonCode;
+import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
 import com.wanted.codebombalms.lecture.application.port.FinalProblemSetCandidatePort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
@@ -15,9 +21,11 @@ import com.wanted.codebombalms.lecture.domain.repository.LectureProblemSetReposi
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -34,8 +42,10 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class FinalProblemSetRecommendationServiceTest {
@@ -55,8 +65,21 @@ class FinalProblemSetRecommendationServiceTest {
     @Mock
     private LectureProgressPort lectureProgressPort;
 
+    @Mock
+    private FinalProblemSetRankingUseCase finalProblemSetRankingUseCase;
+
     @InjectMocks
     private FinalProblemSetRecommendationService service;
+
+    @BeforeEach
+    void setUpAiFallback() {
+        lenient().when(finalProblemSetRankingUseCase.rankFinalProblemSets(
+                        any(), anyLong(), anyLong(), anyLong(), anySet(), any(Boolean.class)
+                ))
+                .thenThrow(new ExternalServiceException(
+                        LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE
+                ));
+    }
 
     @Test
     void findFinalProblemSetCandidates_returnsEmpty_whenLectureHasNoProblemCategory() {
@@ -95,6 +118,47 @@ class FinalProblemSetRecommendationServiceTest {
         assertEquals(Set.of(4001L, 4002L), excludedCaptor.getValue());
         assertEquals(1, result.size());
         assertEquals(4003L, result.get(0).problemSetId());
+    }
+
+    @Test
+    void findFinalProblemSetCandidates_preservesPythonRankingAndReason() {
+        Lecture lecture = lecture(10L, 1L, 3001L);
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(lecture));
+        given(lectureRepository.existsNextLecture(1L, 1)).willReturn(false);
+        given(lectureProgressPort.areLecturesCompleted(20L, List.of(10L))).willReturn(true);
+        given(lectureProblemSetRepository.findByCourseIdAndRole(1L, LectureProblemSetRole.MAIN))
+                .willReturn(List.of());
+        doReturn(new LearningRecommendationResult(
+                "GEMINI_EMBEDDING_PERSONALIZED",
+                List.of(
+                        new RankedProblemSet(
+                                4004L,
+                                new BigDecimal("0.9123"),
+                                ReasonCode.LEVEL_MATCHED,
+                                "현재 학습 수준에 적합한 문제 세트예요."
+                        ),
+                        new RankedProblemSet(
+                                4003L,
+                                new BigDecimal("0.8123"),
+                                ReasonCode.COURSE_RELATED,
+                                "강좌 내용과 연관된 문제 세트예요."
+                        )
+                )
+        )).when(finalProblemSetRankingUseCase).rankFinalProblemSets(
+                20L, 1L, 10L, 3001L, Set.of(), false
+        );
+        given(finalProblemSetCandidatePort.findByProblemSetIds(List.of(4004L, 4003L)))
+                .willReturn(List.of(problemSet(4004L), problemSet(4003L)));
+
+        var result = service.findFinalProblemSetCandidates(10L, 20L, false);
+
+        assertEquals(List.of(4004L, 4003L), result.stream()
+                .map(view -> view.problemSetId())
+                .toList());
+        assertEquals(new BigDecimal("0.9123"), result.get(0).score());
+        assertEquals("LEVEL_MATCHED", result.get(0).reasonCode());
+        assertEquals("현재 학습 수준에 적합한 문제 세트예요.", result.get(0).recommendationReason());
+        verify(finalProblemSetCandidatePort, never()).findCandidates(anyLong(), anySet(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #651
- Closes #652

---

## 🛠️ 기능 관련 작업 내용
- MAIN 문제의 정답 제출, 해설 조회, 시도 횟수 및 최신 테스트 통과율을 집계해 Python 학습 프로필로 전달
- FastAPI 추천 API를 호출하고 문제세트 ID, 점수, 추천 코드 및 최대 300자의 추천 문구를 검증
- Python 추천 순서를 기존 FINAL 문제세트 응답에 반영하고 `score`, `reasonCode`, `recommendationReason` 필드 추가
- Python 장애·timeout·응답 불일치 시 기존 카테고리 기반 최대 2개 추천으로 복구

---

## ♻️ 패키지 변경 사항
- `project/learning`: 학습 프로필 집계, Python 추천 포트·클라이언트·설정 및 응답 검증 추가
- `project/lecture`: 기존 FINAL 추천 API에 AI 추천 결과와 장애 fallback 적용
- `project/problems/set`: Python 추천 ID에 해당하는 ACTIVE 문제세트 조회 기능 추가
- `project/resources`: FastAPI 추천 endpoint 및 연결·응답 timeout 설정 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 강좌 완료 후 학습 기록과 강좌 정보를 기반으로 FINAL 문제세트를 맞춤 추천합니다.
  * 추천 문제세트에 점수와 추천 사유를 함께 제공합니다.
  * 강좌·강의 설명을 활용해 관련성, 취약 영역, 난이도 등을 고려합니다.
* **버그 수정**
  * AI 추천 서비스 장애나 잘못된 응답 발생 시 기존 문제세트 추천으로 자동 전환합니다.
  * 추천 결과 오류를 검증해 안정적인 문제세트 목록을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->