### PR TITLE
[Release] v2.6.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,7 @@ jobs:
           GCP_STORAGE_BUCKET: ${{ vars.GCP_STORAGE_BUCKET }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
           BRIEFING_API_KEY: ${{ secrets.BRIEFING_API_KEY }}
+          INTERNAL_API_TOKEN: ${{ secrets.INTERNAL_API_TOKEN }}
         run: |
           set -euo pipefail
           umask 077
@@ -110,7 +111,7 @@ jobs:
                    CORS_ALLOWED_ORIGINS FASTAPI_URL JWT_SECRET MAIL_USERNAME MAIL_PASSWORD \
                    GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_REDIRECT_URI \
                    OAUTH_ADDITIONAL_INFO_URI OAUTH_SUCCESS_URI OAUTH_ERROR_URI COOKIE_SECURE \
-                   GCP_PROJECT_ID GCP_STORAGE_BUCKET BRIEFING_API_KEY; do
+                   GCP_PROJECT_ID GCP_STORAGE_BUCKET BRIEFING_API_KEY INTERNAL_API_TOKEN; do
             v="${!k}"
             [ -n "$v" ] && printf '%s=%s\n' "$k" "$v" >> deploy.env
           done

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ architecture-user-auth.html
 /src/main/resources/db/seed/03_trusted_device_loadtest.sql
 /rds-tunnel.sh
 /src/main/resources/db/schema/ops_briefing.sql
+
+### Python generated files ###
+__pycache__/
+*.pyc

--- a/http/inquiry.http
+++ b/http/inquiry.http
@@ -16,7 +16,7 @@ POST http://localhost:8080/api/v1/inquiries
 Content-Type: application/json
 
 {
-  "content": "병신 관리자",
+  "content": "시발 관리자",
   "sourceUrl": "/user/problems/123"
 }
 
@@ -50,7 +50,7 @@ Content-Type: application/json
 GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=false
 
 ### 8. 관리자 - 문의 상세 조회 (2번 응답의 inquiryId 확인 후 입력)
-GET http://localhost:8080/api/v1/admin/inquiries/1
+GET http://localhost:8080/api/v1/admin/inquiries/7
 
 ### 9. 관리자 - 존재하지 않는 문의 상세 조회 → 404 INQ-002
 GET http://localhost:8080/api/v1/admin/inquiries/999999
@@ -75,24 +75,24 @@ Content-Type: application/json
 }
 
 ### 12. 관리자 - 문의 필터링 처리 (스팸/무의미로 판단한 경우 시나리오, reason 필수)
-PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+PATCH http://localhost:8080/api/v1/admin/inquiries/10/filter
 Content-Type: application/json
 
 {
   "filtered": true,
-  "reason": "AI는 정상 문의로 판단했지만 실제로는 광고성 문의로 확인됨"
+  "reason": "욕설은 안보고 싶음"
 }
 
 ### 13. 관리자 - 필터링 목록 조회 (12번에서 필터링 처리한 문의가 보여야 정상)
 GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=true
 
 ### 14. 관리자 - 문의 필터링 복구 (다시 정상 문의로, reason 필수)
-PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+PATCH http://localhost:8080/api/v1/admin/inquiries/7/filter
 Content-Type: application/json
 
 {
   "filtered": false,
-  "reason": "재확인 결과 실제 문제 제출 오류 문의로 확인됨"
+  "reason": "욕설 또한 관리자가 볼 필요가 있을거같아요, 이후 신고 처리 가능"
 }
 
 ### 15. 관리자 - 답변 등록 (status=ANSWERED / reply_visible=true 로 함께 갱신됨)

--- a/http/inquiry.http
+++ b/http/inquiry.http
@@ -1,0 +1,149 @@
+### ===== Inquiry API 테스트 시나리오 =====
+### 사전 조건: 사용자 계정(u01@test.com), 관리자 계정(admin@test.com) 가입 완료 상태
+### 흐름: 사용자 문의 등록 → 관리자 목록/상세 확인 → 분류 수정/필터링 → 답변 등록 → 사용자 답변 확인/비노출
+
+### 1. 사용자 로그인 — 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "op@test.com",
+  "password": "Test1234!"
+}
+
+### 2. 사용자 - 문의 등록 (정상). 응답의 data.inquiryId를 이후 요청에 계속 사용한다
+POST http://localhost:8080/api/v1/inquiries
+Content-Type: application/json
+
+{
+  "content": "병신 관리자",
+  "sourceUrl": "/user/problems/123"
+}
+
+### 3. 사용자 - 문의 등록 시도, content 누락 → 400
+POST http://localhost:8080/api/v1/inquiries
+Content-Type: application/json
+
+{
+  "sourceUrl": "/user/problems/123"
+}
+
+### 4. 사용자 - 미확인 답변 조회 (아직 관리자 답변 전이라 data.replies는 빈 배열이어야 정상)
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 5. (사전) 로그아웃 → 관리자 로그인 준비
+POST http://localhost:8080/api/v1/auth/logout
+
+
+### ===== 관리자 처리 =====
+
+### 6. 관리자 로그인 — 쿠키 발급
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "admin@test.com",
+  "password": "Test1234!"
+}
+
+### 7. 관리자 - 문의 목록 조회 (정상 목록, isFiltered=false)
+GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=false
+
+### 8. 관리자 - 문의 상세 조회 (2번 응답의 inquiryId 확인 후 입력)
+GET http://localhost:8080/api/v1/admin/inquiries/1
+
+### 9. 관리자 - 존재하지 않는 문의 상세 조회 → 404 INQ-002
+GET http://localhost:8080/api/v1/admin/inquiries/999999
+
+### 10. 관리자 - 문의 분류 수정 (8번의 inquiryId 입력, reason 필수)
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/classification
+Content-Type: application/json
+
+{
+  "domain": "PROBLEMS",
+  "severity": "HIGH",
+  "reason": "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함"
+}
+
+### 11. 관리자 - 문의 분류 수정 시도, reason 누락 → 400
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/classification
+Content-Type: application/json
+
+{
+  "domain": "PROBLEMS",
+  "severity": "HIGH"
+}
+
+### 12. 관리자 - 문의 필터링 처리 (스팸/무의미로 판단한 경우 시나리오, reason 필수)
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+Content-Type: application/json
+
+{
+  "filtered": true,
+  "reason": "AI는 정상 문의로 판단했지만 실제로는 광고성 문의로 확인됨"
+}
+
+### 13. 관리자 - 필터링 목록 조회 (12번에서 필터링 처리한 문의가 보여야 정상)
+GET http://localhost:8080/api/v1/admin/inquiries?isFiltered=true
+
+### 14. 관리자 - 문의 필터링 복구 (다시 정상 문의로, reason 필수)
+PATCH http://localhost:8080/api/v1/admin/inquiries/1/filter
+Content-Type: application/json
+
+{
+  "filtered": false,
+  "reason": "재확인 결과 실제 문제 제출 오류 문의로 확인됨"
+}
+
+### 15. 관리자 - 답변 등록 (status=ANSWERED / reply_visible=true 로 함께 갱신됨)
+POST http://localhost:8080/api/v1/admin/inquiries/1/reply
+Content-Type: application/json
+
+{
+  "content": "문의 주신 문제 제출 오류를 확인했고 수정 반영했습니다."
+}
+
+### 16. (사전) 로그아웃 → 사용자 재로그인 준비
+POST http://localhost:8080/api/v1/auth/logout
+
+
+### ===== 사용자 답변 확인 =====
+
+### 17. 사용자 재로그인
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "email": "u01@test.com",
+  "password": "Test1234!"
+}
+
+### 18. 사용자 - 미확인 답변 조회 (15번 답변이 data.replies에 노출돼야 정상)
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 19. 사용자 - 답변 비노출 처리 (모달 닫기(X) 액션, 18번 응답의 inquiryId 입력)
+PATCH http://localhost:8080/api/v1/inquiries/1/reply-visibility
+
+### 20. 사용자 - 미확인 답변 재조회 (19번 이후엔 다시 빈 배열이어야 정상)
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 21. (사전) 로그아웃 → 비로그인 상태 준비
+POST http://localhost:8080/api/v1/auth/logout
+
+
+### ===== 인증 실패 시나리오 (비로그인 상태) =====
+
+### 22. 비로그인 상태 - 문의 등록 시도 → 401 AUT-016
+POST http://localhost:8080/api/v1/inquiries
+Content-Type: application/json
+
+{
+  "content": "로그인 안 하고 문의 등록 시도",
+  "sourceUrl": "/user/problems/123"
+}
+
+### 23. 비로그인 상태 - 미확인 답변 조회 시도 → 401 AUT-016
+GET http://localhost:8080/api/v1/inquiries/me/replies/active
+
+### 24. 비로그인 상태 - 답변 비노출 처리 시도 → 401 AUT-016
+PATCH http://localhost:8080/api/v1/inquiries/1/reply-visibility

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/SchedulingConfig.java
@@ -46,6 +46,20 @@ public class SchedulingConfig {
     }
 
 
+    /** 문의 등록 후 Python AI 분석 호출 전용 풀 — 포화 시 드랍 + 로그 기록 (best-effort, 사용자 응답에 영향 없음). */
+    @Bean(name = "inquiryTaskExecutor")
+    public Executor inquiryTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("inquiry-ai-");
+        executor.setRejectedExecutionHandler((runnable, pool) ->
+                log.warn("event=inquiry_ai_analysis_dropped reason=queue_full queueCapacity=100"));
+        executor.initialize();
+        return executor;
+    }
+
     /**
      * 서비스 이벤트 적재 전용 풀 — 포화 시 드랍 + 카운터 기록 (best-effort, 응답 보호).
      * 기존 풀(추천·메일) 재사용 금지 — 즉시 거절 또는 요청 스레드 역류로 응답 지연 전파.

--- a/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/wanted/codebombalms/global/infrastructure/config/security/SecurityConfig.java
@@ -62,6 +62,10 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         // 모니터링 (Prometheus 스크레이핑)
                         .requestMatchers("/actuator/**").permitAll()
+                        // FastAPI opschat 도구 전용 내부 API — JWT 미사용.
+                        // 인증은 InternalOpsController 의 X-Internal-Token 검증(fail-closed)이 담당하고,
+                        // 배포에서는 SG 로 파이썬 박스만 접근 허용 (이중 방어)
+                        .requestMatchers("/internal/ops/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
                         // 인증 불필요
                         .requestMatchers("/api/v1/auth/**").permitAll()

--- a/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/codebombalms/global/presentation/api/common/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import java.util.Arrays;
@@ -63,6 +64,7 @@ public class GlobalExceptionHandler {
             HandlerMethodValidationException.class,
             HttpMessageNotReadableException.class,
             HttpMediaTypeNotSupportedException.class,
+            MultipartException.class,
             MaxUploadSizeExceededException.class
     })
     public ResponseEntity<ApiErrorResponse> handleBadRequestException(

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/ApplyInquiryAiAnalysisCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/ApplyInquiryAiAnalysisCommand.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+
+// Python AI 분석 결과를 문의에 반영할 때 사용하는 값을 담는다.
+public record ApplyInquiryAiAnalysisCommand(
+        Long inquiryId,
+        String title,
+        String aiSummary,
+        InquirySeverity severity,
+        InquiryDomain domain,
+        String estimatedUrl,
+        String aiRecommendedAction,
+        boolean filtered
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/CorrectionExample.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/CorrectionExample.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+
+// Python AI 분석 요청에 함께 실어보낼 관리자 보정 사례 한 건
+public record CorrectionExample(
+        InquiryCorrectionField fieldName,
+        String aiValue,
+        String correctedValue,
+        String reason
+) {
+
+    public static CorrectionExample from(InquiryAiCorrection correction) {
+        return new CorrectionExample(
+                correction.getFieldName(),
+                correction.getAiValue(),
+                correction.getCorrectedValue(),
+                correction.getReason()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/CreateInquiryCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/CreateInquiryCommand.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+// 사용자 문의 등록 요청 값을 담는다.
+public record CreateInquiryCommand(
+        Long userId,
+        String content,
+        String sourceUrl
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/ReplyInquiryCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/ReplyInquiryCommand.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+// 관리자 답변 등록 요청 값을 담는다.
+public record ReplyInquiryCommand(
+        Long inquiryId,
+        Long adminId,
+        String content
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/RequestInquiryAnalysisCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/RequestInquiryAnalysisCommand.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import java.util.List;
+
+// Python AI 분석 서버에 전달할 문의 원문 정보와 관리자 보정 학습 컨텍스트를 담는다.
+public record RequestInquiryAnalysisCommand(
+        Long inquiryId,
+        Long userId,
+        String sourceUrl,
+        String content,
+        List<CorrectionExample> correctionExamples
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryClassificationCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryClassificationCommand.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+
+// 관리자 분류(도메인/심각도) 수정 요청 값을 담는다.
+public record UpdateInquiryClassificationCommand(
+        Long inquiryId,
+        Long adminId,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        String reason
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryFilterCommand.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/command/UpdateInquiryFilterCommand.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.command;
+
+// 관리자 필터링 처리/복구 요청 값을 담는다.
+public record UpdateInquiryFilterCommand(
+        Long inquiryId,
+        Long adminId,
+        Boolean filtered,
+        String reason
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/port/InquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/port/InquiryAnalysisClient.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.port;
+
+import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
+
+// 문의 원문을 Python AI 분석 서버에 전달하는 외부 호출 포트다.
+public interface InquiryAnalysisClient {
+
+    void analyze(RequestInquiryAnalysisCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/ActiveInquiryReply.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/ActiveInquiryReply.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import java.time.LocalDateTime;
+
+// 로그인 첫 화면에 띄울 미확인 문의 답변 정보
+public record ActiveInquiryReply(
+        Long inquiryId,
+        String title,
+        String content,
+        String adminReply,
+        LocalDateTime repliedAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryDetail.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryDetail.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+import java.time.LocalDateTime;
+
+// 관리자 문의 상세 화면에 필요한 원문/AI 분석/처리 결과 전체를 담는다.
+public record AdminInquiryDetail(
+        Long inquiryId,
+        Long userId,
+        String title,
+        String content,
+        String sourceUrl,
+        String estimatedUrl,
+        String summary,
+        String recommendedAction,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        String adminReply,
+        Long repliedBy,
+        LocalDateTime repliedAt,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryListItem.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/AdminInquiryListItem.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+import java.time.LocalDateTime;
+
+// 관리자 문의 목록 한 행에 필요한 AI 요약 기준 정보만 담는다.
+public record AdminInquiryListItem(
+        Long inquiryId,
+        String title,
+        String summary,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/GetAdminInquiriesQuery.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/GetAdminInquiriesQuery.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+// 관리자 문의 목록 조회 조건을 담는다.
+public record GetAdminInquiriesQuery(
+        boolean isFiltered,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.inquiry.application.query;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+
+import java.util.Optional;
+
+public interface InquiryQueryRepository {
+
+    PageResult<AdminInquiryListItem> findAdminInquiries(GetAdminInquiriesQuery query);
+
+    Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/query/InquiryQueryRepository.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.inquiry.application.query;
 
 import com.wanted.codebombalms.admin.operation.common.application.PageResult;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InquiryQueryRepository {
@@ -9,4 +10,6 @@ public interface InquiryQueryRepository {
     PageResult<AdminInquiryListItem> findAdminInquiries(GetAdminInquiriesQuery query);
 
     Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId);
+
+    List<ActiveInquiryReply> findActiveRepliesByUserId(Long userId);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -89,16 +90,17 @@ public class AdminInquiryCommandService implements
                 .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
     }
 
-    // AI 값과 관리자 값이 다를 때만 inquiry_id + field_name 기준으로 마지막 보정값을 upsert한다.
+    // 수정 전 값과 관리자 값이 다를 때만 inquiry_id + field_name 기준으로 마지막 보정값을 upsert한다.
+    // previousValue는 비교 기준이면서, 보정 row가 처음 생성될 때는 그대로 ai_value로 저장된다.
     private void upsertCorrectionIfChanged(
             Long inquiryId,
             Long adminId,
             InquiryCorrectionField fieldName,
-            String aiValue,
+            String previousValue,
             String correctedValue,
             String reason
     ) {
-        if (aiValue.equals(correctedValue)) {
+        if (Objects.equals(previousValue, correctedValue)) {
             return;
         }
 
@@ -109,7 +111,7 @@ public class AdminInquiryCommandService implements
                     return existing;
                 })
                 .orElseGet(() -> InquiryAiCorrection.create(
-                        inquiryId, adminId, fieldName, aiValue, correctedValue, reason, now
+                        inquiryId, adminId, fieldName, previousValue, correctedValue, reason, now
                 ));
 
         inquiryAiCorrectionRepository.save(correction);

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryCommandService.java
@@ -1,0 +1,133 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassificationCommand;
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
+import com.wanted.codebombalms.inquiry.application.usecase.ReplyInquiryUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryClassificationUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryFilterUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminInquiryCommandService implements
+        UpdateInquiryClassificationUseCase,
+        UpdateInquiryFilterUseCase,
+        ReplyInquiryUseCase {
+
+    private final InquiryRepository inquiryRepository;
+    private final InquiryAiCorrectionRepository inquiryAiCorrectionRepository;
+
+    @Override
+    // 문의를 조회해 도메인/심각도를 수정하고, 값이 바뀐 필드만 보정 이력에 upsert한다.
+    public Inquiry updateClassification(UpdateInquiryClassificationCommand command) {
+        validateClassificationCommand(command);
+
+        Inquiry inquiry = findInquiry(command.inquiryId());
+        String previousDomain = inquiry.getDomain().name();
+        String previousSeverity = inquiry.getSeverity().name();
+
+        inquiry.updateClassification(command.domain(), command.severity(), LocalDateTime.now());
+        Inquiry saved = inquiryRepository.save(inquiry);
+
+        upsertCorrectionIfChanged(
+                saved.getInquiryId(), command.adminId(), InquiryCorrectionField.DOMAIN,
+                previousDomain, command.domain().name(), command.reason()
+        );
+        upsertCorrectionIfChanged(
+                saved.getInquiryId(), command.adminId(), InquiryCorrectionField.SEVERITY,
+                previousSeverity, command.severity().name(), command.reason()
+        );
+
+        return saved;
+    }
+
+    @Override
+    // 문의를 조회해 필터링 상태를 바꾸고, 값이 바뀌었으면 보정 이력에 upsert한다.
+    public Inquiry updateFilter(UpdateInquiryFilterCommand command) {
+        validateFilterCommand(command);
+
+        Inquiry inquiry = findInquiry(command.inquiryId());
+        String previousFiltered = String.valueOf(inquiry.isFiltered());
+
+        inquiry.updateFilter(command.filtered(), LocalDateTime.now());
+        Inquiry saved = inquiryRepository.save(inquiry);
+
+        upsertCorrectionIfChanged(
+                saved.getInquiryId(), command.adminId(), InquiryCorrectionField.IS_FILTERED,
+                previousFiltered, String.valueOf(command.filtered()), command.reason()
+        );
+
+        return saved;
+    }
+
+    @Override
+    // 문의를 조회해 관리자 답변을 등록한다. 상태/노출 여부 변경은 도메인 모델이 함께 처리한다.
+    public Inquiry reply(ReplyInquiryCommand command) {
+        Inquiry inquiry = findInquiry(command.inquiryId());
+
+        inquiry.reply(command.content(), command.adminId(), LocalDateTime.now());
+
+        return inquiryRepository.save(inquiry);
+    }
+
+    private Inquiry findInquiry(Long inquiryId) {
+        return inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+    }
+
+    // AI 값과 관리자 값이 다를 때만 inquiry_id + field_name 기준으로 마지막 보정값을 upsert한다.
+    private void upsertCorrectionIfChanged(
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason
+    ) {
+        if (aiValue.equals(correctedValue)) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        InquiryAiCorrection correction = inquiryAiCorrectionRepository.findByInquiryIdAndFieldName(inquiryId, fieldName)
+                .map(existing -> {
+                    existing.updateCorrection(correctedValue, reason, adminId, now);
+                    return existing;
+                })
+                .orElseGet(() -> InquiryAiCorrection.create(
+                        inquiryId, adminId, fieldName, aiValue, correctedValue, reason, now
+                ));
+
+        inquiryAiCorrectionRepository.save(correction);
+    }
+
+    private void validateClassificationCommand(UpdateInquiryClassificationCommand command) {
+        if (command.domain() == null || command.severity() == null || isBlank(command.reason())) {
+            throw new ValidationException(InquiryErrorCode.INVALID_CLASSIFICATION_REQUEST);
+        }
+    }
+
+    private void validateFilterCommand(UpdateInquiryFilterCommand command) {
+        if (command.filtered() == null || isBlank(command.reason())) {
+            throw new ValidationException(InquiryErrorCode.INVALID_FILTER_REQUEST);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/AdminInquiryQueryService.java
@@ -1,0 +1,44 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+import com.wanted.codebombalms.inquiry.application.query.InquiryQueryRepository;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiriesUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiryDetailUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminInquiryQueryService implements GetAdminInquiriesUseCase, GetAdminInquiryDetailUseCase {
+
+    private final InquiryQueryRepository inquiryQueryRepository;
+
+    @Override
+    // isFiltered/domain/severity/status 조건으로 관리자 문의 목록을 페이지 조회한다.
+    public PageResult<AdminInquiryListItem> getInquiries(GetAdminInquiriesQuery query) {
+        validatePage(query.page(), query.size());
+
+        return inquiryQueryRepository.findAdminInquiries(query);
+    }
+
+    @Override
+    // 문의 ID로 상세 정보를 조회하고 없으면 예외를 던진다.
+    public AdminInquiryDetail getInquiryDetail(Long inquiryId) {
+        return inquiryQueryRepository.findAdminInquiryDetail(inquiryId)
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+    }
+
+    private void validatePage(int page, int size) {
+        if (page < 0 || size <= 0 || size > 100) {
+            throw new ValidationException(InquiryErrorCode.INVALID_PAGE_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/InquiryAiAnalysisApplyService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/InquiryAiAnalysisApplyService.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+// UserInquiryCommandService와 별도 빈으로 분리했다.
+// FastApiInquiryAnalysisClient가 이 유스케이스를 호출하는데, UserInquiryCommandService가
+// FastApiInquiryAnalysisClient(InquiryAnalysisClient)를 의존하고 있어서 같은 클래스에 두면
+// UserInquiryCommandService -> FastApiInquiryAnalysisClient -> UserInquiryCommandService
+// 순환 참조가 생긴다.
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InquiryAiAnalysisApplyService implements ApplyInquiryAiAnalysisUseCase {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    // Python AI 분석 응답을 받아 문의의 분류/요약/추정 URL/필터링 여부를 반영한다.
+    public Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command) {
+        Inquiry inquiry = inquiryRepository.findById(command.inquiryId())
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+
+        inquiry.applyAiAnalysis(
+                command.title(),
+                command.aiSummary(),
+                command.severity(),
+                command.domain(),
+                command.estimatedUrl(),
+                command.aiRecommendedAction(),
+                command.filtered(),
+                LocalDateTime.now()
+        );
+
+        return inquiryRepository.save(inquiry);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -14,6 +14,8 @@ import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,12 +33,27 @@ public class UserInquiryCommandService implements CreateInquiryUseCase, HideInqu
     private final InquiryAnalysisClient inquiryAnalysisClient;
 
     @Override
-    // 문의를 등록하고 저장이 끝난 뒤 Python AI 분석을 비동기로 요청한다. 사용자 응답은 분석 결과를 기다리지 않는다.
+    // 문의를 등록하고, 트랜잭션이 실제로 커밋된 뒤에 Python AI 분석을 비동기로 요청한다.
+    // 사용자 응답은 분석 결과를 기다리지 않는다.
     public Inquiry create(CreateInquiryCommand command) {
         Inquiry inquiry = Inquiry.create(command.userId(), command.content(), command.sourceUrl(), LocalDateTime.now());
 
         Inquiry saved = inquiryRepository.save(inquiry);
 
+        // 커밋 전에 analyze()(@Async)를 호출하면, Python 응답이 아주 빠르거나 커밋이 지연될 때
+        // 분석 결과 반영(findById)이 아직 안 보이는 row를 조회해 NotFoundException이 날 수 있다.
+        // 커밋 완료 후로 미뤄서 이 레이스 컨디션을 없앤다.
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                requestAiAnalysis(saved);
+            }
+        });
+
+        return saved;
+    }
+
+    private void requestAiAnalysis(Inquiry saved) {
         List<CorrectionExample> correctionExamples = inquiryAiCorrectionRepository
                 .findRecentCorrections(MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT)
                 .stream()
@@ -50,8 +67,6 @@ public class UserInquiryCommandService implements CreateInquiryUseCase, HideInqu
                 saved.getContent(),
                 correctionExamples
         ));
-
-        return saved;
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -1,22 +1,81 @@
 package com.wanted.codebombalms.inquiry.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
+import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
+import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.port.InquiryAnalysisClient;
+import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.CreateInquiryUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
 import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
 import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserInquiryCommandService implements HideInquiryReplyUseCase {
+public class UserInquiryCommandService
+        implements CreateInquiryUseCase, HideInquiryReplyUseCase, ApplyInquiryAiAnalysisUseCase {
+
+    // 운영 데이터가 쌓일수록 AI 분석 컨텍스트가 좋아지도록, 지금 규모에서는 사실상 전체 보정 이력을 보낸다는 의미의 상한이다.
+    private static final int MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT = 1000;
 
     private final InquiryRepository inquiryRepository;
+    private final InquiryAiCorrectionRepository inquiryAiCorrectionRepository;
+    private final InquiryAnalysisClient inquiryAnalysisClient;
+
+    @Override
+    // 문의를 등록하고 저장이 끝난 뒤 Python AI 분석을 비동기로 요청한다. 사용자 응답은 분석 결과를 기다리지 않는다.
+    public Inquiry create(CreateInquiryCommand command) {
+        Inquiry inquiry = Inquiry.create(command.userId(), command.content(), command.sourceUrl(), LocalDateTime.now());
+
+        Inquiry saved = inquiryRepository.save(inquiry);
+
+        List<CorrectionExample> correctionExamples = inquiryAiCorrectionRepository
+                .findRecentCorrections(MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT)
+                .stream()
+                .map(CorrectionExample::from)
+                .toList();
+
+        inquiryAnalysisClient.analyze(new RequestInquiryAnalysisCommand(
+                saved.getInquiryId(),
+                saved.getUserId(),
+                saved.getSourceUrl(),
+                saved.getContent(),
+                correctionExamples
+        ));
+
+        return saved;
+    }
+
+    @Override
+    // Python AI 분석 응답을 받아 문의의 분류/요약/추정 URL/필터링 여부를 반영한다.
+    public Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command) {
+        Inquiry inquiry = inquiryRepository.findById(command.inquiryId())
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+
+        inquiry.applyAiAnalysis(
+                command.title(),
+                command.aiSummary(),
+                command.severity(),
+                command.domain(),
+                command.estimatedUrl(),
+                command.aiRecommendedAction(),
+                command.filtered(),
+                LocalDateTime.now()
+        );
+
+        return inquiryRepository.save(inquiry);
+    }
 
     @Override
     // 본인 문의 답변을 로그인 첫 화면에서 비노출 처리한다.

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -1,12 +1,10 @@
 package com.wanted.codebombalms.inquiry.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
-import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
 import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
 import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
 import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
 import com.wanted.codebombalms.inquiry.application.port.InquiryAnalysisClient;
-import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.CreateInquiryUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
 import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
@@ -23,8 +21,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserInquiryCommandService
-        implements CreateInquiryUseCase, HideInquiryReplyUseCase, ApplyInquiryAiAnalysisUseCase {
+public class UserInquiryCommandService implements CreateInquiryUseCase, HideInquiryReplyUseCase {
 
     // 운영 데이터가 쌓일수록 AI 분석 컨텍스트가 좋아지도록, 지금 규모에서는 사실상 전체 보정 이력을 보낸다는 의미의 상한이다.
     private static final int MAX_CORRECTION_EXAMPLES_FOR_AI_CONTEXT = 1000;
@@ -55,26 +52,6 @@ public class UserInquiryCommandService
         ));
 
         return saved;
-    }
-
-    @Override
-    // Python AI 분석 응답을 받아 문의의 분류/요약/추정 URL/필터링 여부를 반영한다.
-    public Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command) {
-        Inquiry inquiry = inquiryRepository.findById(command.inquiryId())
-                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
-
-        inquiry.applyAiAnalysis(
-                command.title(),
-                command.aiSummary(),
-                command.severity(),
-                command.domain(),
-                command.estimatedUrl(),
-                command.aiRecommendedAction(),
-                command.filtered(),
-                LocalDateTime.now()
-        );
-
-        return inquiryRepository.save(inquiry);
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryCommandService.java
@@ -1,0 +1,31 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserInquiryCommandService implements HideInquiryReplyUseCase {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    // 본인 문의 답변을 로그인 첫 화면에서 비노출 처리한다.
+    public Inquiry hideReply(Long inquiryId, Long userId) {
+        Inquiry inquiry = inquiryRepository.findByIdAndUserId(inquiryId, userId)
+                .orElseThrow(() -> new NotFoundException(InquiryErrorCode.INQUIRY_NOT_FOUND));
+
+        inquiry.hideReply(LocalDateTime.now());
+
+        return inquiryRepository.save(inquiry);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/service/UserInquiryQueryService.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.inquiry.application.service;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+import com.wanted.codebombalms.inquiry.application.query.InquiryQueryRepository;
+import com.wanted.codebombalms.inquiry.application.usecase.GetActiveInquiryRepliesUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserInquiryQueryService implements GetActiveInquiryRepliesUseCase {
+
+    private final InquiryQueryRepository inquiryQueryRepository;
+
+    @Override
+    // 로그인 첫 화면에 노출할 답변 확인 전 문의 답변 목록을 조회한다.
+    public List<ActiveInquiryReply> getActiveReplies(Long userId) {
+        return inquiryQueryRepository.findActiveRepliesByUserId(userId);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ApplyInquiryAiAnalysisUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ApplyInquiryAiAnalysisUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// Python AI 분석 결과를 문의에 반영하는 유스케이스 진입점이다.
+public interface ApplyInquiryAiAnalysisUseCase {
+
+    Inquiry applyAiAnalysis(ApplyInquiryAiAnalysisCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/CreateInquiryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/CreateInquiryUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 사용자가 새 문의를 등록하는 유스케이스 진입점이다.
+public interface CreateInquiryUseCase {
+
+    Inquiry create(CreateInquiryCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetActiveInquiryRepliesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetActiveInquiryRepliesUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+
+import java.util.List;
+
+public interface GetActiveInquiryRepliesUseCase {
+
+    List<ActiveInquiryReply> getActiveReplies(Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiriesUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiriesUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+
+public interface GetAdminInquiriesUseCase {
+
+    PageResult<AdminInquiryListItem> getInquiries(GetAdminInquiriesQuery query);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiryDetailUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/GetAdminInquiryDetailUseCase.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+
+public interface GetAdminInquiryDetailUseCase {
+
+    // 문의 ID로 상세 정보를 조회한다.
+    AdminInquiryDetail getInquiryDetail(Long inquiryId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/HideInquiryReplyUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/HideInquiryReplyUseCase.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+public interface HideInquiryReplyUseCase {
+
+    Inquiry hideReply(Long inquiryId, Long userId);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ReplyInquiryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/ReplyInquiryUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 관리자가 문의에 답변을 등록하는 유스케이스 진입점이다.
+public interface ReplyInquiryUseCase {
+
+    Inquiry reply(ReplyInquiryCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryClassificationUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryClassificationUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassificationCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 관리자가 문의의 도메인/심각도 분류를 보정하는 유스케이스 진입점이다.
+public interface UpdateInquiryClassificationUseCase {
+
+    Inquiry updateClassification(UpdateInquiryClassificationCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryFilterUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/application/usecase/UpdateInquiryFilterUseCase.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.application.usecase;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 관리자가 문의 필터링 처리 또는 복구를 수행하는 유스케이스 진입점이다.
+public interface UpdateInquiryFilterUseCase {
+
+    Inquiry updateFilter(UpdateInquiryFilterCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/exception/InquiryErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/exception/InquiryErrorCode.java
@@ -1,0 +1,26 @@
+package com.wanted.codebombalms.inquiry.domain.exception;
+
+import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InquiryErrorCode implements ErrorCode {
+
+    // 조회
+    INVALID_PAGE_REQUEST("INQ-001", "페이지 요청 값이 올바르지 않습니다."),
+    INQUIRY_NOT_FOUND("INQ-002", "문의를 찾을 수 없습니다."),
+
+    // 분류 수정
+    INVALID_CLASSIFICATION_REQUEST("INQ-003", "문의 분류 수정 요청이 올바르지 않습니다."),
+
+    // 필터링 처리/복구
+    INVALID_FILTER_REQUEST("INQ-004", "문의 필터링 처리 요청이 올바르지 않습니다."),
+
+    // 답변 등록
+    INVALID_REPLY_REQUEST("INQ-005", "문의 답변 등록 요청이 올바르지 않습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
@@ -67,6 +67,30 @@ public class Inquiry {
         this.updatedAt = updatedAt;
     }
 
+    // 사용자가 새로 등록한 문의를 생성한다. AI 분석 전까지는 기본값(OPEN/LOW/ETC)을 갖는다.
+    public static Inquiry create(Long userId, String content, String sourceUrl, LocalDateTime createdAt) {
+        return new Inquiry(
+                null,
+                userId,
+                null,
+                content,
+                InquiryStatus.OPEN,
+                InquirySeverity.LOW,
+                InquiryDomain.ETC,
+                sourceUrl,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false,
+                createdAt,
+                createdAt
+        );
+    }
+
     // DB에서 조회한 값으로 도메인 모델을 복원한다.
     public static Inquiry restore(
             Long inquiryId,
@@ -108,6 +132,27 @@ public class Inquiry {
                 createdAt,
                 updatedAt
         );
+    }
+
+    // Python AI 분석 결과를 반영한다. 관리자가 아직 보정하지 않은 초기값이므로 전체 필드를 덮어쓴다.
+    public void applyAiAnalysis(
+            String title,
+            String aiSummary,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String estimatedUrl,
+            String aiRecommendedAction,
+            boolean filtered,
+            LocalDateTime updatedAt
+    ) {
+        this.title = title;
+        this.aiSummary = aiSummary;
+        this.severity = severity;
+        this.domain = domain;
+        this.estimatedUrl = estimatedUrl;
+        this.aiRecommendedAction = aiRecommendedAction;
+        this.filtered = filtered;
+        this.updatedAt = updatedAt;
     }
 
     // 관리자가 AI 분류(도메인/심각도)를 보정한다.

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
@@ -137,6 +137,12 @@ public class Inquiry {
         this.updatedAt = repliedAt;
     }
 
+    // 사용자가 답변을 확인하면 로그인 첫 화면에 다시 노출하지 않는다.
+    public void hideReply(LocalDateTime updatedAt) {
+        this.replyVisible = false;
+        this.updatedAt = updatedAt;
+    }
+
     public Long getInquiryId() {
         return inquiryId;
     }

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/Inquiry.java
@@ -1,0 +1,211 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.inquiry.domain.exception.InquiryErrorCode;
+
+import java.time.LocalDateTime;
+
+// 사용자 문의와 AI 분석/관리자 처리 결과를 함께 갖는 도메인 모델
+public class Inquiry {
+
+    private final Long inquiryId;
+    private final Long userId;
+    private String title;
+    private final String content;
+    private InquiryStatus status;
+    private InquirySeverity severity;
+    private InquiryDomain domain;
+    private final String sourceUrl;
+    private String estimatedUrl;
+    private String adminReply;
+    private Long repliedBy;
+    private LocalDateTime repliedAt;
+    private String aiSummary;
+    private String aiRecommendedAction;
+    private boolean filtered;
+    private boolean replyVisible;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private Inquiry(
+            Long inquiryId,
+            Long userId,
+            String title,
+            String content,
+            InquiryStatus status,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String sourceUrl,
+            String estimatedUrl,
+            String adminReply,
+            Long repliedBy,
+            LocalDateTime repliedAt,
+            String aiSummary,
+            String aiRecommendedAction,
+            boolean filtered,
+            boolean replyVisible,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.inquiryId = inquiryId;
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.severity = severity;
+        this.domain = domain;
+        this.sourceUrl = sourceUrl;
+        this.estimatedUrl = estimatedUrl;
+        this.adminReply = adminReply;
+        this.repliedBy = repliedBy;
+        this.repliedAt = repliedAt;
+        this.aiSummary = aiSummary;
+        this.aiRecommendedAction = aiRecommendedAction;
+        this.filtered = filtered;
+        this.replyVisible = replyVisible;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // DB에서 조회한 값으로 도메인 모델을 복원한다.
+    public static Inquiry restore(
+            Long inquiryId,
+            Long userId,
+            String title,
+            String content,
+            InquiryStatus status,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String sourceUrl,
+            String estimatedUrl,
+            String adminReply,
+            Long repliedBy,
+            LocalDateTime repliedAt,
+            String aiSummary,
+            String aiRecommendedAction,
+            boolean filtered,
+            boolean replyVisible,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new Inquiry(
+                inquiryId,
+                userId,
+                title,
+                content,
+                status,
+                severity,
+                domain,
+                sourceUrl,
+                estimatedUrl,
+                adminReply,
+                repliedBy,
+                repliedAt,
+                aiSummary,
+                aiRecommendedAction,
+                filtered,
+                replyVisible,
+                createdAt,
+                updatedAt
+        );
+    }
+
+    // 관리자가 AI 분류(도메인/심각도)를 보정한다.
+    public void updateClassification(InquiryDomain domain, InquirySeverity severity, LocalDateTime updatedAt) {
+        this.domain = domain;
+        this.severity = severity;
+        this.updatedAt = updatedAt;
+    }
+
+    // 관리자가 필터링 처리 또는 복구를 수행한다.
+    public void updateFilter(boolean filtered, LocalDateTime updatedAt) {
+        this.filtered = filtered;
+        this.updatedAt = updatedAt;
+    }
+
+    // 관리자 답변을 등록하고 상태를 답변 완료로 변경한다.
+    public void reply(String content, Long adminId, LocalDateTime repliedAt) {
+        if (content == null || content.isBlank()) {
+            throw new ValidationException(InquiryErrorCode.INVALID_REPLY_REQUEST);
+        }
+
+        this.adminReply = content;
+        this.repliedBy = adminId;
+        this.repliedAt = repliedAt;
+        this.status = InquiryStatus.ANSWERED;
+        this.replyVisible = true;
+        this.updatedAt = repliedAt;
+    }
+
+    public Long getInquiryId() {
+        return inquiryId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public InquiryStatus getStatus() {
+        return status;
+    }
+
+    public InquirySeverity getSeverity() {
+        return severity;
+    }
+
+    public InquiryDomain getDomain() {
+        return domain;
+    }
+
+    public String getSourceUrl() {
+        return sourceUrl;
+    }
+
+    public String getEstimatedUrl() {
+        return estimatedUrl;
+    }
+
+    public String getAdminReply() {
+        return adminReply;
+    }
+
+    public Long getRepliedBy() {
+        return repliedBy;
+    }
+
+    public LocalDateTime getRepliedAt() {
+        return repliedAt;
+    }
+
+    public String getAiSummary() {
+        return aiSummary;
+    }
+
+    public String getAiRecommendedAction() {
+        return aiRecommendedAction;
+    }
+
+    public boolean isFiltered() {
+        return filtered;
+    }
+
+    public boolean isReplyVisible() {
+        return replyVisible;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryAiCorrection.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryAiCorrection.java
@@ -1,0 +1,131 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+import java.time.LocalDateTime;
+
+// AI 최초 분석값과 관리자 최종 보정값을 inquiry_id + field_name 기준으로 하나만 유지하는 도메인 모델
+public class InquiryAiCorrection {
+
+    private final Long correctionId;
+    private final Long inquiryId;
+    private Long adminId;
+    private final InquiryCorrectionField fieldName;
+    private final String aiValue;
+    private String correctedValue;
+    private String reason;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    private InquiryAiCorrection(
+            Long correctionId,
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.correctionId = correctionId;
+        this.inquiryId = inquiryId;
+        this.adminId = adminId;
+        this.fieldName = fieldName;
+        this.aiValue = aiValue;
+        this.correctedValue = correctedValue;
+        this.reason = reason;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // 해당 필드의 첫 보정을 생성한다.
+    public static InquiryAiCorrection create(
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime now
+    ) {
+        return new InquiryAiCorrection(
+                null,
+                inquiryId,
+                adminId,
+                fieldName,
+                aiValue,
+                correctedValue,
+                reason,
+                now,
+                now
+        );
+    }
+
+    // DB에서 조회한 값으로 도메인 모델을 복원한다.
+    public static InquiryAiCorrection restore(
+            Long correctionId,
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        return new InquiryAiCorrection(
+                correctionId,
+                inquiryId,
+                adminId,
+                fieldName,
+                aiValue,
+                correctedValue,
+                reason,
+                createdAt,
+                updatedAt
+        );
+    }
+
+    // 같은 필드의 재보정. ai_value는 최초값을 유지하고 최종 보정값만 갱신한다.
+    public void updateCorrection(String correctedValue, String reason, Long adminId, LocalDateTime updatedAt) {
+        this.correctedValue = correctedValue;
+        this.reason = reason;
+        this.adminId = adminId;
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getCorrectionId() {
+        return correctionId;
+    }
+
+    public Long getInquiryId() {
+        return inquiryId;
+    }
+
+    public Long getAdminId() {
+        return adminId;
+    }
+
+    public InquiryCorrectionField getFieldName() {
+        return fieldName;
+    }
+
+    public String getAiValue() {
+        return aiValue;
+    }
+
+    public String getCorrectedValue() {
+        return correctedValue;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryCorrectionField.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryCorrectionField.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+// 관리자가 AI 분석 결과를 보정할 수 있는 inquiry 컬럼
+@Getter
+@RequiredArgsConstructor
+public enum InquiryCorrectionField {
+
+    DOMAIN("domain"),
+    SEVERITY("severity"),
+    IS_FILTERED("is_filtered");
+
+    private final String fieldName;
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryDomain.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryDomain.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+// 문의가 속한 서비스 도메인
+public enum InquiryDomain {
+    ADMIN,
+    AUTH,
+    BADGE,
+    CHATBOT,
+    COURSE,
+    ENROLLMENT,
+    PROBLEMS,
+    RANKING,
+    RECOMMENDATION,
+    USER,
+    LECTURE,
+    LEARNING,
+    ETC;
+
+    // Swagger 문서용 값별 의미 설명. @Schema/@Parameter description에서 재사용한다.
+    public static final String SCHEMA_DESCRIPTION =
+            "문의 도메인 (ADMIN: 관리자/운영, AUTH: 로그인/인증, BADGE: 뱃지, CHATBOT: 챗봇, "
+                    + "COURSE: 강의, ENROLLMENT: 수강신청/수강관리, PROBLEMS: 문제/채점/제출, RANKING: 랭킹, "
+                    + "RECOMMENDATION: 추천, USER: 회원/프로필, LECTURE: 강의 영상/자료, LEARNING: 학습 진행, ETC: 기타)";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquirySeverity.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquirySeverity.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+// 문의 심각도
+public enum InquirySeverity {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL;
+
+    // Swagger 문서용 값별 의미 설명. @Schema/@Parameter description에서 재사용한다.
+    public static final String SCHEMA_DESCRIPTION =
+            "문의 심각도 (LOW: 단순 문의/제안, MEDIUM: 일반 오류/불편, "
+                    + "HIGH: 기능 사용에 큰 지장, CRITICAL: 로그인/결제/학습 진행 불가급)";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryStatus.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/model/InquiryStatus.java
@@ -1,0 +1,10 @@
+package com.wanted.codebombalms.inquiry.domain.model;
+
+// 문의 처리 상태
+public enum InquiryStatus {
+    OPEN,
+    ANSWERED;
+
+    // Swagger 문서용 값별 의미 설명. @Schema/@Parameter description에서 재사용한다.
+    public static final String SCHEMA_DESCRIPTION = "문의 처리 상태 (OPEN: 새 문의, ANSWERED: 답변 완료)";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
@@ -3,12 +3,16 @@ package com.wanted.codebombalms.inquiry.domain.repository;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InquiryAiCorrectionRepository {
 
     // inquiry_id + field_name 기준으로 마지막 보정 row를 조회한다.
     Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+
+    // AI 분석 컨텍스트로 전달할 최근 보정 사례를 최신순으로 최대 limit건 조회한다.
+    List<InquiryAiCorrection> findRecentCorrections(int limit);
 
     InquiryAiCorrection save(InquiryAiCorrection correction);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryAiCorrectionRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.inquiry.domain.repository;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+
+import java.util.Optional;
+
+public interface InquiryAiCorrectionRepository {
+
+    // inquiry_id + field_name 기준으로 마지막 보정 row를 조회한다.
+    Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+
+    InquiryAiCorrection save(InquiryAiCorrection correction);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
@@ -1,0 +1,12 @@
+package com.wanted.codebombalms.inquiry.domain.repository;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+import java.util.Optional;
+
+public interface InquiryRepository {
+
+    Optional<Inquiry> findById(Long inquiryId);
+
+    Inquiry save(Inquiry inquiry);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/domain/repository/InquiryRepository.java
@@ -8,5 +8,7 @@ public interface InquiryRepository {
 
     Optional<Inquiry> findById(Long inquiryId);
 
+    Optional<Inquiry> findByIdAndUserId(Long inquiryId, Long userId);
+
     Inquiry save(Inquiry inquiry);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
@@ -9,6 +9,7 @@ import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysi
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import io.netty.channel.ChannelOption;
+import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,22 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
     @Value("${fastapi.url}")
     private String fastApiBaseUrl;
 
+    private WebClient webClient;
+
+    // @Value 필드 주입이 끝난 뒤(생성자 호출 이후) 커넥션 풀을 가진 WebClient를 한 번만 만들어 재사용한다.
+    // 호출마다 새로 만들면 매번 새 커넥션 풀이 생겨 재사용이 안 되고 리소스가 낭비된다.
+    @PostConstruct
+    private void initWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
+
+        this.webClient = WebClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
     /** 문의 등록 요청 스레드를 막지 않도록 전용 executor에서 Python 분석 endpoint를 호출하고, 응답을 받으면 바로 문의에 반영합니다. */
     @Async("inquiryTaskExecutor")
     @Override
@@ -45,7 +62,7 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
         long startedAt = System.nanoTime();
 
         try {
-            PythonInquiryAnalysisResponse response = webClient().post()
+            PythonInquiryAnalysisResponse response = webClient.post()
                     .uri(properties.getAnalyzePath())
                     .bodyValue(toRequest(command))
                     .retrieve()
@@ -75,18 +92,6 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
                 command.content(),
                 command.correctionExamples().stream().map(PythonCorrectionExample::from).toList()
         );
-    }
-
-    /** 문의 기능이 다른 도메인의 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
-    private WebClient webClient() {
-        HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
-                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
-
-        return WebClient.builder()
-                .baseUrl(fastApiBaseUrl)
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .build();
     }
 
     /** Python 문의 분석 API에 전달하는 요청 본문. 단어 하나짜리 필드(content)는 어노테이션이 필요 없다. */

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.inquiry.infrastructure.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
 import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
 import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
@@ -19,7 +20,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
-/** 문의 원문을 Python AI 분석 endpoint로 비동기 전달하고, 응답을 받아 문의에 반영하는 client입니다. */
+/** 문의 원문을 Python AI 분석 endpoint로 비동기 전달하고, 응답을 받아 문의에 반영하는 client입니다.
+ *  chatbot(FastApiChatRequest)과 동일하게 필드별 {@code @JsonProperty}로 snake_case 계약을 맞춘다. */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -45,13 +47,7 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
         try {
             PythonInquiryAnalysisResponse response = webClient().post()
                     .uri(properties.getAnalyzePath())
-                    .bodyValue(new PythonInquiryAnalysisRequest(
-                            command.inquiryId(),
-                            command.userId(),
-                            command.sourceUrl(),
-                            command.content(),
-                            command.correctionExamples()
-                    ))
+                    .bodyValue(toRequest(command))
                     .retrieve()
                     .bodyToMono(PythonInquiryAnalysisResponse.class)
                     .block();
@@ -71,6 +67,16 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
         }
     }
 
+    private PythonInquiryAnalysisRequest toRequest(RequestInquiryAnalysisCommand command) {
+        return new PythonInquiryAnalysisRequest(
+                command.inquiryId(),
+                command.userId(),
+                command.sourceUrl(),
+                command.content(),
+                command.correctionExamples().stream().map(PythonCorrectionExample::from).toList()
+        );
+    }
+
     /** 문의 기능이 다른 도메인의 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
     private WebClient webClient() {
         HttpClient httpClient = HttpClient.create()
@@ -83,14 +89,31 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
                 .build();
     }
 
-    /** Python 문의 분석 API에 전달하는 요청 본문입니다. */
+    /** Python 문의 분석 API에 전달하는 요청 본문. 단어 하나짜리 필드(content)는 어노테이션이 필요 없다. */
     private record PythonInquiryAnalysisRequest(
-            Long inquiryId,
-            Long userId,
-            String sourceUrl,
+            @JsonProperty("inquiry_id") Long inquiryId,
+            @JsonProperty("user_id") Long userId,
+            @JsonProperty("source_url") String sourceUrl,
             String content,
-            List<CorrectionExample> correctionExamples
+            @JsonProperty("correction_examples") List<PythonCorrectionExample> correctionExamples
     ) {
+    }
+
+    /** 관리자 보정 사례 한 건. 애플리케이션 커맨드(CorrectionExample)가 JSON 표현을 몰라도 되도록 어댑터 전용 타입으로 매핑한다. */
+    private record PythonCorrectionExample(
+            @JsonProperty("field_name") String fieldName,
+            @JsonProperty("ai_value") String aiValue,
+            @JsonProperty("corrected_value") String correctedValue,
+            String reason
+    ) {
+        private static PythonCorrectionExample from(CorrectionExample example) {
+            return new PythonCorrectionExample(
+                    example.fieldName().name(),
+                    example.aiValue(),
+                    example.correctedValue(),
+                    example.reason()
+            );
+        }
     }
 
     /** Python 문의 분석 API의 응답 본문입니다. */
@@ -99,8 +122,8 @@ public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
             String summary,
             InquirySeverity severity,
             InquiryDomain domain,
-            String estimatedUrl,
-            String recommendedAction,
+            @JsonProperty("estimated_url") String estimatedUrl,
+            @JsonProperty("recommended_action") String recommendedAction,
             Boolean filtered
     ) {
 

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/FastApiInquiryAnalysisClient.java
@@ -1,0 +1,120 @@
+package com.wanted.codebombalms.inquiry.infrastructure.client;
+
+import com.wanted.codebombalms.inquiry.application.command.ApplyInquiryAiAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.command.CorrectionExample;
+import com.wanted.codebombalms.inquiry.application.command.RequestInquiryAnalysisCommand;
+import com.wanted.codebombalms.inquiry.application.port.InquiryAnalysisClient;
+import com.wanted.codebombalms.inquiry.application.usecase.ApplyInquiryAiAnalysisUseCase;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+/** 문의 원문을 Python AI 분석 endpoint로 비동기 전달하고, 응답을 받아 문의에 반영하는 client입니다. */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FastApiInquiryAnalysisClient implements InquiryAnalysisClient {
+
+    private final InquiryPythonProperties properties;
+    private final ApplyInquiryAiAnalysisUseCase applyInquiryAiAnalysisUseCase;
+
+    @Value("${fastapi.url}")
+    private String fastApiBaseUrl;
+
+    /** 문의 등록 요청 스레드를 막지 않도록 전용 executor에서 Python 분석 endpoint를 호출하고, 응답을 받으면 바로 문의에 반영합니다. */
+    @Async("inquiryTaskExecutor")
+    @Override
+    public void analyze(RequestInquiryAnalysisCommand command) {
+        if (!properties.isEnabled()) {
+            log.info("Python 문의 분석 호출이 비활성화되어 요청을 건너뜁니다. inquiryId={}", command.inquiryId());
+            return;
+        }
+
+        long startedAt = System.nanoTime();
+
+        try {
+            PythonInquiryAnalysisResponse response = webClient().post()
+                    .uri(properties.getAnalyzePath())
+                    .bodyValue(new PythonInquiryAnalysisRequest(
+                            command.inquiryId(),
+                            command.userId(),
+                            command.sourceUrl(),
+                            command.content(),
+                            command.correctionExamples()
+                    ))
+                    .retrieve()
+                    .bodyToMono(PythonInquiryAnalysisResponse.class)
+                    .block();
+
+            log.info("event=inquiry_ai_analysis_requested inquiryId={} correctionExampleCount={} durationMs={}",
+                    command.inquiryId(), command.correctionExamples().size(), (System.nanoTime() - startedAt) / 1_000_000);
+
+            if (response == null) {
+                log.warn("event=inquiry_ai_analysis_empty_response inquiryId={}", command.inquiryId());
+                return;
+            }
+
+            applyInquiryAiAnalysisUseCase.applyAiAnalysis(response.toCommand(command.inquiryId()));
+        } catch (RuntimeException exception) {
+            log.warn("event=inquiry_ai_analysis_failed inquiryId={} exceptionType={}",
+                    command.inquiryId(), exception.getClass().getSimpleName());
+        }
+    }
+
+    /** 문의 기능이 다른 도메인의 WebClient 설정에 의존하지 않도록 전용 client를 구성합니다. */
+    private WebClient webClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
+
+        return WebClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    /** Python 문의 분석 API에 전달하는 요청 본문입니다. */
+    private record PythonInquiryAnalysisRequest(
+            Long inquiryId,
+            Long userId,
+            String sourceUrl,
+            String content,
+            List<CorrectionExample> correctionExamples
+    ) {
+    }
+
+    /** Python 문의 분석 API의 응답 본문입니다. */
+    private record PythonInquiryAnalysisResponse(
+            String title,
+            String summary,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String estimatedUrl,
+            String recommendedAction,
+            Boolean filtered
+    ) {
+
+        private ApplyInquiryAiAnalysisCommand toCommand(Long inquiryId) {
+            return new ApplyInquiryAiAnalysisCommand(
+                    inquiryId,
+                    title,
+                    summary,
+                    severity,
+                    domain,
+                    estimatedUrl,
+                    recommendedAction,
+                    Boolean.TRUE.equals(filtered)
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/InquiryPythonProperties.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/client/InquiryPythonProperties.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.inquiry.infrastructure.client;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/** 문의 AI 분석 전용 Python FastAPI 호출 설정입니다. */
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "inquiry.python")
+public class InquiryPythonProperties {
+
+    private boolean enabled = true;
+
+    @NotBlank
+    private String analyzePath = "/internal/inquiries/analyze";
+
+    @Positive
+    private int connectTimeoutMs = 3000;
+
+    @Positive
+    private int readTimeoutMs = 10000;
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionJpaEntity.java
@@ -1,0 +1,95 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "inquiry_ai_correction",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_inquiry_ai_correction_field",
+                columnNames = {"inquiry_id", "field_name"}
+        )
+)
+@Getter
+@NoArgsConstructor
+public class InquiryAiCorrectionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "correction_id")
+    private Long correctionId;
+
+    @Column(name = "inquiry_id", nullable = false)
+    private Long inquiryId;
+
+    @Column(name = "admin_id", nullable = false)
+    private Long adminId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "field_name", nullable = false, length = 50)
+    private InquiryCorrectionField fieldName;
+
+    @Column(name = "ai_value", length = 500)
+    private String aiValue;
+
+    @Column(name = "corrected_value", nullable = false, length = 500)
+    private String correctedValue;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public InquiryAiCorrectionJpaEntity(
+            Long correctionId,
+            Long inquiryId,
+            Long adminId,
+            InquiryCorrectionField fieldName,
+            String aiValue,
+            String correctedValue,
+            String reason,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.correctionId = correctionId;
+        this.inquiryId = inquiryId;
+        this.adminId = adminId;
+        this.fieldName = fieldName;
+        this.aiValue = aiValue;
+        this.correctedValue = correctedValue;
+        this.reason = reason;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionMapper.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionMapper.java
@@ -1,0 +1,37 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+
+public class InquiryAiCorrectionMapper {
+
+    private InquiryAiCorrectionMapper() {
+    }
+
+    public static InquiryAiCorrection toDomain(InquiryAiCorrectionJpaEntity entity) {
+        return InquiryAiCorrection.restore(
+                entity.getCorrectionId(),
+                entity.getInquiryId(),
+                entity.getAdminId(),
+                entity.getFieldName(),
+                entity.getAiValue(),
+                entity.getCorrectedValue(),
+                entity.getReason(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+    public static InquiryAiCorrectionJpaEntity toEntity(InquiryAiCorrection domain) {
+        return new InquiryAiCorrectionJpaEntity(
+                domain.getCorrectionId(),
+                domain.getInquiryId(),
+                domain.getAdminId(),
+                domain.getFieldName(),
+                domain.getAiValue(),
+                domain.getCorrectedValue(),
+                domain.getReason(),
+                domain.getCreatedAt(),
+                domain.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
@@ -4,8 +4,10 @@ import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
 import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,6 +20,14 @@ public class InquiryAiCorrectionRepositoryAdapter implements InquiryAiCorrection
     public Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName) {
         return springDataRepository.findByInquiryIdAndFieldName(inquiryId, fieldName)
                 .map(InquiryAiCorrectionMapper::toDomain);
+    }
+
+    @Override
+    public List<InquiryAiCorrection> findRecentCorrections(int limit) {
+        return springDataRepository.findAllByOrderByUpdatedAtDesc(PageRequest.of(0, limit))
+                .stream()
+                .map(InquiryAiCorrectionMapper::toDomain)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryAiCorrection;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryAiCorrectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InquiryAiCorrectionRepositoryAdapter implements InquiryAiCorrectionRepository {
+
+    private final SpringDataInquiryAiCorrectionRepository springDataRepository;
+
+    @Override
+    public Optional<InquiryAiCorrection> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName) {
+        return springDataRepository.findByInquiryIdAndFieldName(inquiryId, fieldName)
+                .map(InquiryAiCorrectionMapper::toDomain);
+    }
+
+    @Override
+    public InquiryAiCorrection save(InquiryAiCorrection correction) {
+        InquiryAiCorrectionJpaEntity saved = springDataRepository.save(InquiryAiCorrectionMapper.toEntity(correction));
+
+        return InquiryAiCorrectionMapper.toDomain(saved);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryAiCorrectionRepositoryAdapter.java
@@ -24,7 +24,7 @@ public class InquiryAiCorrectionRepositoryAdapter implements InquiryAiCorrection
 
     @Override
     public List<InquiryAiCorrection> findRecentCorrections(int limit) {
-        return springDataRepository.findAllByOrderByUpdatedAtDesc(PageRequest.of(0, limit))
+        return springDataRepository.findAllByOrderByUpdatedAtDescCorrectionIdDesc(PageRequest.of(0, limit))
                 .stream()
                 .map(InquiryAiCorrectionMapper::toDomain)
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryJpaEntity.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryJpaEntity.java
@@ -1,0 +1,137 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "inquiry")
+@Getter
+@NoArgsConstructor
+public class InquiryJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "inquiry_id")
+    private Long inquiryId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private InquiryStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", nullable = false, length = 30)
+    private InquirySeverity severity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "domain", nullable = false, length = 50)
+    private InquiryDomain domain;
+
+    @Column(name = "source_url", length = 500)
+    private String sourceUrl;
+
+    @Column(name = "estimated_url", length = 500)
+    private String estimatedUrl;
+
+    @Column(name = "admin_reply", columnDefinition = "TEXT")
+    private String adminReply;
+
+    @Column(name = "replied_by")
+    private Long repliedBy;
+
+    @Column(name = "replied_at")
+    private LocalDateTime repliedAt;
+
+    @Column(name = "ai_summary", length = 500)
+    private String aiSummary;
+
+    @Column(name = "ai_recommended_action", columnDefinition = "TEXT")
+    private String aiRecommendedAction;
+
+    @Column(name = "is_filtered", nullable = false)
+    private boolean filtered;
+
+    @Column(name = "reply_visible", nullable = false)
+    private boolean replyVisible;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public InquiryJpaEntity(
+            Long inquiryId,
+            Long userId,
+            String title,
+            String content,
+            InquiryStatus status,
+            InquirySeverity severity,
+            InquiryDomain domain,
+            String sourceUrl,
+            String estimatedUrl,
+            String adminReply,
+            Long repliedBy,
+            LocalDateTime repliedAt,
+            String aiSummary,
+            String aiRecommendedAction,
+            boolean filtered,
+            boolean replyVisible,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.inquiryId = inquiryId;
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+        this.severity = severity;
+        this.domain = domain;
+        this.sourceUrl = sourceUrl;
+        this.estimatedUrl = estimatedUrl;
+        this.adminReply = adminReply;
+        this.repliedBy = repliedBy;
+        this.repliedAt = repliedAt;
+        this.aiSummary = aiSummary;
+        this.aiRecommendedAction = aiRecommendedAction;
+        this.filtered = filtered;
+        this.replyVisible = replyVisible;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryListProjection.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryListProjection.java
@@ -1,0 +1,20 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+import java.time.LocalDateTime;
+
+// 목록 조회에서 원문 없이 AI 요약 기준 컬럼만 뽑아오는 JPQL constructor projection
+public record InquiryListProjection(
+        Long inquiryId,
+        String title,
+        String aiSummary,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryMapper.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryMapper.java
@@ -1,0 +1,55 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+public class InquiryMapper {
+
+    private InquiryMapper() {
+    }
+
+    public static Inquiry toDomain(InquiryJpaEntity entity) {
+        return Inquiry.restore(
+                entity.getInquiryId(),
+                entity.getUserId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getStatus(),
+                entity.getSeverity(),
+                entity.getDomain(),
+                entity.getSourceUrl(),
+                entity.getEstimatedUrl(),
+                entity.getAdminReply(),
+                entity.getRepliedBy(),
+                entity.getRepliedAt(),
+                entity.getAiSummary(),
+                entity.getAiRecommendedAction(),
+                entity.isFiltered(),
+                entity.isReplyVisible(),
+                entity.getCreatedAt(),
+                entity.getUpdatedAt()
+        );
+    }
+
+    public static InquiryJpaEntity toEntity(Inquiry domain) {
+        return new InquiryJpaEntity(
+                domain.getInquiryId(),
+                domain.getUserId(),
+                domain.getTitle(),
+                domain.getContent(),
+                domain.getStatus(),
+                domain.getSeverity(),
+                domain.getDomain(),
+                domain.getSourceUrl(),
+                domain.getEstimatedUrl(),
+                domain.getAdminReply(),
+                domain.getRepliedBy(),
+                domain.getRepliedAt(),
+                domain.getAiSummary(),
+                domain.getAiRecommendedAction(),
+                domain.isFiltered(),
+                domain.isReplyVisible(),
+                domain.getCreatedAt(),
+                domain.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
@@ -1,0 +1,98 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+import com.wanted.codebombalms.inquiry.application.query.InquiryQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InquiryQueryAdapter implements InquiryQueryRepository {
+
+    private final SpringDataInquiryRepository springDataRepository;
+
+    @Override
+    // 최신 문의가 먼저 오도록 정렬해 관리자 목록을 페이지 조회한다.
+    public PageResult<AdminInquiryListItem> findAdminInquiries(GetAdminInquiriesQuery query) {
+        PageRequest pageRequest = PageRequest.of(
+                query.page(),
+                query.size(),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+                        .and(Sort.by(Sort.Direction.DESC, "inquiryId"))
+        );
+
+        Page<InquiryListProjection> result = springDataRepository.findAdminInquiries(
+                query.isFiltered(),
+                query.domain(),
+                query.severity(),
+                query.status(),
+                pageRequest
+        );
+
+        List<AdminInquiryListItem> content = result.getContent().stream()
+                .map(this::toListItem)
+                .toList();
+
+        return new PageResult<>(
+                content,
+                result.getNumber(),
+                result.getSize(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.isFirst(),
+                result.isLast(),
+                result.hasNext(),
+                result.hasPrevious()
+        );
+    }
+
+    @Override
+    // 조인이 필요 없는 단일 테이블 조회라 JPA 기본 findById 결과를 그대로 상세 응답으로 변환한다.
+    public Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId) {
+        return springDataRepository.findById(inquiryId)
+                .map(this::toDetail);
+    }
+
+    private AdminInquiryListItem toListItem(InquiryListProjection projection) {
+        return new AdminInquiryListItem(
+                projection.inquiryId(),
+                projection.title(),
+                projection.aiSummary(),
+                projection.domain(),
+                projection.severity(),
+                projection.status(),
+                projection.filtered(),
+                projection.createdAt()
+        );
+    }
+
+    private AdminInquiryDetail toDetail(InquiryJpaEntity entity) {
+        return new AdminInquiryDetail(
+                entity.getInquiryId(),
+                entity.getUserId(),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getSourceUrl(),
+                entity.getEstimatedUrl(),
+                entity.getAiSummary(),
+                entity.getAiRecommendedAction(),
+                entity.getDomain(),
+                entity.getSeverity(),
+                entity.getStatus(),
+                entity.isFiltered(),
+                entity.getAdminReply(),
+                entity.getRepliedBy(),
+                entity.getRepliedAt(),
+                entity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryQueryAdapter.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.inquiry.infrastructure.persistence;
 
 import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
 import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
 import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
 import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
@@ -60,6 +61,12 @@ public class InquiryQueryAdapter implements InquiryQueryRepository {
     public Optional<AdminInquiryDetail> findAdminInquiryDetail(Long inquiryId) {
         return springDataRepository.findById(inquiryId)
                 .map(this::toDetail);
+    }
+
+    @Override
+    // 로그인 첫 화면에 필요한 미확인 답변만 최신 답변순으로 조회한다.
+    public List<ActiveInquiryReply> findActiveRepliesByUserId(Long userId) {
+        return springDataRepository.findActiveRepliesByUserId(userId);
     }
 
     private AdminInquiryListItem toListItem(InquiryListProjection projection) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class InquiryRepositoryAdapter implements InquiryRepository {
+
+    private final SpringDataInquiryRepository springDataRepository;
+
+    @Override
+    public Optional<Inquiry> findById(Long inquiryId) {
+        return springDataRepository.findById(inquiryId)
+                .map(InquiryMapper::toDomain);
+    }
+
+    @Override
+    public Inquiry save(Inquiry inquiry) {
+        InquiryJpaEntity saved = springDataRepository.save(InquiryMapper.toEntity(inquiry));
+
+        return InquiryMapper.toDomain(saved);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/InquiryRepositoryAdapter.java
@@ -20,6 +20,12 @@ public class InquiryRepositoryAdapter implements InquiryRepository {
     }
 
     @Override
+    public Optional<Inquiry> findByIdAndUserId(Long inquiryId, Long userId) {
+        return springDataRepository.findByInquiryIdAndUserId(inquiryId, userId)
+                .map(InquiryMapper::toDomain);
+    }
+
+    @Override
     public Inquiry save(Inquiry inquiry) {
         InquiryJpaEntity saved = springDataRepository.save(InquiryMapper.toEntity(inquiry));
 

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
@@ -11,5 +11,6 @@ public interface SpringDataInquiryAiCorrectionRepository extends JpaRepository<I
 
     Optional<InquiryAiCorrectionJpaEntity> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
 
-    List<InquiryAiCorrectionJpaEntity> findAllByOrderByUpdatedAtDesc(Pageable pageable);
+    // updatedAt만으로는 동시각 row 간 순서가 안정적이지 않아, 고유 식별자(correctionId)를 2차 정렬 기준으로 둔다.
+    List<InquiryAiCorrectionJpaEntity> findAllByOrderByUpdatedAtDescCorrectionIdDesc(Pageable pageable);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
@@ -1,11 +1,15 @@
 package com.wanted.codebombalms.inquiry.infrastructure.persistence;
 
 import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpringDataInquiryAiCorrectionRepository extends JpaRepository<InquiryAiCorrectionJpaEntity, Long> {
 
     Optional<InquiryAiCorrectionJpaEntity> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+
+    List<InquiryAiCorrectionJpaEntity> findAllByOrderByUpdatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryAiCorrectionRepository.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryCorrectionField;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataInquiryAiCorrectionRepository extends JpaRepository<InquiryAiCorrectionJpaEntity, Long> {
+
+    Optional<InquiryAiCorrectionJpaEntity> findByInquiryIdAndFieldName(Long inquiryId, InquiryCorrectionField fieldName);
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.inquiry.infrastructure.persistence;
 
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
@@ -9,7 +10,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface SpringDataInquiryRepository extends JpaRepository<InquiryJpaEntity, Long> {
+
+    Optional<InquiryJpaEntity> findByInquiryIdAndUserId(Long inquiryId, Long userId);
 
     // isFiltered는 항상 조건으로 걸고, domain/severity/status는 값이 있을 때만 조건에 추가한다.
     @Query(
@@ -39,4 +45,16 @@ public interface SpringDataInquiryRepository extends JpaRepository<InquiryJpaEnt
             @Param("status") InquiryStatus status,
             Pageable pageable
     );
+
+    @Query("""
+            select new com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply(
+                i.inquiryId, i.title, i.content, i.adminReply, i.repliedAt
+            )
+            from InquiryJpaEntity i
+            where i.userId = :userId
+              and i.status = com.wanted.codebombalms.inquiry.domain.model.InquiryStatus.ANSWERED
+              and i.replyVisible = true
+            order by i.repliedAt desc, i.inquiryId desc
+            """)
+    List<ActiveInquiryReply> findActiveRepliesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/infrastructure/persistence/SpringDataInquiryRepository.java
@@ -1,0 +1,42 @@
+package com.wanted.codebombalms.inquiry.infrastructure.persistence;
+
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SpringDataInquiryRepository extends JpaRepository<InquiryJpaEntity, Long> {
+
+    // isFiltered는 항상 조건으로 걸고, domain/severity/status는 값이 있을 때만 조건에 추가한다.
+    @Query(
+            value = """
+                    select new com.wanted.codebombalms.inquiry.infrastructure.persistence.InquiryListProjection(
+                        i.inquiryId, i.title, i.aiSummary, i.domain, i.severity, i.status, i.filtered, i.createdAt
+                    )
+                    from InquiryJpaEntity i
+                    where i.filtered = :isFiltered
+                      and (:domain is null or i.domain = :domain)
+                      and (:severity is null or i.severity = :severity)
+                      and (:status is null or i.status = :status)
+                    """,
+            countQuery = """
+                    select count(i)
+                    from InquiryJpaEntity i
+                    where i.filtered = :isFiltered
+                      and (:domain is null or i.domain = :domain)
+                      and (:severity is null or i.severity = :severity)
+                      and (:status is null or i.status = :status)
+                    """
+    )
+    Page<InquiryListProjection> findAdminInquiries(
+            @Param("isFiltered") boolean isFiltered,
+            @Param("domain") InquiryDomain domain,
+            @Param("severity") InquirySeverity severity,
+            @Param("status") InquiryStatus status,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
@@ -1,0 +1,162 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.inquiry.application.query.GetAdminInquiriesQuery;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiriesUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.GetAdminInquiryDetailUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.ReplyInquiryUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryClassificationUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.UpdateInquiryFilterUseCase;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryClassificationUpdateRequest;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryFilterUpdateRequest;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryReplyRequest;
+import com.wanted.codebombalms.inquiry.presentation.api.response.AdminInquiryDetailResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.AdminInquiryListResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryClassificationUpdateResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryFilterUpdateResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryReplyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Admin - 문의", description = "관리자 문의 목록/상세 조회, 분류 수정, 필터링 처리, 답변 등록 API")
+@RestController
+@RequestMapping("/api/v1/admin/inquiries")
+@RequiredArgsConstructor
+public class AdminInquiryController {
+
+    private final GetAdminInquiriesUseCase getAdminInquiriesUseCase;
+    private final GetAdminInquiryDetailUseCase getAdminInquiryDetailUseCase;
+    private final UpdateInquiryClassificationUseCase updateInquiryClassificationUseCase;
+    private final UpdateInquiryFilterUseCase updateInquiryFilterUseCase;
+    private final ReplyInquiryUseCase replyInquiryUseCase;
+
+    // 문의 목록 조회 (isFiltered로 정상/필터링 목록 구분, domain/severity/status 칼럼 필터)
+    @Operation(summary = "관리자 문의 목록 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-001: 페이지 요청 값이 올바르지 않습니다.")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<AdminInquiryListResponse>> findInquiries(
+            @Parameter(description = "true면 AI가 필터링(스팸/무의미)한 목록, false면 정상 목록", example = "false")
+            @RequestParam(defaultValue = "false") boolean isFiltered,
+            @Parameter(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS")
+            @RequestParam(required = false) InquiryDomain domain,
+            @Parameter(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH")
+            @RequestParam(required = false) InquirySeverity severity,
+            @Parameter(description = InquiryStatus.SCHEMA_DESCRIPTION, example = "OPEN")
+            @RequestParam(required = false) InquiryStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        var result = getAdminInquiriesUseCase.getInquiries(
+                new GetAdminInquiriesQuery(isFiltered, domain, severity, status, page, size)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.RETRIEVED,
+                InquiryResponseMessage.RETRIEVED,
+                AdminInquiryListResponse.from(result)
+        ));
+    }
+
+    // 문의 상세 조회 (원문, AI 분석, 관리자 처리 결과 전체)
+    @Operation(summary = "관리자 문의 상세 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<ApiResponse<AdminInquiryDetailResponse>> findInquiryDetail(
+            @PathVariable Long inquiryId
+    ) {
+        var result = getAdminInquiryDetailUseCase.getInquiryDetail(inquiryId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.RETRIEVED,
+                InquiryResponseMessage.RETRIEVED,
+                AdminInquiryDetailResponse.from(result)
+        ));
+    }
+
+    // 문의 분류(도메인/심각도) 수정, reason 필수
+    @Operation(summary = "관리자 문의 분류 수정")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-003: 문의 분류 수정 요청이 올바르지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PatchMapping("/{inquiryId}/classification")
+    public ResponseEntity<ApiResponse<InquiryClassificationUpdateResponse>> updateInquiryClassification(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long adminId,
+            @RequestBody InquiryClassificationUpdateRequest request
+    ) {
+        var result = updateInquiryClassificationUseCase.updateClassification(
+                request.toCommand(inquiryId, adminId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.CLASSIFICATION_UPDATED,
+                InquiryResponseMessage.CLASSIFICATION_UPDATED,
+                InquiryClassificationUpdateResponse.from(result)
+        ));
+    }
+
+    // 문의 필터링 처리 또는 복구, reason 필수
+    @Operation(summary = "관리자 문의 필터링 처리/복구")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-004: 문의 필터링 처리 요청이 올바르지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PatchMapping("/{inquiryId}/filter")
+    public ResponseEntity<ApiResponse<InquiryFilterUpdateResponse>> updateInquiryFilter(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long adminId,
+            @RequestBody InquiryFilterUpdateRequest request
+    ) {
+        var result = updateInquiryFilterUseCase.updateFilter(
+                request.toCommand(inquiryId, adminId)
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.FILTER_UPDATED,
+                InquiryResponseMessage.FILTER_UPDATED,
+                InquiryFilterUpdateResponse.from(result)
+        ));
+    }
+
+    // 답변 등록, 상태(ANSWERED)/노출 여부/답변자/답변시각까지 한 트랜잭션에서 갱신
+    @Operation(summary = "관리자 문의 답변 등록")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "INQ-005: 문의 답변 등록 요청이 올바르지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PostMapping("/{inquiryId}/reply")
+    public ResponseEntity<ApiResponse<InquiryReplyResponse>> replyInquiry(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long adminId,
+            @RequestBody InquiryReplyRequest request
+    ) {
+        var result = replyInquiryUseCase.reply(
+                request.toCommand(inquiryId, adminId)
+        );
+
+        return ResponseEntity.status(201).body(ApiResponse.created(
+                InquiryResponseCode.REPLIED,
+                InquiryResponseMessage.REPLIED,
+                InquiryReplyResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/AdminInquiryController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -99,7 +100,7 @@ public class AdminInquiryController {
     public ResponseEntity<ApiResponse<InquiryClassificationUpdateResponse>> updateInquiryClassification(
             @PathVariable Long inquiryId,
             @AuthenticationPrincipal Long adminId,
-            @RequestBody InquiryClassificationUpdateRequest request
+            @Valid @RequestBody InquiryClassificationUpdateRequest request
     ) {
         var result = updateInquiryClassificationUseCase.updateClassification(
                 request.toCommand(inquiryId, adminId)
@@ -123,7 +124,7 @@ public class AdminInquiryController {
     public ResponseEntity<ApiResponse<InquiryFilterUpdateResponse>> updateInquiryFilter(
             @PathVariable Long inquiryId,
             @AuthenticationPrincipal Long adminId,
-            @RequestBody InquiryFilterUpdateRequest request
+            @Valid @RequestBody InquiryFilterUpdateRequest request
     ) {
         var result = updateInquiryFilterUseCase.updateFilter(
                 request.toCommand(inquiryId, adminId)
@@ -147,7 +148,7 @@ public class AdminInquiryController {
     public ResponseEntity<ApiResponse<InquiryReplyResponse>> replyInquiry(
             @PathVariable Long inquiryId,
             @AuthenticationPrincipal Long adminId,
-            @RequestBody InquiryReplyRequest request
+            @Valid @RequestBody InquiryReplyRequest request
     ) {
         var result = replyInquiryUseCase.reply(
                 request.toCommand(inquiryId, adminId)

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
@@ -1,0 +1,78 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.inquiry.application.usecase.GetActiveInquiryRepliesUseCase;
+import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
+import com.wanted.codebombalms.inquiry.presentation.api.response.ActiveInquiryReplyListResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryReplyVisibilityResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Inquiry - 사용자 문의", description = "로그인 사용자의 문의 답변 조회/노출 상태 변경 API")
+@RestController
+@RequestMapping("/api/v1/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final GetActiveInquiryRepliesUseCase getActiveInquiryRepliesUseCase;
+    private final HideInquiryReplyUseCase hideInquiryReplyUseCase;
+
+    @Operation(summary = "내 미확인 문의 답변 조회", description = "로그인 첫 화면에서 모달로 노출할 답변 확인 전 문의 답변 목록을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016: 인증이 필요합니다.")
+    })
+    @GetMapping("/me/replies/active")
+    public ResponseEntity<ApiResponse<ActiveInquiryReplyListResponse>> findActiveReplies(
+            @AuthenticationPrincipal Long userId
+    ) {
+        validateAuthenticated(userId);
+
+        var result = getActiveInquiryRepliesUseCase.getActiveReplies(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.ACTIVE_REPLIES_RETRIEVED,
+                InquiryResponseMessage.ACTIVE_REPLIES_RETRIEVED,
+                ActiveInquiryReplyListResponse.from(result)
+        ));
+    }
+
+    @Operation(summary = "문의 답변 비노출 처리", description = "사용자가 답변 모달을 닫으면 해당 문의 답변을 로그인 첫 화면에서 다시 노출하지 않습니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016: 인증이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "INQ-002: 문의를 찾을 수 없습니다.")
+    })
+    @PatchMapping("/{inquiryId}/reply-visibility")
+    public ResponseEntity<ApiResponse<InquiryReplyVisibilityResponse>> hideReply(
+            @PathVariable Long inquiryId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        validateAuthenticated(userId);
+
+        var result = hideInquiryReplyUseCase.hideReply(inquiryId, userId);
+
+        return ResponseEntity.ok(ApiResponse.success(
+                InquiryResponseCode.REPLY_VISIBILITY_UPDATED,
+                InquiryResponseMessage.REPLY_VISIBILITY_UPDATED,
+                InquiryReplyVisibilityResponse.from(result)
+        ));
+    }
+
+    private void validateAuthenticated(Long userId) {
+        if (userId == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryController.java
@@ -3,30 +3,58 @@ package com.wanted.codebombalms.inquiry.presentation.api;
 import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
 import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.inquiry.application.usecase.CreateInquiryUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.GetActiveInquiryRepliesUseCase;
 import com.wanted.codebombalms.inquiry.application.usecase.HideInquiryReplyUseCase;
+import com.wanted.codebombalms.inquiry.presentation.api.request.InquiryCreateRequest;
 import com.wanted.codebombalms.inquiry.presentation.api.response.ActiveInquiryReplyListResponse;
+import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryCreateResponse;
 import com.wanted.codebombalms.inquiry.presentation.api.response.InquiryReplyVisibilityResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Inquiry - 사용자 문의", description = "로그인 사용자의 문의 답변 조회/노출 상태 변경 API")
+@Tag(name = "Inquiry - 사용자 문의", description = "로그인 사용자의 문의 등록/답변 조회/노출 상태 변경 API")
 @RestController
 @RequestMapping("/api/v1/inquiries")
 @RequiredArgsConstructor
 public class InquiryController {
 
+    private final CreateInquiryUseCase createInquiryUseCase;
     private final GetActiveInquiryRepliesUseCase getActiveInquiryRepliesUseCase;
     private final HideInquiryReplyUseCase hideInquiryReplyUseCase;
+
+    @Operation(summary = "문의 등록", description = "자연어 문의를 등록합니다. 등록 즉시 응답하며, AI 분석은 내부적으로 비동기 처리됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016: 인증이 필요합니다.")
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<InquiryCreateResponse>> createInquiry(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody InquiryCreateRequest request
+    ) {
+        validateAuthenticated(userId);
+
+        var result = createInquiryUseCase.create(request.toCommand(userId));
+
+        return ResponseEntity.status(201).body(ApiResponse.created(
+                InquiryResponseCode.CREATED,
+                InquiryResponseMessage.CREATED,
+                InquiryCreateResponse.from(result)
+        ));
+    }
 
     @Operation(summary = "내 미확인 문의 답변 조회", description = "로그인 첫 화면에서 모달로 노출할 답변 확인 전 문의 답변 목록을 조회합니다.")
     @ApiResponses({

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
@@ -10,4 +10,5 @@ public class InquiryResponseCode {
     public static final String REPLIED                  = "ADMIN_INQUIRY-REPLIED";
     public static final String ACTIVE_REPLIES_RETRIEVED = "INQUIRY-ACTIVE_REPLIES_RETRIEVED";
     public static final String REPLY_VISIBILITY_UPDATED = "INQUIRY-REPLY_VISIBILITY_UPDATED";
+    public static final String CREATED                  = "INQUIRY-CREATED";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+public class InquiryResponseCode {
+
+    private InquiryResponseCode() {}
+
+    public static final String RETRIEVED               = "ADMIN_INQUIRY-RETRIEVED";
+    public static final String CLASSIFICATION_UPDATED   = "ADMIN_INQUIRY-CLASSIFICATION_UPDATED";
+    public static final String FILTER_UPDATED           = "ADMIN_INQUIRY-FILTER_UPDATED";
+    public static final String REPLIED                  = "ADMIN_INQUIRY-REPLIED";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseCode.java
@@ -8,4 +8,6 @@ public class InquiryResponseCode {
     public static final String CLASSIFICATION_UPDATED   = "ADMIN_INQUIRY-CLASSIFICATION_UPDATED";
     public static final String FILTER_UPDATED           = "ADMIN_INQUIRY-FILTER_UPDATED";
     public static final String REPLIED                  = "ADMIN_INQUIRY-REPLIED";
+    public static final String ACTIVE_REPLIES_RETRIEVED = "INQUIRY-ACTIVE_REPLIES_RETRIEVED";
+    public static final String REPLY_VISIBILITY_UPDATED = "INQUIRY-REPLY_VISIBILITY_UPDATED";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
@@ -10,4 +10,5 @@ public class InquiryResponseMessage {
     public static final String REPLIED                  = "문의 답변이 등록되었습니다.";
     public static final String ACTIVE_REPLIES_RETRIEVED = "미확인 문의 답변을 조회했습니다.";
     public static final String REPLY_VISIBILITY_UPDATED = "문의 답변 노출 상태가 변경되었습니다.";
+    public static final String CREATED                  = "문의가 접수되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
@@ -8,4 +8,6 @@ public class InquiryResponseMessage {
     public static final String CLASSIFICATION_UPDATED   = "문의 분류가 수정되었습니다.";
     public static final String FILTER_UPDATED           = "문의 필터링 상태가 변경되었습니다.";
     public static final String REPLIED                  = "문의 답변이 등록되었습니다.";
+    public static final String ACTIVE_REPLIES_RETRIEVED = "미확인 문의 답변을 조회했습니다.";
+    public static final String REPLY_VISIBILITY_UPDATED = "문의 답변 노출 상태가 변경되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/InquiryResponseMessage.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.inquiry.presentation.api;
+
+public class InquiryResponseMessage {
+
+    private InquiryResponseMessage() {}
+
+    public static final String RETRIEVED               = "문의 조회에 성공했습니다.";
+    public static final String CLASSIFICATION_UPDATED   = "문의 분류가 수정되었습니다.";
+    public static final String FILTER_UPDATED           = "문의 필터링 상태가 변경되었습니다.";
+    public static final String REPLIED                  = "문의 답변이 등록되었습니다.";
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
@@ -4,22 +4,24 @@ import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassifi
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
-@Getter
-@NoArgsConstructor
 // 관리자 문의 분류(도메인/심각도) 수정 요청을 받는다.
-public class InquiryClassificationUpdateRequest {
+public record InquiryClassificationUpdateRequest(
 
-    @Schema(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS")
-    private InquiryDomain domain;
+        @Schema(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "도메인은 필수입니다.")
+        InquiryDomain domain,
 
-    @Schema(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH")
-    private InquirySeverity severity;
+        @Schema(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "심각도는 필수입니다.")
+        InquirySeverity severity,
 
-    @Schema(description = "분류 수정 사유 (필수)", example = "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함")
-    private String reason;
+        @Schema(description = "분류 수정 사유 (필수)", example = "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "수정 사유는 필수입니다.")
+        String reason
+) {
 
     // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
     public UpdateInquiryClassificationCommand toCommand(Long inquiryId, Long adminId) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryClassificationUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryClassificationCommand;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 관리자 문의 분류(도메인/심각도) 수정 요청을 받는다.
+public class InquiryClassificationUpdateRequest {
+
+    @Schema(description = InquiryDomain.SCHEMA_DESCRIPTION, example = "PROBLEMS")
+    private InquiryDomain domain;
+
+    @Schema(description = InquirySeverity.SCHEMA_DESCRIPTION, example = "HIGH")
+    private InquirySeverity severity;
+
+    @Schema(description = "분류 수정 사유 (필수)", example = "문제 제출 결과 미노출은 강의가 아니라 문제 도메인 이슈로 봐야 함")
+    private String reason;
+
+    // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
+    public UpdateInquiryClassificationCommand toCommand(Long inquiryId, Long adminId) {
+        return new UpdateInquiryClassificationCommand(inquiryId, adminId, domain, severity, reason);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryCreateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryCreateRequest.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.CreateInquiryCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+// 사용자 문의 등록 요청을 받는다.
+public record InquiryCreateRequest(
+
+        @Schema(description = "문의 원문", example = "문제 제출했는데 계속 로딩만 되고 결과가 안 나와요.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "문의 내용은 필수입니다.")
+        String content,
+
+        @Schema(description = "문의를 작성한 프론트 페이지 경로", example = "/user/problems/123")
+        @Size(max = 500, message = "sourceUrl은 500자를 넘을 수 없습니다.")
+        String sourceUrl
+) {
+
+    // 인증된 사용자 ID를 더해 command로 변환한다.
+    public CreateInquiryCommand toCommand(Long userId) {
+        return new CreateInquiryCommand(userId, content, sourceUrl);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
@@ -2,19 +2,20 @@ package com.wanted.codebombalms.inquiry.presentation.api.request;
 
 import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
-@Getter
-@NoArgsConstructor
 // 관리자 문의 필터링 처리/복구 요청을 받는다.
-public class InquiryFilterUpdateRequest {
+public record InquiryFilterUpdateRequest(
 
-    @Schema(description = "true면 필터링(스팸/무의미) 처리, false면 정상 목록으로 복구", example = "false")
-    private Boolean filtered;
+        @Schema(description = "true면 필터링(스팸/무의미) 처리, false면 정상 목록으로 복구", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "필터링 여부는 필수입니다.")
+        Boolean filtered,
 
-    @Schema(description = "필터링 처리/복구 사유 (필수)", example = "AI는 무의미 문의로 판단했지만 실제 문제 제출 오류 문의로 확인됨")
-    private String reason;
+        @Schema(description = "필터링 처리/복구 사유 (필수)", example = "AI는 무의미 문의로 판단했지만 실제 문제 제출 오류 문의로 확인됨", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "처리 사유는 필수입니다.")
+        String reason
+) {
 
     // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
     public UpdateInquiryFilterCommand toCommand(Long inquiryId, Long adminId) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryFilterUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.UpdateInquiryFilterCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 관리자 문의 필터링 처리/복구 요청을 받는다.
+public class InquiryFilterUpdateRequest {
+
+    @Schema(description = "true면 필터링(스팸/무의미) 처리, false면 정상 목록으로 복구", example = "false")
+    private Boolean filtered;
+
+    @Schema(description = "필터링 처리/복구 사유 (필수)", example = "AI는 무의미 문의로 판단했지만 실제 문제 제출 오류 문의로 확인됨")
+    private String reason;
+
+    // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
+    public UpdateInquiryFilterCommand toCommand(Long inquiryId, Long adminId) {
+        return new UpdateInquiryFilterCommand(inquiryId, adminId, filtered, reason);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.inquiry.presentation.api.request;
+
+import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 관리자 문의 답변 등록 요청을 받는다.
+public class InquiryReplyRequest {
+
+    private String content;
+
+    // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
+    public ReplyInquiryCommand toCommand(Long inquiryId, Long adminId) {
+        return new ReplyInquiryCommand(inquiryId, adminId, content);
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/request/InquiryReplyRequest.java
@@ -1,15 +1,16 @@
 package com.wanted.codebombalms.inquiry.presentation.api.request;
 
 import com.wanted.codebombalms.inquiry.application.command.ReplyInquiryCommand;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
-@Getter
-@NoArgsConstructor
 // 관리자 문의 답변 등록 요청을 받는다.
-public class InquiryReplyRequest {
+public record InquiryReplyRequest(
 
-    private String content;
+        @Schema(description = "답변 내용", example = "문의 주신 문제 제출 오류를 확인했고 수정 반영했습니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "답변 내용은 필수입니다.")
+        String content
+) {
 
     // path variable의 문의 ID와 인증된 관리자 ID를 더해 command로 변환한다.
     public ReplyInquiryCommand toCommand(Long inquiryId, Long adminId) {

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyListResponse.java
@@ -1,0 +1,19 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+
+import java.util.List;
+
+// 미확인 답변이 없으면 replies는 빈 배열로 응답한다.
+public record ActiveInquiryReplyListResponse(
+        List<ActiveInquiryReplyResponse> replies
+) {
+
+    public static ActiveInquiryReplyListResponse from(List<ActiveInquiryReply> replies) {
+        return new ActiveInquiryReplyListResponse(
+                replies.stream()
+                        .map(ActiveInquiryReplyResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/ActiveInquiryReplyResponse.java
@@ -1,0 +1,25 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.ActiveInquiryReply;
+
+import java.time.LocalDateTime;
+
+// 로그인 첫 화면에서 모달로 보여줄 문의 답변 한 건
+public record ActiveInquiryReplyResponse(
+        Long inquiryId,
+        String title,
+        String content,
+        String adminReply,
+        LocalDateTime repliedAt
+) {
+
+    public static ActiveInquiryReplyResponse from(ActiveInquiryReply reply) {
+        return new ActiveInquiryReplyResponse(
+                reply.inquiryId(),
+                reply.title(),
+                reply.content(),
+                reply.adminReply(),
+                reply.repliedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
@@ -4,34 +4,28 @@ import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 문의 원문과 AI 분석, 관리자 처리 결과 전체를 응답에 담는다.
-public class AdminInquiryDetailResponse {
-
-    private Long inquiryId;
-    private Long userId;
-    private String title;
-    private String content;
-    private String sourceUrl;
-    private String estimatedUrl;
-    private String summary;
-    private String recommendedAction;
-    private InquiryDomain domain;
-    private InquirySeverity severity;
-    private InquiryStatus status;
-    private boolean filtered;
-    private String adminReply;
-    private Long repliedBy;
-    private LocalDateTime repliedAt;
-    private LocalDateTime createdAt;
+public record AdminInquiryDetailResponse(
+        Long inquiryId,
+        Long userId,
+        String title,
+        String content,
+        String sourceUrl,
+        String estimatedUrl,
+        String summary,
+        String recommendedAction,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        String adminReply,
+        Long repliedBy,
+        LocalDateTime repliedAt,
+        LocalDateTime createdAt
+) {
 
     public static AdminInquiryDetailResponse from(AdminInquiryDetail detail) {
         return new AdminInquiryDetailResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryDetailResponse.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryDetail;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 문의 원문과 AI 분석, 관리자 처리 결과 전체를 응답에 담는다.
+public class AdminInquiryDetailResponse {
+
+    private Long inquiryId;
+    private Long userId;
+    private String title;
+    private String content;
+    private String sourceUrl;
+    private String estimatedUrl;
+    private String summary;
+    private String recommendedAction;
+    private InquiryDomain domain;
+    private InquirySeverity severity;
+    private InquiryStatus status;
+    private boolean filtered;
+    private String adminReply;
+    private Long repliedBy;
+    private LocalDateTime repliedAt;
+    private LocalDateTime createdAt;
+
+    public static AdminInquiryDetailResponse from(AdminInquiryDetail detail) {
+        return new AdminInquiryDetailResponse(
+                detail.inquiryId(),
+                detail.userId(),
+                detail.title(),
+                detail.content(),
+                detail.sourceUrl(),
+                detail.estimatedUrl(),
+                detail.summary(),
+                detail.recommendedAction(),
+                detail.domain(),
+                detail.severity(),
+                detail.status(),
+                detail.filtered(),
+                detail.adminReply(),
+                detail.repliedBy(),
+                detail.repliedAt(),
+                detail.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
@@ -2,26 +2,20 @@ package com.wanted.codebombalms.inquiry.presentation.api.response;
 
 import com.wanted.codebombalms.admin.operation.common.application.PageResult;
 import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class AdminInquiryListResponse {
-
-    private List<AdminInquiryResponse> content;
-    private int page;
-    private int size;
-    private long totalElements;
-    private int totalPages;
-    private boolean first;
-    private boolean last;
-    private boolean hasNext;
-    private boolean hasPrevious;
+public record AdminInquiryListResponse(
+        List<AdminInquiryResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last,
+        boolean hasNext,
+        boolean hasPrevious
+) {
 
     public static AdminInquiryListResponse from(PageResult<AdminInquiryListItem> pageResult) {
         return new AdminInquiryListResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryListResponse.java
@@ -1,0 +1,41 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.admin.operation.common.application.PageResult;
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminInquiryListResponse {
+
+    private List<AdminInquiryResponse> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean first;
+    private boolean last;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    public static AdminInquiryListResponse from(PageResult<AdminInquiryListItem> pageResult) {
+        return new AdminInquiryListResponse(
+                pageResult.getContent().stream()
+                        .map(AdminInquiryResponse::from)
+                        .toList(),
+                pageResult.getPage(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                pageResult.isFirst(),
+                pageResult.isLast(),
+                pageResult.hasNext(),
+                pageResult.hasPrevious()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
@@ -1,0 +1,40 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 목록 한 행을 AI 요약 기준으로만 응답에 담는다.
+public class AdminInquiryResponse {
+
+    private Long inquiryId;
+    private String title;
+    private String summary;
+    private InquiryDomain domain;
+    private InquirySeverity severity;
+    private InquiryStatus status;
+    private boolean filtered;
+    private LocalDateTime createdAt;
+
+    public static AdminInquiryResponse from(AdminInquiryListItem item) {
+        return new AdminInquiryResponse(
+                item.inquiryId(),
+                item.title(),
+                item.summary(),
+                item.domain(),
+                item.severity(),
+                item.status(),
+                item.filtered(),
+                item.createdAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/AdminInquiryResponse.java
@@ -4,26 +4,20 @@ import com.wanted.codebombalms.inquiry.application.query.AdminInquiryListItem;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 목록 한 행을 AI 요약 기준으로만 응답에 담는다.
-public class AdminInquiryResponse {
-
-    private Long inquiryId;
-    private String title;
-    private String summary;
-    private InquiryDomain domain;
-    private InquirySeverity severity;
-    private InquiryStatus status;
-    private boolean filtered;
-    private LocalDateTime createdAt;
+public record AdminInquiryResponse(
+        Long inquiryId,
+        String title,
+        String summary,
+        InquiryDomain domain,
+        InquirySeverity severity,
+        InquiryStatus status,
+        boolean filtered,
+        LocalDateTime createdAt
+) {
 
     public static AdminInquiryResponse from(AdminInquiryListItem item) {
         return new AdminInquiryResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
@@ -3,19 +3,13 @@ package com.wanted.codebombalms.inquiry.presentation.api.response;
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
 import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 분류 수정 결과로 바뀐 도메인/심각도만 응답에 담는다.
-public class InquiryClassificationUpdateResponse {
-
-    private Long inquiryId;
-    private InquiryDomain domain;
-    private InquirySeverity severity;
+public record InquiryClassificationUpdateResponse(
+        Long inquiryId,
+        InquiryDomain domain,
+        InquirySeverity severity
+) {
 
     public static InquiryClassificationUpdateResponse from(Inquiry inquiry) {
         return new InquiryClassificationUpdateResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryClassificationUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryDomain;
+import com.wanted.codebombalms.inquiry.domain.model.InquirySeverity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 분류 수정 결과로 바뀐 도메인/심각도만 응답에 담는다.
+public class InquiryClassificationUpdateResponse {
+
+    private Long inquiryId;
+    private InquiryDomain domain;
+    private InquirySeverity severity;
+
+    public static InquiryClassificationUpdateResponse from(Inquiry inquiry) {
+        return new InquiryClassificationUpdateResponse(
+                inquiry.getInquiryId(),
+                inquiry.getDomain(),
+                inquiry.getSeverity()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryCreateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryCreateResponse.java
@@ -1,0 +1,18 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+
+// 문의 등록 결과. AI 분석은 비동기로 진행되므로 등록 시점 상태만 내려준다.
+public record InquiryCreateResponse(
+        Long inquiryId,
+        InquiryStatus status
+) {
+
+    public static InquiryCreateResponse from(Inquiry inquiry) {
+        return new InquiryCreateResponse(
+                inquiry.getInquiryId(),
+                inquiry.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
@@ -1,18 +1,12 @@
 package com.wanted.codebombalms.inquiry.presentation.api.response;
 
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 필터링 처리/복구 결과로 바뀐 상태만 응답에 담는다.
-public class InquiryFilterUpdateResponse {
-
-    private Long inquiryId;
-    private boolean filtered;
+public record InquiryFilterUpdateResponse(
+        Long inquiryId,
+        boolean filtered
+) {
 
     public static InquiryFilterUpdateResponse from(Inquiry inquiry) {
         return new InquiryFilterUpdateResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryFilterUpdateResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 필터링 처리/복구 결과로 바뀐 상태만 응답에 담는다.
+public class InquiryFilterUpdateResponse {
+
+    private Long inquiryId;
+    private boolean filtered;
+
+    public static InquiryFilterUpdateResponse from(Inquiry inquiry) {
+        return new InquiryFilterUpdateResponse(
+                inquiry.getInquiryId(),
+                inquiry.isFiltered()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
@@ -2,23 +2,17 @@ package com.wanted.codebombalms.inquiry.presentation.api.response;
 
 import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
 import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 // 답변 등록 결과로 바뀐 상태와 답변 내용을 응답에 담는다.
-public class InquiryReplyResponse {
-
-    private Long inquiryId;
-    private InquiryStatus status;
-    private String adminReply;
-    private Long repliedBy;
-    private LocalDateTime repliedAt;
+public record InquiryReplyResponse(
+        Long inquiryId,
+        InquiryStatus status,
+        String adminReply,
+        Long repliedBy,
+        LocalDateTime repliedAt
+) {
 
     public static InquiryReplyResponse from(Inquiry inquiry) {
         return new InquiryReplyResponse(

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyResponse.java
@@ -1,0 +1,32 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+import com.wanted.codebombalms.inquiry.domain.model.InquiryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+// 답변 등록 결과로 바뀐 상태와 답변 내용을 응답에 담는다.
+public class InquiryReplyResponse {
+
+    private Long inquiryId;
+    private InquiryStatus status;
+    private String adminReply;
+    private Long repliedBy;
+    private LocalDateTime repliedAt;
+
+    public static InquiryReplyResponse from(Inquiry inquiry) {
+        return new InquiryReplyResponse(
+                inquiry.getInquiryId(),
+                inquiry.getStatus(),
+                inquiry.getAdminReply(),
+                inquiry.getRepliedBy(),
+                inquiry.getRepliedAt()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyVisibilityResponse.java
+++ b/src/main/java/com/wanted/codebombalms/inquiry/presentation/api/response/InquiryReplyVisibilityResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.inquiry.presentation.api.response;
+
+import com.wanted.codebombalms.inquiry.domain.model.Inquiry;
+
+// 답변 확인 후 노출 상태 변경 결과
+public record InquiryReplyVisibilityResponse(
+        Long inquiryId,
+        boolean replyVisible
+) {
+
+    public static InquiryReplyVisibilityResponse from(Inquiry inquiry) {
+        return new InquiryReplyVisibilityResponse(
+                inquiry.getInquiryId(),
+                inquiry.isReplyVisible()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/README.md
+++ b/src/main/java/com/wanted/codebombalms/learning/README.md
@@ -10,6 +10,7 @@
 - 문제 제출을 학습 흐름에서 처리한다.
 - 강좌별, 사용자별, 강의별 학습 진행률을 집계한다.
 - 학습 진행률 요약과 문제 통계를 제공한다.
+- 강좌 완료 시 MAIN 풀이·해설 기록을 조립해 Python AI 문제세트 추천을 요청한다.
 
 ## 패키지 구조
 
@@ -29,6 +30,7 @@ learning
 │   ├── lecture
 │   ├── persistence
 │   ├── problem
+│   ├── client
 │   └── user
 └── presentation
     └── api          # LearningController, request/response DTO
@@ -53,6 +55,7 @@ learning
 | `LectureProblemProgressService` | 강의 문제 진행률 기록/조회 |
 | `LectureProblemSetService` | 강의 문제 세트 상세 조회와 제출 흐름 |
 | `AdminLearningProgressQueryService` | 관리자용 학습 진행률 집계 조회 |
+| `FinalProblemSetRankingService` | MAIN 학습 지표·강좌 문맥 조립과 Python 추천 요청 |
 
 ## API 목록
 
@@ -82,4 +85,13 @@ learning
 | `submission` | 문제 제출 결과와 풀이 상태 반영 |
 | `enrollment` | 수강 중인 사용자/강좌 기준 검증 |
 | `user` | 사용자별 학습 진행률 집계 |
+
+## 강좌 완료 AI 문제세트 추천
+
+- 기존 `GET /api/v1/lectures/{lectureId}/final-problem-set-candidates`의 마지막 강의·완료 조건은 lecture 도메인이 유지한다.
+- learning 도메인은 MAIN 문제의 정답 제출, 해설 조회, 제출 횟수, 최신 테스트 통과율을 집계한다.
+- 직접 풀이는 정답 제출이 있고 해설 조회 이력이 없는 문제로 계산한다.
+- MAIN 문제가 없거나 운영자 미리보기이면 개인 학습 지표를 모두 0으로 전달한다.
+- Python은 같은 문제 카테고리에서 MAIN 문제세트를 제외하고 최대 2개를 점수순으로 반환한다.
+- Python 호출이 실패하거나 응답이 잘못되면 기존 ID순 후보 조회로 복구한다.
 

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningLecture.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningLecture.java
@@ -2,6 +2,11 @@ package com.wanted.codebombalms.learning.application.port;
 
 public record LearningLecture(
         Long lectureId,
-        String title
+        String title,
+        String description
 ) {
+
+    public LearningLecture(Long lectureId, String title) {
+        this(lectureId, title, null);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
@@ -1,0 +1,70 @@
+package com.wanted.codebombalms.learning.application.port;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/** Python FastAPI의 강좌 완료 문제세트 추천을 호출하는 출력 포트입니다. */
+public interface LearningRecommendationClient {
+
+    LearningRecommendationResult rankFinalProblemSets(LearningRecommendationRequest request);
+
+    record LearningRecommendationRequest(
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            List<Long> excludedProblemSetIds,
+            int recommendationCount,
+            LearningProfile learningProfile,
+            LearningContext learningContext
+    ) {
+    }
+
+    record LearningProfile(
+            int totalMainProblemCount,
+            int correctProblemCount,
+            double directSolveRate,
+            int explanationViewCount,
+            double explanationViewRate,
+            double averageAttemptCount,
+            double averageTestPassRate
+    ) {
+
+        public static LearningProfile empty() {
+            return new LearningProfile(0, 0, 0.0, 0, 0.0, 0.0, 0.0);
+        }
+    }
+
+    record LearningContext(
+            String courseTitle,
+            String courseDescription,
+            List<LectureContext> lectures
+    ) {
+    }
+
+    record LectureContext(
+            String title,
+            String description
+    ) {
+    }
+
+    record LearningRecommendationResult(
+            String algorithm,
+            List<RankedProblemSet> recommendations
+    ) {
+    }
+
+    record RankedProblemSet(
+            Long problemSetId,
+            BigDecimal score,
+            ReasonCode reasonCode,
+            String recommendationReason
+    ) {
+    }
+
+    enum ReasonCode {
+        COURSE_RELATED,
+        REVIEW_WEAK_AREA,
+        LEVEL_MATCHED,
+        NEXT_DIFFICULTY
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/port/LearningRecommendationClient.java
@@ -6,6 +6,8 @@ import java.util.List;
 /** Python FastAPI의 강좌 완료 문제세트 추천을 호출하는 출력 포트입니다. */
 public interface LearningRecommendationClient {
 
+    int MAX_RECOMMENDATION_COUNT = 2;
+
     LearningRecommendationResult rankFinalProblemSets(LearningRecommendationRequest request);
 
     record LearningRecommendationRequest(

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
@@ -1,0 +1,238 @@
+package com.wanted.codebombalms.learning.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningCourseProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningCoursePort;
+import com.wanted.codebombalms.learning.application.port.LearningLecture;
+import com.wanted.codebombalms.learning.application.port.LearningLecturePort;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemExplanationPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningContext;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningProfile;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LectureContext;
+import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
+import com.wanted.codebombalms.learning.domain.model.LearningCourse;
+import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
+import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** MAIN 학습 기록과 강좌 문맥을 조립해 Python 추천 순위를 요청합니다. */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FinalProblemSetRankingService implements FinalProblemSetRankingUseCase {
+
+    private static final int RECOMMENDATION_COUNT = 2;
+    private static final int MAX_EXCLUDED_PROBLEM_SET_COUNT = 100;
+    private static final int MAX_LECTURE_CONTEXT_COUNT = 100;
+    private static final int MAX_TITLE_LENGTH = 100;
+    private static final int MAX_DESCRIPTION_LENGTH = 2000;
+
+    private final LearningRecommendationClient learningRecommendationClient;
+    private final LearningCoursePort learningCoursePort;
+    private final LearningLecturePort learningLecturePort;
+    private final LearningCourseProblemPort learningCourseProblemPort;
+    private final LearningLectureProblemSetPort learningLectureProblemSetPort;
+    private final LearningProblemPort learningProblemPort;
+    private final LearningProblemExplanationPort learningProblemExplanationPort;
+    private final LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
+
+    @Override
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public LearningRecommendationResult rankFinalProblemSets(
+            Long userId,
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            Set<Long> excludedProblemSetIds,
+            boolean operator
+    ) {
+        if (excludedProblemSetIds.size() > MAX_EXCLUDED_PROBLEM_SET_COUNT) {
+            log.warn(
+                    "event=learning_recommendation_skipped reason=excluded_problem_set_limit count={}",
+                    excludedProblemSetIds.size()
+            );
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE);
+        }
+
+        LearningProfile profile = operator || userId == null
+                ? LearningProfile.empty()
+                : buildLearningProfile(userId, courseId);
+        LearningContext context = buildLearningContext(courseId);
+
+        LearningRecommendationRequest request = new LearningRecommendationRequest(
+                courseId,
+                lectureId,
+                problemCategoryId,
+                excludedProblemSetIds.stream().sorted().toList(),
+                RECOMMENDATION_COUNT,
+                profile,
+                context
+        );
+        return learningRecommendationClient.rankFinalProblemSets(request);
+    }
+
+    private LearningProfile buildLearningProfile(Long userId, Long courseId) {
+        List<Long> mainLectureProblemSetIds =
+                learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(courseId);
+        if (mainLectureProblemSetIds.isEmpty()) {
+            return LearningProfile.empty();
+        }
+
+        Map<Long, LearningProblemPort.ProblemDetailForLearning> problemsById = new LinkedHashMap<>();
+        Map<Long, List<LectureProblemSubmission>> submissionsByProblemId = new HashMap<>();
+
+        for (Long lectureProblemSetId : mainLectureProblemSetIds) {
+            Long problemSetId = learningLectureProblemSetPort
+                    .findLectureProblemSet(lectureProblemSetId)
+                    .problemSetId();
+            LearningProblemPort.ProblemSetForLearning problemSet =
+                    learningProblemPort.loadProblemSet(problemSetId);
+            for (LearningProblemPort.ProblemDetailForLearning problem : problemSet.problems()) {
+                problemsById.putIfAbsent(problem.problemId(), problem);
+            }
+
+            for (LectureProblemSubmission submission :
+                    lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(
+                            userId,
+                            lectureProblemSetId
+                    )) {
+                if (problemsById.containsKey(submission.problemId())) {
+                    submissionsByProblemId
+                            .computeIfAbsent(submission.problemId(), ignored -> new ArrayList<>())
+                            .add(submission);
+                }
+            }
+        }
+
+        int totalProblemCount = problemsById.size();
+        if (totalProblemCount == 0) {
+            return LearningProfile.empty();
+        }
+
+        Set<Long> viewedProblemIds = learningProblemExplanationPort.findViewedProblemIds(
+                userId,
+                List.copyOf(problemsById.keySet())
+        );
+
+        int correctProblemCount = 0;
+        int directSolveCount = 0;
+        int totalAttemptCount = 0;
+        double totalLatestTestPassRate = 0.0;
+
+        for (Long problemId : problemsById.keySet()) {
+            List<LectureProblemSubmission> submissions =
+                    submissionsByProblemId.getOrDefault(problemId, List.of());
+            totalAttemptCount += submissions.size();
+
+            boolean correct = submissions.stream().anyMatch(LectureProblemSubmission::correct);
+            if (correct) {
+                correctProblemCount++;
+                if (!viewedProblemIds.contains(problemId)) {
+                    directSolveCount++;
+                }
+            }
+
+            LectureProblemSubmission latest = submissions.stream()
+                    .max(this::compareSubmissionTime)
+                    .orElse(null);
+            totalLatestTestPassRate += calculateTestPassRate(latest);
+        }
+
+        return new LearningProfile(
+                totalProblemCount,
+                correctProblemCount,
+                percentage(directSolveCount, totalProblemCount),
+                viewedProblemIds.size(),
+                percentage(viewedProblemIds.size(), totalProblemCount),
+                roundFour(totalAttemptCount / (double) totalProblemCount),
+                roundFour(totalLatestTestPassRate / totalProblemCount)
+        );
+    }
+
+    private LearningContext buildLearningContext(Long courseId) {
+        LearningCourse course = learningCoursePort.findActiveCourse(courseId);
+        List<LectureContext> lectures = learningLecturePort.findLecturesByCourse(courseId)
+                .stream()
+                .limit(MAX_LECTURE_CONTEXT_COUNT)
+                .map(this::toLectureContext)
+                .toList();
+
+        return new LearningContext(
+                normalizeTitle(course.title(), "강좌 " + courseId),
+                normalizeDescription(course.description()),
+                lectures
+        );
+    }
+
+    private LectureContext toLectureContext(LearningLecture lecture) {
+        return new LectureContext(
+                normalizeTitle(lecture.title(), "강의 " + lecture.lectureId()),
+                normalizeDescription(lecture.description())
+        );
+    }
+
+    private int compareSubmissionTime(
+            LectureProblemSubmission left,
+            LectureProblemSubmission right
+    ) {
+        Comparator<LocalDateTime> timeComparator = Comparator.nullsFirst(Comparator.naturalOrder());
+        int timeCompared = timeComparator.compare(left.submittedAt(), right.submittedAt());
+        if (timeCompared != 0) {
+            return timeCompared;
+        }
+        return Comparator.nullsFirst(Long::compareTo).compare(
+                left.lectureProblemSubmissionId(),
+                right.lectureProblemSubmissionId()
+        );
+    }
+
+    private double calculateTestPassRate(LectureProblemSubmission submission) {
+        if (submission == null
+                || submission.totalTestCount() == null
+                || submission.totalTestCount() <= 0
+                || submission.passedTestCount() == null) {
+            return 0.0;
+        }
+        int passed = Math.max(0, Math.min(submission.passedTestCount(), submission.totalTestCount()));
+        return passed * 100.0 / submission.totalTestCount();
+    }
+
+    private double percentage(int numerator, int denominator) {
+        return roundFour(numerator * 100.0 / denominator);
+    }
+
+    private double roundFour(double value) {
+        return Math.round(value * 10_000.0) / 10_000.0;
+    }
+
+    private String normalizeTitle(String value, String fallback) {
+        String normalized = value == null || value.isBlank() ? fallback : value.strip();
+        return normalized.substring(0, Math.min(normalized.length(), MAX_TITLE_LENGTH));
+    }
+
+    private String normalizeDescription(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.strip();
+        return normalized.substring(0, Math.min(normalized.length(), MAX_DESCRIPTION_LENGTH));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingService.java
@@ -39,7 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FinalProblemSetRankingService implements FinalProblemSetRankingUseCase {
 
-    private static final int RECOMMENDATION_COUNT = 2;
     private static final int MAX_EXCLUDED_PROBLEM_SET_COUNT = 100;
     private static final int MAX_LECTURE_CONTEXT_COUNT = 100;
     private static final int MAX_TITLE_LENGTH = 100;
@@ -57,6 +56,39 @@ public class FinalProblemSetRankingService implements FinalProblemSetRankingUseC
     @Override
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public LearningRecommendationResult rankFinalProblemSets(
+            Long userId,
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            Set<Long> excludedProblemSetIds,
+            boolean operator
+    ) {
+        try {
+            return requestRanking(
+                    userId,
+                    courseId,
+                    lectureId,
+                    problemCategoryId,
+                    excludedProblemSetIds,
+                    operator
+            );
+        } catch (ExternalServiceException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "event=learning_recommendation_preparation_failed courseId={} lectureId={} exceptionType={}",
+                    courseId,
+                    lectureId,
+                    exception.getClass().getSimpleName()
+            );
+            throw new ExternalServiceException(
+                    LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE,
+                    exception
+            );
+        }
+    }
+
+    private LearningRecommendationResult requestRanking(
             Long userId,
             Long courseId,
             Long lectureId,
@@ -82,7 +114,7 @@ public class FinalProblemSetRankingService implements FinalProblemSetRankingUseC
                 lectureId,
                 problemCategoryId,
                 excludedProblemSetIds.stream().sorted().toList(),
-                RECOMMENDATION_COUNT,
+                LearningRecommendationClient.MAX_RECOMMENDATION_COUNT,
                 profile,
                 context
         );

--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
@@ -186,7 +186,7 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
                 lectureProblemSetId,
                 problemId
         );
-        validateAttempt(problem.attemptLimit(), problem.retriable(), previousAttemptCount);
+        validateAttempt(problem.retriable(), previousAttemptCount);
 
         var gradingResult = learningProblemGradingPort.grade(
                 lectureProblemSet.problemSetId(),
@@ -232,10 +232,8 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
             }
         }
 
-        Integer remainingAttemptCount = calculateRemainingAttempts(problem.attemptLimit(), attemptNo);
-        boolean canRetry = !gradingResult.correct()
-                && Boolean.TRUE.equals(problem.retriable())
-                && (remainingAttemptCount == null || remainingAttemptCount > 0);
+        Integer remainingAttemptCount = null;
+        boolean canRetry = !gradingResult.correct() && Boolean.TRUE.equals(problem.retriable());
 
         return new SubmissionView(
                 savedSubmission.lectureProblemSubmissionId(),
@@ -433,17 +431,10 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
         return progress.getCurrentProblemNumber().equals(problemNumber);
     }
 
-    private void validateAttempt(Integer attemptLimit, Boolean retriable, int previousAttemptCount) {
+    private void validateAttempt(Boolean retriable, int previousAttemptCount) {
         if (!Boolean.TRUE.equals(retriable) && previousAttemptCount > 0) {
             throw new ValidationException(SubmissionErrorCode.PROBLEM_NOT_RETRIABLE);
         }
-        if (attemptLimit != null && previousAttemptCount >= attemptLimit) {
-            throw new ValidationException(SubmissionErrorCode.ATTEMPT_LIMIT_EXCEEDED);
-        }
-    }
-
-    private Integer calculateRemainingAttempts(Integer attemptLimit, int attemptNo) {
-        return attemptLimit == null ? null : Math.max(attemptLimit - attemptNo, 0);
     }
 
     private Long findNextProblemId(

--- a/src/main/java/com/wanted/codebombalms/learning/application/usecase/FinalProblemSetRankingUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/usecase/FinalProblemSetRankingUseCase.java
@@ -1,0 +1,17 @@
+package com.wanted.codebombalms.learning.application.usecase;
+
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import java.util.Set;
+
+/** 사용자의 강좌 학습 기록을 기반으로 FINAL 문제세트 순위를 조회합니다. */
+public interface FinalProblemSetRankingUseCase {
+
+    LearningRecommendationResult rankFinalProblemSets(
+            Long userId,
+            Long courseId,
+            Long lectureId,
+            Long problemCategoryId,
+            Set<Long> excludedProblemSetIds,
+            boolean operator
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/learning/domain/exception/LearningErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/learning/domain/exception/LearningErrorCode.java
@@ -18,7 +18,9 @@ public enum LearningErrorCode implements ErrorCode {
     LECTURE_PROBLEM_NOT_UNLOCKED("LRN-008", "Lecture problem is not unlocked."),
     LECTURE_PROBLEM_SET_ALREADY_COMPLETED("LRN-009", "Lecture problem set is already completed."),
     INVALID_LECTURE_PROGRESS("LRN-010", "Lecture progress value is invalid."),
-    LECTURE_PROGRESS_ACCESS_DENIED("LRN-011", "Only enrolled students can access lecture learning content.");
+    LECTURE_PROGRESS_ACCESS_DENIED("LRN-011", "Only enrolled students can access lecture learning content."),
+    LEARNING_RECOMMENDATION_UNAVAILABLE("LRN-012", "AI learning recommendation service is unavailable."),
+    LEARNING_RECOMMENDATION_INVALID_RESPONSE("LRN-013", "AI learning recommendation response is invalid.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/learning/domain/model/LearningCourse.java
+++ b/src/main/java/com/wanted/codebombalms/learning/domain/model/LearningCourse.java
@@ -2,6 +2,11 @@ package com.wanted.codebombalms.learning.domain.model;
 
 public record LearningCourse(
         Long courseId,
-        String title
+        String title,
+        String description
 ) {
+
+    public LearningCourse(Long courseId, String title) {
+        this(courseId, title, null);
+    }
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
@@ -1,0 +1,123 @@
+package com.wanted.codebombalms.learning.infrastructure.client;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
+import io.netty.channel.ChannelOption;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+/** 강좌 완료 추천 전용 FastAPI client입니다. */
+@Slf4j
+@Component
+public class FastApiLearningRecommendationClient implements LearningRecommendationClient {
+
+    private static final int MAX_RECOMMENDATION_COUNT = 2;
+    private static final int MAX_REASON_LENGTH = 300;
+    private static final int MAX_RESPONSE_IN_MEMORY_BYTES = 512 * 1024;
+
+    private final LearningRecommendationProperties properties;
+    private final WebClient webClient;
+
+    public FastApiLearningRecommendationClient(
+            LearningRecommendationProperties properties,
+            @Value("${fastapi.url}") String fastApiBaseUrl
+    ) {
+        this.properties = properties;
+        this.webClient = buildWebClient(fastApiBaseUrl, properties);
+    }
+
+    @Override
+    public LearningRecommendationResult rankFinalProblemSets(LearningRecommendationRequest request) {
+        if (!properties.isEnabled()) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE);
+        }
+
+        long startedAt = System.nanoTime();
+        try {
+            LearningRecommendationResult response = webClient.post()
+                    .uri(properties.getRankPath())
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(LearningRecommendationResult.class)
+                    .block();
+
+            validateResponse(response);
+            log.info(
+                    "event=learning_recommendation_called recommendationCount={} durationMs={}",
+                    response.recommendations().size(),
+                    (System.nanoTime() - startedAt) / 1_000_000
+            );
+            return response;
+        } catch (ExternalServiceException exception) {
+            throw exception;
+        } catch (RuntimeException exception) {
+            log.warn(
+                    "event=learning_recommendation_failed exceptionType={} durationMs={}",
+                    exception.getClass().getSimpleName(),
+                    (System.nanoTime() - startedAt) / 1_000_000
+            );
+            throw new ExternalServiceException(
+                    LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE,
+                    exception
+            );
+        }
+    }
+
+    private void validateResponse(LearningRecommendationResult response) {
+        if (response == null
+                || response.algorithm() == null
+                || response.algorithm().isBlank()
+                || response.recommendations() == null
+                || response.recommendations().size() > MAX_RECOMMENDATION_COUNT) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        Set<Long> ids = new HashSet<>();
+        for (RankedProblemSet item : response.recommendations()) {
+            if (!isValidItem(item) || !ids.add(item.problemSetId())) {
+                throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+            }
+        }
+    }
+
+    private boolean isValidItem(RankedProblemSet item) {
+        if (item == null
+                || item.problemSetId() == null
+                || item.problemSetId() <= 0
+                || item.score() == null
+                || item.reasonCode() == null
+                || item.recommendationReason() == null
+                || item.recommendationReason().isBlank()
+                || item.recommendationReason().length() > MAX_REASON_LENGTH) {
+            return false;
+        }
+        return item.score().compareTo(BigDecimal.ZERO) >= 0
+                && item.score().compareTo(BigDecimal.ONE) <= 0;
+    }
+
+    private WebClient buildWebClient(
+            String fastApiBaseUrl,
+            LearningRecommendationProperties properties
+    ) {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, properties.getConnectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(properties.getReadTimeoutMs()));
+
+        return WebClient.builder()
+                .baseUrl(fastApiBaseUrl)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .codecs(configurer -> configurer.defaultCodecs()
+                        .maxInMemorySize(MAX_RESPONSE_IN_MEMORY_BYTES))
+                .build();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClient.java
@@ -21,7 +21,6 @@ import reactor.netty.http.client.HttpClient;
 @Component
 public class FastApiLearningRecommendationClient implements LearningRecommendationClient {
 
-    private static final int MAX_RECOMMENDATION_COUNT = 2;
     private static final int MAX_REASON_LENGTH = 300;
     private static final int MAX_RESPONSE_IN_MEMORY_BYTES = 512 * 1024;
 
@@ -78,7 +77,8 @@ public class FastApiLearningRecommendationClient implements LearningRecommendati
                 || response.algorithm() == null
                 || response.algorithm().isBlank()
                 || response.recommendations() == null
-                || response.recommendations().size() > MAX_RECOMMENDATION_COUNT) {
+                || response.recommendations().size()
+                > LearningRecommendationClient.MAX_RECOMMENDATION_COUNT) {
             throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
         }
 

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
@@ -1,0 +1,29 @@
+package com.wanted.codebombalms.learning.infrastructure.client;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+/** learning 도메인의 Python 추천 API 호출 설정입니다. */
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "learning.recommendation.python")
+public class LearningRecommendationProperties {
+
+    private boolean enabled = true;
+
+    @NotBlank
+    private String rankPath = "/internal/learning/final-problem-sets/rank";
+
+    @Positive
+    private int connectTimeoutMs = 3000;
+
+    @Positive
+    private int readTimeoutMs = 10000;
+}

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/client/LearningRecommendationProperties.java
@@ -25,5 +25,5 @@ public class LearningRecommendationProperties {
     private int connectTimeoutMs = 3000;
 
     @Positive
-    private int readTimeoutMs = 10000;
+    private int readTimeoutMs = 15000;
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/course/LearningCourseAdapter.java
@@ -36,6 +36,10 @@ public class LearningCourseAdapter implements LearningCoursePort {
     }
 
     private LearningCourse toLearningCourse(Course course) {
-        return new LearningCourse(course.getCourseId(), course.getTitle());
+        return new LearningCourse(
+                course.getCourseId(),
+                course.getTitle(),
+                course.getDescription()
+        );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/learning/infrastructure/lecture/LearningLectureAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/learning/infrastructure/lecture/LearningLectureAdapter.java
@@ -54,7 +54,11 @@ public class LearningLectureAdapter implements LearningLecturePort {
         try {
             return lectureQueryUseCase.findLecturesByCourseId(courseId)
                     .stream()
-                    .map(lecture -> new LearningLecture(lecture.getLectureId(), lecture.getTitle()))
+                    .map(lecture -> new LearningLecture(
+                            lecture.getLectureId(),
+                            lecture.getTitle(),
+                            lecture.getDescription()
+                    ))
                     .toList();
         } catch (NotFoundException e) {
             throw new NotFoundException(LearningErrorCode.COURSE_NOT_FOUND, e);

--- a/src/main/java/com/wanted/codebombalms/lecture/application/port/FinalProblemSetCandidatePort.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/port/FinalProblemSetCandidatePort.java
@@ -7,4 +7,6 @@ import java.util.Set;
 public interface FinalProblemSetCandidatePort {
 
     List<ProblemSetSummary> findCandidates(Long problemCategoryId, Set<Long> excludedProblemSetIds, int limit);
+
+    List<ProblemSetSummary> findByProblemSetIds(List<Long> problemSetIds);
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
@@ -2,6 +2,11 @@ package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.RankedProblemSet;
+import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
 import com.wanted.codebombalms.lecture.application.port.FinalProblemSetCandidatePort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
@@ -13,14 +18,18 @@ import com.wanted.codebombalms.lecture.domain.repository.LectureProblemSetReposi
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FinalProblemSetRecommendationService implements FinalProblemSetRecommendationUseCase {
@@ -32,6 +41,7 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
     private final FinalProblemSetCandidatePort finalProblemSetCandidatePort;
     private final LectureAccessPolicy lectureAccessPolicy;
     private final LectureProgressPort lectureProgressPort;
+    private final FinalProblemSetRankingUseCase finalProblemSetRankingUseCase;
 
     @Override
     public List<FinalProblemSetCandidateView> findFinalProblemSetCandidates(Long lectureId, Long userId, boolean operator) {
@@ -50,14 +60,24 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
                 .map(problemSet -> problemSet.getProblemSetId())
                 .collect(Collectors.toSet());
 
-        return finalProblemSetCandidatePort.findCandidates(
-                        lecture.getProblemCategoryId(),
-                        mainProblemSetIds,
-                        MAX_RECOMMENDATION_COUNT
-                )
-                .stream()
-                .map(this::toView)
-                .toList();
+        try {
+            LearningRecommendationResult ranking = finalProblemSetRankingUseCase.rankFinalProblemSets(
+                    userId,
+                    lecture.getCourse().getCourseId(),
+                    lectureId,
+                    lecture.getProblemCategoryId(),
+                    mainProblemSetIds,
+                    operator
+            );
+            return toRankedViews(ranking, mainProblemSetIds);
+        } catch (ExternalServiceException exception) {
+            log.warn(
+                    "event=final_problem_set_ai_fallback lectureId={} exceptionType={}",
+                    lectureId,
+                    exception.getClass().getSimpleName()
+            );
+            return findLegacyCandidates(lecture, mainProblemSetIds);
+        }
     }
 
     private void validateFinalProblemSetAvailable(Lecture lecture, Long userId, boolean operator) {
@@ -84,7 +104,55 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
         }
     }
 
-    private FinalProblemSetCandidateView toView(ProblemSetSummary problemSet) {
+    private List<FinalProblemSetCandidateView> toRankedViews(
+            LearningRecommendationResult ranking,
+            Set<Long> excludedProblemSetIds
+    ) {
+        if (ranking == null || ranking.recommendations() == null) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        List<Long> rankedIds = ranking.recommendations()
+                .stream()
+                .map(RankedProblemSet::problemSetId)
+                .toList();
+        if (rankedIds.stream().anyMatch(excludedProblemSetIds::contains)) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        List<ProblemSetSummary> problemSets = finalProblemSetCandidatePort.findByProblemSetIds(rankedIds);
+        if (problemSets.size() != rankedIds.size()) {
+            throw new ExternalServiceException(LearningErrorCode.LEARNING_RECOMMENDATION_INVALID_RESPONSE);
+        }
+
+        Map<Long, ProblemSetSummary> problemSetById = new HashMap<>();
+        for (ProblemSetSummary problemSet : problemSets) {
+            problemSetById.put(problemSet.getProblemSetId(), problemSet);
+        }
+
+        return ranking.recommendations().stream()
+                .map(item -> toView(problemSetById.get(item.problemSetId()), item))
+                .toList();
+    }
+
+    private List<FinalProblemSetCandidateView> findLegacyCandidates(
+            Lecture lecture,
+            Set<Long> excludedProblemSetIds
+    ) {
+        return finalProblemSetCandidatePort.findCandidates(
+                        lecture.getProblemCategoryId(),
+                        excludedProblemSetIds,
+                        MAX_RECOMMENDATION_COUNT
+                )
+                .stream()
+                .map(this::toFallbackView)
+                .toList();
+    }
+
+    private FinalProblemSetCandidateView toView(
+            ProblemSetSummary problemSet,
+            RankedProblemSet ranked
+    ) {
         return new FinalProblemSetCandidateView(
                 problemSet.getProblemSetId(),
                 problemSet.getProblemNumber(),
@@ -92,7 +160,25 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
                 problemSet.getDescription(),
                 problemSet.getDifficulty(),
                 problemSet.getAccuracyRate(),
-                problemSet.getCreatedAt()
+                problemSet.getCreatedAt(),
+                ranked.score(),
+                ranked.reasonCode().name(),
+                ranked.recommendationReason()
+        );
+    }
+
+    private FinalProblemSetCandidateView toFallbackView(ProblemSetSummary problemSet) {
+        return new FinalProblemSetCandidateView(
+                problemSet.getProblemSetId(),
+                problemSet.getProblemNumber(),
+                problemSet.getTitle(),
+                problemSet.getDescription(),
+                problemSet.getDifficulty(),
+                problemSet.getAccuracyRate(),
+                problemSet.getCreatedAt(),
+                null,
+                "COURSE_RELATED",
+                "강좌에서 학습한 내용과 연관된 문제 세트예요."
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationService.java
@@ -3,6 +3,7 @@ package com.wanted.codebombalms.lecture.application.service;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
 import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.RankedProblemSet;
 import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
@@ -33,8 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FinalProblemSetRecommendationService implements FinalProblemSetRecommendationUseCase {
-
-    private static final int MAX_RECOMMENDATION_COUNT = 2;
 
     private final LectureRepository lectureRepository;
     private final LectureProblemSetRepository lectureProblemSetRepository;
@@ -142,7 +141,7 @@ public class FinalProblemSetRecommendationService implements FinalProblemSetReco
         return finalProblemSetCandidatePort.findCandidates(
                         lecture.getProblemCategoryId(),
                         excludedProblemSetIds,
-                        MAX_RECOMMENDATION_COUNT
+                        LearningRecommendationClient.MAX_RECOMMENDATION_COUNT
                 )
                 .stream()
                 .map(this::toFallbackView)

--- a/src/main/java/com/wanted/codebombalms/lecture/application/usecase/FinalProblemSetRecommendationUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/application/usecase/FinalProblemSetRecommendationUseCase.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.lecture.application.usecase;
 
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface FinalProblemSetRecommendationUseCase {
@@ -14,7 +15,33 @@ public interface FinalProblemSetRecommendationUseCase {
             String description,
             String difficulty,
             Double accuracyRate,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            BigDecimal score,
+            String reasonCode,
+            String recommendationReason
     ) {
+
+        public FinalProblemSetCandidateView(
+                Long problemSetId,
+                Integer problemNumber,
+                String title,
+                String description,
+                String difficulty,
+                Double accuracyRate,
+                LocalDateTime createdAt
+        ) {
+            this(
+                    problemSetId,
+                    problemNumber,
+                    title,
+                    description,
+                    difficulty,
+                    accuracyRate,
+                    createdAt,
+                    null,
+                    null,
+                    null
+            );
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/infrastructure/problem/FinalProblemSetCandidateAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/infrastructure/problem/FinalProblemSetCandidateAdapter.java
@@ -4,10 +4,14 @@ import com.wanted.codebombalms.lecture.application.port.FinalProblemSetCandidate
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetStatus;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import com.wanted.codebombalms.problems.set.infrastructure.persistence.ProblemSetMapper;
+import com.wanted.codebombalms.problems.set.infrastructure.persistence.ProblemSetJpaEntity;
 import com.wanted.codebombalms.problems.set.infrastructure.persistence.SpringDataProblemSetRepository;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +35,30 @@ public class FinalProblemSetCandidateAdapter implements FinalProblemSetCandidate
                 .filter(problemSet -> !excludedProblemSetIds.contains(problemSet.getProblemSetId()))
                 .limit(limit)
                 .map(problemSet -> ProblemSetMapper.toSummary(problemSet, problemNumber.getAndIncrement()))
+                .toList();
+    }
+
+    @Override
+    public List<ProblemSetSummary> findByProblemSetIds(List<Long> problemSetIds) {
+        if (problemSetIds.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, ProblemSetJpaEntity> entitiesById = problemSetRepository.findByProblemSetIdInAndStatus(
+                        problemSetIds,
+                        ProblemSetStatus.ACTIVE
+                )
+                .stream()
+                .collect(Collectors.toMap(
+                        ProblemSetJpaEntity::getProblemSetId,
+                        Function.identity()
+                ));
+
+        AtomicInteger problemNumber = new AtomicInteger(1);
+        return problemSetIds.stream()
+                .map(entitiesById::get)
+                .filter(java.util.Objects::nonNull)
+                .map(entity -> ProblemSetMapper.toSummary(entity, problemNumber.getAndIncrement()))
                 .toList();
     }
 }

--- a/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/FinalProblemSetCandidateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/lecture/presentation/api/response/FinalProblemSetCandidateResponse.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.lecture.presentation.api.response;
 
 import com.wanted.codebombalms.lecture.application.usecase.FinalProblemSetRecommendationUseCase.FinalProblemSetCandidateView;
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 
 public record FinalProblemSetCandidateResponse(
         Long problemSetId,
@@ -11,7 +12,10 @@ public record FinalProblemSetCandidateResponse(
         String difficulty,
         Double accuracyRate,
         LocalDateTime createdAt,
-        String entryPath
+        String entryPath,
+        BigDecimal score,
+        String reasonCode,
+        String recommendationReason
 ) {
 
     private static final String PROBLEM_SET_ENTRY_PATH_PREFIX = "/api/v1/problem-sets/";
@@ -25,7 +29,10 @@ public record FinalProblemSetCandidateResponse(
                 candidate.difficulty(),
                 candidate.accuracyRate(),
                 candidate.createdAt(),
-                PROBLEM_SET_ENTRY_PATH_PREFIX + candidate.problemSetId()
+                PROBLEM_SET_ENTRY_PATH_PREFIX + candidate.problemSetId(),
+                candidate.score(),
+                candidate.reasonCode(),
+                candidate.recommendationReason()
         );
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
+++ b/src/main/java/com/wanted/codebombalms/problems/exception/ProblemErrorCode.java
@@ -3,7 +3,6 @@ package com.wanted.codebombalms.problems.exception;
 import com.wanted.codebombalms.global.domain.common.error.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,19 +13,19 @@ public enum ProblemErrorCode implements ErrorCode {
     ACCESS_DENIED("PRB-PBL-002", "문제 접근 권한이 없습니다."),
     PROBLEM_NOT_UNLOCKED("PRB-PBL-003", "이전 문제를 먼저 풀어야 합니다."),
     PROBLEM_HAS_SUBMISSION("PRB-PBL-004", "제출 기록이 존재합니다."),
-    PROBLEM_NOT_IN_SET("PRB-PBL-005", "해당 문제 세트에 속한 문제가 아닙니다."),
+    PROBLEM_NOT_IN_SET("PRB-PBL-005", "해당 문제세트에 속한 문제가 아닙니다."),
     PROBLEM_TITLE_REQUIRED("PRB-PBL-006", "소문제 제목은 필수입니다."),
     PROBLEM_CONTENT_REQUIRED("PRB-PBL-007", "소문제 내용은 필수입니다."),
     PROBLEM_REQUIRED("PRB-PBL-009", "소문제는 1개 이상 필요합니다."),
     PROBLEM_POINT_REQUIRED("PRB-PBL-010", "문제 포인트는 1 이상이어야 합니다."),
 
     // 문제 세트 (PRB-SET)
-    PROBLEM_SET_NOT_FOUND("PRB-SET-001", "문제 세트를 찾을 수 없습니다."),
+    PROBLEM_SET_NOT_FOUND("PRB-SET-001", "문제세트를 찾을 수 없습니다."),
     ATTEMPT_LIMIT_EXCEEDED("PRB-SET-002", "제출 가능 횟수를 초과했습니다."),
-    ALREADY_COMPLETED("PRB-SET-003", "이미 완료한 문제 세트입니다."),
-    PROBLEM_SET_NOT_COMPLETED("PRB-SET-004", "문제 세트를 끝까지 풀지 않았습니다."),
+    ALREADY_COMPLETED("PRB-SET-003", "이미 완료한 문제세트입니다."),
+    PROBLEM_SET_NOT_COMPLETED("PRB-SET-004", "문제세트를 끝까지 풀지 않았습니다."),
     NO_CURRENT_PROBLEM("PRB-SET-005", "현재 풀 문제가 없습니다."),
-    PROBLEM_SET_TITLE_REQUIRED("PRB-SET-006", "문제 세트 제목은 필수입니다."),
+    PROBLEM_SET_TITLE_REQUIRED("PRB-SET-006", "문제세트 제목은 필수입니다."),
 
     // 카테고리 (PRB-CAT)
     CATEGORY_NOT_FOUND("PRB-CAT-001", "문제 분야를 찾을 수 없습니다."),
@@ -40,18 +39,19 @@ public enum ProblemErrorCode implements ErrorCode {
 
     // 데이터셋 (PRB-DAT)
     PROBLEM_DATASET_NOT_FOUND("PRB-DAT-001", "데이터셋을 찾을 수 없습니다."),
-    PROBLEM_DATASET_ALREADY_CONNECTED("PRB-DAT-002", "이미 문제 세트에 연결된 데이터셋입니다."),
+    PROBLEM_DATASET_ALREADY_CONNECTED("PRB-DAT-002", "이미 문제세트에 연결된 데이터셋입니다."),
     PROBLEM_DATASET_INVALID_PROBLEM_TYPE("PRB-DAT-003", "코드 실행형 문제에만 데이터셋을 연결할 수 있습니다."),
     PROBLEM_DATASET_INVALID_FILE("PRB-DAT-004", "CSV 파일만 업로드할 수 있습니다."),
     PROBLEM_DATASET_UPLOAD_FAILED("PRB-DAT-005", "데이터셋 업로드에 실패했습니다."),
+    PROBLEM_SET_DATASET_CONNECTION_FAILED("PRB-DAT-006", "문제세트와 데이터셋 연결에 실패했습니다."),
     PROBLEM_DATASET_ACCESS_URL_FAILED("PRB-DAT-007", "데이터셋 접근 URL 생성에 실패했습니다."),
 
-    // 테스트케이스 (PRB-TC)
-    PROBLEM_TEST_CASE_NOT_FOUND("PRB-TC-001", "테스트케이스를 찾을 수 없습니다."),
-    PROBLEM_TEST_CASE_INVALID_INPUT("PRB-TC-002", "테스트케이스 입력값이 올바르지 않습니다."),
-    PROBLEM_TEST_CASE_ALREADY_EXISTS("PRB-TC-003", "이미 등록된 테스트케이스가 있습니다."),
-    PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE("PRB-TC-004", "코드 문제에만 테스트케이스를 등록할 수 있습니다."),
-    PROBLEM_TEST_CASE_DUPLICATE_ORDER( "PRB-TC-006", "이미 같은 순서의 테스트케이스가 존재합니다."),
+    // 테스트 케이스 (PRB-TC)
+    PROBLEM_TEST_CASE_NOT_FOUND("PRB-TC-001", "테스트 케이스를 찾을 수 없습니다."),
+    PROBLEM_TEST_CASE_INVALID_INPUT("PRB-TC-002", "테스트 케이스 입력값이 올바르지 않습니다."),
+    PROBLEM_TEST_CASE_ALREADY_EXISTS("PRB-TC-003", "이미 등록된 테스트 케이스가 있습니다."),
+    PROBLEM_TEST_CASE_INVALID_PROBLEM_TYPE("PRB-TC-004", "코드 문제에만 테스트 케이스를 등록할 수 있습니다."),
+    PROBLEM_TEST_CASE_DUPLICATE_ORDER("PRB-TC-006", "이미 같은 순서의 테스트 케이스가 존재합니다."),
 
     // 코드 실행 (PRB-EXE)
     PROBLEM_CODE_INVALID_INPUT("PRB-EXE-001", "코드 값이 비어 있습니다."),
@@ -64,8 +64,8 @@ public enum ProblemErrorCode implements ErrorCode {
     INVALID_INPUT("PRB-001", "필수값이 누락되었습니다."),
     SERVER_ERROR("PRB-002", "문제 도메인 처리 중 서버 오류가 발생했습니다."),
 
-    // 데이터셋 (PRB-DAT)
-    PROBLEM_SET_DATASET_CONNECTION_FAILED("PRB-DAT-006", "문제 세트와 데이터셋 연결에 실패했습니다.");
+    // AI 문제세트 생성 (PRB-GEN)
+    PROBLEM_SET_DRAFT_GENERATION_FAILED("PRB-GEN-001", "AI 문제세트 초안 생성에 실패했습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftAiCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftAiCommand.java
@@ -1,19 +1,14 @@
 package com.wanted.codebombalms.problems.generation.application.command;
 
-import java.io.InputStream;
-
-public record GenerateProblemSetDraftCommand(
+public record GenerateProblemSetDraftAiCommand(
         Long operatorId,
         String question,
+        String datasetUrl,
         String dataFileName,
         String topic,
         String categoryName,
         String difficulty,
         int problemCount,
-        int subProblemCount,
-        String originalFileName,
-        String contentType,
-        InputStream datasetContent,
-        long datasetFileSize
+        int subProblemCount
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/GenerateProblemSetDraftCommand.java
@@ -1,0 +1,16 @@
+package com.wanted.codebombalms.problems.generation.application.command;
+
+public record GenerateProblemSetDraftCommand(
+        Long operatorId,
+        String question,
+        String datasetUrl,
+        String draftToken,
+        String datasetObjectName,
+        String dataFileName,
+        String topic,
+        String categoryName,
+        String difficulty,
+        int problemCount,
+        int subProblemCount
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
@@ -1,11 +1,13 @@
 package com.wanted.codebombalms.problems.generation.application.command;
 
+import java.io.InputStream;
+
 public record StoreProblemSetDraftDatasetCommand(
         Long operatorId,
         String draftToken,
         String originalFileName,
         String contentType,
-        byte[] content,
+        InputStream content,
         long fileSize
 ) {
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/command/StoreProblemSetDraftDatasetCommand.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.generation.application.command;
+
+public record StoreProblemSetDraftDatasetCommand(
+        Long operatorId,
+        String draftToken,
+        String originalFileName,
+        String contentType,
+        byte[] content,
+        long fileSize
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/DeleteProblemSetDraftDatasetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/DeleteProblemSetDraftDatasetPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+public interface DeleteProblemSetDraftDatasetPort {
+
+    void delete(String objectName);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+
+public interface GenerateProblemSetDraftAiPort {
+
+    ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftAiPort.java
@@ -1,9 +1,9 @@
 package com.wanted.codebombalms.problems.generation.application.port;
 
-import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 
 public interface GenerateProblemSetDraftAiPort {
 
-    ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command);
+    ProblemSetDraftResult generate(GenerateProblemSetDraftAiCommand command);
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftDatasetUrlPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/GenerateProblemSetDraftDatasetUrlPort.java
@@ -1,0 +1,6 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+public interface GenerateProblemSetDraftDatasetUrlPort {
+
+    String generate(String objectName);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/port/StoreProblemSetDraftDatasetPort.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/port/StoreProblemSetDraftDatasetPort.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.generation.application.port;
+
+import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
+import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
+
+public interface StoreProblemSetDraftDatasetPort {
+
+    StoredProblemSetDraftDataset store(StoreProblemSetDraftDatasetCommand command);
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/result/ProblemSetDraftResult.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/result/ProblemSetDraftResult.java
@@ -1,0 +1,11 @@
+package com.wanted.codebombalms.problems.generation.application.result;
+
+import com.wanted.codebombalms.problems.generation.domain.ProblemSetDraft;
+import java.util.List;
+
+public record ProblemSetDraftResult(
+        String answer,
+        ProblemSetDraft draft,
+        List<String> usedTools
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
@@ -1,6 +1,7 @@
 package com.wanted.codebombalms.problems.generation.application.service;
 
 import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
 import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
 import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
@@ -9,13 +10,10 @@ import com.wanted.codebombalms.problems.generation.application.port.StoreProblem
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
 import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
-import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
 import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.UUID;
 
 @Service
@@ -27,42 +25,36 @@ public class ProblemSetDraftGenerationService implements GenerateProblemSetDraft
     private final GenerateProblemSetDraftDatasetUrlPort generateProblemSetDraftDatasetUrlPort;
 
     @Override
-    public ProblemSetDraftResult generate(
-            Long operatorId,
-            ProblemSetDraftGenerateRequest request,
-            MultipartFile datasetFile
-    ) {
-        validateDatasetFile(datasetFile);
+    public ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command) {
+        validateDatasetFile(command);
 
         String draftToken = UUID.randomUUID().toString();
         StoredProblemSetDraftDataset storedDataset = storeProblemSetDraftDataset(
-                operatorId,
+                command.operatorId(),
                 draftToken,
-                datasetFile
+                command
         );
         String datasetUrl = generateProblemSetDraftDatasetUrlPort.generate(
                 storedDataset.objectName()
         );
 
-        GenerateProblemSetDraftCommand command = new GenerateProblemSetDraftCommand(
-                operatorId,
-                request.question(),
+        GenerateProblemSetDraftAiCommand aiCommand = new GenerateProblemSetDraftAiCommand(
+                command.operatorId(),
+                command.question(),
                 datasetUrl,
-                draftToken,
-                storedDataset.objectName(),
-                resolveDataFileName(request, storedDataset),
-                request.topic(),
-                request.categoryName(),
-                request.difficulty(),
-                request.problemCount(),
-                request.subProblemCount()
+                resolveDataFileName(command, storedDataset),
+                command.topic(),
+                command.categoryName(),
+                command.difficulty(),
+                command.problemCount(),
+                command.subProblemCount()
         );
 
-        return generateProblemSetDraftAiPort.generate(command);
+        return generateProblemSetDraftAiPort.generate(aiCommand);
     }
 
-    private void validateDatasetFile(MultipartFile datasetFile) {
-        if (datasetFile == null || datasetFile.isEmpty()) {
+    private void validateDatasetFile(GenerateProblemSetDraftCommand command) {
+        if (command.datasetContent() == null || command.datasetFileSize() <= 0) {
             throw new ValidationException(
                     ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE
             );
@@ -72,33 +64,26 @@ public class ProblemSetDraftGenerationService implements GenerateProblemSetDraft
     private StoredProblemSetDraftDataset storeProblemSetDraftDataset(
             Long operatorId,
             String draftToken,
-            MultipartFile datasetFile
+            GenerateProblemSetDraftCommand command
     ) {
-        try {
-            return storeProblemSetDraftDatasetPort.store(
-                    new StoreProblemSetDraftDatasetCommand(
-                            operatorId,
-                            draftToken,
-                            datasetFile.getOriginalFilename(),
-                            datasetFile.getContentType(),
-                            datasetFile.getBytes(),
-                            datasetFile.getSize()
-                    )
-            );
-        } catch (IOException e) {
-            throw new ValidationException(
-                    ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED,
-                    e
-            );
-        }
+        return storeProblemSetDraftDatasetPort.store(
+                new StoreProblemSetDraftDatasetCommand(
+                        operatorId,
+                        draftToken,
+                        command.originalFileName(),
+                        command.contentType(),
+                        command.datasetContent(),
+                        command.datasetFileSize()
+                )
+        );
     }
 
     private String resolveDataFileName(
-            ProblemSetDraftGenerateRequest request,
+            GenerateProblemSetDraftCommand command,
             StoredProblemSetDraftDataset storedDataset
     ) {
-        if (request.dataFileName() != null && !request.dataFileName().isBlank()) {
-            return request.dataFileName();
+        if (command.dataFileName() != null && !command.dataFileName().isBlank()) {
+            return command.dataFileName();
         }
 
         return storedDataset.originalFileName();

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/service/ProblemSetDraftGenerationService.java
@@ -1,0 +1,106 @@
+package com.wanted.codebombalms.problems.generation.application.service;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftDatasetUrlPort;
+import com.wanted.codebombalms.problems.generation.application.port.StoreProblemSetDraftDatasetPort;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
+import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemSetDraftGenerationService implements GenerateProblemSetDraftUseCase {
+
+    private final GenerateProblemSetDraftAiPort generateProblemSetDraftAiPort;
+    private final StoreProblemSetDraftDatasetPort storeProblemSetDraftDatasetPort;
+    private final GenerateProblemSetDraftDatasetUrlPort generateProblemSetDraftDatasetUrlPort;
+
+    @Override
+    public ProblemSetDraftResult generate(
+            Long operatorId,
+            ProblemSetDraftGenerateRequest request,
+            MultipartFile datasetFile
+    ) {
+        validateDatasetFile(datasetFile);
+
+        String draftToken = UUID.randomUUID().toString();
+        StoredProblemSetDraftDataset storedDataset = storeProblemSetDraftDataset(
+                operatorId,
+                draftToken,
+                datasetFile
+        );
+        String datasetUrl = generateProblemSetDraftDatasetUrlPort.generate(
+                storedDataset.objectName()
+        );
+
+        GenerateProblemSetDraftCommand command = new GenerateProblemSetDraftCommand(
+                operatorId,
+                request.question(),
+                datasetUrl,
+                draftToken,
+                storedDataset.objectName(),
+                resolveDataFileName(request, storedDataset),
+                request.topic(),
+                request.categoryName(),
+                request.difficulty(),
+                request.problemCount(),
+                request.subProblemCount()
+        );
+
+        return generateProblemSetDraftAiPort.generate(command);
+    }
+
+    private void validateDatasetFile(MultipartFile datasetFile) {
+        if (datasetFile == null || datasetFile.isEmpty()) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE
+            );
+        }
+    }
+
+    private StoredProblemSetDraftDataset storeProblemSetDraftDataset(
+            Long operatorId,
+            String draftToken,
+            MultipartFile datasetFile
+    ) {
+        try {
+            return storeProblemSetDraftDatasetPort.store(
+                    new StoreProblemSetDraftDatasetCommand(
+                            operatorId,
+                            draftToken,
+                            datasetFile.getOriginalFilename(),
+                            datasetFile.getContentType(),
+                            datasetFile.getBytes(),
+                            datasetFile.getSize()
+                    )
+            );
+        } catch (IOException e) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED,
+                    e
+            );
+        }
+    }
+
+    private String resolveDataFileName(
+            ProblemSetDraftGenerateRequest request,
+            StoredProblemSetDraftDataset storedDataset
+    ) {
+        if (request.dataFileName() != null && !request.dataFileName().isBlank()) {
+            return request.dataFileName();
+        }
+
+        return storedDataset.originalFileName();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
@@ -1,14 +1,9 @@
 package com.wanted.codebombalms.problems.generation.application.usecase;
 
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
-import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
-import org.springframework.web.multipart.MultipartFile;
 
 public interface GenerateProblemSetDraftUseCase {
 
-    ProblemSetDraftResult generate(
-            Long operatorId,
-            ProblemSetDraftGenerateRequest request,
-            MultipartFile datasetFile
-    );
+    ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command);
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/application/usecase/GenerateProblemSetDraftUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.problems.generation.application.usecase;
+
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface GenerateProblemSetDraftUseCase {
+
+    ProblemSetDraftResult generate(
+            Long operatorId,
+            ProblemSetDraftGenerateRequest request,
+            MultipartFile datasetFile
+    );
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedProblemDraft.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedProblemDraft.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+import java.util.List;
+
+public record GeneratedProblemDraft(
+        String title,
+        int point,
+        String content,
+        String startCode,
+        String hint,
+        String explanation,
+        List<GeneratedTestCaseDraft> testCases
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedTestCaseDraft.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/GeneratedTestCaseDraft.java
@@ -1,0 +1,8 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+public record GeneratedTestCaseDraft(
+        String testCode,
+        boolean hidden,
+        int timeoutMs
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/ProblemSetDraft.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/ProblemSetDraft.java
@@ -1,0 +1,13 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+import java.util.List;
+
+public record ProblemSetDraft(
+        String title,
+        String categoryName,
+        String difficulty,
+        String description,
+        String dataFileName,
+        List<GeneratedProblemDraft> problems
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/domain/StoredProblemSetDraftDataset.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/domain/StoredProblemSetDraftDataset.java
@@ -1,0 +1,9 @@
+package com.wanted.codebombalms.problems.generation.domain;
+
+public record StoredProblemSetDraftDataset(
+        String originalFileName,
+        String storedFileName,
+        String objectName,
+        long fileSize
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
@@ -1,0 +1,22 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai;
+
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.infrastructure.ai.request.FastApiProblemSetDraftRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FastApiProblemSetDraftAdapter implements GenerateProblemSetDraftAiPort {
+
+    private final ProblemSetDraftAiClient problemSetDraftAiClient;
+
+    @Override
+    public ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command) {
+        return problemSetDraftAiClient.generate(
+                FastApiProblemSetDraftRequest.from(command)
+        ).toResult();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/FastApiProblemSetDraftAdapter.java
@@ -1,6 +1,6 @@
 package com.wanted.codebombalms.problems.generation.infrastructure.ai;
 
-import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftAiPort;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 import com.wanted.codebombalms.problems.generation.infrastructure.ai.request.FastApiProblemSetDraftRequest;
@@ -14,7 +14,7 @@ public class FastApiProblemSetDraftAdapter implements GenerateProblemSetDraftAiP
     private final ProblemSetDraftAiClient problemSetDraftAiClient;
 
     @Override
-    public ProblemSetDraftResult generate(GenerateProblemSetDraftCommand command) {
+    public ProblemSetDraftResult generate(GenerateProblemSetDraftAiCommand command) {
         return problemSetDraftAiClient.generate(
                 FastApiProblemSetDraftRequest.from(command)
         ).toResult();

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/ProblemSetDraftAiClient.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/ProblemSetDraftAiClient.java
@@ -1,0 +1,81 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai;
+
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.generation.infrastructure.ai.request.FastApiProblemSetDraftRequest;
+import com.wanted.codebombalms.problems.generation.infrastructure.ai.response.FastApiProblemSetDraftResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class ProblemSetDraftAiClient {
+
+    private static final String GENERATE_PATH = "/problem-set-draft/chat";
+    private static final int CONNECT_TIMEOUT_MS = 5_000;
+    private static final int READ_TIMEOUT_MS = 60_000;
+
+    private final RestClient restClient;
+
+    public ProblemSetDraftAiClient(
+            @Value("${fastapi.url}") String fastApiBaseUrl,
+            RestClient.Builder restClientBuilder
+    ) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        requestFactory.setReadTimeout(READ_TIMEOUT_MS);
+
+        this.restClient = restClientBuilder
+                .baseUrl(fastApiBaseUrl)
+                .requestFactory(requestFactory)
+                .build();
+    }
+
+    public FastApiProblemSetDraftResponse generate(FastApiProblemSetDraftRequest request) {
+        long startedAt = System.nanoTime();
+
+        try {
+            FastApiProblemSetDraftResponse response = restClient.post()
+                    .uri(GENERATE_PATH)
+                    .body(request)
+                    .retrieve()
+                    .body(FastApiProblemSetDraftResponse.class);
+
+            if (response == null) {
+                throw new ExternalServiceException(
+                        ProblemErrorCode.PROBLEM_SET_DRAFT_GENERATION_FAILED
+                );
+            }
+
+            log.info(
+                    "event=problem_set_draft_ai_completed problemCount={} subProblemCount={} durationMs={}",
+                    request.problemCount(),
+                    request.subProblemCount(),
+                    elapsedMillis(startedAt)
+            );
+
+            return response;
+        } catch (ExternalServiceException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error(
+                    "event=problem_set_draft_ai_failed exceptionType={} durationMs={}",
+                    e.getClass().getSimpleName(),
+                    elapsedMillis(startedAt),
+                    e
+            );
+
+            throw new ExternalServiceException(
+                    ProblemErrorCode.PROBLEM_SET_DRAFT_GENERATION_FAILED,
+                    e
+            );
+        }
+    }
+
+    private long elapsedMillis(long startedAt) {
+        return (System.nanoTime() - startedAt) / 1_000_000;
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
@@ -1,0 +1,50 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+
+import java.util.List;
+
+public record FastApiProblemSetDraftRequest(
+        String question,
+
+        @JsonProperty("operator_id")
+        Long operatorId,
+
+        @JsonProperty("dataset_url")
+        String datasetUrl,
+
+        @JsonProperty("data_file_name")
+        String dataFileName,
+
+        String topic,
+
+        @JsonProperty("category_name")
+        String categoryName,
+
+        String difficulty,
+
+        @JsonProperty("problem_count")
+        int problemCount,
+
+        @JsonProperty("sub_problem_count")
+        int subProblemCount,
+
+        List<Object> history
+) {
+
+    public static FastApiProblemSetDraftRequest from(GenerateProblemSetDraftCommand command) {
+        return new FastApiProblemSetDraftRequest(
+                command.question(),
+                command.operatorId(),
+                command.datasetUrl(),
+                command.dataFileName(),
+                command.topic(),
+                command.categoryName(),
+                command.difficulty(),
+                command.problemCount(),
+                command.subProblemCount(),
+                List.of()
+        );
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/request/FastApiProblemSetDraftRequest.java
@@ -1,7 +1,7 @@
 package com.wanted.codebombalms.problems.generation.infrastructure.ai.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftAiCommand;
 
 import java.util.List;
 
@@ -33,7 +33,7 @@ public record FastApiProblemSetDraftRequest(
         List<Object> history
 ) {
 
-    public static FastApiProblemSetDraftRequest from(GenerateProblemSetDraftCommand command) {
+    public static FastApiProblemSetDraftRequest from(GenerateProblemSetDraftAiCommand command) {
         return new FastApiProblemSetDraftRequest(
                 command.question(),
                 command.operatorId(),

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/response/FastApiProblemSetDraftResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/ai/response/FastApiProblemSetDraftResponse.java
@@ -1,0 +1,96 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.ai.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedProblemDraft;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedTestCaseDraft;
+import com.wanted.codebombalms.problems.generation.domain.ProblemSetDraft;
+
+import java.util.List;
+
+public record FastApiProblemSetDraftResponse(
+        String answer,
+        DraftResponse draft,
+
+        @JsonProperty("used_tools")
+        List<String> usedTools
+) {
+
+    public ProblemSetDraftResult toResult() {
+        return new ProblemSetDraftResult(
+                answer,
+                draft == null ? null : draft.toDomain(),
+                usedTools == null ? List.of() : usedTools
+        );
+    }
+
+    public record DraftResponse(
+            String title,
+            String categoryName,
+            String difficulty,
+            String description,
+            String dataFileName,
+            List<ProblemResponse> problems
+    ) {
+
+        private ProblemSetDraft toDomain() {
+            return new ProblemSetDraft(
+                    title,
+                    categoryName,
+                    difficulty,
+                    description,
+                    dataFileName,
+                    problems == null
+                            ? List.of()
+                            : problems.stream()
+                            .map(ProblemResponse::toDomain)
+                            .toList()
+            );
+        }
+    }
+
+    public record ProblemResponse(
+            String title,
+            int point,
+            String content,
+            String startCode,
+            String hint,
+            String explanation,
+            List<TestCaseResponse> testCases
+    ) {
+
+        private GeneratedProblemDraft toDomain() {
+            return new GeneratedProblemDraft(
+                    title,
+                    point,
+                    content,
+                    startCode,
+                    hint,
+                    explanation,
+                    testCases == null
+                            ? List.of()
+                            : testCases.stream()
+                            .map(TestCaseResponse::toDomain)
+                            .toList()
+            );
+        }
+    }
+
+    public record TestCaseResponse(
+            String testCode,
+
+            @JsonProperty("isHidden")
+            boolean hidden,
+
+            int timeoutMs
+    ) {
+
+        private GeneratedTestCaseDraft toDomain() {
+            return new GeneratedTestCaseDraft(
+                    testCode,
+                    hidden,
+                    timeoutMs
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
@@ -1,0 +1,170 @@
+package com.wanted.codebombalms.problems.generation.infrastructure.storage;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageClientFactory;
+import com.wanted.codebombalms.global.infrastructure.storage.GcpStorageProperties;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.generation.application.command.StoreProblemSetDraftDatasetCommand;
+import com.wanted.codebombalms.problems.generation.application.port.DeleteProblemSetDraftDatasetPort;
+import com.wanted.codebombalms.problems.generation.application.port.GenerateProblemSetDraftDatasetUrlPort;
+import com.wanted.codebombalms.problems.generation.application.port.StoreProblemSetDraftDatasetPort;
+import com.wanted.codebombalms.problems.generation.domain.StoredProblemSetDraftDataset;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+public class GcsProblemSetDraftDatasetStorageAdapter implements
+        StoreProblemSetDraftDatasetPort,
+        GenerateProblemSetDraftDatasetUrlPort,
+        DeleteProblemSetDraftDatasetPort {
+
+    private static final String CSV_CONTENT_TYPE = "text/csv";
+    private static final String DRAFT_DIRECTORY = "drafts";
+    private static final long SIGNED_URL_DURATION_MINUTES = 30;
+
+    private final GcpStorageProperties properties;
+    private final GcpStorageClientFactory storageClientFactory;
+    private volatile Storage storage;
+
+    public GcsProblemSetDraftDatasetStorageAdapter(
+            GcpStorageProperties properties,
+            GcpStorageClientFactory storageClientFactory
+    ) {
+        this.properties = properties;
+        this.storageClientFactory = storageClientFactory;
+    }
+
+    @Override
+    public StoredProblemSetDraftDataset store(StoreProblemSetDraftDatasetCommand command) {
+        String originalFileName = sanitizeFileName(command.originalFileName());
+        String storedFileName = command.draftToken() + "_" + originalFileName;
+        String objectName = buildObjectName(command, storedFileName);
+
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(
+                            BlobId.of(properties.getStorage().getBucket(), objectName)
+                    )
+                    .setContentType(CSV_CONTENT_TYPE)
+                    .build();
+
+            getStorage().create(blobInfo, command.content());
+
+            return new StoredProblemSetDraftDataset(
+                    originalFileName,
+                    storedFileName,
+                    objectName,
+                    command.fileSize()
+            );
+        } catch (Exception e) {
+            throw new ExternalServiceException(
+                    ProblemErrorCode.PROBLEM_DATASET_UPLOAD_FAILED,
+                    e
+            );
+        }
+    }
+
+    @Override
+    public String generate(String objectName) {
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(
+                    properties.getStorage().getBucket(),
+                    objectName
+            ).build();
+
+            return getStorage()
+                    .signUrl(
+                            blobInfo,
+                            SIGNED_URL_DURATION_MINUTES,
+                            TimeUnit.MINUTES,
+                            Storage.SignUrlOption.withV4Signature()
+                    )
+                    .toString();
+        } catch (Exception e) {
+            log.error(
+                    "event=problem_set_draft_dataset_signed_url_failed bucket={} objectName={} exceptionType={}",
+                    properties.getStorage().getBucket(),
+                    objectName,
+                    e.getClass().getSimpleName(),
+                    e
+            );
+
+            throw new ExternalServiceException(
+                    ProblemErrorCode.PROBLEM_DATASET_ACCESS_URL_FAILED,
+                    e
+            );
+        }
+    }
+
+    @Override
+    public void delete(String objectName) {
+        if (objectName == null || objectName.isBlank()) {
+            return;
+        }
+
+        try {
+            getStorage().delete(
+                    BlobId.of(properties.getStorage().getBucket(), objectName)
+            );
+        } catch (Exception e) {
+            log.warn(
+                    "event=problem_set_draft_dataset_delete_failed objectName={}",
+                    objectName,
+                    e
+            );
+        }
+    }
+
+    private Storage getStorage() throws IOException {
+        if (storage == null) {
+            synchronized (this) {
+                if (storage == null) {
+                    storage = storageClientFactory.create();
+                }
+            }
+        }
+
+        return storage;
+    }
+
+    private String buildObjectName(
+            StoreProblemSetDraftDatasetCommand command,
+            String storedFileName
+    ) {
+        String prefix = normalizePrefix(properties.getStorage().getDatasetPrefix());
+
+        return prefix
+                + "/"
+                + DRAFT_DIRECTORY
+                + "/"
+                + command.operatorId()
+                + "/"
+                + command.draftToken()
+                + "/"
+                + storedFileName;
+    }
+
+    private String normalizePrefix(String prefix) {
+        if (prefix == null) {
+            return "";
+        }
+
+        return prefix.replaceAll("^/+", "").replaceAll("/+$", "");
+    }
+
+    private String sanitizeFileName(String originalFileName) {
+        if (originalFileName == null || originalFileName.isBlank()) {
+            return "dataset.csv";
+        }
+
+        return originalFileName
+                .replace("\\", "_")
+                .replace("/", "_");
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/infrastructure/storage/GcsProblemSetDraftDatasetStorageAdapter.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -54,7 +55,9 @@ public class GcsProblemSetDraftDatasetStorageAdapter implements
                     .setContentType(CSV_CONTENT_TYPE)
                     .build();
 
-            getStorage().create(blobInfo, command.content());
+            try (InputStream content = command.content()) {
+                getStorage().createFrom(blobInfo, content);
+            }
 
             return new StoredProblemSetDraftDataset(
                     originalFileName,

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
@@ -1,9 +1,12 @@
 package com.wanted.codebombalms.problems.generation.presentation;
 
 
+import com.wanted.codebombalms.global.domain.common.error.exception.ValidationException;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
 import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.problems.exception.ProblemErrorCode;
+import com.wanted.codebombalms.problems.generation.application.command.GenerateProblemSetDraftCommand;
 import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
 import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
 import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
@@ -24,6 +27,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(
         name = "문제세트 AI 초안 생성",
@@ -67,9 +72,7 @@ public class ProblemSetGenerationController {
             @RequestPart("datasetFile") MultipartFile datasetFile
     ) {
         ProblemSetDraftResult result = generateProblemSetDraftUseCase.generate(
-                userId,
-                request,
-                datasetFile
+                toCommand(userId, request, datasetFile)
         );
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -77,5 +80,39 @@ public class ProblemSetGenerationController {
                 ApiResponseMessage.SUCCESS,
                 ProblemSetDraftGenerateResponse.from(result)
         ));
+    }
+
+    private GenerateProblemSetDraftCommand toCommand(
+            Long operatorId,
+            ProblemSetDraftGenerateRequest request,
+            MultipartFile datasetFile
+    ) {
+        if (datasetFile == null || datasetFile.isEmpty()) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE
+            );
+        }
+
+        try {
+            return new GenerateProblemSetDraftCommand(
+                    operatorId,
+                    request.question(),
+                    request.dataFileName(),
+                    request.topic(),
+                    request.categoryName(),
+                    request.difficulty(),
+                    request.problemCount(),
+                    request.subProblemCount(),
+                    datasetFile.getOriginalFilename(),
+                    datasetFile.getContentType(),
+                    datasetFile.getInputStream(),
+                    datasetFile.getSize()
+            );
+        } catch (IOException e) {
+            throw new ValidationException(
+                    ProblemErrorCode.PROBLEM_DATASET_INVALID_FILE,
+                    e
+            );
+        }
     }
 }

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/ProblemSetGenerationController.java
@@ -1,0 +1,81 @@
+package com.wanted.codebombalms.problems.generation.presentation;
+
+
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseCode;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponseMessage;
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.application.usecase.GenerateProblemSetDraftUseCase;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateRequest;
+import com.wanted.codebombalms.problems.generation.presentation.api.request.ProblemSetDraftGenerateSwaggerRequest;
+import com.wanted.codebombalms.problems.generation.presentation.api.response.ProblemSetDraftGenerateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(
+        name = "문제세트 AI 초안 생성",
+        description = "관리자가 데이터셋 기반 문제세트 초안을 AI로 생성하고, 최종 등록 전 검토할 수 있는 API"
+)
+@RestController
+@RequiredArgsConstructor
+public class ProblemSetGenerationController {
+
+    private final GenerateProblemSetDraftUseCase generateProblemSetDraftUseCase;
+
+    @Operation(
+            summary = "AI 문제세트 초안 생성",
+            description = """
+                    관리자가 입력한 문제 생성 방향, 난이도, 카테고리, 데이터셋 정보를 기반으로 문제세트 초안을 생성합니다.
+
+                    이 API는 실제 문제세트를 DB에 저장하지 않습니다.
+                    생성된 초안은 프론트에서 미리보기로 보여준 뒤, 관리자가 반영하기를 누르면 문제 등록 폼에 채워집니다.
+                    최종 저장은 기존 문제 등록 API를 사용합니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content = @Content(
+                    mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schema = @Schema(implementation = ProblemSetDraftGenerateSwaggerRequest.class),
+                    encoding = {
+                            @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE),
+                            @Encoding(name = "datasetFile", contentType = "text/csv")
+                    }
+            )
+    )
+    @PreAuthorize("hasAnyRole('ADMIN', 'OPERATOR')")
+    @PostMapping(
+            value = "/api/v1/admin/problem-set-drafts/generate",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<ApiResponse<ProblemSetDraftGenerateResponse>> generateProblemSetDraft(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart("request") @Valid ProblemSetDraftGenerateRequest request,
+            @RequestPart("datasetFile") MultipartFile datasetFile
+    ) {
+        ProblemSetDraftResult result = generateProblemSetDraftUseCase.generate(
+                userId,
+                request,
+                datasetFile
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                ApiResponseCode.SUCCESS,
+                ApiResponseMessage.SUCCESS,
+                ProblemSetDraftGenerateResponse.from(result)
+        ));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
@@ -1,0 +1,39 @@
+package com.wanted.codebombalms.problems.generation.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "AI 문제세트 초안 생성 요청")
+public record ProblemSetDraftGenerateRequest(
+        @Schema(description = "관리자가 원하는 문제 생성 방향")
+        @NotBlank(message = "문제 생성 요청 문구는 필수입니다.")
+        String question,
+
+        @Schema(description = "데이터 파일명", example = "sw_engineer_salary.csv")
+        String dataFileName,
+
+        @Schema(description = "문제 주제", example = "SW기술자 평균임금 분석")
+        @NotBlank(message = "문제 주제는 필수입니다.")
+        String topic,
+
+        @Schema(description = "카테고리 이름", example = "공공 데이터")
+        @NotBlank(message = "카테고리 이름은 필수입니다.")
+        String categoryName,
+
+        @Schema(description = "난이도", example = "EASY", allowableValues = {"EASY", "MEDIUM", "HARD"})
+        @NotBlank(message = "난이도는 필수입니다.")
+        String difficulty,
+
+        @Schema(description = "생성할 문제세트 개수", example = "1")
+        @Min(1)
+        @Max(1)
+        int problemCount,
+
+        @Schema(description = "생성할 소문제 개수", example = "3")
+        @Min(1)
+        @Max(10)
+        int subProblemCount
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateRequest.java
@@ -4,26 +4,33 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "AI 문제세트 초안 생성 요청")
 public record ProblemSetDraftGenerateRequest(
         @Schema(description = "관리자가 원하는 문제 생성 방향")
         @NotBlank(message = "문제 생성 요청 문구는 필수입니다.")
+        @Size(max = 1_000, message = "문제 생성 요청 문구는 1000자 이하여야 합니다.")
         String question,
 
         @Schema(description = "데이터 파일명", example = "sw_engineer_salary.csv")
+        @Size(max = 255, message = "데이터 파일명은 255자 이하여야 합니다.")
         String dataFileName,
 
         @Schema(description = "문제 주제", example = "SW기술자 평균임금 분석")
         @NotBlank(message = "문제 주제는 필수입니다.")
+        @Size(max = 100, message = "문제 주제는 100자 이하여야 합니다.")
         String topic,
 
         @Schema(description = "카테고리 이름", example = "공공 데이터")
         @NotBlank(message = "카테고리 이름은 필수입니다.")
+        @Size(max = 50, message = "카테고리 이름은 50자 이하여야 합니다.")
         String categoryName,
 
         @Schema(description = "난이도", example = "EASY", allowableValues = {"EASY", "MEDIUM", "HARD"})
         @NotBlank(message = "난이도는 필수입니다.")
+        @Pattern(regexp = "EASY|MEDIUM|HARD", message = "난이도는 EASY, MEDIUM, HARD만 가능합니다.")
         String difficulty,
 
         @Schema(description = "생성할 문제세트 개수", example = "1")

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateSwaggerRequest.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/request/ProblemSetDraftGenerateSwaggerRequest.java
@@ -1,0 +1,23 @@
+package com.wanted.codebombalms.problems.generation.presentation.api.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "AI problem set draft generation multipart request")
+public record ProblemSetDraftGenerateSwaggerRequest(
+        @Schema(
+                description = "Problem set draft generation JSON part",
+                implementation = ProblemSetDraftGenerateRequest.class,
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        ProblemSetDraftGenerateRequest request,
+
+        @Schema(
+                description = "CSV dataset file used for draft generation",
+                type = "string",
+                format = "binary",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        MultipartFile datasetFile
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/response/ProblemSetDraftGenerateResponse.java
+++ b/src/main/java/com/wanted/codebombalms/problems/generation/presentation/api/response/ProblemSetDraftGenerateResponse.java
@@ -1,0 +1,97 @@
+package com.wanted.codebombalms.problems.generation.presentation.api.response;
+
+import com.wanted.codebombalms.problems.generation.application.result.ProblemSetDraftResult;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedProblemDraft;
+import com.wanted.codebombalms.problems.generation.domain.GeneratedTestCaseDraft;
+import com.wanted.codebombalms.problems.generation.domain.ProblemSetDraft;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "AI 문제세트 초안 생성 응답")
+public record ProblemSetDraftGenerateResponse(
+        @Schema(description = "AI 생성 결과 요약")
+        String answer,
+
+        @Schema(description = "문제세트 초안")
+        DraftResponse draft,
+
+        @Schema(description = "AI 서버에서 사용한 도구 목록")
+        List<String> usedTools
+) {
+
+    public static ProblemSetDraftGenerateResponse from(ProblemSetDraftResult result) {
+        return new ProblemSetDraftGenerateResponse(
+                result.answer(),
+                DraftResponse.from(result.draft()),
+                result.usedTools()
+        );
+    }
+
+    public record DraftResponse(
+            String title,
+            String categoryName,
+            String difficulty,
+            String description,
+            String dataFileName,
+            List<ProblemResponse> problems
+    ) {
+
+        public static DraftResponse from(ProblemSetDraft draft) {
+            if (draft == null) {
+                return null;
+            }
+
+            return new DraftResponse(
+                    draft.title(),
+                    draft.categoryName(),
+                    draft.difficulty(),
+                    draft.description(),
+                    draft.dataFileName(),
+                    draft.problems().stream()
+                            .map(ProblemResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record ProblemResponse(
+            String title,
+            int point,
+            String content,
+            String startCode,
+            String hint,
+            String explanation,
+            List<TestCaseResponse> testCases
+    ) {
+
+        public static ProblemResponse from(GeneratedProblemDraft problem) {
+            return new ProblemResponse(
+                    problem.title(),
+                    problem.point(),
+                    problem.content(),
+                    problem.startCode(),
+                    problem.hint(),
+                    problem.explanation(),
+                    problem.testCases().stream()
+                            .map(TestCaseResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record TestCaseResponse(
+            String testCode,
+            boolean isHidden,
+            int timeoutMs
+    ) {
+
+        public static TestCaseResponse from(GeneratedTestCaseDraft testCase) {
+            return new TestCaseResponse(
+                    testCase.testCode(),
+                    testCase.hidden(),
+                    testCase.timeoutMs()
+            );
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
+++ b/src/main/java/com/wanted/codebombalms/problems/set/infrastructure/persistence/SpringDataProblemSetRepository.java
@@ -35,6 +35,11 @@ public interface SpringDataProblemSetRepository extends JpaRepository<ProblemSet
             ProblemSetStatus status
     );
 
+    List<ProblemSetJpaEntity> findByProblemSetIdInAndStatus(
+            Collection<Long> problemSetIds,
+            ProblemSetStatus status
+    );
+
     Page<ProblemSetJpaEntity> findByStatusOrderByProblemSetIdAsc(
             ProblemSetStatus status,
             Pageable pageable

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/OpsQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/OpsQueryPort.java
@@ -1,0 +1,46 @@
+package com.wanted.codebombalms.serviceevent.application.port;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 운영 Q&A 챗봇 도구용 읽기 전용 집계 포트.
+ *
+ * FastAPI opschat 의 function calling 도구가 내부 API(/internal/ops/*)를 통해 호출한다 —
+ * 쿼리·스키마 지식을 Spring 한 곳에 유지하기 위해 파이썬의 DB 직접 조회를 대체 (2026-07-20).
+ * category / eventType 필터는 null 허용(전체).
+ */
+public interface OpsQueryPort {
+
+    List<TypeCount> countEvents(LocalDateTime start, LocalDateTime end, String category, String eventType);
+
+    List<TimelineBucket> eventTimeline(LocalDateTime start, LocalDateTime end, String category, String eventType);
+
+    List<IpCount> topIps(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit);
+
+    List<EventDetail> recentEvents(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit);
+
+    record TypeCount(String eventType, long cnt) {
+    }
+
+    /** bucket = "yyyy-MM-dd HH:00" (KST 벽시계, 시간 단위) */
+    record TimelineBucket(String bucket, long cnt) {
+    }
+
+    record IpCount(String ipAddress, long cnt) {
+    }
+
+    /** detail 컬럼은 개인정보 여지가 있어 의도적으로 미포함 (opschat 방침과 동일) */
+    record EventDetail(
+            String category,
+            String eventType,
+            Long userId,
+            String ipAddress,
+            String uri,
+            Integer httpStatus,
+            Integer durationMs,
+            String traceId,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
@@ -24,8 +24,8 @@ public interface SecuritySummaryQueryPort {
 
     List<RouteAnomaly> findHttpAnomalies(LocalDateTime start, LocalDateTime end);
 
-    /** (route, type) 별 http_status 세부 분포 — statusBreakdown 맵 조립용 */
-    List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end);
+    /** 지정 라우트 집합의 http_status 세부 분포 — statusBreakdown 맵 조립용 (top-N 라우트로 스코핑) */
+    List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end, List<String> routes);
 
     List<HourlyCount> hourlyDistribution(LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/port/SecuritySummaryQueryPort.java
@@ -11,6 +11,7 @@ public interface SecuritySummaryQueryPort {
     record TypeCount(String type, long count) {}
     record RiskIp(String ip, long count, String mainType, List<Long> targetUserIds) {}
     record RouteAnomaly(String route, String type, long count, Integer maxDurationMs) {}
+    record StatusBreakdown(String route, String type, int status, long count) {}
     record HourlyCount(int hour, long count) {}
     record ConcurrentPeak(long peak, LocalDateTime occurredAt) {}
 
@@ -22,6 +23,9 @@ public interface SecuritySummaryQueryPort {
     List<RiskIp> findTopRiskIps(LocalDateTime start, LocalDateTime end);
 
     List<RouteAnomaly> findHttpAnomalies(LocalDateTime start, LocalDateTime end);
+
+    /** (route, type) 별 http_status 세부 분포 — statusBreakdown 맵 조립용 */
+    List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end);
 
     List<HourlyCount> hourlyDistribution(LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/query/SecuritySummaryResult.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/query/SecuritySummaryResult.java
@@ -2,6 +2,7 @@ package com.wanted.codebombalms.serviceevent.application.query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * GET /api/v1/admin/security/summary 응답 data 형태.
@@ -32,7 +33,9 @@ public record SecuritySummaryResult(
 
     public record DomainCount(String group, String label, long count) {}
 
-    public record HttpAnomaly(String route, String type, long count, Integer maxDurationMs) {}
+    public record HttpAnomaly(
+            String route, String type, long count, Integer maxDurationMs,
+            Map<Integer, Long> statusBreakdown) {}
 
     public record RiskIp(String ip, String country, long eventCount, String mainType, List<Long> targetUserIds) {}
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
@@ -103,7 +103,9 @@ public class SecuritySummaryService {
                 period.code,
                 kpi,
                 toDomainCounts(categoryCounts),
-                toHttpAnomalies(summaryQuery.findHttpAnomalies(start, end)),
+                toHttpAnomalies(
+                        summaryQuery.findHttpAnomalies(start, end),
+                        summaryQuery.findHttpStatusBreakdown(start, end)),
                 toRiskIps(summaryQuery.findTopRiskIps(start, end)),
                 toHourly(summaryQuery.hourlyDistribution(start, end))
         );
@@ -145,10 +147,24 @@ public class SecuritySummaryService {
     }
 
     private List<SecuritySummaryResult.HttpAnomaly> toHttpAnomalies(
-            List<SecuritySummaryQueryPort.RouteAnomaly> anomalies) {
+            List<SecuritySummaryQueryPort.RouteAnomaly> anomalies,
+            List<SecuritySummaryQueryPort.StatusBreakdown> breakdowns) {
+        Map<String, Map<Integer, Long>> byRouteType = breakdowns.stream()
+                .collect(Collectors.groupingBy(
+                        b -> routeTypeKey(b.route(), b.type()),
+                        Collectors.toMap(
+                                SecuritySummaryQueryPort.StatusBreakdown::status,
+                                SecuritySummaryQueryPort.StatusBreakdown::count)));
         return anomalies.stream()
-                .map(a -> new SecuritySummaryResult.HttpAnomaly(a.route(), a.type(), a.count(), a.maxDurationMs()))
+                .map(a -> new SecuritySummaryResult.HttpAnomaly(
+                        a.route(), a.type(), a.count(), a.maxDurationMs(),
+                        byRouteType.getOrDefault(routeTypeKey(a.route(), a.type()), Map.of())))
                 .toList();
+    }
+
+    /** (route, type) 복합 키 — 널 안전, 구분자로 route 값 충돌 방지 */
+    private String routeTypeKey(String route, String type) {
+        return route + ' ' + type;
     }
 
     private List<SecuritySummaryResult.RiskIp> toRiskIps(List<SecuritySummaryQueryPort.RiskIp> riskIps) {

--- a/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/application/service/SecuritySummaryService.java
@@ -99,13 +99,19 @@ public class SecuritySummaryService {
                 enrollmentsDelta
         );
 
+        List<SecuritySummaryQueryPort.RouteAnomaly> anomalies = summaryQuery.findHttpAnomalies(start, end);
+        List<String> anomalyRoutes = anomalies.stream()
+                .map(SecuritySummaryQueryPort.RouteAnomaly::route)
+                .distinct()
+                .toList();
+        List<SecuritySummaryQueryPort.StatusBreakdown> breakdowns =
+                summaryQuery.findHttpStatusBreakdown(start, end, anomalyRoutes);
+
         return new SecuritySummaryResult(
                 period.code,
                 kpi,
                 toDomainCounts(categoryCounts),
-                toHttpAnomalies(
-                        summaryQuery.findHttpAnomalies(start, end),
-                        summaryQuery.findHttpStatusBreakdown(start, end)),
+                toHttpAnomalies(anomalies, breakdowns),
                 toRiskIps(summaryQuery.findTopRiskIps(start, end)),
                 toHourly(summaryQuery.hourlyDistribution(start, end))
         );

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
@@ -1,0 +1,87 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.client;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wanted.codebombalms.serviceevent.presentation.api.request.OpsChatRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+/**
+ * FastAPI 운영 Q&A 챗봇(/ops-chat) 릴레이 클라이언트.
+ *
+ * 학생 챗봇(FastApiChatClient)과 달리 프레임을 도메인 모델로 파싱하지 않고
+ * SSE 를 그대로 재송출한다 — event 이름(status/done/error)과 토큰 프레임을
+ * FE 가 FastAPI 계약 그대로 받는다. (메시지 영속화·토큰 집계가 없어 파싱 불필요)
+ *
+ * WebClient 는 chatbot WebClientConfig 의 전역 빈(baseUrl=fastapi.url) 재사용 —
+ * 같은 FastAPI 서버의 다른 엔드포인트라 설정이 동일하다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OpsChatFastApiClient {
+
+    // FastAPI ops_gemini_client.py 의 OPS_RESPONSE_FAILED 와 공유하는 계약
+    private static final String OPS_RESPONSE_FAILED_CODE = "OPS-001";
+    private static final String CALL_FAILED_DATA =
+            "{\"code\": \"" + OPS_RESPONSE_FAILED_CODE + "\", \"message\": \"운영 챗봇 호출에 실패했습니다.\"}";
+
+    private final WebClient webClient;
+
+    public Flux<ServerSentEvent<String>> stream(OpsChatRequest request, String traceId) {
+        return webClient.post()
+                .uri("/ops-chat")
+                // BE↔FastAPI 로그를 같은 traceId 로 엮는다 (학생 챗봇과 동일 컨벤션)
+                .headers(h -> {
+                    if (traceId != null) {
+                        h.set("X-Trace-Id", traceId);
+                    }
+                })
+                .bodyValue(toFastApiRequest(request))
+                .retrieve()
+                .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
+                .map(this::passThrough)
+                .onErrorResume(e -> {
+                    log.warn("event=opschat_ai_call_failed traceId={} - FastAPI 운영 챗봇 호출 실패", traceId, e);
+                    return Flux.just(ServerSentEvent.<String>builder()
+                            .event("error")
+                            .data(CALL_FAILED_DATA)
+                            .build());
+                });
+    }
+
+    /** 수신 프레임을 event 이름 보존 채로 재조립 — 내용은 손대지 않는다. */
+    private ServerSentEvent<String> passThrough(ServerSentEvent<String> sse) {
+        ServerSentEvent.Builder<String> builder = ServerSentEvent.builder(sse.data() == null ? "" : sse.data());
+        if (sse.event() != null) {
+            builder.event(sse.event());
+        }
+        return builder.build();
+    }
+
+    private FastApiOpsChatRequest toFastApiRequest(OpsChatRequest request) {
+        List<FastApiOpsChatRequest.MessageDto> history = request.conversationHistory() == null
+                ? null
+                : request.conversationHistory().stream()
+                        .map(m -> new FastApiOpsChatRequest.MessageDto(m.role(), m.content()))
+                        .toList();
+        return new FastApiOpsChatRequest(request.userMessage(), history);
+    }
+
+    /** FastAPI OpsChatRequest(snake_case) 와의 전송 계약. */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    record FastApiOpsChatRequest(
+            @JsonProperty("user_message") String userMessage,
+            @JsonProperty("conversation_history") List<MessageDto> conversationHistory
+    ) {
+        record MessageDto(String role, String content) {
+        }
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/client/OpsChatFastApiClient.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -33,6 +34,11 @@ public class OpsChatFastApiClient {
     private static final String CALL_FAILED_DATA =
             "{\"code\": \"" + OPS_RESPONSE_FAILED_CODE + "\", \"message\": \"운영 챗봇 호출에 실패했습니다.\"}";
 
+    // 프레임 간(토큰 사이) 무응답 상한 — FastAPI 가 멈추거나 스트림을 닫지 않을 때
+    // 커넥션을 무한 점유하지 않도록 캡한다(정상 스트리밍은 프레임이 계속 흘러 안 걸림).
+    // 도구 라운드 사이 공백까지 감안한 여유값. 초과 시 아래 onErrorResume 으로 흡수.
+    private static final Duration STREAM_TIMEOUT = Duration.ofSeconds(150);
+
     private final WebClient webClient;
 
     public Flux<ServerSentEvent<String>> stream(OpsChatRequest request, String traceId) {
@@ -48,6 +54,7 @@ public class OpsChatFastApiClient {
                 .retrieve()
                 .bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
                 .map(this::passThrough)
+                .timeout(STREAM_TIMEOUT)
                 .onErrorResume(e -> {
                     log.warn("event=opschat_ai_call_failed traceId={} - FastAPI 운영 챗봇 호출 실패", traceId, e);
                     return Flux.just(ServerSentEvent.<String>builder()

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/OpsQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/OpsQueryAdapter.java
@@ -1,0 +1,56 @@
+package com.wanted.codebombalms.serviceevent.infrastructure.persistence;
+
+import com.wanted.codebombalms.serviceevent.application.port.OpsQueryPort;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OpsQueryAdapter implements OpsQueryPort {
+
+    // 리포지토리 네이티브 쿼리의 고정 LIMIT 과 동기 유지
+    private static final int MAX_LIMIT = 20;
+
+    private final SpringDataServiceEventRepository repository;
+
+    @Override
+    public List<TypeCount> countEvents(LocalDateTime start, LocalDateTime end, String category, String eventType) {
+        return repository.countByTypeFiltered(start, end, category, eventType).stream()
+                .map(row -> new TypeCount(row.getEventType(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
+    public List<TimelineBucket> eventTimeline(LocalDateTime start, LocalDateTime end, String category, String eventType) {
+        return repository.eventTimeline(start, end, category, eventType).stream()
+                .map(row -> new TimelineBucket(row.getBucket(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
+    public List<IpCount> topIps(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit) {
+        return repository.topIpsFiltered(start, end, category, eventType).stream()
+                .limit(clamp(limit))
+                .map(row -> new IpCount(row.getIpAddress(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
+    public List<EventDetail> recentEvents(LocalDateTime start, LocalDateTime end, String category, String eventType, int limit) {
+        return repository.recentEvents(start, end, category, eventType).stream()
+                .limit(clamp(limit))
+                .map(row -> new EventDetail(
+                        row.getCategory(), row.getEventType(), row.getUserId(), row.getIpAddress(),
+                        row.getUri(), row.getHttpStatus(), row.getDurationMs(), row.getTraceId(),
+                        row.getCreatedAt()))
+                .toList();
+    }
+
+    private long clamp(int limit) {
+        return Math.max(1, Math.min(limit, MAX_LIMIT));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
@@ -50,8 +50,11 @@ public class SecuritySummaryQueryAdapter implements SecuritySummaryQueryPort {
     }
 
     @Override
-    public List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end) {
-        return repository.findHttpStatusBreakdown(start, end).stream()
+    public List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end, List<String> routes) {
+        if (routes.isEmpty()) {
+            return List.of(); // 빈 목록이면 native IN () 문법 오류 방지 — 조회 생략
+        }
+        return repository.findHttpStatusBreakdown(start, end, routes).stream()
                 .map(row -> new StatusBreakdown(
                         row.getUri(), row.getEventType(), row.getStatus(), row.getCnt()))
                 .toList();

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SecuritySummaryQueryAdapter.java
@@ -50,6 +50,14 @@ public class SecuritySummaryQueryAdapter implements SecuritySummaryQueryPort {
     }
 
     @Override
+    public List<StatusBreakdown> findHttpStatusBreakdown(LocalDateTime start, LocalDateTime end) {
+        return repository.findHttpStatusBreakdown(start, end).stream()
+                .map(row -> new StatusBreakdown(
+                        row.getUri(), row.getEventType(), row.getStatus(), row.getCnt()))
+                .toList();
+    }
+
+    @Override
     public List<HourlyCount> hourlyDistribution(LocalDateTime start, LocalDateTime end) {
         return repository.hourlyDistribution(start, end).stream()
                 .map(row -> new HourlyCount(row.getHr(), row.getCnt()))

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -104,10 +104,12 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             WHERE created_at >= :start AND created_at < :end
               AND category = 'http_anomaly'
               AND http_status IS NOT NULL
+              AND uri IN (:uris)
             GROUP BY uri, event_type, http_status
             """, nativeQuery = true)
     List<HttpStatusBreakdownRow> findHttpStatusBreakdown(
-            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("uris") List<String> uris);
 
     @Query(value = """
             SELECT HOUR(created_at) AS hr, COUNT(*) AS cnt

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -103,7 +103,7 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             FROM service_event
             WHERE created_at >= :start AND created_at < :end
               AND category = 'http_anomaly'
-              AND http_status IS NOT NULL
+              AND http_status >= 400
               AND uri IN (:uris)
             GROUP BY uri, event_type, http_status
             """, nativeQuery = true)

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -27,6 +27,7 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
     interface TypeCountRow { String getEventType(); long getCnt(); }
     interface IpCountRow { String getIpAddress(); long getCnt(); }
     interface RouteAnomalyRow { String getUri(); String getEventType(); long getCnt(); Integer getMaxDuration(); }
+    interface HttpStatusBreakdownRow { String getUri(); String getEventType(); Integer getStatus(); long getCnt(); }
     interface HourlyRow { int getHr(); long getCnt(); }
     interface ConcurrentPeakRow { long getPeak(); LocalDateTime getOccurredAt(); }
 
@@ -96,6 +97,17 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             LIMIT 10
             """, nativeQuery = true)
     List<RouteAnomalyRow> findHttpAnomalies(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    @Query(value = """
+            SELECT uri AS uri, event_type AS eventType, http_status AS status, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND category = 'http_anomaly'
+              AND http_status IS NOT NULL
+            GROUP BY uri, event_type, http_status
+            """, nativeQuery = true)
+    List<HttpStatusBreakdownRow> findHttpStatusBreakdown(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     @Query(value = """
             SELECT HOUR(created_at) AS hr, COUNT(*) AS cnt

--- a/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/infrastructure/persistence/SpringDataServiceEventRepository.java
@@ -116,4 +116,73 @@ public interface SpringDataServiceEventRepository extends JpaRepository<ServiceE
             LIMIT 1
             """, nativeQuery = true)
     ConcurrentPeakRow findConcurrentPeak(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    // ===== 이하 운영 Q&A 챗봇(opschat) 도구용 — 전부 읽기 전용, 필터는 null=전체 =====
+    // LIMIT 고정 상수 규칙 유지: 동적 limit 은 OpsQueryAdapter 에서 subList 로 자른다.
+
+    interface TimelineBucketRow { String getBucket(); long getCnt(); }
+    interface RecentEventRow {
+        String getCategory(); String getEventType(); Long getUserId(); String getIpAddress();
+        String getUri(); Integer getHttpStatus(); Integer getDurationMs(); String getTraceId();
+        LocalDateTime getCreatedAt();
+    }
+
+    @Query(value = """
+            SELECT event_type AS eventType, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            GROUP BY event_type
+            ORDER BY cnt DESC
+            """, nativeQuery = true)
+    List<TypeCountRow> countByTypeFiltered(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
+
+    /** 시간(hour) 버킷 추이 — 최대 7일치(168버킷) */
+    @Query(value = """
+            SELECT DATE_FORMAT(created_at, '%Y-%m-%d %H:00') AS bucket, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            GROUP BY bucket
+            ORDER BY bucket
+            LIMIT 168
+            """, nativeQuery = true)
+    List<TimelineBucketRow> eventTimeline(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
+
+    @Query(value = """
+            SELECT ip_address AS ipAddress, COUNT(*) AS cnt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND ip_address IS NOT NULL
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            GROUP BY ip_address
+            ORDER BY cnt DESC
+            LIMIT 20
+            """, nativeQuery = true)
+    List<IpCountRow> topIpsFiltered(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
+
+    /** detail 컬럼 미포함(개인정보 방침) — opschat recent_events 도구 전용 */
+    @Query(value = """
+            SELECT category AS category, event_type AS eventType, user_id AS userId,
+                   ip_address AS ipAddress, uri AS uri, http_status AS httpStatus,
+                   duration_ms AS durationMs, trace_id AS traceId, created_at AS createdAt
+            FROM service_event
+            WHERE created_at >= :start AND created_at < :end
+              AND (:category IS NULL OR category = :category)
+              AND (:eventType IS NULL OR event_type = :eventType)
+            ORDER BY created_at DESC
+            LIMIT 20
+            """, nativeQuery = true)
+    List<RecentEventRow> recentEvents(
+            @Param("start") LocalDateTime start, @Param("end") LocalDateTime end,
+            @Param("category") String category, @Param("eventType") String eventType);
 }

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
@@ -17,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -33,6 +34,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class InternalOpsController {
 
+    // 조회 기간 상한 — GROUP BY 집계가 넓은 기간에 풀스캔되는 것을 막는다 (LLM 오요청 방어)
+    private static final Duration MAX_RANGE = Duration.ofDays(31);
+
     private final OpsQueryPort opsQueryPort;
     private final BriefingService briefingService;
 
@@ -48,6 +52,7 @@ public class InternalOpsController {
             @RequestParam(required = false) String eventType
     ) {
         verify(token);
+        guardRange(start, end);
         List<OpsQueryPort.TypeCount> rows = opsQueryPort.countEvents(start, end, category, eventType);
         long total = rows.stream().mapToLong(OpsQueryPort.TypeCount::cnt).sum();
         return new CountResponse(start, end, total, rows);
@@ -62,6 +67,7 @@ public class InternalOpsController {
             @RequestParam(required = false) String eventType
     ) {
         verify(token);
+        guardRange(start, end);
         return new TimelineResponse(start, end, "hour", opsQueryPort.eventTimeline(start, end, category, eventType));
     }
 
@@ -75,6 +81,7 @@ public class InternalOpsController {
             @RequestParam(defaultValue = "10") int limit
     ) {
         verify(token);
+        guardRange(start, end);
         return new TopIpsResponse(start, end, opsQueryPort.topIps(start, end, category, eventType, limit));
     }
 
@@ -88,6 +95,7 @@ public class InternalOpsController {
             @RequestParam(defaultValue = "10") int limit
     ) {
         verify(token);
+        guardRange(start, end);
         return new RecentEventsResponse(start, end, opsQueryPort.recentEvents(start, end, category, eventType, limit));
     }
 
@@ -107,6 +115,16 @@ public class InternalOpsController {
                 token.getBytes(StandardCharsets.UTF_8));
         if (!matches) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 내부 토큰");
+        }
+    }
+
+    /** 조회 기간 검증 — 역순/과대 범위를 400 으로 거절 (넓은 GROUP BY 풀스캔 방어) */
+    private void guardRange(LocalDateTime start, LocalDateTime end) {
+        if (!start.isBefore(end)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "start 는 end 보다 앞이어야 합니다.");
+        }
+        if (Duration.between(start, end).compareTo(MAX_RANGE) > 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "조회 기간은 최대 31일까지입니다.");
         }
     }
 

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/InternalOpsController.java
@@ -1,0 +1,131 @@
+package com.wanted.codebombalms.serviceevent.presentation.api;
+
+import com.wanted.codebombalms.serviceevent.application.port.OpsQueryPort;
+import com.wanted.codebombalms.serviceevent.application.query.BriefingResult;
+import com.wanted.codebombalms.serviceevent.application.service.BriefingService;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * FastAPI opschat 도구 전용 내부 조회 API — 외부 공개 아님.
+ *
+ * 인증: X-Internal-Token 헤더 = ${internal.api-token} (fail-closed — 설정이 비어 있으면 전부 401).
+ * 파이썬의 DB 직접 조회를 대체해 쿼리·스키마 지식을 Spring 한 곳에 유지한다 (2026-07-20).
+ * 응답은 opschat tools.py 가 LLM 도구 결과로 그대로 전달하는 계약 — ApiResponse 봉투 미사용.
+ */
+@Hidden
+@RestController
+@RequestMapping("/internal/ops")
+@RequiredArgsConstructor
+public class InternalOpsController {
+
+    private final OpsQueryPort opsQueryPort;
+    private final BriefingService briefingService;
+
+    @Value("${internal.api-token:}")
+    private String internalApiToken;
+
+    @GetMapping("/events/count")
+    public CountResponse countEvents(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType
+    ) {
+        verify(token);
+        List<OpsQueryPort.TypeCount> rows = opsQueryPort.countEvents(start, end, category, eventType);
+        long total = rows.stream().mapToLong(OpsQueryPort.TypeCount::cnt).sum();
+        return new CountResponse(start, end, total, rows);
+    }
+
+    @GetMapping("/events/timeline")
+    public TimelineResponse eventTimeline(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType
+    ) {
+        verify(token);
+        return new TimelineResponse(start, end, "hour", opsQueryPort.eventTimeline(start, end, category, eventType));
+    }
+
+    @GetMapping("/events/top-ips")
+    public TopIpsResponse topIps(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        verify(token);
+        return new TopIpsResponse(start, end, opsQueryPort.topIps(start, end, category, eventType, limit));
+    }
+
+    @GetMapping("/events/recent")
+    public RecentEventsResponse recentEvents(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String eventType,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        verify(token);
+        return new RecentEventsResponse(start, end, opsQueryPort.recentEvents(start, end, category, eventType, limit));
+    }
+
+    @GetMapping("/briefing/latest")
+    public BriefingResponse latestBriefing(
+            @RequestHeader(value = "X-Internal-Token", required = false) String token
+    ) {
+        verify(token);
+        return new BriefingResponse(briefingService.getLatest().orElse(null));
+    }
+
+    /** 상수시간 비교 + fail-closed. 실패 시 401 (내부 소비자 전용이라 봉투 없는 기본 에러로 충분) */
+    private void verify(String token) {
+        boolean configured = internalApiToken != null && !internalApiToken.isBlank();
+        boolean matches = configured && token != null && MessageDigest.isEqual(
+                internalApiToken.getBytes(StandardCharsets.UTF_8),
+                token.getBytes(StandardCharsets.UTF_8));
+        if (!matches) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "유효하지 않은 내부 토큰");
+        }
+    }
+
+    public record CountResponse(LocalDateTime start, LocalDateTime end, long total,
+                         List<OpsQueryPort.TypeCount> byEventType) {
+    }
+
+    public record TimelineResponse(LocalDateTime start, LocalDateTime end, String unit,
+                            List<OpsQueryPort.TimelineBucket> timeline) {
+    }
+
+    public record TopIpsResponse(LocalDateTime start, LocalDateTime end,
+                          List<OpsQueryPort.IpCount> topIps) {
+    }
+
+    public record RecentEventsResponse(LocalDateTime start, LocalDateTime end,
+                                List<OpsQueryPort.EventDetail> events) {
+    }
+
+    public record BriefingResponse(BriefingResult briefing) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/OpsChatController.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/OpsChatController.java
@@ -1,0 +1,61 @@
+package com.wanted.codebombalms.serviceevent.presentation.api;
+
+import com.wanted.codebombalms.serviceevent.infrastructure.client.OpsChatFastApiClient;
+import com.wanted.codebombalms.serviceevent.presentation.api.request.OpsChatRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 관리자 운영 Q&A 챗봇 API — ADMIN·MASTER 전용. 권한 설계는 SecuritySummaryController 와 동일.
+ *
+ * FastAPI(/ops-chat)로 릴레이하고 SSE 를 그대로 흘린다. 관리자 인증이 여기서 끝나므로
+ * FastAPI 쪽은 내부망 전용 무인증 (SG 로 Spring 박스만 허용 전제).
+ */
+@RestController
+@RequestMapping("/api/v1/admin/security/ops-chat")
+@PreAuthorize("hasAnyRole('ADMIN','MASTER')")
+@RequiredArgsConstructor
+public class OpsChatController {
+
+    private final OpsChatFastApiClient opsChatFastApiClient;
+
+    @Operation(
+            summary = "운영 Q&A 챗봇",
+            description = """
+                    관리자 질문을 FastAPI 운영 챗봇으로 릴레이하고 SSE 로 스트리밍합니다.
+                    LLM 이 function calling 으로 service_event/ops_briefing 을 읽기 전용 조회합니다.
+                    - data(이벤트명 없음): {"t": "토큰"}
+                    - event: status → {"tool", "message"} (도구 실행 안내)
+                    - event: done → 토큰 사용량 (누적)
+                    - event: error → {"code": "OPS-001", "message"}
+                    진입부 검증 에러(권한 등)는 스트림 시작 전이므로 기존 JSON 에러 응답을 따릅니다.""")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 스트림 시작"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "AUT-015: 권한 없음")
+    })
+    @PostMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<Flux<ServerSentEvent<String>>> chat(@Valid @RequestBody OpsChatRequest request) {
+        // SSE 스트림 콜백은 별도 reactor 스레드라 MDC(traceId)가 전파되지 않는다.
+        // 호출 스레드인 여기서 캡처해 넘긴다 (학생 챗봇 컨트롤러와 동일 컨벤션).
+        String traceId = MDC.get("traceId");
+
+        return ResponseEntity.ok()
+                .contentType(new MediaType(MediaType.TEXT_EVENT_STREAM, StandardCharsets.UTF_8))
+                .header("X-Accel-Buffering", "no")
+                .body(opsChatFastApiClient.stream(request, traceId));
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
@@ -1,0 +1,24 @@
+package com.wanted.codebombalms.serviceevent.presentation.api.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+/**
+ * 관리자 운영 Q&A 챗봇 요청 (FE → Spring).
+ * 대화 이력은 FE 가 세션 내에서 들고 있다가 매 요청에 실어 보낸다 (서버 무상태).
+ */
+public record OpsChatRequest(
+        @NotBlank(message = "질문을 입력해주세요.")
+        String userMessage,
+
+        @Valid
+        List<Message> conversationHistory
+) {
+    public record Message(
+            @NotBlank String role,      // "user" or "ai"
+            @NotBlank String content
+    ) {
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
+++ b/src/main/java/com/wanted/codebombalms/serviceevent/presentation/api/request/OpsChatRequest.java
@@ -2,23 +2,34 @@ package com.wanted.codebombalms.serviceevent.presentation.api.request;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 /**
  * 관리자 운영 Q&A 챗봇 요청 (FE → Spring).
  * 대화 이력은 FE 가 세션 내에서 들고 있다가 매 요청에 실어 보낸다 (서버 무상태).
+ *
+ * 길이 제한은 과도한 페이로드가 FastAPI/LLM 으로 흘러가 토큰 비용·지연이 폭증하는 것을 막는다.
  */
 public record OpsChatRequest(
         @NotBlank(message = "질문을 입력해주세요.")
+        @Size(max = 2000, message = "질문은 2000자 이내여야 합니다.")
         String userMessage,
 
         @Valid
+        @Size(max = 40, message = "대화 이력은 최대 40개까지 전달할 수 있습니다.")
         List<Message> conversationHistory
 ) {
     public record Message(
-            @NotBlank String role,      // "user" or "ai"
-            @NotBlank String content
+            @NotBlank
+            @Pattern(regexp = "user|ai", message = "role 은 user 또는 ai 여야 합니다.")
+            String role,
+
+            @NotBlank
+            @Size(max = 4000, message = "메시지는 4000자 이내여야 합니다.")
+            String content
     ) {
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,6 +95,10 @@ cors:
 fastapi:
   url: ${FASTAPI_URL:http://localhost:8000}
 
+# FastAPI opschat 도구 → /internal/ops/* 호출용 공유 시크릿 (비어 있으면 fail-closed 전부 401)
+internal:
+  api-token: ${INTERNAL_API_TOKEN:}
+
 chat:
   max-history-messages: 20
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,6 +95,14 @@ cors:
 fastapi:
   url: ${FASTAPI_URL:http://localhost:8000}
 
+learning:
+  recommendation:
+    python:
+      enabled: ${LEARNING_RECOMMENDATION_ENABLED:true}
+      rank-path: ${LEARNING_RECOMMENDATION_RANK_PATH:/internal/learning/final-problem-sets/rank}
+      connect-timeout-ms: ${LEARNING_RECOMMENDATION_CONNECT_TIMEOUT_MS:3000}
+      read-timeout-ms: ${LEARNING_RECOMMENDATION_READ_TIMEOUT_MS:10000}
+
 chat:
   max-history-messages: 20
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,7 +101,7 @@ learning:
       enabled: ${LEARNING_RECOMMENDATION_ENABLED:true}
       rank-path: ${LEARNING_RECOMMENDATION_RANK_PATH:/internal/learning/final-problem-sets/rank}
       connect-timeout-ms: ${LEARNING_RECOMMENDATION_CONNECT_TIMEOUT_MS:3000}
-      read-timeout-ms: ${LEARNING_RECOMMENDATION_READ_TIMEOUT_MS:10000}
+      read-timeout-ms: ${LEARNING_RECOMMENDATION_READ_TIMEOUT_MS:15000}
 
 chat:
   max-history-messages: 20

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
@@ -1,5 +1,7 @@
 package com.wanted.codebombalms.learning.application.service;
 
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
 import com.wanted.codebombalms.learning.application.port.LearningCourseProblemPort;
 import com.wanted.codebombalms.learning.application.port.LearningCoursePort;
 import com.wanted.codebombalms.learning.application.port.LearningLecture;
@@ -13,10 +15,13 @@ import com.wanted.codebombalms.learning.application.port.LearningRecommendationC
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
 import com.wanted.codebombalms.learning.domain.model.LearningCourse;
 import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -25,6 +30,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -138,6 +145,79 @@ class FinalProblemSetRankingServiceTest {
         assertEquals(LearningRecommendationClient.LearningProfile.empty(),
                 captor.getValue().learningProfile());
         verify(learningCourseProblemPort, never()).findMainLectureProblemSetIdsByCourse(1L);
+    }
+
+    @Test
+    void rankFinalProblemSets_rejectsMoreThanMaximumExcludedProblemSets() {
+        Set<Long> excludedProblemSetIds = LongStream.rangeClosed(1, 101)
+                .boxed()
+                .collect(Collectors.toSet());
+
+        assertThrows(ExternalServiceException.class, () ->
+                service.rankFinalProblemSets(
+                        20L,
+                        1L,
+                        10L,
+                        3001L,
+                        excludedProblemSetIds,
+                        false
+                )
+        );
+
+        verify(learningRecommendationClient, never())
+                .rankFinalProblemSets(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void rankFinalProblemSets_convertsProfileAssemblyFailureToFallbackSignal() {
+        NotFoundException cause = new NotFoundException(
+                LearningErrorCode.LECTURE_PROBLEM_SET_NOT_FOUND
+        );
+        given(learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(1L))
+                .willThrow(cause);
+
+        ExternalServiceException exception = assertThrows(
+                ExternalServiceException.class,
+                () -> service.rankFinalProblemSets(
+                        20L,
+                        1L,
+                        10L,
+                        3001L,
+                        Set.of(),
+                        false
+                )
+        );
+
+        assertSame(cause, exception.getCause());
+        verify(learningRecommendationClient, never())
+                .rankFinalProblemSets(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void rankFinalProblemSets_propagatesRecommendationClientFallbackSignal() {
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", null));
+        given(learningLecturePort.findLecturesByCourse(1L)).willReturn(List.of());
+        ExternalServiceException cause = new ExternalServiceException(
+                LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE
+        );
+        given(learningRecommendationClient.rankFinalProblemSets(
+                org.mockito.ArgumentMatchers.any()
+        )).willThrow(cause);
+
+        ExternalServiceException exception = assertThrows(
+                ExternalServiceException.class,
+                () -> service.rankFinalProblemSets(
+                        null,
+                        1L,
+                        10L,
+                        3001L,
+                        Set.of(),
+                        true
+                )
+        );
+
+        assertSame(cause, exception);
     }
 
     private LearningProblemPort.ProblemSetForLearning problemSet(

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/FinalProblemSetRankingServiceTest.java
@@ -1,0 +1,192 @@
+package com.wanted.codebombalms.learning.application.service;
+
+import com.wanted.codebombalms.learning.application.port.LearningCourseProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningCoursePort;
+import com.wanted.codebombalms.learning.application.port.LearningLecture;
+import com.wanted.codebombalms.learning.application.port.LearningLecturePort;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
+import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemExplanationPort;
+import com.wanted.codebombalms.learning.application.port.LearningProblemPort;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.domain.model.LearningCourse;
+import com.wanted.codebombalms.learning.domain.model.LectureProblemSubmission;
+import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class FinalProblemSetRankingServiceTest {
+
+    @Mock
+    private LearningRecommendationClient learningRecommendationClient;
+    @Mock
+    private LearningCoursePort learningCoursePort;
+    @Mock
+    private LearningLecturePort learningLecturePort;
+    @Mock
+    private LearningCourseProblemPort learningCourseProblemPort;
+    @Mock
+    private LearningLectureProblemSetPort learningLectureProblemSetPort;
+    @Mock
+    private LearningProblemPort learningProblemPort;
+    @Mock
+    private LearningProblemExplanationPort learningProblemExplanationPort;
+    @Mock
+    private LectureProblemSubmissionRepository lectureProblemSubmissionRepository;
+
+    @InjectMocks
+    private FinalProblemSetRankingService service;
+
+    @Test
+    void rankFinalProblemSets_buildsAllMainLearningMetrics() {
+        given(learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(1L))
+                .willReturn(List.of(100L, 101L));
+        given(learningLectureProblemSetPort.findLectureProblemSet(100L))
+                .willReturn(new LearningLectureProblemSet(100L, 1L, 10L, 1000L));
+        given(learningLectureProblemSetPort.findLectureProblemSet(101L))
+                .willReturn(new LearningLectureProblemSet(101L, 1L, 11L, 1001L));
+        given(learningProblemPort.loadProblemSet(1000L))
+                .willReturn(problemSet(1000L, problem(1L, 1), problem(2L, 2)));
+        given(learningProblemPort.loadProblemSet(1001L))
+                .willReturn(problemSet(1001L, problem(3L, 1)));
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(20L, 100L))
+                .willReturn(List.of(
+                        submission(1L, 100L, 1L, true, 1, 2, 2, LocalDateTime.of(2026, 7, 20, 10, 0)),
+                        submission(2L, 100L, 2L, false, 1, 0, 2, LocalDateTime.of(2026, 7, 20, 10, 1)),
+                        submission(3L, 100L, 2L, true, 2, 1, 2, LocalDateTime.of(2026, 7, 20, 10, 2))
+                ));
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(20L, 101L))
+                .willReturn(List.of());
+        given(learningProblemExplanationPort.findViewedProblemIds(20L, List.of(1L, 2L, 3L)))
+                .willReturn(Set.of(2L, 3L));
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", "Python basics"));
+        given(learningLecturePort.findLecturesByCourse(1L))
+                .willReturn(List.of(new LearningLecture(10L, "Loop", "for and while")));
+        given(learningRecommendationClient.rankFinalProblemSets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(new LearningRecommendationResult("algorithm", List.of()));
+
+        service.rankFinalProblemSets(20L, 1L, 10L, 3001L, Set.of(1000L), false);
+
+        ArgumentCaptor<LearningRecommendationRequest> captor =
+                ArgumentCaptor.forClass(LearningRecommendationRequest.class);
+        verify(learningRecommendationClient).rankFinalProblemSets(captor.capture());
+        var request = captor.getValue();
+        var profile = request.learningProfile();
+
+        assertEquals(3, profile.totalMainProblemCount());
+        assertEquals(2, profile.correctProblemCount());
+        assertEquals(33.3333, profile.directSolveRate());
+        assertEquals(2, profile.explanationViewCount());
+        assertEquals(66.6667, profile.explanationViewRate());
+        assertEquals(1.0, profile.averageAttemptCount());
+        assertEquals(50.0, profile.averageTestPassRate());
+        assertEquals(List.of(1000L), request.excludedProblemSetIds());
+        assertEquals("Python basics", request.learningContext().courseDescription());
+        assertEquals("for and while", request.learningContext().lectures().get(0).description());
+    }
+
+    @Test
+    void rankFinalProblemSets_sendsZeroProfile_whenCourseHasNoMainProblems() {
+        given(learningCourseProblemPort.findMainLectureProblemSetIdsByCourse(1L))
+                .willReturn(List.of());
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", null));
+        given(learningLecturePort.findLecturesByCourse(1L)).willReturn(List.of());
+        given(learningRecommendationClient.rankFinalProblemSets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(new LearningRecommendationResult("algorithm", List.of()));
+
+        service.rankFinalProblemSets(20L, 1L, 10L, 3001L, Set.of(), false);
+
+        ArgumentCaptor<LearningRecommendationRequest> captor =
+                ArgumentCaptor.forClass(LearningRecommendationRequest.class);
+        verify(learningRecommendationClient).rankFinalProblemSets(captor.capture());
+        assertEquals(LearningRecommendationClient.LearningProfile.empty(),
+                captor.getValue().learningProfile());
+        verify(learningProblemExplanationPort, never())
+                .findViewedProblemIds(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyList());
+    }
+
+    @Test
+    void rankFinalProblemSets_sendsZeroProfile_forOperatorPreview() {
+        given(learningCoursePort.findActiveCourse(1L))
+                .willReturn(new LearningCourse(1L, "Python", null));
+        given(learningLecturePort.findLecturesByCourse(1L)).willReturn(List.of());
+        given(learningRecommendationClient.rankFinalProblemSets(org.mockito.ArgumentMatchers.any()))
+                .willReturn(new LearningRecommendationResult("algorithm", List.of()));
+
+        service.rankFinalProblemSets(null, 1L, 10L, 3001L, Set.of(), true);
+
+        ArgumentCaptor<LearningRecommendationRequest> captor =
+                ArgumentCaptor.forClass(LearningRecommendationRequest.class);
+        verify(learningRecommendationClient).rankFinalProblemSets(captor.capture());
+        assertEquals(LearningRecommendationClient.LearningProfile.empty(),
+                captor.getValue().learningProfile());
+        verify(learningCourseProblemPort, never()).findMainLectureProblemSetIdsByCourse(1L);
+    }
+
+    private LearningProblemPort.ProblemSetForLearning problemSet(
+            Long problemSetId,
+            LearningProblemPort.ProblemDetailForLearning... problems
+    ) {
+        return new LearningProblemPort.ProblemSetForLearning(
+                problemSetId,
+                "Problem Set",
+                "description",
+                List.of(problems)
+        );
+    }
+
+    private LearningProblemPort.ProblemDetailForLearning problem(Long problemId, int number) {
+        return new LearningProblemPort.ProblemDetailForLearning(
+                problemId,
+                number,
+                "Problem",
+                "content",
+                "SQL",
+                0,
+                ""
+        );
+    }
+
+    private LectureProblemSubmission submission(
+            Long submissionId,
+            Long lectureProblemSetId,
+            Long problemId,
+            boolean correct,
+            int attemptNo,
+            int passedTestCount,
+            int totalTestCount,
+            LocalDateTime submittedAt
+    ) {
+        return new LectureProblemSubmission(
+                submissionId,
+                20L,
+                lectureProblemSetId,
+                problemId,
+                "code",
+                correct,
+                attemptNo,
+                passedTestCount,
+                totalTestCount,
+                "SUCCESS",
+                null,
+                submittedAt
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -207,7 +207,7 @@ class LectureProblemSetServiceTest {
         );
 
         assertFalse(result.correct());
-        assertEquals(2, result.remainingAttemptCount());
+        assertEquals(null, result.remainingAttemptCount());
         assertEquals(null, result.nextProblemId());
         verify(learningAccessPolicy).validateLectureProblemSetAccess(
                 userId,
@@ -248,30 +248,34 @@ class LectureProblemSetServiceTest {
     }
 
     @Test
-    void submit_attemptLimitExceeded_doesNotGradeOrSave() {
+    void submit_pastAttemptLimit_stillGradesAndSaves() {
         Long userId = 10L;
         Long lectureProblemSetId = 6001L;
         Long problemSetId = 2001L;
         Long problemId = 3001L;
         var currentProgress = progress(userId, lectureProblemSetId, 1, false);
         givenSubmitContext(userId, lectureProblemSetId, problemSetId, problemId, currentProgress, 3, 3);
+        given(learningProblemGradingPort.grade(problemSetId, problemId, "answer"))
+                .willReturn(new LearningProblemGradingPort.GradingResult(
+                        false,
+                        1,
+                        2,
+                        "WRONG_ANSWER",
+                        "failed"
+                ));
+        given(lectureProblemSubmissionRepository.save(any(LectureProblemSubmission.class)))
+                .willReturn(submission(9003L, userId, lectureProblemSetId, problemId, false, 4));
 
-        assertThrows(
-                com.wanted.codebombalms.global.domain.common.error.exception.ValidationException.class,
-                () -> lectureProblemSetService.submit(
-                        lectureProblemSetId,
-                        problemId,
-                        new SubmitCodeCommand(userId, "answer")
-                )
+        var result = lectureProblemSetService.submit(
+                lectureProblemSetId,
+                problemId,
+                new SubmitCodeCommand(userId, "answer")
         );
 
-        verify(learningProblemGradingPort, never()).grade(any(), any(), any());
-        verify(lectureProblemSubmissionRepository, never()).save(any());
-        verify(learningAccessPolicy).validateLectureProblemSetAccess(
-                userId,
-                new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId)
-        );
-        verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
+        assertFalse(result.correct());
+        assertEquals(null, result.remainingAttemptCount());
+        verify(learningProblemGradingPort).grade(problemSetId, problemId, "answer");
+        verify(lectureProblemSubmissionRepository).save(any(LectureProblemSubmission.class));
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -279,6 +279,29 @@ class LectureProblemSetServiceTest {
     }
 
     @Test
+    void submit_notRetriableWithPriorAttempt_throwsException() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3001L;
+        var currentProgress = progress(userId, lectureProblemSetId, 1, false);
+        givenSubmitContext(userId, lectureProblemSetId, problemSetId, problemId, currentProgress, 1, 3, false);
+
+        assertThrows(
+                com.wanted.codebombalms.global.domain.common.error.exception.ValidationException.class,
+                () -> lectureProblemSetService.submit(
+                        lectureProblemSetId,
+                        problemId,
+                        new SubmitCodeCommand(userId, "answer")
+                )
+        );
+
+        verify(learningProblemGradingPort, never()).grade(any(), any(), any());
+        verify(lectureProblemSubmissionRepository, never()).save(any());
+        verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
+    }
+
+    @Test
     void submit_gradingFailure_doesNotSaveSubmissionOrProgress() {
         Long userId = 10L;
         Long lectureProblemSetId = 6001L;
@@ -428,6 +451,28 @@ class LectureProblemSetServiceTest {
             int previousAttemptCount,
             int attemptLimit
     ) {
+        givenSubmitContext(
+                userId,
+                lectureProblemSetId,
+                problemSetId,
+                problemId,
+                progress,
+                previousAttemptCount,
+                attemptLimit,
+                true
+        );
+    }
+
+    private void givenSubmitContext(
+            Long userId,
+            Long lectureProblemSetId,
+            Long problemSetId,
+            Long problemId,
+            LectureProblemProgress progress,
+            int previousAttemptCount,
+            int attemptLimit,
+            boolean retriable
+    ) {
         given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
                 .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
         given(learningProblemPort.existsProblem(problemId)).willReturn(true);
@@ -440,7 +485,7 @@ class LectureProblemSetServiceTest {
                         "explanation",
                         10,
                         attemptLimit,
-                        true
+                        retriable
                 )
         );
         given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(

--- a/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
@@ -8,6 +8,7 @@ import com.wanted.codebombalms.learning.application.port.LearningRecommendationC
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
 import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LectureContext;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -97,6 +98,43 @@ class FastApiLearningRecommendationClientTest {
 
         assertThrows(ExternalServiceException.class, () ->
                 client.rankFinalProblemSets(request())
+        );
+    }
+
+    @Test
+    void rankFinalProblemSets_rejectsCall_whenRecommendationIsDisabled() {
+        LearningRecommendationProperties properties = new LearningRecommendationProperties();
+        properties.setEnabled(false);
+        FastApiLearningRecommendationClient disabledClient =
+                new FastApiLearningRecommendationClient(
+                        properties,
+                        server.url("/").toString()
+                );
+
+        assertThrows(ExternalServiceException.class, () ->
+                disabledClient.rankFinalProblemSets(request())
+        );
+
+        assertEquals(0, server.getRequestCount());
+    }
+
+    @Test
+    void rankFinalProblemSets_convertsReadTimeoutToFallbackSignal() {
+        LearningRecommendationProperties properties = new LearningRecommendationProperties();
+        properties.setReadTimeoutMs(50);
+        FastApiLearningRecommendationClient timeoutClient =
+                new FastApiLearningRecommendationClient(
+                        properties,
+                        server.url("/").toString()
+                );
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("{}")
+                .setBodyDelay(500, TimeUnit.MILLISECONDS));
+
+        assertThrows(ExternalServiceException.class, () ->
+                timeoutClient.rankFinalProblemSets(request())
         );
     }
 

--- a/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/infrastructure/client/FastApiLearningRecommendationClientTest.java
@@ -1,0 +1,118 @@
+package com.wanted.codebombalms.learning.infrastructure.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningContext;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningProfile;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationRequest;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LectureContext;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FastApiLearningRecommendationClientTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private MockWebServer server;
+    private FastApiLearningRecommendationClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        LearningRecommendationProperties properties = new LearningRecommendationProperties();
+        client = new FastApiLearningRecommendationClient(
+                properties,
+                server.url("/").toString()
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void rankFinalProblemSets_matchesPythonJsonContract() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "algorithm": "GEMINI_EMBEDDING_PERSONALIZED",
+                          "recommendations": [
+                            {
+                              "problemSetId": 53,
+                              "score": 0.8914,
+                              "reasonCode": "REVIEW_WEAK_AREA",
+                              "recommendationReason": "해설을 확인한 학습 기록을 바탕으로 복습용 문제를 추천해요."
+                            }
+                          ]
+                        }
+                        """));
+
+        var result = client.rankFinalProblemSets(request());
+
+        assertEquals(1, result.recommendations().size());
+        assertEquals(53L, result.recommendations().get(0).problemSetId());
+        assertEquals("REVIEW_WEAK_AREA", result.recommendations().get(0).reasonCode().name());
+
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals("/internal/learning/final-problem-sets/rank", recorded.getPath());
+        JsonNode body = objectMapper.readTree(recorded.getBody().readUtf8());
+        assertEquals(20L, body.get("courseId").asLong());
+        assertEquals(30L, body.get("lectureId").asLong());
+        assertEquals(3106L, body.get("problemCategoryId").asLong());
+        assertEquals(1001L, body.get("excludedProblemSetIds").get(0).asLong());
+        assertEquals(10, body.get("learningProfile").get("totalMainProblemCount").asInt());
+        assertEquals("Python", body.get("learningContext").get("courseTitle").asText());
+    }
+
+    @Test
+    void rankFinalProblemSets_rejectsInvalidPythonResponse() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "algorithm": "GEMINI_EMBEDDING_PERSONALIZED",
+                          "recommendations": [
+                            {
+                              "problemSetId": 53,
+                              "score": 1.5,
+                              "reasonCode": "COURSE_RELATED",
+                              "recommendationReason": "추천 문구예요."
+                            }
+                          ]
+                        }
+                        """));
+
+        assertThrows(ExternalServiceException.class, () ->
+                client.rankFinalProblemSets(request())
+        );
+    }
+
+    private LearningRecommendationRequest request() {
+        return new LearningRecommendationRequest(
+                20L,
+                30L,
+                3106L,
+                List.of(1001L),
+                2,
+                new LearningProfile(10, 6, 60.0, 3, 30.0, 2.4, 72.5),
+                new LearningContext(
+                        "Python",
+                        "Python basics",
+                        List.of(new LectureContext("Loop", "for and while"))
+                )
+        );
+    }
+}

--- a/src/test/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/lecture/application/service/FinalProblemSetRecommendationServiceTest.java
@@ -2,7 +2,13 @@ package com.wanted.codebombalms.lecture.application.service;
 
 import com.wanted.codebombalms.course.domain.model.Course;
 import com.wanted.codebombalms.global.domain.common.error.exception.ForbiddenException;
+import com.wanted.codebombalms.global.domain.common.error.exception.ExternalServiceException;
 import com.wanted.codebombalms.global.domain.common.error.exception.NotFoundException;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.LearningRecommendationResult;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.RankedProblemSet;
+import com.wanted.codebombalms.learning.application.port.LearningRecommendationClient.ReasonCode;
+import com.wanted.codebombalms.learning.application.usecase.FinalProblemSetRankingUseCase;
+import com.wanted.codebombalms.learning.domain.exception.LearningErrorCode;
 import com.wanted.codebombalms.lecture.application.port.FinalProblemSetCandidatePort;
 import com.wanted.codebombalms.lecture.application.port.LectureProgressPort;
 import com.wanted.codebombalms.lecture.application.policy.LectureAccessPolicy;
@@ -15,9 +21,11 @@ import com.wanted.codebombalms.lecture.domain.repository.LectureProblemSetReposi
 import com.wanted.codebombalms.lecture.domain.repository.LectureRepository;
 import com.wanted.codebombalms.problems.set.domain.model.ProblemSetSummary;
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -34,8 +42,10 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class FinalProblemSetRecommendationServiceTest {
@@ -55,8 +65,21 @@ class FinalProblemSetRecommendationServiceTest {
     @Mock
     private LectureProgressPort lectureProgressPort;
 
+    @Mock
+    private FinalProblemSetRankingUseCase finalProblemSetRankingUseCase;
+
     @InjectMocks
     private FinalProblemSetRecommendationService service;
+
+    @BeforeEach
+    void setUpAiFallback() {
+        lenient().when(finalProblemSetRankingUseCase.rankFinalProblemSets(
+                        any(), anyLong(), anyLong(), anyLong(), anySet(), any(Boolean.class)
+                ))
+                .thenThrow(new ExternalServiceException(
+                        LearningErrorCode.LEARNING_RECOMMENDATION_UNAVAILABLE
+                ));
+    }
 
     @Test
     void findFinalProblemSetCandidates_returnsEmpty_whenLectureHasNoProblemCategory() {
@@ -95,6 +118,47 @@ class FinalProblemSetRecommendationServiceTest {
         assertEquals(Set.of(4001L, 4002L), excludedCaptor.getValue());
         assertEquals(1, result.size());
         assertEquals(4003L, result.get(0).problemSetId());
+    }
+
+    @Test
+    void findFinalProblemSetCandidates_preservesPythonRankingAndReason() {
+        Lecture lecture = lecture(10L, 1L, 3001L);
+        given(lectureRepository.findByLectureIdAndDeletedAtIsNull(10L)).willReturn(Optional.of(lecture));
+        given(lectureRepository.existsNextLecture(1L, 1)).willReturn(false);
+        given(lectureProgressPort.areLecturesCompleted(20L, List.of(10L))).willReturn(true);
+        given(lectureProblemSetRepository.findByCourseIdAndRole(1L, LectureProblemSetRole.MAIN))
+                .willReturn(List.of());
+        doReturn(new LearningRecommendationResult(
+                "GEMINI_EMBEDDING_PERSONALIZED",
+                List.of(
+                        new RankedProblemSet(
+                                4004L,
+                                new BigDecimal("0.9123"),
+                                ReasonCode.LEVEL_MATCHED,
+                                "현재 학습 수준에 적합한 문제 세트예요."
+                        ),
+                        new RankedProblemSet(
+                                4003L,
+                                new BigDecimal("0.8123"),
+                                ReasonCode.COURSE_RELATED,
+                                "강좌 내용과 연관된 문제 세트예요."
+                        )
+                )
+        )).when(finalProblemSetRankingUseCase).rankFinalProblemSets(
+                20L, 1L, 10L, 3001L, Set.of(), false
+        );
+        given(finalProblemSetCandidatePort.findByProblemSetIds(List.of(4004L, 4003L)))
+                .willReturn(List.of(problemSet(4004L), problemSet(4003L)));
+
+        var result = service.findFinalProblemSetCandidates(10L, 20L, false);
+
+        assertEquals(List.of(4004L, 4003L), result.stream()
+                .map(view -> view.problemSetId())
+                .toList());
+        assertEquals(new BigDecimal("0.9123"), result.get(0).score());
+        assertEquals("LEVEL_MATCHED", result.get(0).reasonCode());
+        assertEquals("현재 학습 수준에 적합한 문제 세트예요.", result.get(0).recommendationReason());
+        verify(finalProblemSetCandidatePort, never()).findCandidates(anyLong(), anySet(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
# 🚀 Backend Release Pull Request

> PR 제목은 반드시 `[Release] vX.Y.Z` 형식으로 작성해주세요.
>
> 예시: `[Release] v1.2.0`
>
> Release PR이 `main`에 머지되면 GitHub Actions가 PR 제목의 버전을 기준으로 태그와 GitHub Release를 생성합니다.

## 📌 릴리즈 정보

| 항목 | 내용 |
|------|------|
| **버전** | `v2.5.0 → v2.6.0` |
| **릴리즈 날짜** | 2026-07-21 |
| **기준 브랜치** | `develop` |
| **병합 브랜치** | `main` |
| **배포 환경** | `EC2 / Docker Compose / ECR / SSM / RDS / Redis / GCP Storage` |

---

# 📖 릴리즈 요약

- 사용자·관리자 문의 처리와 FastAPI 기반 AI 문의 분석 기능을 추가했습니다.
- 관리자 운영 Q&A 챗봇과 내부 운영 데이터 조회 API를 추가했습니다.
- 데이터셋 기반 AI 문제세트 초안 생성 API를 추가했습니다.
- 강좌 완료 후 학습 기록을 활용한 AI FINAL 문제세트 추천과 장애 fallback을 적용했습니다.

---

# 📋 릴리즈 노트

## Auth / User

### Added

- 사용자 문의 등록, 활성 답변 조회, 답변 숨김 API를 추가했습니다.

### Changed

- 문의 생성 후 FastAPI 분석 결과를 비동기로 반영하도록 연동했습니다.

### Fixed

- 없음

---

## Course / Lecture / Enrollment / Learning

### Added

- MAIN 문제 학습 기록과 강좌 문맥을 활용한 AI FINAL 문제세트 추천 기능을 추가했습니다.
- Python 추천 서버 연동과 기존 ID순 추천 fallback을 추가했습니다.

### Changed

- FINAL 문제세트 추천 응답에 `score`, `reasonCode`, `recommendationReason` 필드를 추가했습니다.
- Python HTTP 호출 중 기존 읽기 트랜잭션을 중단해 DB 연결 장기 점유를 방지했습니다.

### Fixed

- 추천 프로필 조립 실패, Python 장애·비활성화·timeout, 잘못된 응답 발생 시 기존 추천으로 복구하도록 보완했습니다.

---

## Problem / Submission / Ranking / Badge / Recommendation

### Added

- `multipart/form-data` 기반 AI 문제세트 초안 생성 API를 추가했습니다.
- 생성용 CSV 데이터셋 임시 GCS 저장과 FastAPI 문제 생성 연동을 추가했습니다.
- AI 초안 생성 실패 에러코드 `PRB-GEN-001`을 추가했습니다.

### Changed

- 문제 및 테스트 케이스 관련 사용자 노출 메시지를 정리했습니다.

### Fixed

- 잘못된 multipart 요청이 서버 오류로 처리되지 않고 400 응답으로 분류되도록 보완했습니다.

---

## Admin / Monitoring / Deploy

### Added

- 관리자 문의 목록·상세·분류·필터·답변 API를 추가했습니다.
- ADMIN·MASTER 전용 운영 Q&A 챗봇 SSE 릴레이 API를 추가했습니다.
- FastAPI 운영 도구용 읽기 전용 내부 조회 API 5종을 추가했습니다.
- 배포 환경에 `INTERNAL_API_TOKEN` 주입을 추가했습니다.

### Changed

- 보안 이벤트 요약 조회와 운영 질의용 persistence 구조를 보완했습니다.
- 내부 운영 API는 `X-Internal-Token`이 없거나 일치하지 않으면 차단하는 fail-closed 정책을 적용했습니다.

### Fixed

- 없음

---

# 🔌 API / DB / 환경변수 변경 사항

## API 변경

- [ ] 없음
- [x] 있음

| 구분 | Method | URL | 변경 내용 | 프론트 영향 |
|------|--------|-----|----------|------------|
| 추가 | `POST` | `/api/v1/inquiries` | 사용자 문의 등록 및 AI 분석 요청 | 있음 |
| 추가 | `GET` | `/api/v1/inquiries/me/replies/active` | 사용자에게 노출되는 활성 답변 조회 | 있음 |
| 추가 | `PATCH` | `/api/v1/inquiries/{inquiryId}/reply-visibility` | 문의 답변 숨김 | 있음 |
| 추가 | `GET` | `/api/v1/admin/inquiries`, `/api/v1/admin/inquiries/{inquiryId}` | 관리자 문의 목록·상세 조회 | 있음 |
| 추가 | `PATCH` | `/api/v1/admin/inquiries/{inquiryId}/classification` | 문의 도메인·심각도 분류 수정 | 있음 |
| 추가 | `PATCH` | `/api/v1/admin/inquiries/{inquiryId}/filter` | 문의 필터 상태 수정 | 있음 |
| 추가 | `POST` | `/api/v1/admin/inquiries/{inquiryId}/reply` | 관리자 문의 답변 등록 | 있음 |
| 추가 | `POST` | `/api/v1/admin/problem-set-drafts/generate` | CSV 기반 AI 문제세트 초안 생성 | 있음 |
| 추가 | `POST` | `/api/v1/admin/security/ops-chat` | 관리자 운영 Q&A SSE 스트림 | 있음 |
| 추가 | `GET` | `/internal/ops/events/*`, `/internal/ops/briefing/latest` | FastAPI 도구용 운영 데이터 내부 조회 | 없음 |
| 변경 | `GET` | `/api/v1/lectures/{lectureId}/final-problem-set-candidates` | AI 추천 점수·이유 필드 추가 | 있음 |

## DB 변경

- [ ] 없음
- [x] 있음

변경 내용:

- `inquiry` 테이블에 대응하는 신규 JPA Entity가 추가되었습니다.
- `inquiry_ai_correction` 테이블과 문의·수정 필드 복합 UNIQUE 제약이 추가되었습니다.
- 별도 SQL 마이그레이션 파일은 확인되지 않아 운영 RDS의 DDL 반영 방식 확인이 필요합니다.
- 시드 데이터 변경은 없습니다.

## 환경변수 / Secrets 변경

- [ ] 없음
- [x] 있음

변경 내용:

- `INTERNAL_API_TOKEN`: 내부 운영 조회 API 인증용 공유 Secret 추가
- `LEARNING_RECOMMENDATION_ENABLED`: AI 추천 활성화 여부 추가, 기본값 `true`
- `LEARNING_RECOMMENDATION_RANK_PATH`: Python 추천 API 경로 추가
- `LEARNING_RECOMMENDATION_CONNECT_TIMEOUT_MS`: 연결 timeout 설정 추가
- `LEARNING_RECOMMENDATION_READ_TIMEOUT_MS`: 응답 timeout 설정 추가
- 학습 추천 설정은 기본값이 있어 별도 주입 없이 동작하며, 운영에서 값을 재정의하려면 EC2 환경변수 전달 설정 확인이 필요합니다.

운영 반영 필요 여부:

- [ ] 없음
- [x] GitHub Secrets 변경 필요
- [ ] EC2 `.env` 변경 필요
- [ ] SSM Parameter Store 변경 필요

> GitHub Secrets에 `INTERNAL_API_TOKEN`을 등록하고 FastAPI에도 동일한 값을 설정해야 합니다.
>
> Secret 값은 PR에 작성하지 않고, 키 이름과 반영 위치만 작성합니다.

---

# 🧪 릴리즈 체크리스트

- [x] `develop` 브랜치의 최신 코드가 반영되었습니다.
- [x] `develop → main` 방향의 Release PR입니다.
- [ ] GitHub Actions CI build가 통과했습니다.
- [ ] 로컬 또는 테스트 환경에서 `./gradlew build`를 확인했습니다.
- [ ] 주요 API 및 도메인 기능 테스트를 완료했습니다.
- [ ] 인증/인가가 필요한 API의 권한 검증을 확인했습니다.
- [ ] API 변경사항이 Swagger 또는 `.ai/API.md`에 반영되었습니다.
- [x] DB 스키마 / 시드 데이터 변경사항을 확인했습니다.
- [x] 운영 환경변수 또는 Secrets 변경사항을 확인했습니다.
- [x] 환경변수 / Secrets 키 추가·변경·삭제 여부를 확인했습니다.
- [x] 변경이 있는 경우 GitHub Secrets / EC2 `.env` / SSM Parameter Store 반영 대상을 확인했습니다.
- [x] Secret 값은 PR 본문에 노출하지 않았습니다.
- [x] Docker / EC2 배포 설정 변경사항을 확인했습니다.
- [x] Merge Conflict가 없습니다.
- [x] 릴리즈 노트를 작성했습니다.
- [x] main 머지 후 생성할 Git Tag 버전을 확인했습니다.

---

# 🏷 버전 정보

| 이전 버전 | 변경 버전 | 버전 변경 유형 |
|----------|----------|----------------|
| `v2.5.0` | `v2.6.0` | `MINOR` |

### 버전 변경 사유

- 사용자·관리자 문의 도메인과 다수의 신규 API가 추가되었습니다.
- 운영 Q&A 챗봇과 내부 운영 조회 기능이 추가되었습니다.
- AI 문제세트 초안 생성과 개인화 FINAL 추천 기능이 추가되었습니다.
- 기존 API를 제거하는 명확한 하위 호환 중단 변경은 확인되지 않아 `MINOR`로 결정했습니다.

---

# 📦 Git Tag

> 태그는 Release PR이 `main`에 머지된 후, `main` 브랜치 기준으로만 생성합니다.

```bash
git checkout main
git pull origin main

git tag v2.6.0
git push origin v2.6.0
```

---

# ✅ 배포 후 검증

```bash
curl http://<BACKEND_HOST>:8080/actuator/health
```

- [ ] `/actuator/health` 상태가 정상입니다.
- [ ] 로그인 / 회원가입이 정상 동작합니다.
- [ ] 문의 등록·조회·관리자 답변 API가 정상 동작합니다.
- [ ] AI 문제세트 초안 생성과 FINAL 추천 API가 정상 동작합니다.
- [ ] 관리자 운영 Q&A SSE 스트림이 정상 동작합니다.
- [ ] DB / Redis / GCP Storage 연결이 정상입니다.
- [ ] EC2 Docker 컨테이너 로그를 확인했습니다.

---

# 💬 기타 사항

- GitHub PR의 base는 `main`, compare는 `develop`으로 지정합니다.
- `.ai/API.md`에는 FINAL AI 추천 변경은 반영되어 있으나 문의·운영 챗봇·AI 문제세트 초안 API 명세는 추가 확인이 필요합니다.
- 운영 배포 전 `inquiry`, `inquiry_ai_correction` 테이블 생성 방식을 확인해야 합니다.
- GitHub Secrets의 `INTERNAL_API_TOKEN`과 FastAPI 측 내부 토큰을 동일하게 설정해야 합니다.
- `origin/main`과 `origin/develop`의 커밋 이력은 분기되어 있지만 사전 merge-tree 확인에서는 충돌 표시가 발견되지 않았습니다.