### PR TITLE
[Fix] 서버 타임존 KST 고정 — UTC 표기 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN ./gradlew clean bootJar --no-daemon -x test
 # ===== run: JRE 17 =====
 FROM eclipse-temurin:17-jre
 WORKDIR /app
+ENV TZ=Asia/Seoul
 COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app/app.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,8 +31,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${DDL_AUTO:validate}   # 공통 기본 validate. loadtest 는 update override, deploy 는 .env
-    open-in-view:
-      false
+    open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul   # Instant → DATETIME 저장 시 KST 기준 변환 (챗봇 created_at 통일)
 
   data:
     redis:


### PR DESCRIPTION
- Dockerfile 실행 스테이지에 ENV TZ 및 -Duser.timezone=Asia/Seoul 추가
- application.yml 에 hibernate.jdbc.time_zone: Asia/Seoul 추가
- 챗봇 Instant.now() 및 serviceevent LocalDateTime.now() 시각을 KST 로 통일

## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #N

---

## 🛠️ 기능 관련 작업 내용
- 컨테이너 JVM 기본 타임존이 UTC 라 `created_at` 및 보안 요약 콘솔 시각이 미국 시간으로 저장/표기되던 문제 수정
- `Dockerfile` 실행 스테이지에 `ENV TZ=Asia/Seoul` + `-Duser.timezone=Asia/Seoul` 추가해 JVM/OS 기준 시간을 KST 로 고정
- `application.yml` 에 `hibernate.jdbc.time_zone: Asia/Seoul` 추가해 `Instant` → DATETIME 변환을 KST 기준으로 명시
- 챗봇(`Instant.now()`) 및 serviceevent(`LocalDateTime.now()`) 저장 시각을 기존 KST 엔티티와 통일

---

## ♻️ 패키지 변경 사항
- `Dockerfile`: 실행 스테이지 타임존 환경변수/JVM 옵션 추가
- `codebombalms/src/main/resources/application.yml`: Hibernate JDBC 타임존 설정 추가

---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 날짜 및 시간 데이터가 한국 표준시(Asia/Seoul) 기준으로 일관되게 저장되도록 개선했습니다.
  * JPA 데이터베이스 연결 설정 구조를 정리하고, 기존의 `open-in-view` 비활성화 설정을 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->