### PR TITLE
[Fix] 추천 질문 조회 네이티브 쿼리 컬럼명 오류 수정

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SuggestedQuestionSourceJpaRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SuggestedQuestionSourceJpaRepository.java
@@ -41,7 +41,7 @@ public interface SuggestedQuestionSourceJpaRepository extends JpaRepository<Chat
             WHERE cr.problem_set_id = :problemSetId
               AND cr.problem_id = :problemId
               AND cm.role = 'USER'
-            ORDER BY cm.created_at DESC, cm.id DESC
+            ORDER BY cm.created_at DESC, cm.message_id DESC
             LIMIT :limit
             """, nativeQuery = true)
     List<String> findRecentUserQuestions(@Param("problemSetId") Long problemSetId,


### PR DESCRIPTION
## 🚨 Pull Request 유형

- [ ] ⭐ FEATURE
- [x] 🪛 UPDATE
- [x] 🐞 BUGFIX
- [ ] ♻️ REFACTOR

---

## 📌 작업한 이슈

관련 이슈 없음

---

## 🛠️ 기능 관련 작업 내용

- 추천 질문 조회 API(`GET /api/v1/suggested-questions`) 호출 시 500 에러 발생 (SQL Error 1054: Unknown column 'cm.id')
- `SuggestedQuestionSourceJpaRepository.findRecentUserQuestions` 네이티브 쿼리의 ORDER BY tie-break 절에서 `chat_message` 테이블의 실제 PK 컬럼명 `message_id`를 사용하도록 수정 (`cm.id` → `cm.message_id`)
- 같은 파일의 다른 네이티브 쿼리(`findEligibleProblems`)와 JPA 엔티티(`ChatMessageJpaEntity`, `ChatRoomJpaEntity`)의 컬럼명 대조 확인 완료

---

## ♻️ 패키지 변경 사항

- `chatbot/infrastructure/persistence/SuggestedQuestionSourceJpaRepository` : 네이티브 쿼리 컬럼명 오류 수정 (ORDER BY)

---

## 체크리스트

- [x] 팀에서 정한 컨벤션을 준수했습니다.
- [x] 정상적으로 동작합니다.
- [x] 불필요한 코드를 최소화했습니다.
- [x] 팀원들과 변경 내용을 공유했습니다.