### PR TITLE
[Release] v2.9.2

### DIFF
--- a/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SuggestedQuestionSourceJpaRepository.java
+++ b/src/main/java/com/wanted/codebombalms/chatbot/infrastructure/persistence/SuggestedQuestionSourceJpaRepository.java
@@ -41,7 +41,7 @@ public interface SuggestedQuestionSourceJpaRepository extends JpaRepository<Chat
             WHERE cr.problem_set_id = :problemSetId
               AND cr.problem_id = :problemId
               AND cm.role = 'USER'
-            ORDER BY cm.created_at DESC, cm.id DESC
+            ORDER BY cm.created_at DESC, cm.message_id DESC
             LIMIT :limit
             """, nativeQuery = true)
     List<String> findRecentUserQuestions(@Param("problemSetId") Long problemSetId,


### PR DESCRIPTION
# 🚀 Backend Release Pull Request

> Release PR이 `main`에 머지되면 GitHub Actions가 PR 제목의 버전을 기준으로 태그와 GitHub Release를 생성합니다.

## 📌 릴리즈 정보

| 항목 | 내용 |
|------|------|
| **버전** | `v2.9.1 → v2.9.2` |
| **릴리즈 날짜** | 2026-07-26 |
| **기준 브랜치** | `develop` |
| **병합 브랜치** | `main` |
| **배포 환경** | `EC2 / Docker Compose / ECR / SSM / RDS / Redis / GCP Storage` |

---

# 📖 릴리즈 요약

- 추천 질문 생성 배치의 최근 사용자 질문 조회 쿼리를 수정했습니다.
- `chat_message` 테이블의 실제 PK 컬럼명인 `message_id`를 사용하도록 정정했습니다.
- 추천 질문 생성 시 발생하던 SQL 1054 오류를 해결했습니다.

---

# 📋 릴리즈 노트

## Auth / User

### Added

- 없음

### Changed

- 없음

### Fixed

- 없음

---

## Course / Lecture / Enrollment / Learning

### Added

- 없음

### Changed

- 없음

### Fixed

- 없음

---

## Problem / Submission / Ranking / Badge / Recommendation

### Added

- 없음

### Changed

- 없음

### Fixed

- 추천 질문 생성 대상의 최근 사용자 질문을 조회할 때 잘못된 컬럼명 `cm.id`를 사용하던 네이티브 쿼리를 수정했습니다.
- 동일한 생성일시를 가진 메시지의 정렬 기준으로 실제 PK 컬럼인 `cm.message_id`를 사용하도록 변경했습니다.
- 추천 질문 생성 배치와 관리자 수동 생성 과정에서 발생하던 `Unknown column 'cm.id' in 'order clause'` 오류를 해결했습니다.

---

## Admin / Monitoring / Deploy

### Added

- 없음

### Changed

- 없음

### Fixed

- 관리자 추천 질문 수동 생성 시 원천 질문 조회 쿼리가 정상 실행되도록 수정했습니다.

---

# 🔌 API / DB / 환경변수 변경 사항

## API 변경

- [x] 없음
- [ ] 있음

| 구분 | Method | URL | 변경 내용 | 프론트 영향 |
|------|--------|-----|----------|------------|
| 없음 | - | - | 기존 API 경로와 요청·응답 구조 유지 | 없음 |

## DB 변경

- [x] 없음
- [ ] 있음

변경 내용:

- 테이블, 컬럼, Entity 및 시드 데이터 변경 없음
- 기존 `chat_message.message_id` 컬럼을 사용하도록 조회 쿼리만 수정

## 환경변수 / Secrets 변경

- [x] 없음
- [ ] 있음

변경 내용:

- 환경변수 및 Secret 키 추가·변경·삭제 없음

운영 반영 필요 여부:

- [x] 없음
- [ ] GitHub Secrets 변경 필요
- [ ] EC2 `.env` 변경 필요
- [ ] SSM Parameter Store 변경 필요

> Secret 값은 PR에 작성하지 않고, 키 이름과 반영 위치만 작성합니다.

---

# 🧪 릴리즈 체크리스트

- [x] `develop` 브랜치의 최신 코드가 반영되었습니다.
- [x] `develop → main` 방향의 Release PR입니다.
- [x] GitHub Actions CI build가 통과했습니다.
- [ ] 로컬 또는 테스트 환경에서 `./gradlew build`를 확인했습니다.
- [ ] 주요 API 및 도메인 기능 테스트를 완료했습니다.
- [ ] 인증/인가가 필요한 API의 권한 검증을 확인했습니다.
- [x] API 변경사항이 Swagger 또는 `.ai/API.md`에 반영되었습니다.
- [x] DB 스키마 / 시드 데이터 변경사항을 확인했습니다.
- [x] 운영 환경변수 또는 Secrets 변경사항을 확인했습니다.
- [x] 환경변수 / Secrets 키 추가·변경·삭제 여부를 확인했습니다.
- [x] 변경이 있는 경우 GitHub Secrets / EC2 `.env` / SSM Parameter Store 반영 대상을 확인했습니다.
- [x] Secret 값은 PR 본문에 노출하지 않았습니다.
- [x] Docker / EC2 배포 설정 변경사항을 확인했습니다.
- [x] Merge Conflict가 없습니다.
- [x] 릴리즈 노트를 작성했습니다.
- [x] main 머지 후 생성할 Git Tag 버전을 확인했습니다.

---

# 🏷 버전 정보

| 이전 버전 | 변경 버전 | 버전 변경 유형 |
|----------|----------|----------------|
| `v2.9.1` | `v2.9.2` | `PATCH` |

### 버전 변경 사유

- 신규 기능이나 API를 추가하지 않고 기존 추천 질문 생성 쿼리의 컬럼명 오류만 수정했습니다.
- API 요청·응답, DB 스키마 및 인증 방식의 하위 호환성 변경이 없습니다.
- 운영 중 발생하는 SQL 오류를 해결하는 버그 수정이므로 `PATCH` 버전으로 올립니다.

---

# 📦 Git Tag

> Release PR이 `main`에 머지되면 GitHub Actions가 `v2.9.2` 태그와 GitHub Release를 자동 생성합니다.
>
> 아래 명령어는 자동 생성이 실패했을 때만 사용합니다.

```bash
git checkout main
git pull origin main

git tag v2.9.2
git push origin v2.9.2
```

---

# ✅ 배포 후 검증

```bash
curl http://<BACKEND_HOST>:8080/actuator/health
```

- [ ] `/actuator/health` 상태가 정상입니다.
- [ ] 관리자 추천 질문 수동 생성 API가 정상 동작합니다.
- [ ] 추천 질문 생성 배치가 최근 사용자 질문을 정상적으로 조회합니다.
- [ ] 로그에 SQL 1054 또는 `Unknown column 'cm.id'` 오류가 발생하지 않습니다.
- [ ] 생성된 추천 질문이 학생용 조회 API에서 정상적으로 반환됩니다.
- [ ] DB / Redis / GCP Storage 연결이 정상입니다.
- [ ] EC2 Docker 컨테이너 로그를 확인했습니다.

---

# 💬 기타 사항

- 릴리즈 대상은 `develop`에 병합된 PR #669입니다.
- 실제 변경 범위는 `SuggestedQuestionSourceJpaRepository`의 네이티브 쿼리 컬럼명 수정 1건입니다.
- 신규 API, DB 마이그레이션 및 운영 Secret 변경은 없습니다.