### PR TITLE
[Fix] 기존 해설 열람자의 강의 문제 진행도 복구

### DIFF
--- a/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
+++ b/src/main/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetService.java
@@ -269,21 +269,53 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
         }
 
         var problem = learningProblemPort.loadProblem(problemId);
+        LectureProblemProgress progress = lockProgress(userId, lectureProblemSetId);
 
         LectureProblemSubmission latestSubmission =
                 findLatestSubmissions(userId, lectureProblemSetId).get(problemId);
         if (latestSubmission != null && latestSubmission.correct()) {
-            return readOnlyExplanation(problem, ProblemProgressStatus.CORRECT);
+            return advanceExplanationProgressIfCurrent(
+                    userId,
+                    lectureProblemSet,
+                    problem,
+                    progress,
+                    ProblemProgressStatus.CORRECT
+            );
         }
 
         if (learningProblemExplanationPort.existsViewed(userId, problemId)) {
-            return readOnlyExplanation(problem, ProblemProgressStatus.EXPLANATION_VIEWED);
+            return advanceExplanationProgressIfCurrent(
+                    userId,
+                    lectureProblemSet,
+                    problem,
+                    progress,
+                    ProblemProgressStatus.EXPLANATION_VIEWED
+            );
         }
 
-        LectureProblemProgress progress = lockProgress(userId, lectureProblemSetId);
         validateSubmissionProgress(progress, problem.problemNumber());
 
         learningProblemExplanationPort.saveViewed(userId, problemId, lectureProblemSet.problemSetId());
+
+        return advanceExplanationProgressIfCurrent(
+                userId,
+                lectureProblemSet,
+                problem,
+                progress,
+                ProblemProgressStatus.EXPLANATION_VIEWED
+        );
+    }
+
+    private ExplanationView advanceExplanationProgressIfCurrent(
+            Long userId,
+            LearningLectureProblemSet lectureProblemSet,
+            LearningProblemPort.ProblemForLearning problem,
+            LectureProblemProgress progress,
+            ProblemProgressStatus status
+    ) {
+        if (progress.isCompleted() || !isCurrentProblem(progress, problem.problemNumber())) {
+            return readOnlyExplanation(problem, status);
+        }
 
         var problemSet = learningProblemPort.loadProblemSet(lectureProblemSet.problemSetId());
         Long nextProblemId = findNextProblemId(problemSet.problems(), problem.problemNumber());
@@ -295,12 +327,12 @@ public class LectureProblemSetService implements LectureProblemSetQueryUseCase, 
             serviceEventRecorder.record(ServiceEventEnvelope.business(
                     ServiceEventType.PROBLEM_SET_COMPLETED, userId,
                     lectureProblemSet.problemSetId(),
-                    "source=lecture lectureProblemSetId=" + lectureProblemSetId));
+                    "source=lecture lectureProblemSetId=" + lectureProblemSet.lectureProblemSetId()));
         }
 
         return new ExplanationView(
-                problemId,
-                ProblemProgressStatus.EXPLANATION_VIEWED,
+                problem.problemId(),
+                status,
                 ProblemProgressStatus.CORRECT,
                 problem.explanation(),
                 nextProblemId,

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -1,5 +1,6 @@
 package com.wanted.codebombalms.learning.application.service;
 
+import com.wanted.codebombalms.learning.application.command.RecordLectureProblemProgressCommand;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSet;
 import com.wanted.codebombalms.learning.application.policy.LearningAccessPolicy;
 import com.wanted.codebombalms.learning.application.port.LearningLectureProblemSetPort;
@@ -13,6 +14,9 @@ import com.wanted.codebombalms.learning.domain.repository.LectureProblemProgress
 import com.wanted.codebombalms.learning.domain.repository.LectureProblemSubmissionRepository;
 import com.wanted.codebombalms.problems.explanation.application.usecase.ViewProblemExplanationUseCase.ExplanationView;
 import com.wanted.codebombalms.problems.progress.enums.ProblemProgressStatus;
+import com.wanted.codebombalms.serviceevent.application.port.ServiceEventRecorder;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventEnvelope;
+import com.wanted.codebombalms.serviceevent.domain.model.ServiceEventType;
 import com.wanted.codebombalms.submission.application.command.SubmitCodeCommand;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -60,6 +64,9 @@ class LectureProblemSetServiceTest {
 
     @Mock
     private LearningAccessPolicy learningAccessPolicy;
+
+    @Mock
+    private ServiceEventRecorder serviceEventRecorder;
 
     @InjectMocks
     private LectureProblemSetService lectureProblemSetService;
@@ -416,6 +423,48 @@ class LectureProblemSetServiceTest {
     }
 
     @Test
+    void viewExplanation_alreadyCorrectAndCurrent_repairsLectureProgress() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3001L;
+        var currentProgress = progress(userId, lectureProblemSetId, 1, false);
+
+        given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
+        given(learningProblemPort.existsProblem(problemId)).willReturn(true);
+        given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
+        given(learningProblemPort.loadProblem(problemId)).willReturn(
+                new LearningProblemPort.ProblemForLearning(
+                        problemId,
+                        problemSetId,
+                        1,
+                        "explanation text",
+                        10,
+                        3,
+                        true
+                )
+        );
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(List.of(submission(9001L, userId, lectureProblemSetId, problemId, true, 1)));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(Optional.of(currentProgress));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetIdForUpdate(
+                userId,
+                lectureProblemSetId
+        )).willReturn(Optional.of(currentProgress));
+        given(learningProblemPort.loadProblemSet(problemSetId)).willReturn(problemSet(problemSetId));
+
+        ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
+
+        assertEquals(ProblemProgressStatus.CORRECT, result.status());
+        assertEquals(3002L, result.nextProblemId());
+        assertFalse(result.problemSetCompleted());
+        verify(learningProblemExplanationPort, never()).saveViewed(any(), any(), any());
+        verify(lectureProblemProgressCommandUseCase).recordProgress(any());
+    }
+
+    @Test
     void viewExplanation_alreadyViewedAndCurrent_repairsLectureProgress() {
         Long userId = 10L;
         Long lectureProblemSetId = 6001L;
@@ -456,6 +505,60 @@ class LectureProblemSetServiceTest {
         assertFalse(result.problemSetCompleted());
         verify(learningProblemExplanationPort, never()).saveViewed(any(), any(), any());
         verify(lectureProblemProgressCommandUseCase).recordProgress(any());
+    }
+
+    @Test
+    void viewExplanation_alreadyViewedAndCurrentLastProblem_completesProblemSetAndRecordsEvent() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3002L;
+        var currentProgress = progress(userId, lectureProblemSetId, 2, false);
+
+        given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
+        given(learningProblemPort.existsProblem(problemId)).willReturn(true);
+        given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
+        given(learningProblemPort.loadProblem(problemId)).willReturn(
+                new LearningProblemPort.ProblemForLearning(
+                        problemId,
+                        problemSetId,
+                        2,
+                        "last explanation text",
+                        10,
+                        3,
+                        true
+                )
+        );
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(List.of());
+        given(learningProblemExplanationPort.existsViewed(userId, problemId)).willReturn(true);
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(Optional.of(currentProgress));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetIdForUpdate(
+                userId,
+                lectureProblemSetId
+        )).willReturn(Optional.of(currentProgress));
+        given(learningProblemPort.loadProblemSet(problemSetId)).willReturn(problemSet(problemSetId));
+
+        ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
+
+        assertEquals(ProblemProgressStatus.EXPLANATION_VIEWED, result.status());
+        assertEquals(null, result.nextProblemId());
+        assertTrue(result.problemSetCompleted());
+
+        ArgumentCaptor<RecordLectureProblemProgressCommand> progressCaptor =
+                ArgumentCaptor.forClass(RecordLectureProblemProgressCommand.class);
+        verify(lectureProblemProgressCommandUseCase).recordProgress(progressCaptor.capture());
+        assertEquals(2, progressCaptor.getValue().currentProblemNumber());
+        assertTrue(progressCaptor.getValue().completed());
+
+        ArgumentCaptor<ServiceEventEnvelope> eventCaptor =
+                ArgumentCaptor.forClass(ServiceEventEnvelope.class);
+        verify(serviceEventRecorder).record(eventCaptor.capture());
+        assertEquals(ServiceEventType.PROBLEM_SET_COMPLETED, eventCaptor.getValue().type());
+        assertEquals(userId, eventCaptor.getValue().userId());
+        assertEquals(problemSetId, eventCaptor.getValue().targetId());
     }
 
     @Test

--- a/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
+++ b/src/test/java/com/wanted/codebombalms/learning/application/service/LectureProblemSetServiceTest.java
@@ -381,6 +381,7 @@ class LectureProblemSetServiceTest {
         Long lectureProblemSetId = 6001L;
         Long problemSetId = 2001L;
         Long problemId = 3001L;
+        var advancedProgress = progress(userId, lectureProblemSetId, 2, false);
 
         given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
                 .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
@@ -399,6 +400,12 @@ class LectureProblemSetServiceTest {
         );
         given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
                 .willReturn(List.of(submission(9001L, userId, lectureProblemSetId, problemId, true, 1)));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(Optional.of(advancedProgress));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetIdForUpdate(
+                userId,
+                lectureProblemSetId
+        )).willReturn(Optional.of(advancedProgress));
 
         ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
 
@@ -409,11 +416,12 @@ class LectureProblemSetServiceTest {
     }
 
     @Test
-    void viewExplanation_alreadyViewed_returnsReadOnlyWithoutSideEffects() {
+    void viewExplanation_alreadyViewedAndCurrent_repairsLectureProgress() {
         Long userId = 10L;
         Long lectureProblemSetId = 6001L;
         Long problemSetId = 2001L;
         Long problemId = 3001L;
+        var currentProgress = progress(userId, lectureProblemSetId, 1, false);
 
         given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
                 .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
@@ -433,11 +441,62 @@ class LectureProblemSetServiceTest {
         given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
                 .willReturn(List.of());
         given(learningProblemExplanationPort.existsViewed(userId, problemId)).willReturn(true);
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(Optional.of(currentProgress));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetIdForUpdate(
+                userId,
+                lectureProblemSetId
+        )).willReturn(Optional.of(currentProgress));
+        given(learningProblemPort.loadProblemSet(problemSetId)).willReturn(problemSet(problemSetId));
+
+        ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
+
+        assertEquals(ProblemProgressStatus.EXPLANATION_VIEWED, result.status());
+        assertEquals(3002L, result.nextProblemId());
+        assertFalse(result.problemSetCompleted());
+        verify(learningProblemExplanationPort, never()).saveViewed(any(), any(), any());
+        verify(lectureProblemProgressCommandUseCase).recordProgress(any());
+    }
+
+    @Test
+    void viewExplanation_alreadyViewedAndProgressAdvanced_returnsReadOnlyWithoutSideEffects() {
+        Long userId = 10L;
+        Long lectureProblemSetId = 6001L;
+        Long problemSetId = 2001L;
+        Long problemId = 3001L;
+        var advancedProgress = progress(userId, lectureProblemSetId, 2, false);
+
+        given(learningLectureProblemSetPort.findLectureProblemSet(lectureProblemSetId))
+                .willReturn(new LearningLectureProblemSet(lectureProblemSetId, 1L, 101L, problemSetId));
+        given(learningProblemPort.existsProblem(problemId)).willReturn(true);
+        given(learningProblemPort.existsProblemInSet(problemSetId, problemId)).willReturn(true);
+        given(learningProblemPort.loadProblem(problemId)).willReturn(
+                new LearningProblemPort.ProblemForLearning(
+                        problemId,
+                        problemSetId,
+                        1,
+                        "explanation text",
+                        10,
+                        3,
+                        true
+                )
+        );
+        given(lectureProblemSubmissionRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(List.of());
+        given(learningProblemExplanationPort.existsViewed(userId, problemId)).willReturn(true);
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetId(userId, lectureProblemSetId))
+                .willReturn(Optional.of(advancedProgress));
+        given(lectureProblemProgressRepository.findByUserIdAndLectureProblemSetIdForUpdate(
+                userId,
+                lectureProblemSetId
+        )).willReturn(Optional.of(advancedProgress));
 
         ExplanationView result = lectureProblemSetService.viewExplanation(userId, lectureProblemSetId, problemId);
 
         assertEquals(ProblemProgressStatus.EXPLANATION_VIEWED, result.status());
         assertTrue(result.explanation() != null);
+        assertEquals(null, result.nextProblemId());
+        assertFalse(result.problemSetCompleted());
         verify(learningProblemExplanationPort, never()).saveViewed(any(), any(), any());
         verify(lectureProblemProgressCommandUseCase, never()).recordProgress(any());
     }


### PR DESCRIPTION
해당하는 항목에 체크해주세요.

- [ ] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #659

---

## 🛠️ 기능 관련 작업 내용
- 기존 해설 또는 정답 제출 이력이 있어도 현재 강의 문제에 머물러 있으면 다음 소문제로 진행하도록 수정
- 마지막 소문제 해설 조회 시 강의 문제세트 완료 상태와 완료 이벤트가 정상 반영되도록 기존 동작 유지
- 이미 진행되거나 완료된 문제는 진행도를 중복 갱신하지 않도록 읽기 전용 처리
- 기존 데이터 불일치 복구 및 중복 갱신 방지 회귀 테스트 추가

---

## ♻️ 패키지 변경 사항
- `project/learning/application/service`: 강의 문제 해설 조회 시 진행도 자동 복구 로직 추가
- `project/learning/application/service`: 기존 해설 이력 및 진행 상태별 단위 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 문제 해설을 확인할 때 학습 진행 상태가 일관되게 반영됩니다.
  - 이미 정답을 맞혔거나 해설을 본 문제도 현재 학습 위치에 따라 진행 상태가 정확히 처리됩니다.
  - 필요한 경우 다음 문제로 진행되며, 문제 세트 완료 여부가 올바르게 표시됩니다.
  - 진행이 완료되었거나 현재 학습 대상이 아닌 문제는 읽기 전용 해설로 제공됩니다.
  - 해설 화면에 실제 진행 상태가 정확히 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->