### PR TITLE
[Feat] 문제세트 AI 초안 생성 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ architecture-user-auth.html
 /src/main/resources/db/seed/03_trusted_device_loadtest.sql
 /rds-tunnel.sh
 /src/main/resources/db/schema/ops_briefing.sql
+
+### Python generated files ###
+__pycache__/
+*.pyc

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import java.util.Arrays;
@@ -63,6 +64,7 @@ public class GlobalExceptionHandler {
             HandlerMethodValidationException.class,
             HttpMessageNotReadableException.class,
             HttpMediaTypeNotSupportedException.class,
+            MultipartException.class,
             MaxUploadSizeExceededException.class
     })
     public ResponseEntity<ApiErrorResponse> handleBadRequestException(

--- a/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
@@ -3,7 +3,6 @@ package com.wanted.codebombalms.problems.exception;
 import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,19 +13,19 @@ public enum ProblemErrorCode implements ErrorCode {
     ACCESS_DENIED("PRB-PBL-002", "문제 접근 권한이 없습니다."),
     PROBLEM_NOT_UNLOCKED("PRB-PBL-003", "이전 문제를 먼저 풀어야 합니다."),
     PROBLEM_HAS_SUBMISSION("PRB-PBL-004", "제출 기록이 존재합니다."),
-    PROBLEM_NOT_IN_SET("PRB-PBL-005", "해당 문제 세트에 속한 문제가 아닙니다."),
+    PROBLEM_NOT_IN_SET("PRB-PBL-005", "해당 문제세트에 속한 문제가 아닙니다."),
     PROBLEM_TITLE_REQUIRED("PRB-PBL-006", "소문제 제목은 필수입니다."),
     PROBLEM_CONTENT_REQUIRED("PRB-PBL-007", "소문제 내용은 필수입니다."),
     PROBLEM_REQUIRED("PRB-PBL-009", "소문제는 1개 이상 필요합니다."),
     PROBLEM_POINT_REQUIRED("PRB-PBL-010", "문제 포인트는 1 이상이어야 합니다."),
 
     // 문제 세트 (PRB-SET)
-    PROBLEM_SET_NOT_FOUND("PRB-SET-001", "문제 세트를 찾을 수 없습니다."),
+    PROBLEM_SET_NOT_FOUND("PRB-SET-001", "문제세트를 찾을 수 없습니다."),
     ATTEMPT_LIMIT_EXCEEDED("PRB-SET-002", "제출 가능 횟수를 초과했습니다."),
-    ALREADY_COMPLETED("PRB-SET-003", "이미 완료한 문제 세트입니다."),
-    PROBLEM_SET_NOT_COMPLETED("PRB-SET-004", "문제 세트를 끝까지 풀지 않았습니다."),
+    ALREADY_COMPLETED("PRB-SET-003", "이미 완료한 문제세트입니다."),
+    PROBLEM_SET_NOT_COMPLETED("PRB-SET-004", "문제세트를 끝까지 풀지 않았습니다."),
     NO_CURRENT_PROBLEM("PRB-SET-005", "현재 풀 문제가 없습니다."),
-    PROBLEM_SET_TITLE_REQUIRED("PRB-SET-006", "문제 세트 제목은 필수입니다."),
+    PROBLEM_SET_TITLE_REQUIRED("PRB-SET-006", "문제세트 제목은 필수입니다."),
 
     // 카테고리 (PRB-CAT)
     CATEGORY_NOT_FOUND("PRB-CAT-001", "문제 분야를 찾을 수 없습니다."),
@@ -40,18 +39,19 @@ public enum ProblemErrorCode implements ErrorCode {
 
     // 데이터셋 (PRB-DAT)
     PROBLEM_DATASET_NOT_FOUND("PRB-DAT-001", "데이터셋을 찾을 수 없습니다."),
-    PROBLEM_DATASET_ALREADY_CONNECTED("PRB-DAT-002", "이미 문제 세트에 연결된 데이터셋입니다."),
+    PROBLEM_DATASET_ALREADY_CONNECTED("PRB-DAT-002", "이미 문제세트에 연결된 데이터셋입니다."),
     PROBLEM_DATASET_INVALID_PROBLEM_TYPE("PRB-DAT-003", "코드 실행형 문제에만 데이터셋을 연결할 수 있습니다."),
     PROBLEM_DATASET_INVALID_FILE("PRB-DAT-004", "CSV 파일만 업로드할 수 있습니다."),
     PROBLEM_DATASET_UPLOAD_FAILED("PRB-DAT-005", "데이터셋 업로드에 실패했습니다."),
+    PROBLEM_SET_DATASET_CONNECTION_FAILED("PRB-DAT-006", "문제세트와 데이터셋 연결에 실패했습니다."),
     PROBLEM_DATASET_ACCESS_URL_FAILED("PRB-DAT-007", "데이터셋 접근 URL 생성에 실패했습니다."),
 
-    // 테스트케이스 (PRB-TC)
-    PROBLEM_TEST_CASE_NOT_FOUND("PRB-TC-001", "테스트케이스를 찾을 수 없습니다."),
-    PROBLEM_TEST_CASE_INVALID_INPUT("PRB-TC-002", "테스트케이스 입력값이 올바르지 않습니다."),
-    PROBLEM_TEST_CASE_ALREADY_EXISTS("PRB-TC-003", "이미 등록된 테스트케이스가 있습니다."),
-    PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE("PRB-TC-004", "코드 문제에만 테스트케이스를 등록할 수 있습니다."),
-    PROBLEM_TEST_CASE_DUPLICATE_ORDER( "PRB-TC-006", "이미 같은 순서의 테스트케이스가 존재합니다."),
+    // 테스트 케이스 (PRB-TC)
+    PROBLEM_TEST_CASE_NOT_FOUND("PRB-TC-001", "테스트 케이스를 찾을 수 없습니다."),
+    PROBLEM_TEST_CASE_INVALID_INPUT("PRB-TC-002", "테스트 케이스 입력값이 올바르지 않습니다."),
+    PROBLEM_TEST_CASE_ALREADY_EXISTS("PRB-TC-003", "이미 등록된 테스트 케이스가 있습니다."),
+    PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE("PRB-TC-004", "코드 문제에만 테스트 케이스를 등록할 수 있습니다."),
+    PROBLEM_TEST_CASE_DUPLICATE_ORDER("PRB-TC-006", "이미 같은 순서의 테스트 케이스가 존재합니다."),
 
     // 코드 실행 (PRB-EXE)
     PROBLEM_CODE_INVALID_INPUT("PRB-EXE-001", "코드 값이 비어 있습니다."),
@@ -64,8 +64,8 @@ public enum ProblemErrorCode implements ErrorCode {
     INVALID_INPUT("PRB-001", "필수값이 누락되었습니다."),
     SERVER_ERROR("PRB-002", "문제 도메인 처리 중 서버 오류가 발생했습니다."),
 
-    // 데이터셋 (PRB-DAT)
-    PROBLEM_SET_DATASET_CONNECTION_FAILED("PRB-DAT-006", "문제 세트와 데이터셋 연결에 실패했습니다.");
+    // AI 문제세트 생성 (PRB-GEN)
+    PROBLEM_SET_DRAFT_GENERATION_FAILED("PRB-GEN-001", "AI 문제세트 초안 생성에 실패했습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftAiCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftAiCommand.java
@@ -1,19 +1,14 @@
 package com.wanted.codebombalms.problems.generation.application.command;
 
-import java.io.InputStream;
-
-public record GenerateProblemSetDraftCommand(
+public record GenerateProblemSetDraftAiCommand(
         Long operatorId,
         String question,
+        String datasetUrl,
         String dataFileName,
         String topic,
         String categoryName,
         String difficulty,
         int problemCount,
-        int subProblemCount,
-        String originalFileName,
-        String contentType,
-        InputStream datasetContent,
-        long datasetFileSize
+        int subProblemCount
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftCommand.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.problems.generation.application.command;
+
+public record GenerateProblemSetDraftCommand(
+        Long operatorId,
+        String question,
+        String datasetUrl,
+        String draftToken,
+        String datasetObjectName,
+        String dataFileName,
+        String topic,
+        String categoryName,
+        String difficulty,
+        int problemCount,
+        int subProblemCount
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
@@ -1,11 +1,13 @@
 package com.wanted.codebombalms.problems.generation.application.command;
 
+import java.io.InputStream;
+
 public record StoreProblemSetDraftDatasetCommand(
         Long operatorId,
         String draftToken,
         String originalFileName,
         String contentType,
-        byte[] content,
+        InputStream content,
         long fileSize
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.generation.application.command;
+
+public record StoreProblemSetDraftDatasetCommand(
+        Long operatorId,
+        String draftToken,
+        String originalFileName,
+        String contentType,
+        byte[] content,
+        long fileSize
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/DeleteProblemSetDraftDatasetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/DeleteProblemSetDraftDatasetPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+public interface DeleteProblemSetDraftDatasetPort {
+
+    void delete(String objectName);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+
+public interface GenerateProblemSetDraftAiPort {
+
+    ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
@@ -1,9 +1,9 @@
 package com.wanted.codebombalms.problems.generation.application.port;
 
-import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 
 public interface GenerateProblemSetDraftAiPort {
 
-    ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command);
+    ProblemSetDraftResult generate(GenerateProblemSetDraftAiCommand command);
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftDatasetUrlPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftDatasetUrlPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+public interface GenerateProblemSetDraftDatasetUrlPort {
+
+    String generate(String objectName);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/StoreProblemSetDraftDatasetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/StoreProblemSetDraftDatasetPort.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
+import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
+
+public interface StoreProblemSetDraftDatasetPort {
+
+    StoredProblemSetDraftDataset store(StoreProblemSetDraftDatasetCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/result/ProblemSetDraftResult.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/result/ProblemSetDraftResult.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.generation.application.result;
+
+import com.wanted.codebombalms.problems.generation.domain.ProblemSetDraft;
+import java.util.List;
+
+public record ProblemSetDraftResult(
+        String answer,
+        ProblemSetDraft draft,
+        List<String> usedTools
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.problems.generation.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
 import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
 import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
@@ -9,13 +10,10 @@ import com.wanted.codebombalms.problems.generation.application.port.StoreProblem
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
 import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
-import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
 import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.UUID;
 
 @Service
@@ -27,42 +25,36 @@ public class ProblemSetDraftGenerationService implements GenerateProblemSetDraft
     private final GenerateProblemSetDraftDatasetUrlPort generateProblemSetDraftDatasetUrlPort;
 
     @Override
-    public ProblemSetDraftResult generate(
-            Long operatorId,
-            ProblemSetDraftGenerateRequest request,
-            MultipartFile datasetFile
-    ) {
-        validateDatasetFile(datasetFile);
+    public ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command) {
+        validateDatasetFile(command);
 
         String draftToken = UUID.randomUUID().toString();
         StoredProblemSetDraftDataset storedDataset = storeProblemSetDraftDataset(
-                operatorId,
+                command.operatorId(),
                 draftToken,
-                datasetFile
+                command
         );
         String datasetUrl = generateProblemSetDraftDatasetUrlPort.generate(
                 storedDataset.objectName()
         );
 
-        GenerateProblemSetDraftCommand command = new GenerateProblemSetDraftCommand(
-                operatorId,
-                request.question(),
+        GenerateProblemSetDraftAiCommand aiCommand = new GenerateProblemSetDraftAiCommand(
+                command.operatorId(),
+                command.question(),
                 datasetUrl,
-                draftToken,
-                storedDataset.objectName(),
-                resolveDataFileName(request, storedDataset),
-                request.topic(),
-                request.categoryName(),
-                request.difficulty(),
-                request.problemCount(),
-                request.subProblemCount()
+                resolveDataFileName(command, storedDataset),
+                command.topic(),
+                command.categoryName(),
+                command.difficulty(),
+                command.problemCount(),
+                command.subProblemCount()
         );
 
-        return generateProblemSetDraftAiPort.generate(command);
+        return generateProblemSetDraftAiPort.generate(aiCommand);
     }
 
-    private void validateDatasetFile(MultipartFile datasetFile) {
-        if (datasetFile == null || datasetFile.isEmpty()) {
+    private void validateDatasetFile(GenerateProblemSetDraftCommand command) {
+        if (command.datasetContent() == null || command.datasetFileSize() <= 0) {
             throw new ValidationException(
                     ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE
             );
@@ -72,33 +64,26 @@ public class ProblemSetDraftGenerationService implements GenerateProblemSetDraft
     private StoredProblemSetDraftDataset storeProblemSetDraftDataset(
             Long operatorId,
             String draftToken,
-            MultipartFile datasetFile
+            GenerateProblemSetDraftCommand command
     ) {
-        try {
-            return storeProblemSetDraftDatasetPort.store(
-                    new StoreProblemSetDraftDatasetCommand(
-                            operatorId,
-                            draftToken,
-                            datasetFile.getOriginalFilename(),
-                            datasetFile.getContentType(),
-                            datasetFile.getBytes(),
-                            datasetFile.getSize()
-                    )
-            );
-        } catch (IOException e) {
-            throw new ValidationException(
-                    ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED,
-                    e
-            );
-        }
+        return storeProblemSetDraftDatasetPort.store(
+                new StoreProblemSetDraftDatasetCommand(
+                        operatorId,
+                        draftToken,
+                        command.originalFileName(),
+                        command.contentType(),
+                        command.datasetContent(),
+                        command.datasetFileSize()
+                )
+        );
     }
 
     private String resolveDataFileName(
-            ProblemSetDraftGenerateRequest request,
+            GenerateProblemSetDraftCommand command,
             StoredProblemSetDraftDataset storedDataset
     ) {
-        if (request.dataFileName() != null && !request.dataFileName().isBlank()) {
-            return request.dataFileName();
+        if (command.dataFileName() != null && !command.dataFileName().isBlank()) {
+            return command.dataFileName();
         }
 
         return storedDataset.originalFileName();

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
@@ -1,0 +1,106 @@
+package com.wanted.codebombalms.problems.generation.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftDatasetUrlPort;
+import com.wanted.codebombalms.problems.generation.application.port.StoreProblemSetDraftDatasetPort;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
+import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemSetDraftGenerationService implements GenerateProblemSetDraftUseCase {
+
+    private final GenerateProblemSetDraftAiPort generateProblemSetDraftAiPort;
+    private final StoreProblemSetDraftDatasetPort storeProblemSetDraftDatasetPort;
+    private final GenerateProblemSetDraftDatasetUrlPort generateProblemSetDraftDatasetUrlPort;
+
+    @Override
+    public ProblemSetDraftResult generate(
+            Long operatorId,
+            ProblemSetDraftGenerateRequest request,
+            MultipartFile datasetFile
+    ) {
+        validateDatasetFile(datasetFile);
+
+        String draftToken = UUID.randomUUID().toString();
+        StoredProblemSetDraftDataset storedDataset = storeProblemSetDraftDataset(
+                operatorId,
+                draftToken,
+                datasetFile
+        );
+        String datasetUrl = generateProblemSetDraftDatasetUrlPort.generate(
+                storedDataset.objectName()
+        );
+
+        GenerateProblemSetDraftCommand command = new GenerateProblemSetDraftCommand(
+                operatorId,
+                request.question(),
+                datasetUrl,
+                draftToken,
+                storedDataset.objectName(),
+                resolveDataFileName(request, storedDataset),
+                request.topic(),
+                request.categoryName(),
+                request.difficulty(),
+                request.problemCount(),
+                request.subProblemCount()
+        );
+
+        return generateProblemSetDraftAiPort.generate(command);
+    }
+
+    private void validateDatasetFile(MultipartFile datasetFile) {
+        if (datasetFile == null || datasetFile.isEmpty()) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE
+            );
+        }
+    }
+
+    private StoredProblemSetDraftDataset storeProblemSetDraftDataset(
+            Long operatorId,
+            String draftToken,
+            MultipartFile datasetFile
+    ) {
+        try {
+            return storeProblemSetDraftDatasetPort.store(
+                    new StoreProblemSetDraftDatasetCommand(
+                            operatorId,
+                            draftToken,
+                            datasetFile.getOriginalFilename(),
+                            datasetFile.getContentType(),
+                            datasetFile.getBytes(),
+                            datasetFile.getSize()
+                    )
+            );
+        } catch (IOException e) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED,
+                    e
+            );
+        }
+    }
+
+    private String resolveDataFileName(
+            ProblemSetDraftGenerateRequest request,
+            StoredProblemSetDraftDataset storedDataset
+    ) {
+        if (request.dataFileName() != null && !request.dataFileName().isBlank()) {
+            return request.dataFileName();
+        }
+
+        return storedDataset.originalFileName();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
@@ -1,14 +1,9 @@
 package com.wanted.codebombalms.problems.generation.application.usecase;
 
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
-import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface GenerateProblemSetDraftUseCase {
 
-    ProblemSetDraftResult generate(
-            Long operatorId,
-            ProblemSetDraftGenerateRequest request,
-            MultipartFile datasetFile
-    );
+    ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command);
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.problems.generation.application.usecase;
+
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface GenerateProblemSetDraftUseCase {
+
+    ProblemSetDraftResult generate(
+            Long operatorId,
+            ProblemSetDraftGenerateRequest request,
+            MultipartFile datasetFile
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedProblemDraft.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedProblemDraft.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+import java.util.List;
+
+public record GeneratedProblemDraft(
+        String title,
+        int point,
+        String content,
+        String startCode,
+        String hint,
+        String explanation,
+        List<GeneratedTestCaseDraft> testCases
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedTestCaseDraft.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedTestCaseDraft.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+public record GeneratedTestCaseDraft(
+        String testCode,
+        boolean hidden,
+        int timeoutMs
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/ProblemSetDraft.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/ProblemSetDraft.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+import java.util.List;
+
+public record ProblemSetDraft(
+        String title,
+        String categoryName,
+        String difficulty,
+        String description,
+        String dataFileName,
+        List<GeneratedProblemDraft> problems
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/StoredProblemSetDraftDataset.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/StoredProblemSetDraftDataset.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+public record StoredProblemSetDraftDataset(
+        String originalFileName,
+        String storedFileName,
+        String objectName,
+        long fileSize
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai;
+
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.infrastructure.ai.request.FastApiProblemSetDraftRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FastApiProblemSetDraftAdapter implements GenerateProblemSetDraftAiPort {
+
+    private final ProblemSetDraftAiClient problemSetDraftAiClient;
+
+    @Override
+    public ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command) {
+        return problemSetDraftAiClient.generate(
+                FastApiProblemSetDraftRequest.from(command)
+        ).toResult();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
@@ -1,6 +1,6 @@
 package com.wanted.codebombalms.problems.generation.infrastructure.ai;
 
-import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 import com.wanted.codebombalms.problems.generation.infrastructure.ai.request.FastApiProblemSetDraftRequest;
@@ -14,7 +14,7 @@ public class FastApiProblemSetDraftAdapter implements GenerateProblemSetDraftAiP
     private final ProblemSetDraftAiClient problemSetDraftAiClient;
 
     @Override
-    public ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command) {
+    public ProblemSetDraftResult generate(GenerateProblemSetDraftAiCommand command) {
         return problemSetDraftAiClient.generate(
                 FastApiProblemSetDraftRequest.from(command)
         ).toResult();

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/ProblemSetDraftAiClient.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/ProblemSetDraftAiClient.java
@@ -1,0 +1,81 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.generation.infrastructure.ai.request.FastApiProblemSetDraftRequest;
+import com.wanted.codebombalms.problems.generation.infrastructure.ai.response.FastApiProblemSetDraftResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class ProblemSetDraftAiClient {
+
+    private static final String GENERATE_PATH = "/problem-set-draft/chat";
+    private static final int CONNECT_TIMEOUT_MS = 5_000;
+    private static final int READ_TIMEOUT_MS = 60_000;
+
+    private final RestClient restClient;
+
+    public ProblemSetDraftAiClient(
+            @Value("${fastapi.url}") String fastApiBaseUrl,
+            RestClient.Builder restClientBuilder
+    ) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        requestFactory.setReadTimeout(READ_TIMEOUT_MS);
+
+        this.restClient = restClientBuilder
+                .baseUrl(fastApiBaseUrl)
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    public FastApiProblemSetDraftResponse generate(FastApiProblemSetDraftRequest request) {
+        long startedAt = System.nanoTime();
+
+        try {
+            FastApiProblemSetDraftResponse response = restClient.post()
+                    .uri(GENERATE_PATH)
+                    .body(request)
+                    .retrieve()
+                    .body(FastApiProblemSetDraftResponse.class);
+
+            if (response == null) {
+                throw new ExternalServiceException(
+                        ProblemErrorCode.PROBLEM_SET_DRAFT_GENERATION_FAILED
+                );
+            }
+
+            log.info(
+                    "event=problem_set_draft_ai_completed problemCount={} subProblemCount={} durationMs={}",
+                    request.problemCount(),
+                    request.subProblemCount(),
+                    elapsedMillis(startedAt)
+            );
+
+            return response;
+        } catch (ExternalServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "event=problem_set_draft_ai_failed exceptionType={} durationMs={}",
+                    e.getClass().getSimpleName(),
+                    elapsedMillis(startedAt),
+                    e
+            );
+
+            throw new ExternalServiceException(
+                    ProblemErrorCode.PROBLEM_SET_DRAFT_GENERATION_FAILED,
+                    e
+            );
+        }
+    }
+
+    private long elapsedMillis(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
@@ -1,0 +1,50 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+
+import java.util.List;
+
+public record FastApiProblemSetDraftRequest(
+        String question,
+
+        @JsonProperty("operator_id")
+        Long operatorId,
+
+        @JsonProperty("dataset_url")
+        String datasetUrl,
+
+        @JsonProperty("data_file_name")
+        String dataFileName,
+
+        String topic,
+
+        @JsonProperty("category_name")
+        String categoryName,
+
+        String difficulty,
+
+        @JsonProperty("problem_count")
+        int problemCount,
+
+        @JsonProperty("sub_problem_count")
+        int subProblemCount,
+
+        List<Object> history
+) {
+
+    public static FastApiProblemSetDraftRequest from(GenerateProblemSetDraftCommand command) {
+        return new FastApiProblemSetDraftRequest(
+                command.question(),
+                command.operatorId(),
+                command.datasetUrl(),
+                command.dataFileName(),
+                command.topic(),
+                command.categoryName(),
+                command.difficulty(),
+                command.problemCount(),
+                command.subProblemCount(),
+                List.of()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
@@ -1,7 +1,7 @@
 package com.wanted.codebombalms.problems.generation.infrastructure.ai.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 
 import java.util.List;
 
@@ -33,7 +33,7 @@ public record FastApiProblemSetDraftRequest(
         List<Object> history
 ) {
 
-    public static FastApiProblemSetDraftRequest from(GenerateProblemSetDraftCommand command) {
+    public static FastApiProblemSetDraftRequest from(GenerateProblemSetDraftAiCommand command) {
         return new FastApiProblemSetDraftRequest(
                 command.question(),
                 command.operatorId(),

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/response/FastApiProblemSetDraftResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/response/FastApiProblemSetDraftResponse.java
@@ -1,0 +1,96 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedProblemDraft;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedTestCaseDraft;
+import com.wanted.codebombalms.problems.generation.domain.ProblemSetDraft;
+
+import java.util.List;
+
+public record FastApiProblemSetDraftResponse(
+        String answer,
+        DraftResponse draft,
+
+        @JsonProperty("used_tools")
+        List<String> usedTools
+) {
+
+    public ProblemSetDraftResult toResult() {
+        return new ProblemSetDraftResult(
+                answer,
+                draft == null ? null : draft.toDomain(),
+                usedTools == null ? List.of() : usedTools
+        );
+    }
+
+    public record DraftResponse(
+            String title,
+            String categoryName,
+            String difficulty,
+            String description,
+            String dataFileName,
+            List<ProblemResponse> problems
+    ) {
+
+        private ProblemSetDraft toDomain() {
+            return new ProblemSetDraft(
+                    title,
+                    categoryName,
+                    difficulty,
+                    description,
+                    dataFileName,
+                    problems == null
+                            ? List.of()
+                            : problems.stream()
+                            .map(ProblemResponse::toDomain)
+                            .toList()
+            );
+        }
+    }
+
+    public record ProblemResponse(
+            String title,
+            int point,
+            String content,
+            String startCode,
+            String hint,
+            String explanation,
+            List<TestCaseResponse> testCases
+    ) {
+
+        private GeneratedProblemDraft toDomain() {
+            return new GeneratedProblemDraft(
+                    title,
+                    point,
+                    content,
+                    startCode,
+                    hint,
+                    explanation,
+                    testCases == null
+                            ? List.of()
+                            : testCases.stream()
+                            .map(TestCaseResponse::toDomain)
+                            .toList()
+            );
+        }
+    }
+
+    public record TestCaseResponse(
+            String testCode,
+
+            @JsonProperty("isHidden")
+            boolean hidden,
+
+            int timeoutMs
+    ) {
+
+        private GeneratedTestCaseDraft toDomain() {
+            return new GeneratedTestCaseDraft(
+                    testCode,
+                    hidden,
+                    timeoutMs
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
@@ -1,0 +1,170 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.storage;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
+import com.wanted.codebombalms.problems.generation.application.port.DeleteProblemSetDraftDatasetPort;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftDatasetUrlPort;
+import com.wanted.codebombalms.problems.generation.application.port.StoreProblemSetDraftDatasetPort;
+import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+public class GcsProblemSetDraftDatasetStorageAdapter implements
+        StoreProblemSetDraftDatasetPort,
+        GenerateProblemSetDraftDatasetUrlPort,
+        DeleteProblemSetDraftDatasetPort {
+
+    private static final String CSV_CONTENT_TYPE = "text/csv";
+    private static final String DRAFT_DIRECTORY = "drafts";
+    private static final long SIGNED_URL_DURATION_MINUTES = 30;
+
+    private final GcpStorageProperties properties;
+    private final GcpStorageClientFactory storageClientFactory;
+    private volatile Storage storage;
+
+    public GcsProblemSetDraftDatasetStorageAdapter(
+            GcpStorageProperties properties,
+            GcpStorageClientFactory storageClientFactory
+    ) {
+        this.properties = properties;
+        this.storageClientFactory = storageClientFactory;
+    }
+
+    @Override
+    public StoredProblemSetDraftDataset store(StoreProblemSetDraftDatasetCommand command) {
+        String originalFileName = sanitizeFileName(command.originalFileName());
+        String storedFileName = command.draftToken() + "_" + originalFileName;
+        String objectName = buildObjectName(command, storedFileName);
+
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(
+                            BlobId.of(properties.getStorage().getBucket(), objectName)
+                    )
+                    .setContentType(CSV_CONTENT_TYPE)
+                    .build();
+
+            getStorage().create(blobInfo, command.content());
+
+            return new StoredProblemSetDraftDataset(
+                    originalFileName,
+                    storedFileName,
+                    objectName,
+                    command.fileSize()
+            );
+        } catch (Exception e) {
+            throw new ExternalServiceException(
+                    ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED,
+                    e
+            );
+        }
+    }
+
+    @Override
+    public String generate(String objectName) {
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(
+                    properties.getStorage().getBucket(),
+                    objectName
+            ).build();
+
+            return getStorage()
+                    .signUrl(
+                            blobInfo,
+                            SIGNED_URL_DURATION_MINUTES,
+                            TimeUnit.MINUTES,
+                            Storage.SignUrlOption.withV4Signature()
+                    )
+                    .toString();
+        } catch (Exception e) {
+            log.error(
+                    "event=problem_set_draft_dataset_signed_url_failed bucket={} objectName={} exceptionType={}",
+                    properties.getStorage().getBucket(),
+                    objectName,
+                    e.getClass().getSimpleName(),
+                    e
+            );
+
+            throw new ExternalServiceException(
+                    ProblemErrorCode.PROBLEM_DATASET_ACCESS_URL_FAILED,
+                    e
+            );
+        }
+    }
+
+    @Override
+    public void delete(String objectName) {
+        if (objectName == null || objectName.isBlank()) {
+            return;
+        }
+
+        try {
+            getStorage().delete(
+                    BlobId.of(properties.getStorage().getBucket(), objectName)
+            );
+        } catch (Exception e) {
+            log.warn(
+                    "event=problem_set_draft_dataset_delete_failed objectName={}",
+                    objectName,
+                    e
+            );
+        }
+    }
+
+    private Storage getStorage() throws IOException {
+        if (storage == null) {
+            synchronized (this) {
+                if (storage == null) {
+                    storage = storageClientFactory.create();
+                }
+            }
+        }
+
+        return storage;
+    }
+
+    private String buildObjectName(
+            StoreProblemSetDraftDatasetCommand command,
+            String storedFileName
+    ) {
+        String prefix = normalizePrefix(properties.getStorage().getDatasetPrefix());
+
+        return prefix
+                + "/"
+                + DRAFT_DIRECTORY
+                + "/"
+                + command.operatorId()
+                + "/"
+                + command.draftToken()
+                + "/"
+                + storedFileName;
+    }
+
+    private String normalizePrefix(String prefix) {
+        if (prefix == null) {
+            return "";
+        }
+
+        return prefix.replaceAll("^/+", "").replaceAll("/+$", "");
+    }
+
+    private String sanitizeFileName(String originalFileName) {
+        if (originalFileName == null || originalFileName.isBlank()) {
+            return "dataset.csv";
+        }
+
+        return originalFileName
+                .replace("\\", "_")
+                .replace("/", "_");
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -54,7 +55,9 @@ public class GcsProblemSetDraftDatasetStorageAdapter implements
                     .setContentType(CSV_CONTENT_TYPE)
                     .build();
 
-            getStorage().create(blobInfo, command.content());
+            try (InputStream content = command.content()) {
+                getStorage().createFrom(blobInfo, content);
+            }
 
             return new StoredProblemSetDraftDataset(
                     originalFileName,

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
@@ -1,9 +1,12 @@
 package com.wanted.codebombalms.problems.generation.presentation;
 
 
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
 import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
@@ -24,6 +27,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(
         name = "문제세트 AI 초안 생성",
@@ -67,9 +72,7 @@ public class ProblemSetGenerationController {
             @RequestPart("datasetFile") MultipartFile datasetFile
     ) {
         ProblemSetDraftResult result = generateProblemSetDraftUseCase.generate(
-                userId,
-                request,
-                datasetFile
+                toCommand(userId, request, datasetFile)
         );
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -77,5 +80,39 @@ public class ProblemSetGenerationController {
                 ApiResponseMessage.SUCCESS,
                 ProblemSetDraftGenerateResponse.from(result)
         ));
+    }
+
+    private GenerateProblemSetDraftCommand toCommand(
+            Long operatorId,
+            ProblemSetDraftGenerateRequest request,
+            MultipartFile datasetFile
+    ) {
+        if (datasetFile == null || datasetFile.isEmpty()) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE
+            );
+        }
+
+        try {
+            return new GenerateProblemSetDraftCommand(
+                    operatorId,
+                    request.question(),
+                    request.dataFileName(),
+                    request.topic(),
+                    request.categoryName(),
+                    request.difficulty(),
+                    request.problemCount(),
+                    request.subProblemCount(),
+                    datasetFile.getOriginalFilename(),
+                    datasetFile.getContentType(),
+                    datasetFile.getInputStream(),
+                    datasetFile.getSize()
+            );
+        } catch (IOException e) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE,
+                    e
+            );
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
@@ -1,0 +1,81 @@
+package com.wanted.codebombalms.problems.generation.presentation;
+
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateSwaggerRequest;
+import com.wanted.codebombalms.problems.generation.presentation.api.response.ProblemSetDraftGenerateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(
+        name = "문제세트 AI 초안 생성",
+        description = "관리자가 데이터셋 기반 문제세트 초안을 AI로 생성하고, 최종 등록 전 검토할 수 있는 API"
+)
+@RestController
+@RequiredArgsConstructor
+public class ProblemSetGenerationController {
+
+    private final GenerateProblemSetDraftUseCase generateProblemSetDraftUseCase;
+
+    @Operation(
+            summary = "AI 문제세트 초안 생성",
+            description = """
+                    관리자가 입력한 문제 생성 방향, 난이도, 카테고리, 데이터셋 정보를 기반으로 문제세트 초안을 생성합니다.
+
+                    이 API는 실제 문제세트를 DB에 저장하지 않습니다.
+                    생성된 초안은 프론트에서 미리보기로 보여준 뒤, 관리자가 반영하기를 누르면 문제 등록 폼에 채워집니다.
+                    최종 저장은 기존 문제 등록 API를 사용합니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(
+                    mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schema = @Schema(implementation = ProblemSetDraftGenerateSwaggerRequest.class),
+                    encoding = {
+                            @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE),
+                            @Encoding(name = "datasetFile", contentType = "text/csv")
+                    }
+            )
+    )
+    @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
+    @PostMapping(
+            value = "/api/v1/admin/problem-set-drafts/generate",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<ApiResponse<ProblemSetDraftGenerateResponse>> generateProblemSetDraft(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart("request") @Valid ProblemSetDraftGenerateRequest request,
+            @RequestPart("datasetFile") MultipartFile datasetFile
+    ) {
+        ProblemSetDraftResult result = generateProblemSetDraftUseCase.generate(
+                userId,
+                request,
+                datasetFile
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                ProblemSetDraftGenerateResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
@@ -1,0 +1,39 @@
+package com.wanted.codebombalms.problems.generation.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "AI 문제세트 초안 생성 요청")
+public record ProblemSetDraftGenerateRequest(
+        @Schema(description = "관리자가 원하는 문제 생성 방향")
+        @NotBlank(message = "문제 생성 요청 문구는 필수입니다.")
+        String question,
+
+        @Schema(description = "데이터 파일명", example = "sw_engineer_salary.csv")
+        String dataFileName,
+
+        @Schema(description = "문제 주제", example = "SW기술자 평균임금 분석")
+        @NotBlank(message = "문제 주제는 필수입니다.")
+        String topic,
+
+        @Schema(description = "카테고리 이름", example = "공공 데이터")
+        @NotBlank(message = "카테고리 이름은 필수입니다.")
+        String categoryName,
+
+        @Schema(description = "난이도", example = "EASY", allowableValues = {"EASY", "MEDIUM", "HARD"})
+        @NotBlank(message = "난이도는 필수입니다.")
+        String difficulty,
+
+        @Schema(description = "생성할 문제세트 개수", example = "1")
+        @Min(1)
+        @Max(1)
+        int problemCount,
+
+        @Schema(description = "생성할 소문제 개수", example = "3")
+        @Min(1)
+        @Max(10)
+        int subProblemCount
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
@@ -4,26 +4,33 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "AI 문제세트 초안 생성 요청")
 public record ProblemSetDraftGenerateRequest(
         @Schema(description = "관리자가 원하는 문제 생성 방향")
         @NotBlank(message = "문제 생성 요청 문구는 필수입니다.")
+        @Size(max = 1_000, message = "문제 생성 요청 문구는 1000자 이하여야 합니다.")
         String question,
 
         @Schema(description = "데이터 파일명", example = "sw_engineer_salary.csv")
+        @Size(max = 255, message = "데이터 파일명은 255자 이하여야 합니다.")
         String dataFileName,
 
         @Schema(description = "문제 주제", example = "SW기술자 평균임금 분석")
         @NotBlank(message = "문제 주제는 필수입니다.")
+        @Size(max = 100, message = "문제 주제는 100자 이하여야 합니다.")
         String topic,
 
         @Schema(description = "카테고리 이름", example = "공공 데이터")
         @NotBlank(message = "카테고리 이름은 필수입니다.")
+        @Size(max = 50, message = "카테고리 이름은 50자 이하여야 합니다.")
         String categoryName,
 
         @Schema(description = "난이도", example = "EASY", allowableValues = {"EASY", "MEDIUM", "HARD"})
         @NotBlank(message = "난이도는 필수입니다.")
+        @Pattern(regexp = "EASY|MEDIUM|HARD", message = "난이도는 EASY, MEDIUM, HARD만 가능합니다.")
         String difficulty,
 
         @Schema(description = "생성할 문제세트 개수", example = "1")

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateSwaggerRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateSwaggerRequest.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.problems.generation.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "AI problem set draft generation multipart request")
+public record ProblemSetDraftGenerateSwaggerRequest(
+        @Schema(
+                description = "Problem set draft generation JSON part",
+                implementation = ProblemSetDraftGenerateRequest.class,
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        ProblemSetDraftGenerateRequest request,
+
+        @Schema(
+                description = "CSV dataset file used for draft generation",
+                type = "string",
+                format = "binary",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        MultipartFile datasetFile
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/response/ProblemSetDraftGenerateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/response/ProblemSetDraftGenerateResponse.java
@@ -1,0 +1,97 @@
+package com.wanted.codebombalms.problems.generation.presentation.api.response;
+
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedProblemDraft;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedTestCaseDraft;
+import com.wanted.codebombalms.problems.generation.domain.ProblemSetDraft;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "AI 문제세트 초안 생성 응답")
+public record ProblemSetDraftGenerateResponse(
+        @Schema(description = "AI 생성 결과 요약")
+        String answer,
+
+        @Schema(description = "문제세트 초안")
+        DraftResponse draft,
+
+        @Schema(description = "AI 서버에서 사용한 도구 목록")
+        List<String> usedTools
+) {
+
+    public static ProblemSetDraftGenerateResponse from(ProblemSetDraftResult result) {
+        return new ProblemSetDraftGenerateResponse(
+                result.answer(),
+                DraftResponse.from(result.draft()),
+                result.usedTools()
+        );
+    }
+
+    public record DraftResponse(
+            String title,
+            String categoryName,
+            String difficulty,
+            String description,
+            String dataFileName,
+            List<ProblemResponse> problems
+    ) {
+
+        public static DraftResponse from(ProblemSetDraft draft) {
+            if (draft == null) {
+                return null;
+            }
+
+            return new DraftResponse(
+                    draft.title(),
+                    draft.categoryName(),
+                    draft.difficulty(),
+                    draft.description(),
+                    draft.dataFileName(),
+                    draft.problems().stream()
+                            .map(ProblemResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record ProblemResponse(
+            String title,
+            int point,
+            String content,
+            String startCode,
+            String hint,
+            String explanation,
+            List<TestCaseResponse> testCases
+    ) {
+
+        public static ProblemResponse from(GeneratedProblemDraft problem) {
+            return new ProblemResponse(
+                    problem.title(),
+                    problem.point(),
+                    problem.content(),
+                    problem.startCode(),
+                    problem.hint(),
+                    problem.explanation(),
+                    problem.testCases().stream()
+                            .map(TestCaseResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record TestCaseResponse(
+            String testCode,
+            boolean isHidden,
+            int timeoutMs
+    ) {
+
+        public static TestCaseResponse from(GeneratedTestCaseDraft testCase) {
+            return new TestCaseResponse(
+                    testCase.testCode(),
+                    testCase.hidden(),
+                    testCase.timeoutMs()
+            );
+        }
+    }
+}


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #

---

## 🛠️ 기능 관련 작업 내용
- 관리자용 문제세트 AI 초안 생성 API를 추가했습니다.
- 업로드된 CSV 데이터셋을 GCS에 저장한 뒤 Signed URL을 생성해 FastAPI 서버로 전달하도록 구현했습니다.
- FastAPI에서 반환한 문제세트 초안 응답을 Spring 도메인 결과 및 API 응답 DTO로 변환했습니다.
- 데이터셋 파일 오류, 업로드 실패, Signed URL 생성 실패, AI 초안 생성 실패에 대한 에러코드를 추가했습니다.

---

## ♻️ 패키지 변경 사항
- `problems/generation/presentation`: 문제세트 AI 초안 생성 Controller 및 요청/응답 DTO 추가
- `problems/generation/application`: 초안 생성 UseCase, Service, Command, Port, Result 추가
- `problems/generation/domain`: AI 생성 문제세트 초안 도메인 모델 추가
- `problems/generation/infrastructure/ai`: FastAPI 호출 Client, Adapter, 요청/응답 매핑 추가
- `problems/generation/infrastructure/storage`: GCS 데이터셋 저장 및 Signed URL 생성 Adapter 추가
- `problems/exception`: 문제세트 초안 생성 관련 에러코드 추가
- `global/presentation/api/common`: 외부 서비스 예외 응답 처리 보완
- `.gitignore`: Python 생성 파일 및 캐시 파일 ignore 규칙 보완

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - CSV 데이터셋을 업로드해 AI 문제세트 초안을 생성하는 기능을 추가했습니다.
  - 생성 결과에 문제, 테스트케이스, 설명 및 사용 도구 정보가 포함됩니다.
  - 생성된 데이터셋의 임시 저장과 다운로드 URL 발급을 지원합니다.
  - 관리자 및 운영자용 API와 입력값 검증을 제공합니다.

- **버그 수정**
  - multipart 요청 오류가 일관된 잘못된 요청(400) 응답으로 처리됩니다.
  - AI 초안 생성 실패 시 전용 오류 메시지를 제공합니다.
  - 문제세트 및 테스트케이스 관련 오류 메시지의 띄어쓰기를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->