### PR TITLE
[Feat] 세션 잔여 시간 조회 / 세션 연장 API 추가

### DIFF
--- a/src/main/java/com/wanted/codebombalms/auth/application/dto/SessionStatus.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/dto/SessionStatus.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.auth.application.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 현재 세션의 잔여 시간 정보.
+ *
+ * <p>AT/RT 모두 HttpOnly 쿠키라 프론트가 exp 를 읽을 수 없어 서버가 계산해 내려준다.
+ *
+ * @param remainingSeconds  Access Token 만료까지 남은 초 (만료됐으면 0)
+ * @param expiresAt         Access Token 만료 시각
+ * @param sessionExpiresAt  Refresh Token 만료 시각 (연장 없이 유지 가능한 한계)
+ * @param extendable        지금 세션 연장이 가능한지 (RT 가 DB 에 살아있는지)
+ */
+public record SessionStatus(
+        long remainingSeconds,
+        LocalDateTime expiresAt,
+        LocalDateTime sessionExpiresAt,
+        boolean extendable
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SessionQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SessionQueryService.java
@@ -1,0 +1,67 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+import com.wanted.codebombalms.auth.application.usecase.SessionQueryUseCase;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SessionQueryService implements SessionQueryUseCase {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public SessionStatus query(String accessToken, String refreshToken) {
+
+        // 1. AT 만료 시각 → 잔여 초 (프론트 자동 로그아웃 모달용)
+        LocalDateTime expiresAt = expirationOf(accessToken);
+        long remainingSeconds = secondsUntil(expiresAt);
+
+        // 2. RT 만료 시각 = 연장 없이 버틸 수 있는 한계
+        LocalDateTime sessionExpiresAt = expirationOf(refreshToken);
+
+        // 3. 연장 가능 여부 — /reissue 성공 조건과 동일하게 판정
+        boolean extendable = sessionExpiresAt != null && isReissuable(refreshToken);
+
+        return new SessionStatus(remainingSeconds, expiresAt, sessionExpiresAt, extendable);
+    }
+
+    /** 토큰 exp claim → LocalDateTime. 만료·위변조 토큰은 null (= 잔여 0 취급) */
+    private LocalDateTime expirationOf(String token) {
+        if (token == null) {
+            return null;
+        }
+        try {
+            Date expiration = jwtTokenProvider.getClaims(token).getExpiration();
+            return LocalDateTime.ofInstant(expiration.toInstant(), ZoneId.systemDefault());
+        } catch (JwtException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private long secondsUntil(LocalDateTime expiresAt) {
+        if (expiresAt == null) {
+            return 0L;
+        }
+        return Math.max(Duration.between(LocalDateTime.now(), expiresAt).toSeconds(), 0L);
+    }
+
+    /** RT 가 DB 에 등록돼 있고 아직 만료되지 않았는지 (RTR 이라 폐기된 RT 는 조회 안 됨) */
+    private boolean isReissuable(String refreshToken) {
+        return refreshTokenRepository.findByToken(refreshToken)
+                .filter(stored -> !stored.isExpired())
+                .isPresent();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/SessionQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/SessionQueryUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+
+public interface SessionQueryUseCase {
+
+    /**
+     * 세션 잔여 시간 조회.
+     *
+     * @param accessToken  accessToken 쿠키 값 (없으면 null)
+     * @param refreshToken refreshToken 쿠키 값 (없으면 null)
+     */
+    SessionStatus query(String accessToken, String refreshToken);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
@@ -24,4 +24,7 @@ public class AuthResponseCode {
     public static final String STEP_UP_VERIFIED = "AUTH-STEP-UP-VERIFIED";
     public static final String STEP_UP_CODE_RESENT = "AUTH-STEP-UP-CODE-RESENT";
     public static final String ACCOUNT_LOCKED = "AUTH-ACCOUNT-LOCKED";
+
+    public static final String SESSION_STATUS_RETRIEVED = "AUTH-SESSION-STATUS-RETRIEVED";
+    public static final String SESSION_EXTENDED = "AUTH-SESSION-EXTENDED";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
@@ -24,4 +24,7 @@ public class AuthResponseMessage {
     public static final String STEP_UP_VERIFIED = "추가 인증이 완료되었습니다.";
     public static final String STEP_UP_CODE_RESENT = "인증 코드를 재발송했습니다.";
     public static final String ACCOUNT_LOCKED = "계정이 잠겼습니다. 비밀번호 재설정 후 이용해주세요.";
+
+    public static final String SESSION_STATUS_RETRIEVED = "세션 정보를 조회했습니다.";
+    public static final String SESSION_EXTENDED = "세션이 연장되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
@@ -1,0 +1,107 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.usecase.SessionQueryUseCase;
+import com.wanted.codebombalms.auth.application.usecase.TokenReissueUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.presentation.api.dto.response.SessionStatusResponse;
+import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.WebUtils;
+
+@Tag(name = "Auth - 인증", description = "회원가입 / 로그인 / 토큰 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final SessionQueryUseCase sessionQueryUseCase;
+    private final TokenReissueUseCase tokenReissueUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthCookieFactory authCookieFactory;
+
+    @Operation(
+            summary = "세션 잔여 시간 조회",
+            description = "현재 세션의 남은 시간(초)과 만료 시각을 반환. AT/RT 모두 HttpOnly 쿠키라 프론트가 직접 exp 를 읽을 수 없어 서버가 계산해준다. 자동 로그아웃 안내 모달용."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @GetMapping("/session")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<SessionStatusResponse>> status(HttpServletRequest request) {
+
+        SessionStatus status = sessionQueryUseCase.query(
+                cookieValue(request, "accessToken"),
+                cookieValue(request, "refreshToken")
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.SESSION_STATUS_RETRIEVED,
+                AuthResponseMessage.SESSION_STATUS_RETRIEVED,
+                SessionStatusResponse.from(status)
+        ));
+    }
+
+    @Operation(
+            summary = "세션 연장",
+            description = "refreshToken 쿠키로 accessToken/refreshToken 을 재발급해 세션을 연장한다(RTR — 기존 RT 즉시 폐기). "
+                    + "동작은 /reissue 와 동일하되, 사용자가 직접 '연장하기'를 누른 흐름이라 응답으로 갱신된 잔여 시간을 함께 준다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "연장 성공 — 새 쿠키 2개 + 갱신된 잔여 시간")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-004 유효하지 않은 Refresh Token / AUT-005 만료된 Refresh Token")
+    @PostMapping("/session/extend")
+    public ResponseEntity<ApiResponse<SessionStatusResponse>> extend(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        // 1. 쿠키에서 refreshToken 추출
+        String refreshToken = cookieValue(request, "refreshToken");
+        if (refreshToken == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+        }
+
+        // 2. 재발급(RTR) — sid 회전까지 기존 로직 그대로 재사용
+        TokenPair pair = tokenReissueUseCase.reissue(refreshToken);
+
+        // 3. 새 쿠키 2개 발급 (기존 쿠키 덮어쓰기)
+        response.addCookie(authCookieFactory.create(
+                "accessToken",
+                pair.accessToken(),
+                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
+        ));
+        response.addCookie(authCookieFactory.create(
+                "refreshToken",
+                pair.refreshToken(),
+                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
+        ));
+
+        // 4. 갱신된 잔여 시간 응답 — 프론트가 타이머를 곧바로 리셋할 수 있게
+        SessionStatus status = sessionQueryUseCase.query(pair.accessToken(), pair.refreshToken());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.SESSION_EXTENDED,
+                AuthResponseMessage.SESSION_EXTENDED,
+                SessionStatusResponse.from(status)
+        ));
+    }
+
+    private String cookieValue(HttpServletRequest request, String name) {
+        Cookie cookie = WebUtils.getCookie(request, name);
+        return cookie == null ? null : cookie.getValue();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
@@ -30,6 +30,9 @@ import org.springframework.web.util.WebUtils;
 @RequiredArgsConstructor
 public class SessionController {
 
+    private static final String COOKIE_ACCESS_TOKEN = "accessToken";
+    private static final String COOKIE_REFRESH_TOKEN = "refreshToken";
+
     private final SessionQueryUseCase sessionQueryUseCase;
     private final TokenReissueUseCase tokenReissueUseCase;
     private final JwtTokenProvider jwtTokenProvider;
@@ -46,8 +49,8 @@ public class SessionController {
     public ResponseEntity<ApiResponse<SessionStatusResponse>> status(HttpServletRequest request) {
 
         SessionStatus status = sessionQueryUseCase.query(
-                cookieValue(request, "accessToken"),
-                cookieValue(request, "refreshToken")
+                cookieValue(request, COOKIE_ACCESS_TOKEN),
+                cookieValue(request, COOKIE_REFRESH_TOKEN)
         );
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -70,7 +73,7 @@ public class SessionController {
             HttpServletResponse response
     ) {
         // 1. 쿠키에서 refreshToken 추출
-        String refreshToken = cookieValue(request, "refreshToken");
+        String refreshToken = cookieValue(request, COOKIE_REFRESH_TOKEN);
         if (refreshToken == null) {
             throw new UnauthorizedException(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID);
         }
@@ -79,16 +82,7 @@ public class SessionController {
         TokenPair pair = tokenReissueUseCase.reissue(refreshToken);
 
         // 3. 새 쿠키 2개 발급 (기존 쿠키 덮어쓰기)
-        response.addCookie(authCookieFactory.create(
-                "accessToken",
-                pair.accessToken(),
-                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
-        ));
-        response.addCookie(authCookieFactory.create(
-                "refreshToken",
-                pair.refreshToken(),
-                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
-        ));
+        issueTokenCookies(response, pair);
 
         // 4. 갱신된 잔여 시간 응답 — 프론트가 타이머를 곧바로 리셋할 수 있게
         SessionStatus status = sessionQueryUseCase.query(pair.accessToken(), pair.refreshToken());
@@ -97,6 +91,20 @@ public class SessionController {
                 AuthResponseCode.SESSION_EXTENDED,
                 AuthResponseMessage.SESSION_EXTENDED,
                 SessionStatusResponse.from(status)
+        ));
+    }
+
+    /** 재발급된 토큰 쌍을 쿠키로 내려준다 (기존 쿠키 덮어쓰기). */
+    private void issueTokenCookies(HttpServletResponse response, TokenPair pair) {
+        response.addCookie(authCookieFactory.create(
+                COOKIE_ACCESS_TOKEN,
+                pair.accessToken(),
+                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
+        ));
+        response.addCookie(authCookieFactory.create(
+                COOKIE_REFRESH_TOKEN,
+                pair.refreshToken(),
+                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
         ));
     }
 

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/SessionStatusResponse.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/SessionStatusResponse.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.response;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record SessionStatusResponse(
+        @Schema(description = "세션 만료까지 남은 초", example = "1180")
+        long remainingSeconds,
+
+        @Schema(description = "세션(Access Token) 만료 시각", example = "2026-07-23T15:00:00")
+        LocalDateTime expiresAt,
+
+        @Schema(description = "연장 없이 유지 가능한 한계 시각(Refresh Token 만료)", example = "2026-07-30T14:00:00")
+        LocalDateTime sessionExpiresAt,
+
+        @Schema(description = "지금 세션 연장이 가능한지", example = "true")
+        boolean extendable
+) {
+
+    public static SessionStatusResponse from(SessionStatus status) {
+        return new SessionStatusResponse(
+                status.remainingSeconds(),
+                status.expiresAt(),
+                status.sessionExpiresAt(),
+                status.extendable()
+        );
+    }
+}


### PR DESCRIPTION
- GET /api/v1/auth/session — AT 만료 기준 잔여 시간·만료 시각·연장 가능 여부 반환
- POST /api/v1/auth/session/extend — RT 로 토큰 쌍 재발급(RTR)하여 세션 연장
- SessionQueryService — JWT exp claim 파싱 + RT DB 생존 여부로 extendable 판정
- 응답 코드 AUTH-SESSION-STATUS-RETRIEVED / AUTH-SESSION-EXTENDED 신설

## 🚨 Pull Request 유형

해당하는 항목에 체크해주세요.

- [x] ⭐ FEATURE
- [ ] 🌱 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈
- Closes #N

---

## 🛠️ 기능 관련 작업 내용
- `GET /api/v1/auth/session` 추가 — AT/RT 가 HttpOnly 쿠키라 프론트가 exp 를 읽을 수 없어, 서버가 잔여 시간(`remainingSeconds`)·만료 시각·연장 가능 여부를 계산해 반환
- `POST /api/v1/auth/session/extend` 추가 — 기존 `TokenReissueUseCase` 를 재사용해 토큰 쌍 재발급(RTR, sid 회전)하고 갱신된 잔여 시간을 함께 응답
- `SessionQueryService` 구현 — JWT `exp` claim 파싱(만료·위변조 토큰은 잔여 0 처리) + RT 의 DB 생존/만료 여부로 `extendable` 판정하여 `/reissue` 성공 조건과 일치시킴
- 세션 연장은 AT 만료 후에도 호출 가능하도록 `@PreAuthorize` 미적용 (`/reissue` 와 동일 정책), 조회는 `isAuthenticated()` 로 보호

---

## ♻️ 패키지 변경 사항
- `codebombalms/auth/application/dto`: `SessionStatus` 레코드 추가 (잔여 시간 응답용)
- `codebombalms/auth/application/usecase`: `SessionQueryUseCase` 인터페이스 추가
- `codebombalms/auth/application/service`: `SessionQueryService` 추가 (잔여 시간 계산 + 연장 가능 판정)
- `codebombalms/auth/presentation/api`: `SessionController` 추가, `AuthResponseCode`·`AuthResponseMessage` 상수 2종 추가
- `codebombalms/auth/presentation/api/dto/response`: `SessionStatusResponse` 추가
---

## 체크리스트

- [ ] 팀에서 정한 컨벤션을 준수했습니다.
- [ ] 정상적으로 동작합니다.
- [ ] 불필요한 코드를 최소화했습니다.
- [ ] 팀원들과 변경 내용을 공유했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 현재 세션의 액세스 토큰 잔여 시간과 만료 시각을 조회할 수 있습니다.
  * 세션 연장 가능 여부와 세션 유지 한계 시각을 확인할 수 있습니다.
  * 리프레시 토큰을 사용해 세션을 연장하고 토큰을 갱신할 수 있습니다.
  * 세션 조회 및 연장 결과에 대한 응답 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->