### PR TITLE
[Release] v2.8.0

### DIFF
--- a/monitoring-local/grafana/provisioning/dashboards/lms-final-problem-candidates-dashboard.json
+++ b/monitoring-local/grafana/provisioning/dashboards/lms-final-problem-candidates-dashboard.json
@@ -1,0 +1,813 @@
+{
+  "uid": "domain-final-problem-candidates",
+  "title": "Domain - Final Problem Candidates",
+  "tags": [
+    "learning",
+    "lecture",
+    "final-problem",
+    "recommendation",
+    "bottleneck",
+    "prod-monitoring"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "이 화면의 역할",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 4
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### 이 화면의 역할\n- LMS Overview의 Slow API Top 10에서 `/api/v1/lectures/{lectureId}/final-problem-set-candidates` 응답 지연이 높게 관측된 흐름을 따로 추적합니다.\n- 이 API는 강의 완료 후 추가 문제 후보를 노출하기 위해 Spring 데이터 조립, Python 추천 호출, fallback 처리, 문제세트 상세 조회가 함께 일어납니다.\n- 시연 또는 운영 중 응답 지연이 보이면 `요청/응답 시간` → `상태코드/에러율` → `DB 커넥션 대기` → `AI 추천 fallback 로그` 순서로 원인을 좁힙니다."
+      }
+    },
+    {
+      "id": 100,
+      "type": "row",
+      "title": "1. 추가 문제 후보 조회 현황",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "[요약] 추가 문제 후보 조회 요청 수",
+      "description": "최근 5분 동안 강의 완료 후 추가 문제 후보 조회 API가 몇 번 호출됐는지 보여줍니다. 시연 중 추가 문제 영역을 열었을 때 이 값이 올라가야 모니터링 대상 요청이 실제로 들어온 것입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "req",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(increase(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[5m])) or vector(0)",
+          "legendFormat": "최근 5분 요청 수",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "[요약] 평균 응답 시간",
+      "description": "추가 문제 후보 조회 API의 평균 응답 시간입니다. 이 값이 높으면 사용자 입장에서는 추가 문제 카드가 늦게 보입니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1500
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1000 * sum(rate(http_server_requests_seconds_sum{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[5m])), 0.0001) or vector(0)",
+          "legendFormat": "평균 응답 시간",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "[요약] 최대 응답 시간",
+      "description": "선택 시간 범위에서 가장 느리게 응답한 추가 문제 후보 조회 요청입니다. Overview의 Slow API Top 10에서 튄 값과 함께 확인합니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1000
+              },
+              {
+                "color": "red",
+                "value": 3000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1000 * max(max_over_time(http_server_requests_seconds_max{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[5m])) or vector(0)",
+          "legendFormat": "최대 응답 시간",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "[요약] 에러율",
+      "description": "추가 문제 후보 조회 API의 4xx/5xx 비율입니다. 4xx는 완료 조건 미충족/권한 문제일 수 있고, 5xx는 서버 또는 외부 추천 연동 장애 가능성이 큽니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 5,
+        "w": 6,
+        "h": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\",status=~\"4..|5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[5m])), 0.0001) or vector(0)",
+          "legendFormat": "에러율",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "2. 응답 지연 / 상태코드",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 9,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "[API] 추가 문제 후보 조회 RPS",
+      "description": "초당 요청 수입니다. 강의 완료 직후 학생들이 추가 문제 영역을 동시에 열거나 시연에서 반복 조회하면 값이 상승합니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 10,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[1m])) or vector(0)",
+          "legendFormat": "추가 문제 후보 조회 RPS",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "[API] 평균/최대 응답 시간",
+      "description": "평균 응답 시간과 최대 응답 시간을 같이 봅니다. 평균은 낮은데 최대만 튀면 특정 강의/사용자/추천 요청에서만 느린 케이스일 가능성이 큽니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 10,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1000 * sum(rate(http_server_requests_seconds_sum{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[1m])), 0.0001) or vector(0)",
+          "legendFormat": "평균 응답 시간",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "1000 * max(http_server_requests_seconds_max{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}) or vector(0)",
+          "legendFormat": "최대 응답 시간",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "[API] 상태코드별 요청 수",
+      "description": "상태코드별 요청 수입니다. 403이 늘면 강의 완료 조건 미충족, 5xx가 늘면 서버/외부 추천 연동 장애를 먼저 의심합니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 17,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "req",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (status) (increase(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[5m])) or vector(0)",
+          "legendFormat": "{{status}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "[API] 에러율 추이",
+      "description": "4xx/5xx 비율입니다. 4xx는 시연 데이터 조건 문제인지 먼저 확인하고, 5xx는 로그에서 AI fallback 또는 서버 예외를 확인합니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 17,
+        "w": 12,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\",status=~\"4..|5..\"}[1m])) / clamp_min(sum(rate(http_server_requests_seconds_count{uri=\"/api/v1/lectures/{lectureId}/final-problem-set-candidates\"}[1m])), 0.0001) or vector(0)",
+          "legendFormat": "에러율",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 300,
+      "type": "row",
+      "title": "3. DB 커넥션 위험",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "[DB위험] 커넥션 풀 사용/대기",
+      "description": "Hikari active는 사용 중인 DB 커넥션, pending은 커넥션을 못 잡고 기다리는 요청 수입니다. 추가 문제 후보 조회가 느릴 때 pending이 함께 뜨면 DB 커넥션 고갈 또는 느린 쿼리 가능성을 봅니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 25,
+        "w": 18,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "(hikaricp_connections_active) or vector(0)",
+          "legendFormat": "active 사용 중",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "B",
+          "expr": "(hikaricp_connections_pending) or vector(0)",
+          "legendFormat": "pending 대기",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        },
+        {
+          "refId": "C",
+          "expr": "(hikaricp_connections_max) or vector(0)",
+          "legendFormat": "max 최대",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "[DB위험] 커넥션 대기 여부",
+      "description": "현재 DB 커넥션을 기다리는 요청 수입니다. 0보다 큰 값이 지속되면 API 지연의 원인이 DB 커넥션 부족일 가능성이 있습니다.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 25,
+        "w": 6,
+        "h": 7
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "max(hikaricp_connections_pending) or vector(0)",
+          "legendFormat": "pending",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 400,
+      "type": "row",
+      "title": "4. AI 추천 / fallback 로그",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 12,
+      "type": "logs",
+      "title": "[근거] 추가 문제 후보 조회 요청 로그",
+      "description": "그래프에서 응답 지연이 튄 시각의 실제 요청 로그를 확인합니다. lectureId와 traceId를 기준으로 전후 로그를 따라갑니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 33,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": false,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{job=\"lms\"} |= \"final-problem-set-candidates\"",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "logs",
+      "title": "[근거] AI 추천 호출 / fallback 로그",
+      "description": "Python 추천 호출 성공, 실패, fallback 여부를 확인합니다. fallback이 찍히면 사용자는 기존 추천 순서로 응답을 받지만, 개인화 추천 품질이 낮아질 수 있어 Python 서버 상태를 봐야 합니다.",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 33,
+        "w": 12,
+        "h": 8
+      },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "wrapLogMessage": false,
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{job=\"lms\"} |= \"event=learning_recommendation\"",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "queryType": "range"
+        },
+        {
+          "refId": "B",
+          "expr": "{job=\"lms\"} |= \"event=final_problem_set_ai_fallback\"",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/dto/SessionStatus.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/dto/SessionStatus.java
@@ -1,0 +1,21 @@
+package com.wanted.codebombalms.auth.application.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 현재 세션의 잔여 시간 정보.
+ *
+ * <p>AT/RT 모두 HttpOnly 쿠키라 프론트가 exp 를 읽을 수 없어 서버가 계산해 내려준다.
+ *
+ * @param remainingSeconds  Access Token 만료까지 남은 초 (만료됐으면 0)
+ * @param expiresAt         Access Token 만료 시각
+ * @param sessionExpiresAt  Refresh Token 만료 시각 (연장 없이 유지 가능한 한계)
+ * @param extendable        지금 세션 연장이 가능한지 (RT 가 DB 에 살아있는지)
+ */
+public record SessionStatus(
+        long remainingSeconds,
+        LocalDateTime expiresAt,
+        LocalDateTime sessionExpiresAt,
+        boolean extendable
+) {
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/service/SessionQueryService.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/service/SessionQueryService.java
@@ -1,0 +1,67 @@
+package com.wanted.codebombalms.auth.application.service;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+import com.wanted.codebombalms.auth.application.usecase.SessionQueryUseCase;
+import com.wanted.codebombalms.auth.domain.repository.RefreshTokenRepository;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SessionQueryService implements SessionQueryUseCase {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public SessionStatus query(String accessToken, String refreshToken) {
+
+        // 1. AT 만료 시각 → 잔여 초 (프론트 자동 로그아웃 모달용)
+        LocalDateTime expiresAt = expirationOf(accessToken);
+        long remainingSeconds = secondsUntil(expiresAt);
+
+        // 2. RT 만료 시각 = 연장 없이 버틸 수 있는 한계
+        LocalDateTime sessionExpiresAt = expirationOf(refreshToken);
+
+        // 3. 연장 가능 여부 — /reissue 성공 조건과 동일하게 판정
+        boolean extendable = sessionExpiresAt != null && isReissuable(refreshToken);
+
+        return new SessionStatus(remainingSeconds, expiresAt, sessionExpiresAt, extendable);
+    }
+
+    /** 토큰 exp claim → LocalDateTime. 만료·위변조 토큰은 null (= 잔여 0 취급) */
+    private LocalDateTime expirationOf(String token) {
+        if (token == null) {
+            return null;
+        }
+        try {
+            Date expiration = jwtTokenProvider.getClaims(token).getExpiration();
+            return LocalDateTime.ofInstant(expiration.toInstant(), ZoneId.systemDefault());
+        } catch (JwtException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private long secondsUntil(LocalDateTime expiresAt) {
+        if (expiresAt == null) {
+            return 0L;
+        }
+        return Math.max(Duration.between(LocalDateTime.now(), expiresAt).toSeconds(), 0L);
+    }
+
+    /** RT 가 DB 에 등록돼 있고 아직 만료되지 않았는지 (RTR 이라 폐기된 RT 는 조회 안 됨) */
+    private boolean isReissuable(String refreshToken) {
+        return refreshTokenRepository.findByToken(refreshToken)
+                .filter(stored -> !stored.isExpired())
+                .isPresent();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/application/usecase/SessionQueryUseCase.java
+++ b/src/main/java/com/wanted/codebombalms/auth/application/usecase/SessionQueryUseCase.java
@@ -1,0 +1,14 @@
+package com.wanted.codebombalms.auth.application.usecase;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+
+public interface SessionQueryUseCase {
+
+    /**
+     * 세션 잔여 시간 조회.
+     *
+     * @param accessToken  accessToken 쿠키 값 (없으면 null)
+     * @param refreshToken refreshToken 쿠키 값 (없으면 null)
+     */
+    SessionStatus query(String accessToken, String refreshToken);
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseCode.java
@@ -24,4 +24,7 @@ public class AuthResponseCode {
     public static final String STEP_UP_VERIFIED = "AUTH-STEP-UP-VERIFIED";
     public static final String STEP_UP_CODE_RESENT = "AUTH-STEP-UP-CODE-RESENT";
     public static final String ACCOUNT_LOCKED = "AUTH-ACCOUNT-LOCKED";
+
+    public static final String SESSION_STATUS_RETRIEVED = "AUTH-SESSION-STATUS-RETRIEVED";
+    public static final String SESSION_EXTENDED = "AUTH-SESSION-EXTENDED";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/AuthResponseMessage.java
@@ -24,4 +24,7 @@ public class AuthResponseMessage {
     public static final String STEP_UP_VERIFIED = "추가 인증이 완료되었습니다.";
     public static final String STEP_UP_CODE_RESENT = "인증 코드를 재발송했습니다.";
     public static final String ACCOUNT_LOCKED = "계정이 잠겼습니다. 비밀번호 재설정 후 이용해주세요.";
+
+    public static final String SESSION_STATUS_RETRIEVED = "세션 정보를 조회했습니다.";
+    public static final String SESSION_EXTENDED = "세션이 연장되었습니다.";
 }

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
@@ -1,0 +1,107 @@
+package com.wanted.codebombalms.auth.presentation.api;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+import com.wanted.codebombalms.auth.application.dto.TokenPair;
+import com.wanted.codebombalms.auth.application.usecase.SessionQueryUseCase;
+import com.wanted.codebombalms.auth.application.usecase.TokenReissueUseCase;
+import com.wanted.codebombalms.auth.domain.exception.AuthErrorCode;
+import com.wanted.codebombalms.auth.presentation.api.dto.response.SessionStatusResponse;
+import com.wanted.codebombalms.auth.presentation.api.support.AuthCookieFactory;
+import com.wanted.codebombalms.global.domain.common.error.exception.UnauthorizedException;
+import com.wanted.codebombalms.global.infrastructure.jwt.JwtTokenProvider;
+import com.wanted.codebombalms.global.presentation.api.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.WebUtils;
+
+@Tag(name = "Auth - 인증", description = "회원가입 / 로그인 / 토큰 관리 (담당: 김동현)")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final SessionQueryUseCase sessionQueryUseCase;
+    private final TokenReissueUseCase tokenReissueUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthCookieFactory authCookieFactory;
+
+    @Operation(
+            summary = "세션 잔여 시간 조회",
+            description = "현재 세션의 남은 시간(초)과 만료 시각을 반환. AT/RT 모두 HttpOnly 쿠키라 프론트가 직접 exp 를 읽을 수 없어 서버가 계산해준다. 자동 로그아웃 안내 모달용."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-016 인증이 필요합니다 (미로그인)")
+    @GetMapping("/session")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<SessionStatusResponse>> status(HttpServletRequest request) {
+
+        SessionStatus status = sessionQueryUseCase.query(
+                cookieValue(request, "accessToken"),
+                cookieValue(request, "refreshToken")
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.SESSION_STATUS_RETRIEVED,
+                AuthResponseMessage.SESSION_STATUS_RETRIEVED,
+                SessionStatusResponse.from(status)
+        ));
+    }
+
+    @Operation(
+            summary = "세션 연장",
+            description = "refreshToken 쿠키로 accessToken/refreshToken 을 재발급해 세션을 연장한다(RTR — 기존 RT 즉시 폐기). "
+                    + "동작은 /reissue 와 동일하되, 사용자가 직접 '연장하기'를 누른 흐름이라 응답으로 갱신된 잔여 시간을 함께 준다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "연장 성공 — 새 쿠키 2개 + 갱신된 잔여 시간")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUT-004 유효하지 않은 Refresh Token / AUT-005 만료된 Refresh Token")
+    @PostMapping("/session/extend")
+    public ResponseEntity<ApiResponse<SessionStatusResponse>> extend(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        // 1. 쿠키에서 refreshToken 추출
+        String refreshToken = cookieValue(request, "refreshToken");
+        if (refreshToken == null) {
+            throw new UnauthorizedException(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID);
+        }
+
+        // 2. 재발급(RTR) — sid 회전까지 기존 로직 그대로 재사용
+        TokenPair pair = tokenReissueUseCase.reissue(refreshToken);
+
+        // 3. 새 쿠키 2개 발급 (기존 쿠키 덮어쓰기)
+        response.addCookie(authCookieFactory.create(
+                "accessToken",
+                pair.accessToken(),
+                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
+        ));
+        response.addCookie(authCookieFactory.create(
+                "refreshToken",
+                pair.refreshToken(),
+                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
+        ));
+
+        // 4. 갱신된 잔여 시간 응답 — 프론트가 타이머를 곧바로 리셋할 수 있게
+        SessionStatus status = sessionQueryUseCase.query(pair.accessToken(), pair.refreshToken());
+
+        return ResponseEntity.ok(ApiResponse.success(
+                AuthResponseCode.SESSION_EXTENDED,
+                AuthResponseMessage.SESSION_EXTENDED,
+                SessionStatusResponse.from(status)
+        ));
+    }
+
+    private String cookieValue(HttpServletRequest request, String name) {
+        Cookie cookie = WebUtils.getCookie(request, name);
+        return cookie == null ? null : cookie.getValue();
+    }
+}

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/SessionController.java
@@ -30,6 +30,9 @@ import org.springframework.web.util.WebUtils;
 @RequiredArgsConstructor
 public class SessionController {
 
+    private static final String COOKIE_ACCESS_TOKEN = "accessToken";
+    private static final String COOKIE_REFRESH_TOKEN = "refreshToken";
+
     private final SessionQueryUseCase sessionQueryUseCase;
     private final TokenReissueUseCase tokenReissueUseCase;
     private final JwtTokenProvider jwtTokenProvider;
@@ -46,8 +49,8 @@ public class SessionController {
     public ResponseEntity<ApiResponse<SessionStatusResponse>> status(HttpServletRequest request) {
 
         SessionStatus status = sessionQueryUseCase.query(
-                cookieValue(request, "accessToken"),
-                cookieValue(request, "refreshToken")
+                cookieValue(request, COOKIE_ACCESS_TOKEN),
+                cookieValue(request, COOKIE_REFRESH_TOKEN)
         );
 
         return ResponseEntity.ok(ApiResponse.success(
@@ -70,7 +73,7 @@ public class SessionController {
             HttpServletResponse response
     ) {
         // 1. 쿠키에서 refreshToken 추출
-        String refreshToken = cookieValue(request, "refreshToken");
+        String refreshToken = cookieValue(request, COOKIE_REFRESH_TOKEN);
         if (refreshToken == null) {
             throw new UnauthorizedException(AuthErrorCode.AUTH_REFRESH_TOKEN_INVALID);
         }
@@ -79,16 +82,7 @@ public class SessionController {
         TokenPair pair = tokenReissueUseCase.reissue(refreshToken);
 
         // 3. 새 쿠키 2개 발급 (기존 쿠키 덮어쓰기)
-        response.addCookie(authCookieFactory.create(
-                "accessToken",
-                pair.accessToken(),
-                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
-        ));
-        response.addCookie(authCookieFactory.create(
-                "refreshToken",
-                pair.refreshToken(),
-                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
-        ));
+        issueTokenCookies(response, pair);
 
         // 4. 갱신된 잔여 시간 응답 — 프론트가 타이머를 곧바로 리셋할 수 있게
         SessionStatus status = sessionQueryUseCase.query(pair.accessToken(), pair.refreshToken());
@@ -97,6 +91,20 @@ public class SessionController {
                 AuthResponseCode.SESSION_EXTENDED,
                 AuthResponseMessage.SESSION_EXTENDED,
                 SessionStatusResponse.from(status)
+        ));
+    }
+
+    /** 재발급된 토큰 쌍을 쿠키로 내려준다 (기존 쿠키 덮어쓰기). */
+    private void issueTokenCookies(HttpServletResponse response, TokenPair pair) {
+        response.addCookie(authCookieFactory.create(
+                COOKIE_ACCESS_TOKEN,
+                pair.accessToken(),
+                (int) (jwtTokenProvider.getAccessExpiration() / 1000)
+        ));
+        response.addCookie(authCookieFactory.create(
+                COOKIE_REFRESH_TOKEN,
+                pair.refreshToken(),
+                (int) (jwtTokenProvider.getRefreshExpiration() / 1000)
         ));
     }
 

--- a/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/SessionStatusResponse.java
+++ b/src/main/java/com/wanted/codebombalms/auth/presentation/api/dto/response/SessionStatusResponse.java
@@ -1,0 +1,30 @@
+package com.wanted.codebombalms.auth.presentation.api.dto.response;
+
+import com.wanted.codebombalms.auth.application.dto.SessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record SessionStatusResponse(
+        @Schema(description = "세션 만료까지 남은 초", example = "1180")
+        long remainingSeconds,
+
+        @Schema(description = "세션(Access Token) 만료 시각", example = "2026-07-23T15:00:00")
+        LocalDateTime expiresAt,
+
+        @Schema(description = "연장 없이 유지 가능한 한계 시각(Refresh Token 만료)", example = "2026-07-30T14:00:00")
+        LocalDateTime sessionExpiresAt,
+
+        @Schema(description = "지금 세션 연장이 가능한지", example = "true")
+        boolean extendable
+) {
+
+    public static SessionStatusResponse from(SessionStatus status) {
+        return new SessionStatusResponse(
+                status.remainingSeconds(),
+                status.expiresAt(),
+                status.sessionExpiresAt(),
+                status.extendable()
+        );
+    }
+}


### PR DESCRIPTION
# 🚀 Backend Release Pull Request

> PR 제목은 반드시 `[Release] vX.Y.Z` 형식으로 작성해주세요.
>
> 예시: `[Release] v1.2.0`
>
> Release PR이 `main`에 머지되면 GitHub Actions가 PR 제목의 버전을 기준으로 태그와 GitHub Release를 생성합니다.

## 📌 릴리즈 정보

| 항목 | 내용 |
|------|------|
| **버전** | `v2.7.0 → v2.8.0` |
| **릴리즈 날짜** | 2026-07-23 |
| **기준 브랜치** | `develop` |
| **병합 브랜치** | `main` |
| **배포 환경** | `EC2 / Docker Compose / ECR / SSM / RDS / Redis / GCP Storage` |

---

# 📖 릴리즈 요약

- 프론트엔드의 자동 로그아웃 안내를 위한 세션 잔여 시간 조회 API를 추가했습니다.
- 사용자가 직접 세션을 연장할 수 있는 토큰 재발급 API를 추가했습니다.
- FINAL 문제세트 추천 API의 요청·응답 시간과 fallback 상태를 추적하는 Grafana 대시보드를 추가했습니다.

---

# 📋 릴리즈 노트

## Auth / User

### Added

- Access Token의 잔여 시간과 만료 시각을 조회하는 세션 상태 API를 추가했습니다.
- Refresh Token을 이용해 세션을 연장하는 API를 추가했습니다.
- 세션 연장 가능 여부와 Refresh Token 만료 시각을 응답하는 기능을 추가했습니다.
- 세션 상태 조회·연장 전용 응답 코드와 메시지를 추가했습니다.

### Changed

- 토큰 쿠키 이름을 상수로 통합했습니다.
- 토큰 쿠키 발급 로직을 공통 helper로 분리했습니다.
- 세션 연장 시 기존 RTR 정책을 재사용해 기존 Refresh Token을 폐기하고 새 토큰 쌍을 발급합니다.

### Fixed

- 없음

---

## Course / Lecture / Enrollment / Learning

### Added

- 없음

### Changed

- 없음

### Fixed

- 없음

---

## Problem / Submission / Ranking / Badge / Recommendation

### Added

- 없음

### Changed

- 없음

### Fixed

- 없음

---

## Admin / Monitoring / Deploy

### Added

- FINAL 문제세트 추천 API 전용 Grafana 모니터링 대시보드를 추가했습니다.
- 추천 요청 수, 응답 시간, 상태코드, 에러율, DB 커넥션 대기 및 AI fallback 로그를 확인할 수 있도록 구성했습니다.

### Changed

- 없음

### Fixed

- 없음

---

# 🔌 API / DB / 환경변수 변경 사항

## API 변경

- [ ] 없음
- [x] 있음

| 구분 | Method | URL | 변경 내용 | 프론트 영향 |
|------|--------|-----|----------|------------|
| 추가 | `GET` | `/api/v1/auth/session` | 세션 잔여 시간·만료 시각·연장 가능 여부 조회 | 있음 |
| 추가 | `POST` | `/api/v1/auth/session/extend` | Refresh Token 기반 세션 연장 및 새 토큰 쿠키 발급 | 있음 |

## DB 변경

- [x] 없음
- [ ] 있음

변경 내용:

- 신규 Entity, 테이블, 컬럼 및 시드 데이터 변경은 없습니다.
- 기존 Refresh Token 저장소를 재사용합니다.

## 환경변수 / Secrets 변경

- [x] 없음
- [ ] 있음

변경 내용:

- 신규 GitHub Secret 또는 Variable은 없습니다.
- 기존 JWT 만료 시간과 쿠키 설정을 그대로 사용합니다.

운영 반영 필요 여부:

- [x] 없음
- [ ] GitHub Secrets 변경 필요
- [ ] EC2 `.env` 변경 필요
- [ ] SSM Parameter Store 변경 필요

> Secret 값은 PR에 작성하지 않고, 키 이름과 반영 위치만 작성합니다.

---

# 🧪 릴리즈 체크리스트

- [x] `develop` 브랜치의 최신 코드가 반영되었습니다.
- [x] `develop → main` 방향의 Release PR입니다.
- [ ] GitHub Actions CI build가 통과했습니다.
- [ ] 로컬 또는 테스트 환경에서 `./gradlew build`를 확인했습니다.
- [ ] 주요 API 및 도메인 기능 테스트를 완료했습니다.
- [ ] 인증/인가가 필요한 API의 권한 검증을 확인했습니다.
- [ ] API 변경사항이 Swagger 또는 `.ai/API.md`에 반영되었습니다.
- [x] DB 스키마 / 시드 데이터 변경사항을 확인했습니다.
- [x] 운영 환경변수 또는 Secrets 변경사항을 확인했습니다.
- [x] 환경변수 / Secrets 키 추가·변경·삭제 여부를 확인했습니다.
- [x] 변경이 있는 경우 GitHub Secrets / EC2 `.env` / SSM Parameter Store 반영 대상을 확인했습니다.
- [x] Secret 값은 PR 본문에 노출하지 않았습니다.
- [x] Docker / EC2 배포 설정 변경사항을 확인했습니다.
- [x] Merge Conflict가 없습니다.
- [x] 릴리즈 노트를 작성했습니다.
- [x] main 머지 후 생성할 Git Tag 버전을 확인했습니다.

---

# 🏷 버전 정보

| 이전 버전 | 변경 버전 | 버전 변경 유형 |
|----------|----------|----------------|
| `v2.7.0` | `v2.8.0` | `MINOR` |

### 버전 변경 사유

- 세션 상태 조회와 세션 연장 API가 새로 추가되었습니다.
- 기존 로그인·재발급 API를 삭제하거나 요청·응답 구조를 변경하지 않아 하위 호환성이 유지됩니다.
- 신규 사용자 기능 추가에 해당하므로 `MINOR` 버전으로 결정했습니다.

---

# 📦 Git Tag

> Release PR이 `main`에 머지되면 GitHub Actions가 `v2.8.0` 태그와 GitHub Release를 자동 생성합니다.
>
> 아래 명령은 Release workflow 실패 시 복구가 필요한 경우에만 사용하며 정상 배포에서는 수동 실행하지 않습니다.

```bash
git checkout main
git pull origin main

git tag v2.8.0
git push origin v2.8.0
```

---

# ✅ 배포 후 검증

```bash
curl http://<BACKEND_HOST>:8080/actuator/health
```

- [ ] `/actuator/health` 상태가 정상입니다.
- [ ] 로그인 / 회원가입이 정상 동작합니다.
- [ ] 로그인 사용자의 세션 잔여 시간이 정상 조회됩니다.
- [ ] 미로그인 사용자의 세션 조회 요청이 401로 처리됩니다.
- [ ] 세션 연장 후 Access Token과 Refresh Token 쿠키가 모두 갱신됩니다.
- [ ] 세션 연장 응답의 잔여 시간이 새 Access Token 기준으로 초기화됩니다.
- [ ] 만료·폐기된 Refresh Token으로 세션을 연장할 수 없습니다.
- [ ] 기존 로그인·로그아웃·토큰 재발급 기능이 정상 동작합니다.
- [ ] DB / Redis 연결이 정상입니다.
- [ ] EC2 Docker 컨테이너 로그를 확인했습니다.

---

# 💬 기타 사항

- GitHub PR의 base는 `main`, compare는 `develop`으로 지정합니다.
- 신규 세션 API가 `.ai/API.md`에 반영되지 않은 상태이므로 머지 전 문서 보완이 필요합니다.
- 세션 Controller·Service 관련 신규 테스트 파일이 변경 목록에서 확인되지 않아 CI와 인증 시나리오 검증이 필요합니다.
- 세션 연장은 기존 RTR 정책을 사용하므로 동일 Refresh Token의 중복 연장 요청과 동시 요청 동작을 확인해야 합니다.
- Grafana 파일은 `monitoring-local` 경로에 있어 운영 Grafana에 자동 반영되지 않습니다. 운영 반영이 필요하면 별도 import 또는 provisioning 작업이 필요합니다.
- `v2.8.0` 태그는 Release workflow가 자동 생성하므로 수동으로 생성하지 않습니다.